### PR TITLE
Per-seat onboarding: connect wizard + self-describing seat + inventory

### DIFF
--- a/kb/access.py
+++ b/kb/access.py
@@ -60,6 +60,7 @@ class AccessIdentity:
     default_dataset: str | None = None
     default_session: str | None = None
     allowed_datasets: tuple[str, ...] = field(default_factory=tuple)
+    seat_slug: str | None = None
 
 
 @dataclass(frozen=True)
@@ -544,6 +545,9 @@ class AccessStore:
             default_dataset=default_dataset,
             default_session=default_session,
             allowed_datasets=allowed_datasets,
+            # Carry the seat marker straight off this token's own principal so a
+            # self-describing scope can never name another seat's slug.
+            seat_slug=principal.seat_slug,
         )
         return TokenSession(identity=identity, token_hash=api_token.token_hash)
 

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -552,7 +552,11 @@ def create_mcp_server(
         session_id: str | None = None,
         top_k: int = 10,
     ) -> dict[str, Any]:
-        """Search the Citadel Organization Vault."""
+        """Search the Citadel Organization Vault.
+
+        Searches your personal node and shared Central together by default; pass
+        dataset to narrow. Leave session_id default.
+        """
         return await _call_async(
             "citadel_search",
             lambda: resolve_client(ctx).post(
@@ -617,7 +621,12 @@ def create_mcp_server(
         tags: list[str] | None = None,
         session_id: str | None = None,
     ) -> dict[str, Any]:
-        """Add durable context to the Citadel Organization Vault. Requires writer access."""
+        """Add durable context to the Citadel Organization Vault. Requires writer access.
+
+        Writes to your personal node (seat:{slug}) by default. Add tag org-ready or
+        vault-contribution to also promote to shared Central; set dataset to
+        override. Leave session_id default.
+        """
 
         def post_ingest() -> dict[str, Any]:
             normalized_data = _require_non_empty(data, "data")
@@ -651,7 +660,9 @@ def create_mcp_server(
 
         The easy write path for agents: same route as POST /api/contribute,
         with enrichment (when enabled) and Knowledge Conflict detection on.
-        Requires writer access.
+        Routes through Central promotion via the Learning Process, so the
+        contribution is curated into shared Central rather than left in your
+        personal node. Requires writer access.
         """
 
         def post_contribute() -> dict[str, Any]:

--- a/kb/server.py
+++ b/kb/server.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 
 from kb.access import (
     CENTRAL_DATASET,
+    SEAT_DATASET_PREFIX,
     AccessIdentity,
     AccessStore,
     ROLE_ORDER,
@@ -846,16 +847,30 @@ def resolve_search_sessions(
     }
 
 
+def node_label(dataset: str | None) -> str | None:
+    # A friendly, human label for the caller's private Node dataset. Only seat
+    # nodes get a label; shared datasets like Central are not a personal Node.
+    if not is_seat_dataset(dataset):
+        return None
+    slug = dataset[len(SEAT_DATASET_PREFIX) :]
+    return f"{slug}'s private Node"
+
+
 def resolved_memory_scope(
     identity: AccessIdentity,
     config: CitadelConfig,
 ) -> dict[str, Any]:
     search_datasets = resolve_search_datasets(identity, None, config)
+    # Reflect ONLY the authenticated caller's own identity: seat_slug is read
+    # straight off this identity (null for non-seat callers), never another seat.
+    seat_slug = identity.seat_slug
     return {
         "default_dataset": search_datasets[0],
         "default_session": identity.default_session,
         "allowed_datasets": list(identity.allowed_datasets) or None,
         "search_datasets": search_datasets if len(search_datasets) > 1 else None,
+        "seat_slug": seat_slug,
+        "node_label": node_label(identity.default_dataset),
     }
 
 
@@ -1283,6 +1298,56 @@ async def audit_snapshot(
         "audit_events": returned_events,
         "summary": audit_summary(all_events=events, returned_events=returned_events),
     }
+
+
+@app.get("/api/access/seats")
+async def list_access_seats(request: Request) -> dict[str, Any]:
+    require_access(request, "admin", "access:manage")
+    snapshot = get_access_store().snapshot()
+    tokens_by_principal: dict[str, list[dict[str, Any]]] = {}
+    for token in snapshot["tokens"]:
+        tokens_by_principal.setdefault(token["principal_id"], []).append(token)
+    seats: list[dict[str, Any]] = []
+    # A seat is a principal that carries a seat_slug; derive the list purely from
+    # the existing snapshot (no new store schema), joining each seat to its tokens.
+    for principal in snapshot["principals"]:
+        if not principal.get("seat_slug"):
+            continue
+        seat_tokens = sorted(
+            tokens_by_principal.get(principal["id"], []),
+            key=lambda token: token.get("created_at") or "",
+        )
+        token_rows = [
+            {
+                "id": token["id"],
+                "name": token["name"],
+                "role": token["role"],
+                # prefix is the masked, non-secret head already stored at rest.
+                "prefix": token["prefix"],
+                "revoked": bool(token.get("revoked_at")),
+                "revoked_at": token.get("revoked_at"),
+                "last_used_at": token.get("last_used_at"),
+                "created_at": token.get("created_at"),
+            }
+            for token in seat_tokens
+        ]
+        active_tokens = sum(1 for token in token_rows if not token["revoked"])
+        seats.append(
+            {
+                "principal_id": principal["id"],
+                "name": principal["name"],
+                "seat_slug": principal["seat_slug"],
+                "node_dataset": principal.get("default_dataset"),
+                "email": principal.get("email"),
+                "role": principal["role"],
+                "disabled": bool(principal.get("disabled_at")),
+                "active_token_count": active_tokens,
+                "token_count": len(token_rows),
+                "tokens": token_rows,
+            }
+        )
+    seats.sort(key=lambda seat: seat["seat_slug"])
+    return {"ok": True, "seats": seats}
 
 
 @app.post("/api/access/seats")

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -62,6 +62,8 @@ const feedbackResult = document.getElementById("feedbackResult");
 const accessTokenStatus = document.getElementById("accessTokenStatus");
 const accessPrincipalList = document.getElementById("accessPrincipalList");
 const accessTokenList = document.getElementById("accessTokenList");
+const accessSeatsList = document.getElementById("accessSeatsList");
+const accessSeatsStatus = document.getElementById("accessSeatsStatus");
 const accessAuditList = document.getElementById("accessAuditList");
 const newAccessToken = document.getElementById("newAccessToken");
 const dashboardCronStatus = document.getElementById("dashboardCronStatus");
@@ -2192,6 +2194,10 @@ async function loadAccess() {
     }
     accessPrincipalList.innerHTML = "";
     accessPrincipalList.append(emptyState("Could not load access", error.message));
+    if (accessSeatsList) {
+      accessSeatsList.innerHTML = "";
+      accessSeatsList.append(emptyState("Could not load seats", error.message));
+    }
     if (agentsTokenList) {
       agentsTokenList.innerHTML = "";
       agentsTokenList.append(emptyState("Could not load agents", error.message));
@@ -2209,6 +2215,7 @@ function renderAccess(snapshot) {
   accessAuditList.innerHTML = "";
   renderDashboardMcpAccess(snapshot);
   renderAgents(snapshot);
+  loadSeats();
   renderAuditAccessEvents(snapshot.audit_events || []);
 
   if (!snapshot.principals?.length) {
@@ -2299,6 +2306,73 @@ function renderAgents(snapshot) {
       <span class="status-chip ${revoked ? "status-error" : "status-enabled"}">${escapeHtml(revoked ? "revoked" : token.prefix + "...")}</span>
     `;
     agentsTokenList.append(item);
+  });
+}
+
+async function loadSeats() {
+  if (!accessSeatsList) return;
+  if (accessSeatsStatus) {
+    accessSeatsStatus.textContent = "Loading";
+    accessSeatsStatus.className = "status-chip status-standby";
+  }
+  try {
+    const response = await api("/api/access/seats");
+    renderSeats(response.seats || []);
+    if (accessSeatsStatus) {
+      const count = (response.seats || []).length;
+      accessSeatsStatus.textContent = `${count} seat${count === 1 ? "" : "s"}`;
+      accessSeatsStatus.className = `status-chip ${count ? "status-enabled" : "status-standby"}`;
+    }
+  } catch (error) {
+    accessSeatsList.innerHTML = "";
+    accessSeatsList.append(emptyState("Could not load seats", error.message));
+    if (accessSeatsStatus) {
+      accessSeatsStatus.textContent = "Error";
+      accessSeatsStatus.className = "status-chip status-error";
+    }
+  }
+}
+
+function renderSeats(seats = []) {
+  accessSeatsList.innerHTML = "";
+  if (!seats.length) {
+    accessSeatsList.append(emptyState("No seats yet", "Create a seat to provision a private node."));
+    return;
+  }
+  seats.forEach((seat) => {
+    const item = document.createElement("div");
+    item.className = "entity-item";
+    const meta = document.createElement("div");
+    meta.innerHTML = `
+      <strong>${escapeHtml(seat.name)}</strong>
+      <p>Seat ${escapeHtml(seat.seat_slug)} - ${escapeHtml(seat.node_dataset || "unset")}</p>
+      <p>${escapeHtml(roleLabel(seat.role))} - ${seat.active_token_count} active / ${seat.token_count} token${seat.token_count === 1 ? "" : "s"}</p>
+    `;
+    item.append(meta);
+    const tokens = seat.tokens || [];
+    if (!tokens.length) {
+      const chip = document.createElement("span");
+      chip.className = "status-chip status-standby";
+      chip.textContent = "no token";
+      item.append(chip);
+    } else {
+      const actions = document.createElement("div");
+      actions.className = "seat-token-actions";
+      tokens.forEach((token) => {
+        const action = document.createElement("button");
+        action.className = "secondary-button compact-button";
+        action.type = "button";
+        const revoked = Boolean(token.revoked);
+        action.textContent = revoked ? `${token.prefix}... revoked` : `Revoke ${token.prefix}...`;
+        action.disabled = revoked;
+        action.title = revoked ? "Revoked" : `Last used ${formatDate(token.last_used_at)}`;
+        // Reuse the existing token revoke flow + endpoint.
+        action.addEventListener("click", () => revokeAccessToken(token.id));
+        actions.append(action);
+      });
+      item.append(actions);
+    }
+    accessSeatsList.append(item);
   });
 }
 
@@ -2764,6 +2838,105 @@ document.getElementById("obsidianVaultForm").addEventListener("submit", async (e
   }
 });
 
+function mcpEndpointUrl() {
+  // Derive from the current origin so the snippet always points at this host.
+  return `${window.location.origin}/mcp/`;
+}
+
+function renderMcpSnippetCard(containerId, label, chip, snippet) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const codeId = `${containerId}Code`;
+  container.innerHTML = `
+    <article class="mcp-snippet-card">
+      <div class="event-row">
+        <strong>${escapeHtml(label)}</strong>
+        <div class="mcp-snippet-actions">
+          <span class="status-chip">${escapeHtml(chip)}</span>
+          <button type="button" class="copy-button" data-copy-target="${codeId}">Copy</button>
+        </div>
+      </div>
+      <pre><code id="${codeId}">${escapeHtml(snippet)}</code></pre>
+    </article>
+  `;
+  const button = container.querySelector(".copy-button");
+  button.addEventListener("click", () => copyMcpSnippet(codeId));
+}
+
+function renderStorageScopeGuide(seatResponse) {
+  const container = document.getElementById("storageScopeGuide");
+  if (!container) return;
+  const slug = seatResponse.principal.seat_slug || "";
+  const nodeDataset = seatResponse.principal.default_dataset || `seat:${slug}`;
+  container.innerHTML = `
+    <p class="storage-scope-explainer">
+      This seat's <code>${escapeHtml(nodeDataset)}</code> Node is private agent
+      memory; add tag <code>org-ready</code> or <code>vault-contribution</code> to
+      a write to also promote it into shared Central.
+    </p>
+  `;
+}
+
+function renderTeammateOnboarding(seatResponse) {
+  // The snippet token is the seat-scoped writer token from create_seat
+  // (allowed_datasets = seat:{slug} + Central). create_seat forbids the admin
+  // role, so this is never an admin token. It is shown once: only the hash is
+  // stored, and it is unrecoverable if not copied now.
+  const reveal = document.getElementById("newSeatToken");
+  const token = seatResponse.token;
+  const nodeDataset = seatResponse.principal.default_dataset;
+  const endpoint = mcpEndpointUrl();
+  reveal.hidden = false;
+  reveal.innerHTML = `
+    <strong>Seat created</strong>
+    <p>Node dataset: ${escapeHtml(nodeDataset)}</p>
+    <p>One-time writer token. Citadel stores only the hash; if you do not copy it
+      now it cannot be recovered and you will need to re-issue.</p>
+    <code>${escapeHtml(token)}</code>
+  `;
+
+  const claudeSnippet = `{
+  "mcpServers": {
+    "citadel": {
+      "type": "http",
+      "url": "${endpoint}",
+      "headers": {
+        "Authorization": "Bearer ${token}"
+      }
+    }
+  }
+}`;
+  const codexSnippet = `[mcp_servers.citadel]
+command = "npx"
+args = [
+  "-y", "mcp-remote",
+  "${endpoint}",
+  "--header", "Authorization: Bearer ${token}"
+]`;
+  renderMcpSnippetCard("mcpSnippetClaude", "Claude Code", "http", claudeSnippet);
+  renderMcpSnippetCard("mcpSnippetCodex", "Codex", "hosted", codexSnippet);
+  renderStorageScopeGuide(seatResponse);
+}
+
+async function copyMcpSnippet(elementId) {
+  const node = document.getElementById(elementId);
+  if (!node) return;
+  const text = node.textContent || "";
+  const button = document.querySelector(`[data-copy-target="${elementId}"]`);
+  try {
+    await navigator.clipboard.writeText(text);
+    if (button) {
+      const original = button.textContent;
+      button.textContent = "Copied";
+      window.setTimeout(() => {
+        button.textContent = original;
+      }, 1500);
+    }
+  } catch (error) {
+    if (button) button.textContent = "Copy failed";
+  }
+}
+
 document.getElementById("accessSeatForm").addEventListener("submit", async (event) => {
   event.preventDefault();
   const form = event.currentTarget;
@@ -2777,6 +2950,10 @@ document.getElementById("accessSeatForm").addEventListener("submit", async (even
   error.textContent = "";
   reveal.hidden = true;
   reveal.innerHTML = "";
+  ["mcpSnippetClaude", "mcpSnippetCodex", "storageScopeGuide"].forEach((id) => {
+    const node = document.getElementById(id);
+    if (node) node.innerHTML = "";
+  });
   if (!name || !slug) {
     error.textContent = "Name and seat slug are required.";
     return;
@@ -2795,13 +2972,7 @@ document.getElementById("accessSeatForm").addEventListener("submit", async (even
         issue_token: true,
       }),
     });
-    reveal.hidden = false;
-    reveal.innerHTML = `
-      <strong>Seat created</strong>
-      <p>Node dataset: ${escapeHtml(response.principal.default_dataset)}</p>
-      <p>Copy this writer token now. Citadel stores only the hash.</p>
-      <code>${escapeHtml(response.token)}</code>
-    `;
+    renderTeammateOnboarding(response);
     form.reset();
     await loadAccess();
   } catch (err) {

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -851,6 +851,9 @@
                 <p id="accessSeatError" class="form-error" role="alert"></p>
               </form>
               <div id="newSeatToken" class="token-reveal" hidden></div>
+              <div id="mcpSnippetClaude"></div>
+              <div id="mcpSnippetCodex"></div>
+              <div id="storageScopeGuide"></div>
             </section>
             <section class="window action-panel">
               <div class="window-titlebar">
@@ -960,6 +963,16 @@
                 <div id="accessTokenList" class="entity-list"></div>
               </section>
             </div>
+            <section class="window action-panel">
+              <div class="window-titlebar">
+                <div>
+                  <h2>Seats</h2>
+                  <p class="panel-kicker">Licensed members and their node tokens</p>
+                </div>
+                <span id="accessSeatsStatus" class="status-chip">Loading</span>
+              </div>
+              <div id="accessSeatsList" class="entity-list"></div>
+            </section>
             <section class="window action-panel">
               <div class="window-titlebar">
                 <div>

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -938,6 +938,76 @@ pre {
   white-space: pre;
 }
 
+.mcp-snippet-card {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  overflow-wrap: anywhere;
+}
+
+.mcp-snippet-card pre {
+  max-width: 100%;
+  margin: 8px 0 0;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.mcp-snippet-card code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--primary-strong);
+}
+
+.mcp-snippet-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.copy-button {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background-color var(--speed) ease-out,
+    border-color var(--speed) ease-out;
+}
+
+.copy-button:hover {
+  border-color: var(--primary-border);
+  background: var(--surface-hover);
+}
+
+.storage-scope-explainer {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--primary-border);
+  border-radius: var(--radius);
+  background: var(--primary-soft);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.storage-scope-explainer code {
+  font-family: var(--mono);
+  color: var(--primary-strong);
+}
+
+.seat-token-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-end;
+}
+
 .index-item {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2045,6 +2045,112 @@ def test_create_seat_api_rejects_admin_role(tmp_path: Any) -> None:
     assert "admin role" in response.json()["detail"]
 
 
+def test_seat_session_reports_own_seat_slug_and_node(tmp_path: Any) -> None:
+    # A seat's self-describing scope must reflect only the authenticated caller:
+    # its own seat_slug and a friendly label for its private node dataset.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats",
+        json={"name": "Nora", "slug": "nora"},
+    ).json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    session = api_client.get(
+        "/api/session", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert session.status_code == 200
+    payload = session.json()
+    assert payload["seat_slug"] == "nora"
+    assert payload["default_dataset"] == "seat:nora"
+    assert payload["node_label"] == "nora's private Node"
+    assert payload["search_datasets"] == ["seat:nora", "masumi-network"]
+
+
+def test_non_seat_token_session_nulls_seat_slug(tmp_path: Any) -> None:
+    # A plain (non-seat) token carries no seat marker; the self-describing scope
+    # must null seat_slug and node_label rather than invent one.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    token = client.post(
+        "/api/access/tokens",
+        json={
+            "name": "plain-reader",
+            "role": "reader",
+            "kind": "service_account",
+            "default_dataset": "personal",
+        },
+    ).json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    session = api_client.get(
+        "/api/session", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert session.status_code == 200
+    payload = session.json()
+    assert payload["seat_slug"] is None
+    assert payload["node_label"] is None
+
+
+def test_list_seats_returns_active_seats_with_token_counts(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    created = client.post(
+        "/api/access/seats",
+        json={"name": "Olive", "slug": "olive", "email": "olive@example.com"},
+    ).json()
+    # A non-seat principal/token must never appear in the seat inventory.
+    client.post(
+        "/api/access/tokens",
+        json={"name": "plain-agent", "role": "reader", "kind": "service_account"},
+    )
+
+    listing = client.get("/api/access/seats")
+
+    assert listing.status_code == 200
+    seats = listing.json()["seats"]
+    assert len(seats) == 1
+    seat = seats[0]
+    assert seat["seat_slug"] == "olive"
+    assert seat["node_dataset"] == "seat:olive"
+    assert seat["email"] == "olive@example.com"
+    assert seat["active_token_count"] == 1
+    assert seat["token_count"] == 1
+    assert seat["tokens"][0]["id"] == created["api_token"]["id"]
+    assert seat["tokens"][0]["prefix"] == created["api_token"]["prefix"]
+    assert seat["tokens"][0]["revoked"] is False
+    # The seat list is a redacted aggregation: no token hash leaks through.
+    assert "token_hash" not in seat["tokens"][0]
+
+    # Revoking the seat's token drops the active count to zero but keeps the seat.
+    revoked = client.post(
+        f"/api/access/tokens/{created['api_token']['id']}/revoke"
+    )
+    assert revoked.status_code == 200
+    after = client.get("/api/access/seats").json()["seats"]
+    assert after[0]["active_token_count"] == 0
+    assert after[0]["token_count"] == 1
+    assert after[0]["tokens"][0]["revoked"] is True
+
+
+def test_list_seats_requires_admin(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    writer_token = admin.post(
+        "/api/access/tokens",
+        json={"name": "writer-agent", "role": "writer", "kind": "service_account"},
+    ).json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    forbidden = api_client.get(
+        "/api/access/seats", headers={"Authorization": f"Bearer {writer_token}"}
+    )
+
+    assert forbidden.status_code == 403
+
+
 def test_admin_scope_override_is_audited(tmp_path: Any) -> None:
     # An admin-role token that carries its own allowlist but reaches outside it
     # bypasses enforcement by design; the bypass must be flagged in the audit log.


### PR DESCRIPTION
## What (per-seat onboarding, Phases 1-3)

Turns the existing (tested) seat/node/Central engine into a usable onboarding product. Additive only — isolation, write-routing, token scoping reused unchanged.

- **Connect wizard** — Create Seat now renders ready-to-paste MCP config (Claude Code + Codex) with the seat's scoped writer token + origin-derived `/mcp/` URL + copy buttons + a personal-vs-shared explainer.
- **Self-describing seat** — `resolved_memory_scope` surfaces the caller's own `seat_slug` + node label (flows to `/api/session` + `citadel_session`); `citadel_ingest`/`search`/`contribute` docstrings now state personal-by-default, tag-to-share.
- **Seat inventory** — admin `GET /api/access/seats` + per-seat revoke in the Access UI.

## Quality

`316 passed` (+4 tests). Two independent adversarial reviews → SHIP-ABLE; all 5 seat-isolation invariants traced PASS (snippet token seat-scoped never admin; `/api/access/seats` admin-gated; `resolved_memory_scope` caller-only; no token leakage; HTTPS-derived MCP URL).

## Risk

Low — pure frontend + additive backend (2 new `/api/session` fields, 1 new admin endpoint, docstring-only MCP changes), fully backward-compatible.