### PR TITLE
feat(promotion): smart selective seat-node → Central promotion engine (ADR-0005 step 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,16 @@ GITHUB_TOKEN=
 CITADEL_CONTENT_SCAN_ENABLED=true
 CITADEL_CONTENT_SCAN_BLOCK_SEVERITY=high
 
+# Selective promotion of seat-node content to Central (ADR-0005 step 2).
+# Opt-in: when enabled, POST /api/promote/run enumerates a seat node, classifies
+# each item for org-relevance + sensitivity (secret scan + LLM), and promotes
+# qualifying items (relevant AND not sensitive AND secret-clean AND
+# score >= threshold) via the org-ready dual-write. dry_run defaults TRUE
+# (propose only, write nothing); a human sets dry_run=false to actually promote.
+CITADEL_PROMOTION_ENABLED=false
+CITADEL_PROMOTION_RELEVANCE_THRESHOLD=0.7
+CITADEL_PROMOTION_MAX_ITEMS=20
+
 # Organization Update Digest for the learning-agent cron.
 CITADEL_ORG_DIGEST_ENABLED=true
 CITADEL_ORG_DIGEST_WINDOW_HOURS=24

--- a/kb/config.py
+++ b/kb/config.py
@@ -36,6 +36,15 @@ def _int(value: str | None, *, default: int) -> int:
         return default
 
 
+def _float(value: str | None, *, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
 def _state_root() -> str:
     return (
         os.getenv("CITADEL_STATE_DIRECTORY")
@@ -167,6 +176,9 @@ class CitadelConfig:
     github_sync_security_block_severity: str = "high"
     content_scan_enabled: bool = True
     content_scan_block_severity: str = "high"
+    promotion_enabled: bool = False
+    promotion_relevance_threshold: float = 0.7
+    promotion_max_items: int = 20
     github_token: str | None = None
     repo_content_sync_enabled: bool = True
     repo_content_sync_dataset: str = "masumi-network"
@@ -295,6 +307,18 @@ class CitadelConfig:
             content_scan_block_severity=os.getenv(
                 "CITADEL_CONTENT_SCAN_BLOCK_SEVERITY",
                 "high",
+            ),
+            promotion_enabled=_bool(
+                os.getenv("CITADEL_PROMOTION_ENABLED"),
+                default=False,
+            ),
+            promotion_relevance_threshold=_float(
+                os.getenv("CITADEL_PROMOTION_RELEVANCE_THRESHOLD"),
+                default=0.7,
+            ),
+            promotion_max_items=_int(
+                os.getenv("CITADEL_PROMOTION_MAX_ITEMS"),
+                default=20,
             ),
             github_token=os.getenv("CITADEL_GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN") or None,
             repo_content_sync_enabled=_bool(

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -1,0 +1,470 @@
+"""ADR-0005 step 2: selective promotion of seat-node content to Central.
+
+A :class:`PromotionEngine` enumerates a personal seat node's content, decides
+per item whether it is org-relevant and non-sensitive, and (when not a dry run)
+promotes the qualifying items into the curated Central vault by reusing the
+existing org-ready dual-write path. Every gate is conservative: an item is only
+promoted when it is secret-clean AND classified relevant AND not sensitive AND
+scores at/above the configured threshold. On ANY uncertainty — a blocked secret
+scan, an LLM failure, unparseable output, or a missing field — the item is
+SKIPPED. Promotion never happens on uncertainty.
+
+``dry_run`` defaults to ``True``: the engine proposes promotions and writes
+nothing. A human flips ``dry_run=False`` to actually promote.
+
+The module mirrors the best-effort, no-raise style of :mod:`kb.llm_enrichment`:
+classification failures degrade to a safe SKIP rather than raising.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from kb.access import AccessIdentity, AccessStore, is_seat_dataset
+from kb.config import CitadelConfig
+from kb.learning import LearningProcess
+from kb.llm_enrichment import (
+    default_llm_model,
+    openrouter_chat,
+    parse_json_payload,
+    redacted_preview,
+)
+from kb.security_scan import SecurityScanEntry, scan_text_entries
+from kb.service import Citadel
+
+logger = logging.getLogger(__name__)
+
+PROMOTION_TAG = "org-ready"
+
+# Broad seed queries used to enumerate a seat node. cognee.recall is semantic,
+# not an exhaustive listing, so a few complementary seeds widen coverage; the
+# results are deduped and capped. This is best-effort top-N by design.
+DEFAULT_SEED_QUERIES: tuple[str, ...] = (
+    "notable knowledge, decisions, facts, and information",
+    "project work, technical notes, and learnings",
+)
+
+CLASSIFIER_SYSTEM_PROMPT = (
+    "You triage one piece of a person's private notes for promotion into a "
+    "shared organization knowledge vault. Decide whether the content is "
+    "organization-relevant (useful to teammates, about the company's projects, "
+    "products, or shared work) and whether it is sensitive (personal, private, "
+    "secret, credentials, financial, health, or otherwise unsafe to share "
+    "org-wide). Return ONLY a JSON object shaped as "
+    '{"relevant": true|false, "sensitive": true|false, "score": 0.0, '
+    '"reason": "..."} where score is your 0..1 confidence that the content is '
+    "both relevant AND safe to promote. Never include the original text or any "
+    "secret in the reason."
+)
+
+CLASSIFIER_MAX_INPUT_CHARS = 6000
+
+
+@dataclass(frozen=True)
+class Classification:
+    """A strict, validated classifier verdict for one candidate."""
+
+    relevant: bool
+    sensitive: bool
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class ProposedPromotion:
+    """One candidate plus the promote/skip decision and why."""
+
+    candidate: str
+    decision: str  # "promote" | "skip"
+    reason: str
+    relevant: bool | None = None
+    sensitive: bool | None = None
+    score: float | None = None
+    secret_blocked: bool = False
+    promoted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "reason": self.reason,
+            "relevant": self.relevant,
+            "sensitive": self.sensitive,
+            "score": self.score,
+            "secret_blocked": self.secret_blocked,
+            "promoted": self.promoted,
+            "preview": redacted_preview(self.candidate),
+        }
+
+
+def _candidate_text(result: Any) -> str:
+    """Extract real node text using the same field priority as search dedup.
+
+    Mirrors :func:`kb.server.search_result_dedup_key` so promotion reads the
+    same body text the rest of the system treats as a node's content.
+    """
+    if isinstance(result, str):
+        return result.strip()
+    if isinstance(result, dict):
+        for key in ("text", "content", "chunk", "body", "summary", "title"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _coerce_classification(parsed: Any) -> Classification | None:
+    """Strictly validate the classifier JSON. Any deviation -> None (skip)."""
+    if not isinstance(parsed, dict):
+        return None
+    relevant = parsed.get("relevant")
+    sensitive = parsed.get("sensitive")
+    score = parsed.get("score")
+    reason = parsed.get("reason")
+    if not isinstance(relevant, bool) or not isinstance(sensitive, bool):
+        return None
+    if isinstance(score, bool) or not isinstance(score, (int, float)):
+        return None
+    score_value = float(score)
+    if not 0.0 <= score_value <= 1.0:
+        return None
+    if not isinstance(reason, str) or not reason.strip():
+        return None
+    return Classification(
+        relevant=relevant,
+        sensitive=sensitive,
+        score=score_value,
+        reason=reason.strip()[:300],
+    )
+
+
+class PromotionEngine:
+    """Selective seat-to-Central promotion (ADR-0005 step 2)."""
+
+    def __init__(
+        self,
+        citadel: Citadel,
+        learning: LearningProcess,
+        access_store: AccessStore,
+        config: CitadelConfig,
+    ) -> None:
+        self.citadel = citadel
+        self.learning = learning
+        self.access_store = access_store
+        self.config = config
+
+    async def enumerate(self, seat_dataset: str, max_items: int) -> list[str]:
+        """Best-effort list of a seat node's promotable text, capped at ``max_items``.
+
+        Uses :meth:`Citadel.search` (cognee.recall) per seed query because that is
+        the only primitive that returns real node body text. recall is semantic,
+        not exhaustive, so this under-samples large nodes by design — documented as
+        a known limitation (ADR-0005 open risk).
+        """
+        cap = max(1, max_items)
+        seen: set[str] = set()
+        candidates: list[str] = []
+        for query in DEFAULT_SEED_QUERIES:
+            if len(candidates) >= cap:
+                break
+            try:
+                results = await self.citadel.search(
+                    query, dataset=seat_dataset, top_k=cap
+                )
+            except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
+                logger.warning(
+                    "promotion.enumerate search failed for %s: %s",
+                    seat_dataset,
+                    exc.__class__.__name__,
+                )
+                continue
+            for result in results:
+                text = _candidate_text(result)
+                if not text:
+                    continue
+                key = text.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                candidates.append(text)
+                if len(candidates) >= cap:
+                    break
+        return candidates[:cap]
+
+    def classify(self, text: str) -> Classification | None:
+        """Classify one candidate via the OpenRouter direct-HTTP helper.
+
+        Returns ``None`` on ANY failure (missing key, HTTP/URL/timeout error,
+        unparseable output, or a missing/malformed field) so the caller can
+        deterministically SKIP. Never raises.
+        """
+        try:
+            content = openrouter_chat(
+                [
+                    {"role": "system", "content": CLASSIFIER_SYSTEM_PROMPT},
+                    {"role": "user", "content": text[:CLASSIFIER_MAX_INPUT_CHARS]},
+                ],
+                model=default_llm_model(),
+                operation="promotion.classify",
+                max_tokens=300,
+            )
+        except Exception as exc:  # pragma: no cover - openrouter_chat is itself guarded.
+            logger.warning(
+                "promotion.classify call raised %s; skipping candidate",
+                exc.__class__.__name__,
+            )
+            return None
+        if content is None:
+            return None
+        return _coerce_classification(parse_json_payload(content))
+
+    def _secret_blocked(self, seat_dataset: str, text: str) -> bool:
+        """True when the candidate trips the blocking-severity secret scanner."""
+        try:
+            scan = scan_text_entries(
+                [
+                    SecurityScanEntry(
+                        source="promotion", location=seat_dataset, text=text
+                    )
+                ],
+                block_severity=self.config.content_scan_block_severity,
+            )
+        except Exception:  # pragma: no cover - scan is best-effort; fail closed.
+            return True
+        return bool(scan.get("blocked"))
+
+    def decide(self, seat_dataset: str, candidate: str) -> ProposedPromotion:
+        """Apply secret scan, then the LLM classifier + threshold. Default SKIP."""
+        if self._secret_blocked(seat_dataset, candidate):
+            return ProposedPromotion(
+                candidate=candidate,
+                decision="skip",
+                reason="secret_content",
+                secret_blocked=True,
+            )
+        verdict = self.classify(candidate)
+        if verdict is None:
+            # LLM unavailable or output unusable -> never promote on uncertainty.
+            return ProposedPromotion(
+                candidate=candidate,
+                decision="skip",
+                reason="llm_unavailable",
+            )
+        threshold = self.config.promotion_relevance_threshold
+        qualifies = (
+            verdict.relevant
+            and not verdict.sensitive
+            and verdict.score >= threshold
+        )
+        if qualifies:
+            decision, reason = "promote", verdict.reason
+        else:
+            decision = "skip"
+            if verdict.sensitive:
+                reason = "sensitive"
+            elif not verdict.relevant:
+                reason = "not_relevant"
+            else:
+                reason = "below_threshold"
+        return ProposedPromotion(
+            candidate=candidate,
+            decision=decision,
+            reason=reason,
+            relevant=verdict.relevant,
+            sensitive=verdict.sensitive,
+            score=verdict.score,
+        )
+
+    def _promotion_identity(self, seat_dataset: str) -> AccessIdentity:
+        """Synthetic admin/env identity whose default node IS the seat.
+
+        ``resolve_write_targets`` only fires the seat-light + Central-full
+        dual-write when ``identity.default_dataset`` is the seat node (the
+        ``is_promotion`` branch). An ``env`` source + ``admin`` role bypasses the
+        dataset allowlist so the engine can write both targets.
+        """
+        return AccessIdentity(
+            role="admin",
+            actor_id="promotion-engine",
+            actor_kind="service_account",
+            actor_name="promotion-engine",
+            source="env",
+            default_dataset=seat_dataset,
+        )
+
+    async def _promote(
+        self,
+        seat_dataset: str,
+        identity: AccessIdentity,
+        proposal: ProposedPromotion,
+    ) -> bool:
+        """Promote one qualifying item via the org-ready dual-write path.
+
+        Reuses ``resolve_write_targets`` (is_promotion -> [seat light, Central
+        full]) + ``execute_learning_writes`` so the ADR-0005 step-1 secret gate
+        re-runs inside ``learning.learn``. Records one audit event per promotion.
+        On a secret block at write time the item is recorded as skipped, not
+        promoted. Never raises out of the run loop.
+        """
+        # Imported lazily to avoid a circular import (server imports promotion).
+        from kb.security_scan import SecretContentError
+        from kb.server import execute_learning_writes, resolve_write_targets
+
+        central = None
+        try:
+            targets = resolve_write_targets(
+                identity, None, [PROMOTION_TAG], self.config
+            )
+            central = next(
+                (t.dataset for t in targets if t.tier == "full"),
+                targets[-1].dataset,
+            )
+            await execute_learning_writes(
+                self.learning,
+                data=proposal.candidate,
+                targets=targets,
+                tags=[PROMOTION_TAG],
+                session_id=None,
+                operation="promotion",
+            )
+        except SecretContentError as exc:
+            self.access_store.record_event(
+                action="promotion.promote",
+                actor=identity,
+                success=False,
+                dataset=central or seat_dataset,
+                detail={
+                    "seat": seat_dataset,
+                    "blocked": "secret_content",
+                    "highest_severity": exc.highest_severity,
+                    "accepted": False,
+                    "score": proposal.score,
+                    "relevant": proposal.relevant,
+                    "sensitive": proposal.sensitive,
+                    "reason": proposal.reason,
+                },
+            )
+            return False
+        except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
+            self.access_store.record_event(
+                action="promotion.promote",
+                actor=identity,
+                success=False,
+                dataset=central or seat_dataset,
+                detail={
+                    "seat": seat_dataset,
+                    "error_type": exc.__class__.__name__,
+                    "accepted": False,
+                    "reason": proposal.reason,
+                },
+            )
+            return False
+
+        self.access_store.record_event(
+            action="promotion.promote",
+            actor=identity,
+            success=True,
+            dataset=central,
+            detail={
+                "seat": seat_dataset,
+                "score": proposal.score,
+                "relevant": proposal.relevant,
+                "sensitive": proposal.sensitive,
+                "reason": proposal.reason,
+                "accepted": True,
+                "tags": [PROMOTION_TAG],
+            },
+        )
+        return True
+
+    async def run(
+        self,
+        seat_dataset: str,
+        *,
+        dry_run: bool = True,
+        max_items: int | None = None,
+    ) -> dict[str, Any]:
+        """Enumerate, decide, and (when ``dry_run=False``) promote.
+
+        ``dry_run`` defaults to ``True``: returns the proposed promotions and
+        writes NOTHING. ``dry_run=False`` actually promotes qualifying items via
+        the org-ready dual-write and records one audit event each. Gated on
+        ``config.promotion_enabled`` (opt-in): when disabled, returns a disabled
+        status and does nothing.
+        """
+        if not self.config.promotion_enabled:
+            return {
+                "ok": True,
+                "enabled": False,
+                "dry_run": dry_run,
+                "dataset": seat_dataset,
+                "reason": "disabled",
+                "candidates": 0,
+                "promoted": 0,
+                "proposals": [],
+            }
+        if not is_seat_dataset(seat_dataset):
+            raise ValueError(f"Not a seat dataset: {seat_dataset}")
+
+        cap = max_items if max_items and max_items > 0 else self.config.promotion_max_items
+        candidates = await self.enumerate(seat_dataset, cap)
+        proposals = [self.decide(seat_dataset, text) for text in candidates]
+
+        promoted = 0
+        if not dry_run:
+            identity = self._promotion_identity(seat_dataset)
+            settled: list[ProposedPromotion] = []
+            for proposal in proposals:
+                if proposal.decision != "promote":
+                    settled.append(proposal)
+                    continue
+                ok = await self._promote(seat_dataset, identity, proposal)
+                if ok:
+                    promoted += 1
+                    settled.append(
+                        ProposedPromotion(
+                            candidate=proposal.candidate,
+                            decision="promote",
+                            reason=proposal.reason,
+                            relevant=proposal.relevant,
+                            sensitive=proposal.sensitive,
+                            score=proposal.score,
+                            promoted=True,
+                        )
+                    )
+                else:
+                    settled.append(
+                        ProposedPromotion(
+                            candidate=proposal.candidate,
+                            decision="skip",
+                            reason="write_blocked",
+                            relevant=proposal.relevant,
+                            sensitive=proposal.sensitive,
+                            score=proposal.score,
+                            secret_blocked=True,
+                        )
+                    )
+            proposals = settled
+
+        return {
+            "ok": True,
+            "enabled": True,
+            "dry_run": dry_run,
+            "dataset": seat_dataset,
+            "max_items": cap,
+            "candidates": len(candidates),
+            "proposed": sum(1 for p in proposals if p.decision == "promote"),
+            "promoted": promoted,
+            "proposals": [p.to_dict() for p in proposals],
+        }
+
+    def status(self) -> dict[str, Any]:
+        """Read-only config/status snapshot for the GET endpoint."""
+        return {
+            "enabled": self.config.promotion_enabled,
+            "relevance_threshold": self.config.promotion_relevance_threshold,
+            "max_items": self.config.promotion_max_items,
+            "dry_run_default": True,
+            "promotion_tag": PROMOTION_TAG,
+        }

--- a/kb/server.py
+++ b/kb/server.py
@@ -44,6 +44,7 @@ from kb.mcp_server import TOOL_POLICIES, create_mcp_server
 from kb.mesh import MeshState
 from kb.models import FeedbackRequest
 from kb.obsidian_sync import ObsidianSyncStore, SyncPushDocument, normalize_path
+from kb.promotion import PromotionEngine
 from kb.repo_content_sync import RepoContentSyncer
 from kb.security_scan import SecretContentError
 from kb.self_improve import SelfImprovement
@@ -217,6 +218,12 @@ class BackupMirrorRunBody(BaseModel):
     dry_run: bool = True
 
 
+class PromoteRunBody(BaseModel):
+    dataset: str = Field(min_length=1)
+    dry_run: bool = True
+    max_items: int | None = Field(default=None, ge=1, le=200)
+
+
 class CognifyRunBody(BaseModel):
     dataset: str | None = None
     verify: bool = False
@@ -332,6 +339,16 @@ def get_learning_agent() -> LearningAgent:
 
 def get_backup_mirror() -> BackupMirror:
     return BackupMirror(get_citadel().config)
+
+
+def get_promotion_engine() -> PromotionEngine:
+    citadel = get_citadel()
+    return PromotionEngine(
+        citadel,
+        get_learning_process(),
+        get_access_store(),
+        citadel.config,
+    )
 
 
 def get_access_store() -> AccessStore:
@@ -2125,6 +2142,68 @@ async def run_backup_mirror(body: BackupMirrorRunBody, request: Request) -> Any:
             "tracked_files": summary.get("tracked_files"),
             "available_files": summary.get("available_files"),
             "missing_files": summary.get("missing_files"),
+        },
+    )
+    return jsonable_encoder(result)
+
+
+@app.get("/api/promote")
+async def promotion_status(request: Request) -> Any:
+    require_access(request, "admin", "sources:sync")
+    return jsonable_encoder(get_promotion_engine().status())
+
+
+@app.post("/api/promote/run")
+async def run_promotion(body: PromoteRunBody, request: Request) -> Any:
+    actor = require_access(request, "admin", "sources:sync")
+    if not is_seat_dataset(body.dataset):
+        raise HTTPException(
+            status_code=400,
+            detail="dataset must be a seat node (seat:<slug>) to promote from.",
+        )
+    try:
+        result = await get_promotion_engine().run(
+            body.dataset,
+            dry_run=body.dry_run,
+            max_items=body.max_items,
+        )
+    except SecretContentError as exc:
+        get_access_store().record_event(
+            action="promotion.run",
+            actor=actor,
+            success=False,
+            dataset=body.dataset,
+            detail={
+                "dry_run": body.dry_run,
+                "blocked": "secret_content",
+                "highest_severity": exc.highest_severity,
+            },
+        )
+        raise HTTPException(status_code=422, detail=exc.public_message) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
+        logger.error("Promotion run failed: %s", exc.__class__.__name__)
+        get_access_store().record_event(
+            action="promotion.run",
+            actor=actor,
+            success=False,
+            dataset=body.dataset,
+            detail={"dry_run": body.dry_run, "error_type": exc.__class__.__name__},
+        )
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    get_access_store().record_event(
+        action="promotion.run",
+        actor=actor,
+        success=True,
+        dataset=body.dataset,
+        detail={
+            "dry_run": body.dry_run,
+            "enabled": result.get("enabled"),
+            "candidates": result.get("candidates"),
+            "proposed": result.get("proposed"),
+            "promoted": result.get("promoted"),
+            "max_items": result.get("max_items"),
         },
     )
     return jsonable_encoder(result)

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kb.access import AccessStore, seat_dataset
+from kb.config import CitadelConfig
+from kb.models import IngestResult
+from kb.promotion import PromotionEngine, _coerce_classification
+import kb.promotion as promotion
+
+SEAT = seat_dataset("alice")
+CENTRAL = "masumi-network"  # CitadelConfig.github_sync_dataset default
+
+# A blocking-severity AWS access key (critical) for the secret-gate test.
+# Assembled at runtime so no literal key is committed (GitHub push protection
+# scans literals); the joined string still trips the scanner at test time.
+SECRET_TEXT = "deploy creds " + "AKIA" + "ABCDEFGHIJKLMNOP" + " rotate me"
+
+
+class FakeCitadel:
+    def __init__(self, config: CitadelConfig, nodes: list[str]) -> None:
+        self.config = config
+        self._nodes = nodes
+
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        # Same nodes for every seed query; the engine dedupes by text.
+        return [{"text": node} for node in self._nodes]
+
+
+class FakeLearning:
+    """Records every learn() call so tests can assert on the write targets."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def learn(self, data: str, **kwargs: Any) -> IngestResult:
+        self.calls.append({"data": data, "dataset": kwargs.get("dataset"), "tier": kwargs.get("tier"), "tags": kwargs.get("tags")})
+        return IngestResult(True, "accepted", kwargs.get("dataset") or CENTRAL, tuple(kwargs.get("tags") or ()))
+
+    @property
+    def central_writes(self) -> list[dict[str, Any]]:
+        return [call for call in self.calls if call["dataset"] == CENTRAL]
+
+
+def _config(**overrides: Any) -> CitadelConfig:
+    base: dict[str, Any] = {"promotion_enabled": True}
+    base.update(overrides)
+    return CitadelConfig(**base)
+
+
+def _engine(tmp_path: Path, nodes: list[str], config: CitadelConfig | None = None) -> tuple[PromotionEngine, FakeLearning, AccessStore]:
+    config = config or _config()
+    learning = FakeLearning()
+    store = AccessStore(str(tmp_path / "access.json"))
+    engine = PromotionEngine(FakeCitadel(config, nodes), learning, store, config)
+    return engine, learning, store
+
+
+def _stub_llm(monkeypatch: pytest.MonkeyPatch, *, relevant: bool = True, sensitive: bool = False, score: float = 0.9, fail: bool = False) -> None:
+    def fake_chat(*args: Any, **kwargs: Any) -> str | None:
+        if fail:
+            return None
+        return json.dumps({"relevant": relevant, "sensitive": sensitive, "score": score, "reason": "stubbed"})
+
+    monkeypatch.setattr(promotion, "openrouter_chat", fake_chat)
+
+
+def test_coerce_classification_rejects_malformed() -> None:
+    assert _coerce_classification({"relevant": True, "sensitive": False, "score": 0.8, "reason": "ok"}) is not None
+    assert _coerce_classification({"relevant": "yes", "sensitive": False, "score": 0.8, "reason": "ok"}) is None
+    assert _coerce_classification({"relevant": True, "sensitive": False, "score": 2, "reason": "ok"}) is None
+    assert _coerce_classification({"relevant": True, "sensitive": False, "score": 0.8}) is None
+    assert _coerce_classification("not a dict") is None
+
+
+async def test_dry_run_proposes_but_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=True)
+
+    assert result["dry_run"] is True
+    assert result["proposed"] == 1
+    assert result["promoted"] == 0
+    assert any(p["decision"] == "promote" for p in result["proposals"])
+    # The core safety invariant: a dry run performs NO writes at all.
+    assert learning.calls == []
+    assert store.recent_audit_events(action="promotion.promote") == []
+
+
+async def test_relevant_clean_item_is_promoted_to_central_with_audit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 1
+    # Promotion routed through the org-ready dual-write -> a real Central write.
+    assert len(learning.central_writes) == 1
+    assert "org-ready" in learning.central_writes[0]["tags"]
+    promote_events = store.recent_audit_events(action="promotion.promote")
+    assert len(promote_events) == 1
+    assert promote_events[0]["success"] is True
+    assert promote_events[0]["dataset"] == CENTRAL
+    assert promote_events[0]["detail"]["seat"] == SEAT
+
+
+async def test_sensitive_item_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, store = _engine(tmp_path, ["my personal salary and home address"])
+    _stub_llm(monkeypatch, relevant=True, sensitive=True, score=0.95)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert learning.central_writes == []
+    assert result["proposals"][0]["decision"] == "skip"
+    assert result["proposals"][0]["reason"] == "sensitive"
+
+
+async def test_secret_bearing_item_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, _store = _engine(tmp_path, [SECRET_TEXT])
+    # Even if the classifier would say "promote", the secret gate must win.
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.99)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert learning.calls == []
+    assert result["proposals"][0]["decision"] == "skip"
+    assert result["proposals"][0]["reason"] == "secret_content"
+    assert result["proposals"][0]["secret_blocked"] is True
+
+
+async def test_llm_failure_falls_back_to_skip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, _store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    _stub_llm(monkeypatch, fail=True)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert learning.calls == []
+    assert result["proposals"][0]["decision"] == "skip"
+    assert result["proposals"][0]["reason"] == "llm_unavailable"
+
+
+async def test_below_threshold_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, _store = _engine(tmp_path, ["a marginal note"])
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.5)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert learning.calls == []
+    assert result["proposals"][0]["reason"] == "below_threshold"
+
+
+async def test_disabled_returns_status_and_does_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine, learning, _store = _engine(tmp_path, ["anything"], config=_config(promotion_enabled=False))
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["enabled"] is False
+    assert result["reason"] == "disabled"
+    assert learning.calls == []
+
+
+async def test_non_seat_dataset_rejected(tmp_path: Path) -> None:
+    engine, _learning, _store = _engine(tmp_path, ["anything"])
+    with pytest.raises(ValueError):
+        await engine.run(CENTRAL, dry_run=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2351,3 +2351,49 @@ def test_contribute_blocks_high_severity_secret(tmp_path: Any) -> None:
     assert blocked
     assert blocked[-1]["action"] == "contribute"
     assert blocked[-1]["success"] is False
+
+
+def test_promotion_status_requires_admin_and_reports_config() -> None:
+    client = authed_client()
+
+    response = client.get("/api/promote")
+
+    assert response.status_code == 200
+    body = response.json()
+    # FakeCitadel config leaves promotion opt-in (disabled) by default.
+    assert body["enabled"] is False
+    assert body["dry_run_default"] is True
+    assert body["promotion_tag"] == "org-ready"
+    assert body["max_items"] == 20
+
+
+def test_promotion_run_rejects_non_seat_dataset() -> None:
+    client = authed_client()
+    app.state.access_store = AccessStore(Path(tempfile.mkdtemp()) / "access.json")
+
+    response = client.post(
+        "/api/promote/run",
+        json={"dataset": "masumi-network", "dry_run": True},
+    )
+
+    assert response.status_code == 400
+    assert "seat" in response.json()["detail"].lower()
+
+
+def test_promotion_run_disabled_returns_status_and_audits() -> None:
+    client = authed_client()
+    app.state.access_store = AccessStore(Path(tempfile.mkdtemp()) / "access.json")
+
+    response = client.post(
+        "/api/promote/run",
+        json={"dataset": "seat:alice", "dry_run": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["reason"] == "disabled"
+    assert body["promoted"] == 0
+    events = app.state.access_store.snapshot()["audit_events"]
+    runs = [e for e in events if e["action"] == "promotion.run"]
+    assert runs and runs[-1]["success"] is True


### PR DESCRIPTION
Stacked on #6 (the secret gate). Implements ADR-0005 step 2.

## What it does
A `PromotionEngine` (`kb/promotion.py`) that moves **org-relevant, non-sensitive** content from a personal seat node to Central — selectively, not everything:
1. **Enumerate** a seat node's real content via `Citadel.search`/`cognee.recall` (capped by `CITADEL_PROMOTION_MAX_ITEMS`).
2. **Decide** per item: an **unconditional secret scan first** (so secrets never even reach the LLM), then an OpenRouter relevance+sensitivity classifier reusing `kb/llm_enrichment` (direct HTTP, not litellm). **Any LLM failure / malformed output → SKIP** (fail-closed).
3. **Promote** qualifiers (relevant ∧ ¬sensitive ∧ secret-clean ∧ score ≥ threshold) to Central through the **existing curated org-ready dual-write**, so the #6 secret gate re-runs on the way in. One audit event per promotion (no candidate text stored).

## Safe by default
**Two opt-in locks** before anything reaches Central: `CITADEL_PROMOTION_ENABLED` defaults **false**, and `dry_run` defaults **true** (proposes; writes nothing). Admin-gated `GET /api/promote` + `POST /api/promote/run`.

## Adversarial review: PASSED
No path for sensitive/secret/personal content to reach Central — dry-run writes nothing, the gate runs twice, LLM-failure skips, sensitive items are AND-gated out, endpoints are admin-only, audits store no candidate text.

## Known v1 limitations (documented, non-blocking)
Best-effort semantic enumeration (not exhaustive); no cross-run dedup of already-promoted items; binary promote/skip (no human-approve middle band yet). These are the ADR-0005 open questions for a later pass.

Config: `CITADEL_PROMOTION_ENABLED` / `_RELEVANCE_THRESHOLD` (0.7) / `_MAX_ITEMS` (20). 12 new tests; full suite **364 passing**, ruff clean. Secret test fixtures assembled at runtime (no literal secret committed).