### PR TITLE
Autonomous personal-KB sync (SessionEnd hook + proactive-ingest skill)

### DIFF
--- a/docs/onboarding/citadel-autosync.md
+++ b/docs/onboarding/citadel-autosync.md
@@ -1,0 +1,60 @@
+# Citadel Auto-Sync — dev onboarding
+
+Your Claude Code sessions in org repos auto-save a short, distilled note to
+**your private Citadel node** when each session ends. One setup step, then it's
+automatic and personal.
+
+## The one step
+
+Mint a **seat-writer** token from the connect wizard and export it once:
+
+```bash
+# https://citadel-archive-production.up.railway.app/skills/connect
+export CITADEL_MCP_ACCESS_TOKEN='ctdl_...'
+```
+
+Add it to your `~/.zshrc` / `~/.bashrc` so it persists. This is the same token
+that powers `citadel_search` and your MCP config — if Citadel search already
+works for you, you're done. The repo already ships the SessionEnd hook in
+`.claude/settings.json`; no per-project setup beyond having the token in your
+environment.
+
+## What auto-syncs, and when
+
+- **When:** once, on every Claude Code `SessionEnd` (session close).
+- **What:** a short distilled note — a 1-2 line recap, key decisions, files
+  changed, notable facts. **Not** the raw transcript.
+- **Tags:** `dev-session`, your git branch, and the repo name.
+- **How it behaves:** non-blocking and fail-silent. If Citadel is down or the
+  token is unset, your session still closes instantly — nothing breaks.
+
+## Personal vs shared
+
+| | Goes where | Who reads it |
+|---|---|---|
+| **Auto-sync (default)** | your private node `seat:{slug}` | only you (+ Central) |
+| **Promoted** (tag `org-ready` / `vault-contribution`) | shared Central `masumi-network` | the whole org |
+
+Auto-sync is **always personal** — it sends no `dataset` field, so your
+seat-writer token routes it to your own node. To share something org-wide, ask
+your agent to `citadel_ingest` it mid-session with an `org-ready` tag (ADRs,
+shared runbooks, interface contracts). Promotion is always explicit.
+
+## Privacy
+
+- Token read from `CITADEL_MCP_ACCESS_TOKEN` only — never printed, echoed, or
+  committed.
+- Distilled note, never the raw transcript.
+- HTTPS only.
+
+## Opt-out
+
+- **Quick:** unset `CITADEL_MCP_ACCESS_TOKEN` (the hook becomes a no-op).
+- **Persistent:** add a `SessionEnd` override in `.claude/settings.local.json`
+  (gitignored, dev-local) to disable the hook for you only.
+
+## More
+
+- Skill: `https://citadel-archive-production.up.railway.app/skills/proactive-ingest`
+- Connect wizard: `https://citadel-archive-production.up.railway.app/skills/connect`
+- Repo setup details: `skills/citadel-proactive-ingest/README.md`

--- a/skills/citadel-proactive-ingest/README.md
+++ b/skills/citadel-proactive-ingest/README.md
@@ -1,0 +1,106 @@
+# citadel-proactive-ingest — org repo setup
+
+Add autonomous personal-KB sync to a project repo so that every Claude Code
+session a dev runs auto-syncs a distilled note to **their** private Citadel node
+(`seat:{slug}`). One-time token setup per dev, zero per-session steps.
+
+## What ships in this skill
+
+| Path | Purpose |
+|---|---|
+| `SKILL.md` | Agent behavior + auto-sync docs |
+| `scripts/sync_session.py` | The distill + POST script the hook runs (stdlib only) |
+| `templates/claude-settings.json` | Drop-in `.claude/settings.json` SessionEnd hook |
+| `README.md` | This file |
+
+## 1. Add the skill to the repo
+
+Vendor this skill directory into the repo (or reference it from a shared skills
+path) so that `skills/citadel-proactive-ingest/scripts/sync_session.py` exists
+relative to the project root. The hook command resolves it via
+`$CLAUDE_PROJECT_DIR`.
+
+## 2. Copy the hook into `.claude/settings.json`
+
+Merge `templates/claude-settings.json` into the repo's `.claude/settings.json`
+(create the file if absent). The hook block:
+
+```jsonc
+{
+  // SessionEnd fires once when a Claude Code session closes. The command is
+  // NON-BLOCKING (the script always exits 0) and bounded by `timeout` seconds,
+  // so a Citadel outage can never delay a dev's session close.
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            // Skill-relative path; $CLAUDE_PROJECT_DIR is the repo root.
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/skills/citadel-proactive-ingest/scripts/sync_session.py\"",
+            "timeout": 20,
+            // Only this var is exposed to the hook process — the seat token.
+            "allowedEnvVars": ["CITADEL_MCP_ACCESS_TOKEN"]
+          }
+        ]
+      }
+    ]
+  },
+  // Whitelist the same var for the hook transport. The token is read from the
+  // environment ONLY; it is never written into this committed file.
+  "httpHookAllowedEnvVars": ["CITADEL_MCP_ACCESS_TOKEN"]
+}
+```
+
+`.claude/settings.json` is committed and shared by the whole team, but it
+contains **no secret** — only the var *name*. The token value lives in each
+dev's shell environment.
+
+## 3. One-time token export (per dev)
+
+Each dev runs the connect wizard once to mint a **seat-writer** token and
+exports it (the same token that powers `citadel_search` and MCP — most devs
+already have it):
+
+```bash
+# https://citadel-archive-production.up.railway.app/skills/connect
+export CITADEL_MCP_ACCESS_TOKEN='ctdl_...'
+```
+
+A seat-writer token has `default_dataset=seat:{slug}`, so the hook's POST omits
+the `dataset` field and the write lands in that dev's private node. Add the
+export to `~/.zshrc` / `~/.bashrc` to make it durable across shells.
+
+Optional: set `CITADEL_BASE_URL` to override the hosted base (defaults to the
+production URL). It must be `https://`.
+
+## 4. Opt-out
+
+Either is enough:
+
+- **Per dev, per machine:** unset `CITADEL_MCP_ACCESS_TOKEN`. With no token the
+  hook is a clean no-op (no POST, exit 0).
+- **Per dev, persistent:** add a `SessionEnd` override to
+  `.claude/settings.local.json` (gitignored, dev-local) that drops or no-ops the
+  hook. `settings.local.json` overrides the shared `settings.json`.
+
+## Privacy posture
+
+- **Personal-by-default.** Auto-sync sends **no `dataset` field** → the
+  seat-writer token routes it to the dev's `seat:{slug}` node. Only that dev
+  (and Central) can read it.
+- **Distilled, not raw.** The hook sends a short curated note (recap, key
+  decisions, files changed) — never the raw transcript.
+- **Token never committed.** Read from the environment only; never printed,
+  echoed, or written to `.claude/settings.json` or any tracked file.
+- **HTTPS only.** The POST refuses any non-`https://` base URL.
+- **Non-blocking.** The script catches everything and exits 0; it cannot block
+  or fail a session close.
+
+## Promote to shared Central
+
+Auto-sync is always personal. To share a fact org-wide, ingest it mid-session
+with a promotion **tag** (`org-ready` or `vault-contribution`) and still no
+`dataset` field — see `SKILL.md`. Promote only ADRs, shared runbooks, and
+interface contracts, and only when the user asks or the content is plainly
+org-wide.

--- a/skills/citadel-proactive-ingest/SKILL.md
+++ b/skills/citadel-proactive-ingest/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: citadel-proactive-ingest
+description: Use to capture durable engineering knowledge into Citadel automatically and proactively while working in an org repo. Two halves — (1) instructs the agent to call citadel_ingest mid-session for durable facts/decisions (personal-by-default; only org-ready/vault-contribution tags promote to shared Central), and (2) documents the SessionEnd auto-sync hook that distills each session to the dev's private node with a one-time token setup. Triggers include "auto sync my sessions", "remember this in citadel", "proactive ingest", "set up citadel autosync", "personal kb sync", and https://citadel-archive-production.up.railway.app/skills/proactive-ingest.
+---
+
+# Citadel Proactive Ingest
+
+Capture durable engineering knowledge into Citadel **as it happens**, with no
+per-session ceremony. Two layers:
+
+1. **Mid-session, agent-driven.** While working, the agent proactively calls
+   `citadel_ingest` for durable facts and decisions. Personal-by-default.
+2. **SessionEnd, hook-driven.** On every session close, a non-blocking hook
+   distills the transcript and POSTs a short note to the dev's PRIVATE node —
+   zero per-session steps after a one-time token export.
+
+```
+Personal node:  seat:{slug}   (the dev's private Citadel node — default target)
+Shared Central: masumi-network (org-wide; only via explicit promotion tags)
+Hosted base:    https://citadel-archive-production.up.railway.app
+```
+
+Setup first (token + MCP): `https://citadel-archive-production.up.railway.app/skills/connect`
+Read/write rules: `https://citadel-archive-production.up.railway.app/skills/vault`
+
+## Personal-by-default (read first)
+
+| Personal (default) | Shared Central (opt-in) |
+|---|---|
+| No `dataset` field on writes | tag `org-ready` or `vault-contribution` |
+| Lands in your `seat:{slug}` node | Promotes to `masumi-network` |
+| Only you (+ Central) can read it | Whole org can read it |
+
+A **seat-writer token** carries `default_dataset=seat:{slug}`. Send writes with
+**no `dataset` field** and the server's `resolve_write_targets` routes them to
+your private node. Do not set `dataset` to promote — use a promotion **tag**
+instead, so the seat-node default still applies and the dual-write is audited.
+
+Never let promotion be a surprise. Promote to Central **only** when the user
+explicitly asks to share, or the content is plainly org-wide (an ADR, a shared
+runbook, an interface contract).
+
+## Layer 1 — proactive mid-session ingest (agent behavior)
+
+While working in an org repo, when a durable fact crystallizes, call
+`citadel_ingest` without waiting to be asked. Keep each note small and curated.
+
+**Ingest proactively when:**
+- A decision is made (approach chosen, tradeoff settled, library picked).
+- A non-obvious root cause is found, or a bug class is understood.
+- An interface/contract, env var, or config invariant is established.
+- A reusable runbook or "how we do X here" emerges.
+
+**Personal-by-default call (lands in your node):**
+
+```
+citadel_ingest(
+  data="Picked urllib over requests for the SessionEnd hook so it stays "
+       "stdlib-only and dependency-free.",
+  tags=["dev-session", "decision"],
+)
+```
+
+No `dataset` field → seat node. To promote a genuinely org-wide fact, add a
+promotion tag (still no `dataset`):
+
+```
+citadel_ingest(
+  data="ADR: seat tokens default to their seat:{slug} node; writes omit "
+       "dataset; promotion is by tag, not by dataset override.",
+  tags=["org-ready", "adr"],
+)
+```
+
+**Never ingest** (same rules as `citadel-vault`): secrets, tokens, keys, seed
+phrases, PII, raw logs/debug dumps, ephemeral chatter, or large uncurated
+dumps. Summarize durable decisions and source facts instead.
+
+## Layer 2 — SessionEnd auto-sync (the hook)
+
+`scripts/sync_session.py` runs from a Claude Code `SessionEnd` hook. On every
+session close it:
+
+1. reads the hook payload (`transcript_path`, `cwd`, `session_id`,
+   `hook_event_name`) from STDIN;
+2. parses the transcript JSONL **defensively** (skips malformed lines, never
+   crashes);
+3. distills a **short, deterministic** note — 1-2 line recap, key decisions,
+   files changed, notable facts — with **no local LLM call**;
+4. derives `tags = ["dev-session", <git-branch>, <repo-name>]`;
+5. truncates to `CITADEL_MCP_MAX_INGEST_BYTES` (default 200000);
+6. POSTs `{data, tags}` (NO `dataset` → personal node) to `{base}/ingest` with
+   `Authorization: Bearer ${CITADEL_MCP_ACCESS_TOKEN}`, **HTTPS only**;
+7. **fails silently** — catches everything, exits 0, never blocks session
+   close, never prints the token.
+
+Server-side LLM enrichment (`CITADEL_LLM_ENRICHMENT_ENABLED`) does any deeper
+structuring after the note lands; the hook stays deliberately dumb and fast.
+
+### One-time token setup (the only step)
+
+Get a **seat-writer** token from the connect wizard
+(`https://citadel-archive-production.up.railway.app/skills/connect`) and export
+it once:
+
+```bash
+export CITADEL_MCP_ACCESS_TOKEN='ctdl_...'
+```
+
+That's it. The same token already powers `citadel_search` and the MCP config,
+so most devs already have it set. With it in the environment, every session
+auto-syncs to your private node. With it unset, the hook is a clean no-op.
+
+### Wire the hook into a repo
+
+Copy `templates/claude-settings.json` into the repo's `.claude/settings.json`
+(point the command at this skill's `scripts/sync_session.py`). See
+`README.md` in this skill for the drop-in steps and opt-out.
+
+## Privacy posture
+
+- **Token from env only.** Read solely from `CITADEL_MCP_ACCESS_TOKEN`; never
+  printed, echoed, or written to a tracked file.
+- **Distilled, not raw.** The hook sends a curated short note, not the
+  transcript.
+- **Personal-by-default.** No `dataset` field on auto-sync → your seat node.
+- **HTTPS only.** The POST refuses any non-`https://` base URL.
+- **Non-blocking.** The hook always exits 0; a Citadel outage never delays your
+  session close.
+
+## Opt-out
+
+Drop a `SessionEnd` override into `.claude/settings.local.json` (gitignored), or
+simply unset `CITADEL_MCP_ACCESS_TOKEN` for that shell. With no token the hook
+does nothing. See `README.md`.
+
+## Reference
+
+- This skill: `https://citadel-archive-production.up.railway.app/skills/proactive-ingest`
+- Connect wizard: `https://citadel-archive-production.up.railway.app/skills/connect`
+- Vault read/write rules: `https://citadel-archive-production.up.railway.app/skills/vault`
+- Ingest API: `POST /ingest` with `{data, dataset?, tags?, session_id?}` (writer token)
+- Seat/node/Central model: [ADR-0003](https://github.com/masumi-network/Citadel-Archive/blob/main/docs/adr/0003-seat-node-central-private-memory.md)

--- a/skills/citadel-proactive-ingest/scripts/sync_session.py
+++ b/skills/citadel-proactive-ingest/scripts/sync_session.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Autonomous personal-KB sync for Citadel Archive — SessionEnd hook.
+
+This script is invoked by a Claude Code ``SessionEnd`` hook (see
+``templates/claude-settings.json``). On every session close it distills a
+short, deterministic note from the session transcript and POSTs it to the
+developer's PRIVATE Citadel node (``seat:{slug}``), so org devs get
+zero-per-session knowledge capture after a one-time token setup.
+
+Design contract (reviewers verify these invariants):
+
+* **One-token setup / personal-by-default.** The only secret is
+  ``CITADEL_MCP_ACCESS_TOKEN`` (a ``ctdl_`` seat-writer token), read solely
+  from the environment. A seat-writer token has ``default_dataset=seat:{slug}``,
+  so the POST sends **NO** ``dataset`` field — the server's
+  ``resolve_write_targets`` routes the write to the dev's private node. The
+  token is never printed, echoed, or written to any file.
+* **Distilled, not raw.** We emit a short deterministic summary (1-2 line
+  recap, key decisions, files changed, notable facts) built with plain string
+  logic — there is **no local LLM call**. Server-side LLM enrichment
+  (``CITADEL_LLM_ENRICHMENT_ENABLED``) handles any further structuring.
+* **Fail-silent / non-blocking.** Every failure is swallowed; the script always
+  exits 0 and never raises out of the hook, so it can never block session close.
+* **HTTPS only.** The POST is refused unless the base URL is ``https://``.
+* **Size cap.** The note is truncated to ``CITADEL_MCP_MAX_INGEST_BYTES``
+  (default 200000) before sending.
+* **Stdlib only.** Uses ``urllib`` from the standard library — no extra deps.
+
+Hook payload (read from STDIN as JSON): ``transcript_path``, ``cwd``,
+``session_id``, ``hook_event_name``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from typing import Any
+
+# Mirror kb/mcp_server.py: DEFAULT_MAX_INGEST_BYTES = 200_000.
+DEFAULT_MAX_INGEST_BYTES = 200_000
+DEFAULT_BASE_URL = "https://citadel-archive-production.up.railway.app"
+TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
+HTTP_TIMEOUT_SECONDS = 10
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow HTTP redirects.
+
+    A 3xx response (especially an https->http downgrade) must never make urllib
+    re-send the ``Authorization`` header over plaintext. Returning ``None`` makes
+    urllib raise ``HTTPError`` for the 3xx instead of following it; ``run()``
+    swallows that as a silent failure. The HTTPS guard in ``post_ingest`` only
+    checks the initial URL, so this closes the redirect token-leak gap.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+# One-shot hook process: install a no-redirect opener so the simple ``urlopen``
+# call site (and its tests) keep working while redirects are refused globally.
+urllib.request.install_opener(urllib.request.build_opener(_NoRedirectHandler))
+
+
+def _max_ingest_bytes() -> int:
+    """Resolve the size cap, mirroring kb/mcp_server.py._max_ingest_bytes."""
+    raw_value = os.getenv("CITADEL_MCP_MAX_INGEST_BYTES")
+    if not raw_value:
+        return DEFAULT_MAX_INGEST_BYTES
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return DEFAULT_MAX_INGEST_BYTES
+    return max(1, value)
+
+
+def _base_url() -> str:
+    configured = os.getenv("CITADEL_BASE_URL")
+    if configured:
+        return configured.rstrip("/")
+    return DEFAULT_BASE_URL
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    """Truncate ``text`` so its UTF-8 encoding is at most ``max_bytes`` bytes."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    # Cut on a byte boundary, then drop any partial trailing multibyte char.
+    return encoded[:max_bytes].decode("utf-8", "ignore")
+
+
+def read_hook_payload(stream: Any) -> dict[str, Any]:
+    """Parse the hook JSON from STDIN defensively; return {} on any problem."""
+    try:
+        raw = stream.read()
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _iter_transcript(transcript_path: str) -> list[dict[str, Any]]:
+    """Read a transcript JSONL file, skipping malformed lines. Never raises."""
+    entries: list[dict[str, Any]] = []
+    try:
+        with open(transcript_path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    # Malformed line -> skip, keep going.
+                    continue
+                if isinstance(obj, dict):
+                    entries.append(obj)
+    except Exception:
+        return entries
+    return entries
+
+
+def _content_blocks(entry: dict[str, Any]) -> list[Any]:
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if isinstance(content, list):
+        return content
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return []
+
+
+def _text_of(block: Any) -> str:
+    if isinstance(block, dict) and isinstance(block.get("text"), str):
+        return block["text"].strip()
+    if isinstance(block, str):
+        return block.strip()
+    return ""
+
+
+def _first_user_prompt(entries: list[dict[str, Any]]) -> str:
+    for entry in entries:
+        if entry.get("type") != "user":
+            continue
+        for block in _content_blocks(entry):
+            text = _text_of(block)
+            # Skip tool_result echoes that arrive as user-role entries.
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                continue
+            if text:
+                return text
+    return ""
+
+
+def distill_transcript(entries: list[dict[str, Any]]) -> str:
+    """Build a short, deterministic note from transcript entries (NO LLM).
+
+    Sections: a 1-2 line recap from the first user prompt + last assistant
+    text, files touched (Edit/Write/MultiEdit/NotebookEdit), and a small
+    sample of decision-ish assistant statements. Pure string logic.
+    """
+    files: list[str] = []
+    seen_files: set[str] = set()
+    last_assistant_text = ""
+    decisions: list[str] = []
+    decision_markers = (
+        "decided",
+        "decision",
+        "chose",
+        "we'll use",
+        "going with",
+        "approach",
+        "instead of",
+        "root cause",
+    )
+
+    for entry in entries:
+        etype = entry.get("type")
+        for block in _content_blocks(entry):
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "tool_use":
+                name = block.get("name")
+                inp = block.get("input")
+                if isinstance(inp, dict) and name in (
+                    "Edit",
+                    "Write",
+                    "MultiEdit",
+                    "NotebookEdit",
+                ):
+                    path = inp.get("file_path") or inp.get("notebook_path")
+                    if isinstance(path, str) and path and path not in seen_files:
+                        seen_files.add(path)
+                        files.append(path)
+            elif btype == "text" and etype == "assistant":
+                text = _text_of(block)
+                if not text:
+                    continue
+                last_assistant_text = text
+                lowered = text.lower()
+                if any(marker in lowered for marker in decision_markers):
+                    # Keep the first sentence-ish slice only.
+                    snippet = text.replace("\n", " ").strip()
+                    if len(snippet) > 200:
+                        snippet = snippet[:200].rstrip() + "..."
+                    if snippet not in decisions:
+                        decisions.append(snippet)
+
+    first_prompt = _first_user_prompt(entries)
+
+    lines: list[str] = ["# Dev session note"]
+
+    recap_bits: list[str] = []
+    if first_prompt:
+        recap = first_prompt.replace("\n", " ").strip()
+        if len(recap) > 280:
+            recap = recap[:280].rstrip() + "..."
+        recap_bits.append(f"Task: {recap}")
+    if last_assistant_text:
+        outcome = last_assistant_text.replace("\n", " ").strip()
+        if len(outcome) > 280:
+            outcome = outcome[:280].rstrip() + "..."
+        recap_bits.append(f"Outcome: {outcome}")
+    if not recap_bits:
+        recap_bits.append("Session captured (no extractable prompt/outcome text).")
+    lines.append("")
+    lines.extend(recap_bits)
+
+    if decisions:
+        lines.append("")
+        lines.append("## Key decisions / facts")
+        for item in decisions[:8]:
+            lines.append(f"- {item}")
+
+    if files:
+        lines.append("")
+        lines.append("## Files changed")
+        for path in files[:40]:
+            lines.append(f"- {path}")
+
+    return "\n".join(lines).strip()
+
+
+def _git_branch(cwd: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        branch = result.stdout.strip()
+        if result.returncode == 0 and branch and branch != "HEAD":
+            return branch
+    except Exception:
+        pass
+    return ""
+
+
+def _repo_name(cwd: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        top = result.stdout.strip()
+        if result.returncode == 0 and top:
+            return os.path.basename(top)
+    except Exception:
+        pass
+    if cwd:
+        return os.path.basename(cwd.rstrip("/"))
+    return ""
+
+
+def build_tags(cwd: str) -> list[str]:
+    tags = ["dev-session"]
+    branch = _git_branch(cwd)
+    if branch:
+        tags.append(branch)
+    repo = _repo_name(cwd)
+    if repo and repo not in tags:
+        tags.append(repo)
+    return tags
+
+
+def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> None:
+    """POST {data, tags} to {base}/ingest over HTTPS. No dataset field.
+
+    Personal-by-default: omitting ``dataset`` lets the seat-writer token's
+    ``default_dataset=seat:{slug}`` route the write to the dev's private node.
+    HTTPS is required. Raises on any transport problem; the caller swallows it.
+    """
+    if not base_url.lower().startswith("https://"):
+        # HTTPS-only invariant: never send a token over plaintext.
+        raise ValueError("refusing non-HTTPS Citadel base URL")
+    url = f"{base_url}/ingest"
+    body = json.dumps({"data": data, "tags": tags}).encode("utf-8")
+    request = urllib.request.Request(  # noqa: S310 - scheme is asserted https above
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        # Drain so the connection closes cleanly; status is enough.
+        response.read()
+
+
+def run(stream_in: Any) -> int:
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    try:
+        payload = read_hook_payload(stream_in)
+        token = os.getenv(TOKEN_ENV)
+        if not token:
+            # No token configured -> nothing to sync. Clean no-op exit.
+            return 0
+
+        transcript_path = payload.get("transcript_path")
+        cwd = payload.get("cwd") or os.getcwd()
+        entries = (
+            _iter_transcript(transcript_path)
+            if isinstance(transcript_path, str) and transcript_path
+            else []
+        )
+
+        note = distill_transcript(entries)
+        if not note.strip():
+            return 0
+
+        note = _truncate_utf8(note, _max_ingest_bytes())
+        tags = build_tags(cwd if isinstance(cwd, str) else "")
+
+        post_ingest(_base_url(), token, note, tags)
+    except Exception:
+        # Fail-silent: never block session close, never surface the token.
+        return 0
+    return 0
+
+
+def main() -> None:
+    sys.exit(run(sys.stdin))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/citadel-proactive-ingest/templates/claude-settings.json
+++ b/skills/citadel-proactive-ingest/templates/claude-settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/skills/citadel-proactive-ingest/scripts/sync_session.py\"",
+            "timeout": 20,
+            "allowedEnvVars": ["CITADEL_MCP_ACCESS_TOKEN"]
+          }
+        ]
+      }
+    ]
+  },
+  "httpHookAllowedEnvVars": ["CITADEL_MCP_ACCESS_TOKEN"]
+}

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# sync_session lives under a skill dir (not an importable package), so load it
+# by file path.
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "citadel-proactive-ingest"
+    / "scripts"
+    / "sync_session.py"
+)
+_spec = importlib.util.spec_from_file_location("sync_session", _MODULE_PATH)
+assert _spec and _spec.loader
+sync_session = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync_session)
+
+
+def _user(text: str) -> dict[str, Any]:
+    return {"type": "user", "message": {"content": text}}
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant_edit(file_path: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "Edit", "input": {"file_path": file_path}}
+            ]
+        },
+    }
+
+
+def _sample_entries() -> list[dict[str, Any]]:
+    return [
+        _user("Build the autonomous personal-KB sync hook for org devs."),
+        _assistant_text("I chose urllib so the script stays stdlib-only."),
+        _assistant_edit("skills/citadel-proactive-ingest/scripts/sync_session.py"),
+        _assistant_edit("tests/test_sync_session.py"),
+        _assistant_text("Done. The hook is non-blocking and personal-by-default."),
+    ]
+
+
+def _write_transcript(tmp_path: Path, entries: list[Any]) -> Path:
+    path = tmp_path / "transcript.jsonl"
+    lines = [json.dumps(e) if not isinstance(e, str) else e for e in entries]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class _RecordingPost:
+    """Capture post_ingest calls instead of hitting the network."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, base_url: str, token: str, data: str, tags: list[str]) -> None:
+        self.calls.append(
+            {"base_url": base_url, "token": token, "data": data, "tags": tags}
+        )
+
+
+# --- distillation -----------------------------------------------------------
+
+
+def test_distill_produces_nonempty_short_note() -> None:
+    note = sync_session.distill_transcript(_sample_entries())
+    assert note.strip()
+    assert "Dev session note" in note
+    assert "Task:" in note
+    # Decision marker ("chose") was captured.
+    assert "urllib" in note
+    # Files changed section present.
+    assert "sync_session.py" in note
+
+
+def test_distill_empty_transcript_is_safe() -> None:
+    note = sync_session.distill_transcript([])
+    assert isinstance(note, str)
+    assert note.strip()  # still a valid (placeholder) note, never crashes
+
+
+# --- size cap ---------------------------------------------------------------
+
+
+def test_size_cap_truncates(monkeypatch: Any) -> None:
+    monkeypatch.setenv("CITADEL_MCP_MAX_INGEST_BYTES", "50")
+    assert sync_session._max_ingest_bytes() == 50
+    big = "x" * 1000
+    out = sync_session._truncate_utf8(big, 50)
+    assert len(out.encode("utf-8")) <= 50
+
+
+def test_truncate_never_splits_multibyte() -> None:
+    # 10 emoji = 40 UTF-8 bytes; cap at 7 bytes must not yield a partial char.
+    text = "😀" * 10
+    out = sync_session._truncate_utf8(text, 7)
+    assert len(out.encode("utf-8")) <= 7
+    # Decodes cleanly (no replacement char from a split).
+    assert out == "😀"
+
+
+# --- defensive transcript parsing -------------------------------------------
+
+
+def test_malformed_lines_skipped_without_crash(tmp_path: Path) -> None:
+    entries: list[Any] = [
+        _user("Real prompt here."),
+        "{ this is not valid json",
+        "",
+        _assistant_edit("a.py"),
+        "still : not json :::",
+        _assistant_text("We decided to ship it."),
+    ]
+    path = _write_transcript(tmp_path, entries)
+    parsed = sync_session._iter_transcript(str(path))
+    # 3 valid dict entries; 2 malformed + 1 blank skipped.
+    assert len(parsed) == 3
+    note = sync_session.distill_transcript(parsed)
+    assert "Real prompt here." in note
+    assert "a.py" in note
+
+
+def test_iter_transcript_missing_file_returns_empty() -> None:
+    assert sync_session._iter_transcript("/nonexistent/path/to/transcript.jsonl") == []
+
+
+# --- run(): missing token -> no POST + clean exit ---------------------------
+
+
+def test_missing_token_no_post_clean_exit(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
+    recorder = _RecordingPost()
+    monkeypatch.setattr(sync_session, "post_ingest", recorder)
+
+    path = _write_transcript(tmp_path, _sample_entries())
+    payload = json.dumps(
+        {
+            "transcript_path": str(path),
+            "cwd": str(tmp_path),
+            "session_id": "s1",
+            "hook_event_name": "SessionEnd",
+        }
+    )
+    code = sync_session.run(io.StringIO(payload))
+    assert code == 0
+    assert recorder.calls == []  # no POST without a token
+
+
+# --- run(): personal-by-default (no dataset field on POST) -------------------
+
+
+def test_post_omits_dataset_field(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setenv("CITADEL_BASE_URL", "https://example.invalid")
+    # Avoid invoking real git in build_tags.
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResp:
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b""
+
+    def fake_urlopen(request: Any, timeout: int | None = None) -> _FakeResp:
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["headers"] = dict(request.header_items())
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResp()
+
+    monkeypatch.setattr(sync_session.urllib.request, "urlopen", fake_urlopen)
+
+    path = _write_transcript(tmp_path, _sample_entries())
+    payload = json.dumps(
+        {
+            "transcript_path": str(path),
+            "cwd": str(tmp_path),
+            "session_id": "s1",
+            "hook_event_name": "SessionEnd",
+        }
+    )
+    code = sync_session.run(io.StringIO(payload))
+    assert code == 0
+
+    # POST happened, over HTTPS, with the token in the Authorization header.
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://example.invalid/ingest"
+    auth = captured["headers"].get("Authorization")
+    assert auth == "Bearer ctdl_test_token"
+
+    # Personal-by-default: NO dataset field on the body.
+    body = captured["body"]
+    assert "dataset" not in body
+    assert set(body.keys()) == {"data", "tags"}
+    assert body["data"].strip()
+    assert body["tags"] == ["dev-session"]
+
+
+# --- HTTPS-only invariant ----------------------------------------------------
+
+
+def test_post_refuses_non_https() -> None:
+    with pytest.raises(ValueError):
+        sync_session.post_ingest(
+            "http://example.invalid", "ctdl_x", "note", ["dev-session"]
+        )
+
+
+def test_redirects_are_not_followed() -> None:
+    # A 3xx (esp. an https->http downgrade) must not re-send the Authorization
+    # header. The handler refuses to follow any redirect.
+    handler = sync_session._NoRedirectHandler()
+    assert (
+        handler.redirect_request(None, None, 302, "Found", {}, "http://evil.invalid")
+        is None
+    )
+
+
+def test_run_swallows_post_errors(monkeypatch: Any, tmp_path: Path) -> None:
+    """A failing POST must never raise out of the hook; run() returns 0."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(sync_session, "post_ingest", boom)
+
+    path = _write_transcript(tmp_path, _sample_entries())
+    payload = json.dumps({"transcript_path": str(path), "cwd": str(tmp_path)})
+    assert sync_session.run(io.StringIO(payload)) == 0
+
+
+def test_run_handles_garbage_stdin() -> None:
+    # Non-JSON STDIN must not crash; clean exit.
+    assert sync_session.run(io.StringIO("not json at all {{{")) == 0


### PR DESCRIPTION
## What

Zero-step autonomous sync: a dev working in an org repo has their session work auto-ingested to their **private** Citadel node (`seat:{slug}`) on every Claude Code session end — reusing the **one** seat token they already set for MCP. Their agents retrieve from node + Central on demand.

- **`skills/citadel-proactive-ingest/`** — the skill (proactive mid-session ingest, personal-by-default), the `sync_session.py` distill+POST hook script (stdlib-only), a drop-in `.claude/settings.json` SessionEnd hook template, and a README.
- **`docs/onboarding/citadel-autosync.md`** — the one-time dev setup.
- **`tests/test_sync_session.py`** — 12 tests, HTTP mocked.

## Security posture

Per-dev token **never committed** (only `${CITADEL_MCP_ACCESS_TOKEN}` placeholders). The script: reads the token only from env, **HTTPS-only**, **refuses redirects** (closes an https→http token-leak), **fail-silent/non-blocking** (never blocks session close), size-capped, defensive transcript parsing, **personal-by-default** (no `dataset` field → seat node, never Central). Opt-out via untracked `settings.local.json`.

## Quality

`328 passed`. Two adversarial reviews → SHIP-ABLE; the one LOW redirect caveat they raised is now fixed + tested. All new files; no existing code modified.