### PR TITLE
cognee 1.2.1 upgrade + server-side re-cognify/verify path

### DIFF
--- a/kb/cli.py
+++ b/kb/cli.py
@@ -58,6 +58,12 @@ async def _improve(args: argparse.Namespace) -> None:
     _print_json(result)
 
 
+async def _cognify(args: argparse.Namespace) -> None:
+    kb = Citadel.from_env()
+    result = await kb.cognify_dataset(dataset=args.dataset, verify=args.verify)
+    _print_json(result)
+
+
 async def _sync_github(args: argparse.Namespace) -> None:
     syncer = GitHubOrgSyncer(
         Citadel.from_env(),
@@ -121,6 +127,18 @@ def build_parser() -> argparse.ArgumentParser:
     improve.add_argument("--dataset")
     improve.add_argument("--session-id", action="append")
     improve.set_defaults(handler=_improve)
+
+    cognify = subcommands.add_parser(
+        "cognify",
+        help="Cognify already-added data in a dataset (recover uncognified data)",
+    )
+    cognify.add_argument("--dataset")
+    cognify.add_argument(
+        "--verify",
+        action="store_true",
+        help="Ingest a unique marker, cognify, and confirm it lands in the graph",
+    )
+    cognify.set_defaults(handler=_cognify)
 
     sync_github = subcommands.add_parser(
         "sync-github",

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -48,6 +48,9 @@ class CogneeGateway(Protocol):
     ) -> Any:
         ...
 
+    async def cognify(self, *, datasets: list[str]) -> Any:
+        ...
+
 
 class CogneePublicClient:
     def __init__(self) -> None:
@@ -271,6 +274,20 @@ class CogneePublicClient:
         engine = await get_graph_engine()
         nodes, edges = await engine.get_graph_data()
         return list(nodes), list(edges)
+
+    async def cognify(self, *, datasets: list[str]) -> Any:
+        """Cognify already-added data in ``datasets``.
+
+        ``cognee.cognify`` defaults to ``incremental_loading=True``, so this only
+        processes uncognified data and is idempotent over a dataset. It exists to
+        recover data that was added but never cognified (e.g. a prior cognify
+        failed with a bad LLM config).
+        """
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        return await cognee.cognify(datasets=datasets)
 
     async def add_feedback(
         self,

--- a/kb/server.py
+++ b/kb/server.py
@@ -210,6 +210,11 @@ class BackupMirrorRunBody(BaseModel):
     dry_run: bool = True
 
 
+class CognifyRunBody(BaseModel):
+    dataset: str | None = None
+    verify: bool = False
+
+
 class AccessTokenBody(BaseModel):
     name: str = Field(min_length=1, max_length=120)
     role: str = Field(default="reader")
@@ -2067,6 +2072,64 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
             "google_chat_sent": (
                 (result.get("notifications") or {}).get("google_chat") or {}
             ).get("sent"),
+        },
+    )
+    return jsonable_encoder(result)
+
+
+@app.post("/api/cognify/run")
+async def run_cognify(body: CognifyRunBody, request: Request) -> Any:
+    actor = require_access(request, "admin", "sources:sync")
+    citadel = get_citadel()
+    dataset = body.dataset or citadel.config.default_dataset
+    try:
+        result = await citadel.cognify_dataset(dataset=dataset, verify=body.verify)
+    except Exception as exc:  # pragma: no cover - depends on Cognee config.
+        logger.error("Cognify run failed: %s", exc.__class__.__name__)
+        get_access_store().record_event(
+            action="cognify.run",
+            actor=actor,
+            success=False,
+            dataset=dataset,
+            detail={"verify": body.verify, "error": str(exc)},
+        )
+        record_mcp_audit(
+            request,
+            actor=actor,
+            success=False,
+            dataset=dataset,
+            detail={
+                "operation": "cognify.run",
+                "verify": body.verify,
+                "error_type": exc.__class__.__name__,
+            },
+        )
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    verification = result.get("verification") or {}
+    get_access_store().record_event(
+        action="cognify.run",
+        actor=actor,
+        success=True,
+        dataset=dataset,
+        detail={
+            "verify": body.verify,
+            "graph_grew": result.get("graph_grew"),
+            "graph_before": result.get("graph_before"),
+            "graph_after": result.get("graph_after"),
+            "verification_ok": verification.get("ok") if body.verify else None,
+        },
+    )
+    record_mcp_audit(
+        request,
+        actor=actor,
+        success=True,
+        dataset=dataset,
+        detail={
+            "operation": "cognify.run",
+            "verify": body.verify,
+            "graph_grew": result.get("graph_grew"),
+            "verification_ok": verification.get("ok") if body.verify else None,
         },
     )
     return jsonable_encoder(result)

--- a/kb/service.py
+++ b/kb/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from hashlib import sha256
 import logging
+from uuid import uuid4
 from typing import Any
 
 from kb.cognee_client import CogneeGateway, CogneePublicClient
@@ -121,3 +122,65 @@ class Citadel:
             session_ids=session_ids,
             build_global_context_index=self.config.build_global_context_index,
         )
+
+    async def _graph_counts(self) -> dict[str, int]:
+        nodes, edges = await self.cognee.graph_data()
+        return {"nodes": len(nodes), "edges": len(edges)}
+
+    async def cognify_dataset(
+        self,
+        *,
+        dataset: str | None = None,
+        verify: bool = False,
+    ) -> dict[str, Any]:
+        """Cognify already-added data in ``dataset`` and report graph growth.
+
+        This recovers data that was added but never cognified. ``cognee.cognify``
+        only processes uncognified data (incremental by default), so re-running is
+        safe and idempotent. ``verify=True`` is a superset: it runs the same
+        recovery cognify and *also* ingests a unique marker, cognifies it, and
+        searches for it — an end-to-end health check that ingest + cognify fills
+        the graph. The marker is cognified explicitly because the modern Cognee
+        ``remember`` path does not cognify inline.
+        """
+        target_dataset = dataset or self.config.default_dataset
+        before = await self._graph_counts()
+
+        # Recovery: cognify already-added-but-uncognified data for the dataset.
+        await self.cognee.cognify(datasets=[target_dataset])
+
+        verification: dict[str, Any] | None = None
+        if verify:
+            marker = f"COGNIFY_TEST_MARKER_{uuid4().hex}"
+            await self.ingest(marker, dataset=target_dataset)
+            await self.cognee.cognify(datasets=[target_dataset])
+            matches = await self.search(marker, dataset=target_dataset, top_k=10)
+            verification = {
+                "marker": marker,
+                "search_hit": _marker_in_results(marker, matches),
+            }
+
+        after = await self._graph_counts()
+        graph_grew = (
+            after["nodes"] > before["nodes"] or after["edges"] > before["edges"]
+        )
+        if verification is not None:
+            verification["graph_grew"] = graph_grew
+            verification["ok"] = bool(verification["search_hit"] or graph_grew)
+
+        return {
+            "ok": True,
+            "dataset": target_dataset,
+            "graph_before": before,
+            "graph_after": after,
+            "graph_grew": graph_grew,
+            "verify": verify,
+            "verification": verification,
+        }
+
+
+def _marker_in_results(marker: str, results: list[Any]) -> bool:
+    for item in results:
+        if marker in str(item):
+            return True
+    return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [
-    "cognee[fastembed,postgres-binary]>=1.1.0,<2.0.0",
+    "cognee[fastembed,postgres-binary]>=1.2.1,<2.0.0",
     "fastapi>=0.116.2,<1.0.0",
     "google-auth>=2.40.0,<3.0.0",
     "mcp>=1.23.0,<2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cognee[fastembed,postgres-binary]>=1.1.0,<2.0.0
+cognee[fastembed,postgres-binary]>=1.2.1,<2.0.0
 fastapi>=0.116.2,<1.0.0
 google-auth>=2.40.0,<3.0.0
 mcp>=1.23.0,<2.0.0

--- a/scripts/run_github_sync.py
+++ b/scripts/run_github_sync.py
@@ -240,6 +240,7 @@ def run() -> int:
         "include_digest_preview": include_digest_preview,
     }
     endpoint = _target_endpoint()
+    logger.info("GitHub sync mode: %s", "HTTP endpoint" if endpoint else "in-process")
 
     if endpoint:
         access_key = _access_key()

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -6,6 +6,10 @@ Modes (via ``CITADEL_RUN_MODE``):
 - ``web`` (default): the FastAPI Organization Vault service.
 - ``github-sync`` / ``learning-agent``: the single GitHub org learning job.
 - ``backup-mirror``: the single Vault Backup Mirror export job.
+- ``cognify`` / ``cognify-verify``: re-cognify already-added data in a dataset
+  (``CITADEL_COGNIFY_DATASET``, default dataset otherwise) to recover data that
+  was added but never cognified; ``cognify-verify`` also ingests a unique marker
+  and confirms it lands in the graph.
 - ``pipeline`` (also ``all``/``cron``): the full scheduled pipeline —
   GitHub org sync, skills catalog refresh, self-improvement pass, and backup
   mirror export. Each stage is toggleable via env, logs a per-stage summary
@@ -92,6 +96,25 @@ def _repo_content_sync_stage() -> int:
         result.get("files_skipped"),
         result.get("improved"),
     )
+    return 0
+
+
+def _cognify_mode(*, verify: bool) -> int:
+    from kb.service import Citadel
+
+    dataset = os.getenv("CITADEL_COGNIFY_DATASET") or None
+    result = asyncio.run(Citadel.from_env().cognify_dataset(dataset=dataset, verify=verify))
+    logger.info(
+        "Cognify finished: dataset=%s graph_before=%s graph_after=%s grew=%s verify=%s",
+        result.get("dataset"),
+        result.get("graph_before"),
+        result.get("graph_after"),
+        result.get("graph_grew"),
+        (result.get("verification") or {}).get("ok") if verify else result.get("verify"),
+    )
+    if verify and not (result.get("verification") or {}).get("ok"):
+        logger.error("Cognify verification failed: %s", result.get("verification"))
+        return 1
     return 0
 
 
@@ -190,6 +213,8 @@ def run(mode: str | None = None) -> int:
         from scripts.run_backup_mirror import run as run_backup_mirror
 
         return run_backup_mirror()
+    if resolved_mode in {"cognify", "cognify-verify"}:
+        return _cognify_mode(verify=resolved_mode == "cognify-verify")
     if resolved_mode in {"pipeline", "all", "cron"}:
         return run_pipeline()
     print(f"Unsupported CITADEL_RUN_MODE: {resolved_mode}", file=sys.stderr)

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -272,6 +272,33 @@ async def test_cognee_public_client_falls_back_when_session_has_no_data(
     assert received["search"]["datasets"] == ["notes"]
 
 
+@pytest.mark.asyncio
+async def test_cognee_public_client_cognify_wraps_cognee_cognify(monkeypatch: Any) -> None:
+    received: dict[str, Any] = {}
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(**kwargs: Any) -> dict[str, Any]:
+        received["kwargs"] = kwargs
+        return {"cognified": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            run_startup_migrations=run_startup_migrations,
+            cognify=cognify,
+        ),
+    )
+    client = CogneePublicClient()
+
+    result = await client.cognify(datasets=["masumi-network"])
+
+    assert result == {"cognified": True}
+    assert received["kwargs"] == {"datasets": ["masumi-network"]}
+
+
 def test_cognee_public_client_derives_db_env_from_database_url(monkeypatch: Any) -> None:
     monkeypatch.setenv("DATABASE_URL", "postgresql://db_user:db%23pass@db.example:6543/citadel")
     monkeypatch.setenv("VECTOR_DB_PROVIDER", "pgvector")

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -247,6 +248,15 @@ async def test_github_sync_can_skip_unchanged_ingest(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_github_sync_returns_open_and_merged_pull_requests(tmp_path: Any) -> None:
+    def hours_ago(hours: int) -> str:
+        # Relative to now so the PRs always fall inside the reporting window
+        # (hardcoded absolute dates silently age out and break this test).
+        return (
+            (datetime.now(UTC) - timedelta(hours=hours))
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+
     class PullRequestGitHubClient(FakeGitHubClient):
         def fetch_pull_requests(
             self,
@@ -263,8 +273,8 @@ async def test_github_sync_returns_open_and_merged_pull_requests(tmp_path: Any) 
                     state="open",
                     draft=False,
                     user_login="sarthib7",
-                    created_at="2026-06-03T07:00:00Z",
-                    updated_at="2026-06-03T08:00:00Z",
+                    created_at=hours_ago(26),
+                    updated_at=hours_ago(1),
                     merged_at=None,
                 ),
                 GitHubPullRequest(
@@ -275,9 +285,9 @@ async def test_github_sync_returns_open_and_merged_pull_requests(tmp_path: Any) 
                     state="closed",
                     draft=False,
                     user_login="sarthib7",
-                    created_at="2026-06-02T07:00:00Z",
-                    updated_at="2026-06-03T08:00:00Z",
-                    merged_at="2026-06-03T08:30:00Z",
+                    created_at=hours_ago(48),
+                    updated_at=hours_ago(2),
+                    merged_at=hours_ago(2),
                 ),
             ][:max_pull_requests]
 

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -76,6 +76,42 @@ def test_backup_mirror_mode_runs_backup_job(monkeypatch: Any) -> None:
     assert calls == ["backup-mirror"]
 
 
+def test_cognify_mode_runs_cognify_without_verify(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeCitadel:
+        async def cognify_dataset(self, *, dataset: Any, verify: bool) -> dict[str, Any]:
+            calls.append({"dataset": dataset, "verify": verify})
+            return {"ok": True, "dataset": dataset, "graph_grew": True, "verify": verify}
+
+    import kb.service as service
+
+    monkeypatch.setattr(service.Citadel, "from_env", classmethod(lambda cls: FakeCitadel()))
+    monkeypatch.delenv("CITADEL_COGNIFY_DATASET", raising=False)
+
+    assert run_railway.run("cognify") == 0
+    assert calls == [{"dataset": None, "verify": False}]
+
+
+def test_cognify_verify_mode_fails_when_verification_fails(monkeypatch: Any) -> None:
+    class FakeCitadel:
+        async def cognify_dataset(self, *, dataset: Any, verify: bool) -> dict[str, Any]:
+            return {
+                "ok": True,
+                "dataset": dataset,
+                "graph_grew": False,
+                "verify": verify,
+                "verification": {"ok": False, "search_hit": False, "graph_grew": False},
+            }
+
+    import kb.service as service
+
+    monkeypatch.setattr(service.Citadel, "from_env", classmethod(lambda cls: FakeCitadel()))
+    monkeypatch.delenv("CITADEL_COGNIFY_DATASET", raising=False)
+
+    assert run_railway.run("cognify-verify") == 1
+
+
 def test_unknown_mode_fails() -> None:
     assert run_railway.run("not-real") == 1
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,6 +40,21 @@ class FakeCitadel:
     async def improve(self, **kwargs: Any) -> dict[str, Any]:
         return {"dataset": kwargs["dataset"], "session_ids": kwargs["session_ids"]}
 
+    async def cognify_dataset(self, *, dataset: Any = None, verify: bool = False) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "dataset": dataset or self.config.default_dataset,
+            "graph_before": {"nodes": 0, "edges": 0},
+            "graph_after": {"nodes": 5, "edges": 7},
+            "graph_grew": True,
+            "verify": verify,
+            "verification": (
+                {"marker": "COGNIFY_TEST_MARKER_x", "search_hit": True, "graph_grew": True, "ok": True}
+                if verify
+                else None
+            ),
+        }
+
 
 class FakeGitHubSyncer:
     async def status(self) -> dict[str, Any]:
@@ -337,6 +352,29 @@ def test_api_uses_configured_citadel_service() -> None:
     assert updated_mesh.status_code == 200
     assert updated_mesh.json()["stats"]["feedback"] == 1
     assert upgrade.status_code == 200
+
+
+def test_admin_can_run_cognify_recovery_and_verification() -> None:
+    client = authed_client()
+
+    recover = client.post("/api/cognify/run", json={"dataset": "masumi-network"})
+    verify = client.post("/api/cognify/run", json={"verify": True})
+
+    assert recover.status_code == 200
+    assert recover.json()["dataset"] == "masumi-network"
+    assert recover.json()["graph_grew"] is True
+    assert recover.json()["verification"] is None
+    assert verify.status_code == 200
+    assert verify.json()["verify"] is True
+    assert verify.json()["verification"]["ok"] is True
+
+
+def test_cognify_run_requires_admin() -> None:
+    client = authed_client("test-writer")
+
+    response = client.post("/api/cognify/run", json={})
+
+    assert response.status_code == 403
 
 
 def test_knowledge_events_api_returns_resumable_timeline() -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15,9 +15,16 @@ class FakeCognee:
         self.remember_calls: list[dict[str, Any]] = []
         self.feedback_calls: list[dict[str, Any]] = []
         self.improve_calls: list[dict[str, Any]] = []
+        self.cognify_calls: list[dict[str, Any]] = []
+        self.nodes: list[Any] = []
+        self.edges: list[Any] = []
+        self._pending: list[Any] = []
 
     async def remember(self, data: Any, **kwargs: Any) -> dict[str, Any]:
         self.remember_calls.append({"data": data, **kwargs})
+        # Cognee.add stores data, but it only enters the graph once cognify
+        # runs — the modern remember path does not cognify inline.
+        self._pending.append(data)
         return {"ok": True}
 
     async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
@@ -30,6 +37,16 @@ class FakeCognee:
     async def improve(self, **kwargs: Any) -> dict[str, Any]:
         self.improve_calls.append(kwargs)
         return {"improved": True}
+
+    async def cognify(self, **kwargs: Any) -> dict[str, Any]:
+        self.cognify_calls.append(kwargs)
+        # Cognify turns added-but-uncognified data into graph nodes.
+        self.nodes.extend(self._pending)
+        self._pending.clear()
+        return {"cognified": True}
+
+    async def graph_data(self) -> tuple[list[Any], list[Any]]:
+        return list(self.nodes), list(self.edges)
 
 
 class EmptyCognee(FakeCognee):
@@ -114,6 +131,45 @@ async def test_search_falls_back_to_persisted_github_digest(tmp_path: Any) -> No
     assert result[0]["source"] == "github_sync_state"
     assert result[0]["metadata"]["org"] == "masumi-network"
     assert any("organization seat assignment" in item["content"] for item in result)
+
+
+@pytest.mark.asyncio
+async def test_cognify_dataset_reports_graph_growth() -> None:
+    fake = FakeCognee()
+    kb = Citadel(CitadelConfig(default_dataset="masumi-network"), cognee=fake)
+
+    result = await kb.cognify_dataset()
+
+    assert result["ok"]
+    assert result["dataset"] == "masumi-network"
+    assert result["verify"] is False
+    assert fake.cognify_calls == [{"datasets": ["masumi-network"]}]
+    assert result["graph_before"] == {"nodes": 0, "edges": 0}
+
+
+@pytest.mark.asyncio
+async def test_cognify_dataset_verify_ingests_marker_and_confirms_hit() -> None:
+    class RecallingCognee(FakeCognee):
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            return [{"content": query}]
+
+    fake = RecallingCognee()
+    kb = Citadel(CitadelConfig(default_dataset="masumi-network"), cognee=fake)
+
+    result = await kb.cognify_dataset(verify=True)
+
+    assert result["verify"] is True
+    marker = fake.remember_calls[0]["data"]
+    assert marker.startswith("COGNIFY_TEST_MARKER_")
+    assert result["verification"]["search_hit"] is True
+    assert result["verification"]["graph_grew"] is True
+    assert result["verification"]["ok"] is True
+    # verify is a superset: recovery cognify + an explicit cognify of the marker
+    # (remember does not cognify inline on the modern Cognee path).
+    assert fake.cognify_calls == [
+        {"datasets": ["masumi-network"]},
+        {"datasets": ["masumi-network"]},
+    ]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", extras = ["fastembed", "postgres-binary"], specifier = ">=1.1.0,<2.0.0" },
+    { name = "cognee", extras = ["fastembed", "postgres-binary"], specifier = ">=1.2.1,<2.0.0" },
     { name = "fastapi", specifier = ">=0.116.2,<1.0.0" },
     { name = "google-auth", specifier = ">=2.40.0,<3.0.0" },
     { name = "mcp", specifier = ">=1.23.0,<2.0.0" },
@@ -806,7 +806,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.1.2"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -820,6 +820,7 @@ dependencies = [
     { name = "fakeredis", extra = ["lua"] },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
+    { name = "filelock" },
     { name = "filetype" },
     { name = "gunicorn" },
     { name = "instructor" },
@@ -854,9 +855,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/b1/1f2ad87bc25a64a62781f23f299d58f9502804b705ee87d364d3efbb0564/cognee-1.1.2.tar.gz", hash = "sha256:ef80b8da94ad148b32deb6a9ba1315bc7105508d741a47eff70c6645b30485bf", size = 18954198, upload-time = "2026-05-30T18:14:03.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/f1/7eca21f6bb468a86d0f57cefcae642382b614b3af3da8b7c83f90a3f1aa4/cognee-1.2.1.tar.gz", hash = "sha256:c527d3b58978759a73079fbb7e081620499f2bd8d80dc01dd4466971123b9a81", size = 19272567, upload-time = "2026-06-21T18:30:04.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/fa/a74f83a7dc19b52056c18afaf60b6c3ee4f56a5521a6b6cbdace1e9164d1/cognee-1.1.2-py3-none-any.whl", hash = "sha256:0d092f84c4df2c2a418ca1ddfaab64e28878ee620b6728c95d1b080a93f48f97", size = 2473205, upload-time = "2026-05-30T18:14:00.306Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4a/ccdb4b5a6256559cf8bcdb13b483cade9a5c7432a2a65d01dd13c1ccb56d/cognee-1.2.1-py3-none-any.whl", hash = "sha256:4d3248d7551ae07b5248dd82ca2756e75e2c8891404e8823e524c0d00cf718d1", size = 2830094, upload-time = "2026-06-21T18:30:00.918Z" },
 ]
 
 [package.optional-dependencies]
@@ -3493,16 +3494,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Three commits:
1. **chore(deps): cognee 1.1.2 -> 1.2.1** — bump pin + regenerate lock (clean re-resolution). Breaking changes in the window don't affect Citadel (unused renamed vars; version-defensive cognee_client).
2. **feat(cognify): server-side re-cognify + verify path** — recovers data added-but-never-cognified (empty graph). Adds CLI `citadel cognify [--verify]`, admin `POST /api/cognify/run`, run-modes `cognify`/`cognify-verify`, and `CogneePublicClient.cognify` / `Citadel.cognify_dataset`. `verify` is a superset of recovery (always cognifies, then marker-checks). Default behavior of `/api/learning-agent/run` unchanged.
3. **test(github-sync): time-independent PR-window test** — backprop fix; the test hardcoded dates that aged out of the window.

## Context

Production ingest was broken because `LLM_MODEL=openrouter/free` was invalid -> cognify failed -> empty graph. That root cause was fixed in prod separately (config: `LLM_MODEL=openrouter/openai/gpt-4o-mini`) and **verified** (ingest -> cognify -> search round-trip works). This branch is the cognee upgrade + the recovery tooling to heal data stranded during the broken era.

## Tests

`312 passed` locally (full suite green; the cognify feature was hardened after an adversarial review caught a verify-skips-recovery bug).

## Deploy note

cognee 1.2.1 is runtime-unverified for the Kuzu graph store + the 1.2.0 auth-posture default — watch web service startup logs on deploy.