### PR TITLE
fix(mesh): rehydrate graph projection on startup (no more "reset after deploy")

### DIFF
--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -5,7 +5,9 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha1
+import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from kb.config import CitadelConfig
@@ -40,6 +42,7 @@ class MeshState:
     pending_chunks: int = 0
     failed_chunks: int = 0
     last_indexed_at: str | None = None
+    _rehydrated: bool = False
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
@@ -49,6 +52,158 @@ class MeshState:
 
     def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
         self.subscribers.discard(queue)
+
+    async def rehydrate(
+        self,
+        config: CitadelConfig,
+        *,
+        sources: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Seed the snapshot's source graph projection + ``last_indexed_at`` from
+        persistent source state, once at startup.
+
+        A web-service restart drops the in-memory mesh, so the dashboard graph looks
+        wiped even though the persistent knowledge graph and source state survive.
+        Rehydrate re-projects lightweight source/repository nodes (keyed by id, so a
+        later live sync overwrites rather than duplicates) and seeds
+        ``last_indexed_at`` from the cheap source-state JSON files.
+
+        It deliberately does NOT seed the accumulating ``documents`` /
+        ``indexed_chunks`` counters: github and repo-content syncs already flow
+        through ``record_ingest`` (``documents += 1``), so seeding them would
+        double-count the same source data after the next sync.
+
+        Once-only (``_rehydrated`` guard) and best-effort: missing or unreadable
+        state files never raise, so a fresh deploy with no state seeds nothing and
+        startup proceeds.
+        """
+        async with self._lock:
+            if self._rehydrated:
+                return
+            self._rehydrated = True
+            try:
+                self._ensure_base_graph(config)
+                baselines = (
+                    sources if sources is not None else self._read_source_baselines(config)
+                )
+                latest_ts: str | None = None
+                for source in baselines:
+                    ts = source.get("last_indexed_at")
+                    if isinstance(ts, str) and ts and (latest_ts is None or ts > latest_ts):
+                        latest_ts = ts
+                    self._seed_source_nodes(config, source)
+                if self.last_indexed_at is None and latest_ts is not None:
+                    self.last_indexed_at = latest_ts
+            except Exception as exc:  # noqa: BLE001 - never block startup on rehydrate
+                logger.warning("Mesh rehydrate skipped: %s", exc)
+
+    def _read_state_json(self, path: str | None) -> dict[str, Any]:
+        if not path:
+            return {}
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _read_source_baselines(self, config: CitadelConfig) -> list[dict[str, Any]]:
+        """Cheap one-time reads of the persistent source-state JSON files.
+
+        Each baseline is ``{type, label, dataset, documents, last_indexed_at, repos}``.
+        Only sources with data are returned; all reads are best-effort.
+        """
+        baselines: list[dict[str, Any]] = []
+
+        github = self._read_state_json(config.github_sync_state_path)
+        repos = github.get("repos") if isinstance(github.get("repos"), dict) else {}
+        digest = github.get("last_digest")
+        if isinstance(digest, str) and digest.strip():
+            from kb.source_search import _digest_sections
+
+            github_docs = len(_digest_sections(digest))
+        else:
+            github_docs = len(repos)
+        if github_docs:
+            baselines.append(
+                {
+                    "type": "github",
+                    "label": f"GitHub / {github.get('org') or config.github_org}",
+                    "dataset": config.github_sync_dataset,
+                    "documents": github_docs,
+                    "last_indexed_at": github.get("last_checked_at"),
+                    "repos": list(repos.keys()),
+                }
+            )
+
+        repo = self._read_state_json(config.repo_content_sync_state_path)
+        files = repo.get("files") if isinstance(repo.get("files"), dict) else {}
+        if files:
+            baselines.append(
+                {
+                    "type": "repo_content",
+                    "label": f"Repo content / {config.github_org}",
+                    "dataset": config.repo_content_sync_dataset,
+                    "documents": len(files),
+                    "last_indexed_at": repo.get("last_checked_at"),
+                    "repos": [],
+                }
+            )
+
+        linear = self._read_state_json(config.linear_sync_state_path)
+        issues = linear.get("issues") if isinstance(linear.get("issues"), list) else []
+        if issues:
+            baselines.append(
+                {
+                    "type": "linear",
+                    "label": "Linear",
+                    "dataset": config.linear_sync_dataset,
+                    "documents": len(issues),
+                    "last_indexed_at": linear.get("last_synced_at"),
+                    "repos": [],
+                }
+            )
+
+        return baselines
+
+    def _seed_source_nodes(self, config: CitadelConfig, source: dict[str, Any]) -> None:
+        """Re-project lightweight source/dataset/repository nodes from persisted state.
+
+        Keeps the snapshot's graph 'records' projection non-empty after a restart. The
+        authoritative knowledge graph survives separately via /api/mesh/graph (Kuzu),
+        so this projection is intentionally decoupled from any cognee read.
+        """
+        dataset_id = self._dataset_node(source.get("dataset") or config.default_dataset)
+        source_id = stable_id(
+            "source", f"rehydrate:{source.get('type')}:{source.get('label')}"
+        )
+        self.nodes[source_id] = {
+            "id": source_id,
+            "label": source.get("label") or "Source",
+            "type": "source",
+            "status": "synced",
+            "size": 46,
+            "metadata": {
+                "source_type": source.get("type"),
+                "documents": source.get("documents"),
+                "last_indexed_at": source.get("last_indexed_at"),
+                "rehydrated": True,
+            },
+        }
+        self._edge(source_id, dataset_id, "updates")
+        for repo_name in (source.get("repos") or [])[:12]:
+            if not isinstance(repo_name, str) or not repo_name:
+                continue
+            repo_id = stable_id("repository", repo_name)
+            self.nodes[repo_id] = {
+                "id": repo_id,
+                "label": repo_name.split("/")[-1],
+                "type": "repository",
+                "status": "synced",
+                "size": 26,
+                "metadata": {"full_name": repo_name, "rehydrated": True},
+            }
+            self._edge(source_id, repo_id, "observed")
+            self._edge(repo_id, dataset_id, "summarized")
 
     async def snapshot(self, config: CitadelConfig) -> dict[str, Any]:
         async with self._lock:

--- a/kb/server.py
+++ b/kb/server.py
@@ -64,8 +64,18 @@ mcp_app = mcp_server.streamable_http_app()
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI) -> Any:
+async def lifespan(app: FastAPI) -> Any:
     async with mcp_server.session_manager.run():
+        # Eagerly build the mesh and seed its in-memory activity counters from
+        # persistent source state so a redeploy does not look like the graph reset.
+        # get_mesh() then returns this already-seeded instance. Best-effort: a failed
+        # rehydrate must never block startup.
+        mesh = MeshState()
+        app.state.mesh = mesh
+        try:
+            await mesh.rehydrate(get_citadel().config)
+        except Exception:
+            logger.exception("Mesh rehydrate failed; starting with empty counters")
         yield
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from kb.config import CitadelConfig
 from kb.mesh import MeshState
 from kb.models import FeedbackResult, IngestResult
@@ -152,6 +155,121 @@ async def test_snapshot_always_includes_central_dataset_node() -> None:
         edge["source"] == central_id and edge["target"] == "index:graph"
         for edge in snapshot["edges"]
     )
+
+
+async def test_rehydrate_seeds_graph_and_timestamp_not_counters() -> None:
+    mesh = MeshState()
+
+    await mesh.rehydrate(
+        CONFIG,
+        sources=[
+            {
+                "type": "github",
+                "label": "GitHub / acme",
+                "dataset": "notes",
+                "documents": 4,
+                "last_indexed_at": "2026-06-20T00:00:00Z",
+                "repos": ["acme/one", "acme/two"],
+            },
+            {
+                "type": "linear",
+                "label": "Linear",
+                "dataset": "notes",
+                "documents": 6,
+                "last_indexed_at": "2026-06-25T00:00:00Z",
+                "repos": [],
+            },
+        ],
+    )
+    snapshot = await mesh.snapshot(CONFIG)
+
+    # Counters are NOT seeded (that would double-count the github/repo data the
+    # next live sync re-ingests); the graph projection + last_indexed_at carry it.
+    assert snapshot["stats"]["documents"] == 0
+    assert snapshot["stats"]["indexed_chunks"] == 0
+    assert snapshot["stats"]["last_indexed_at"] == "2026-06-25T00:00:00Z"
+    # Graph projection is non-empty: source + repository nodes survive the "restart".
+    source_nodes = [node for node in snapshot["nodes"] if node["type"] == "source"]
+    repo_nodes = [node for node in snapshot["nodes"] if node["type"] == "repository"]
+    assert len(source_nodes) == 2
+    assert {node["label"] for node in repo_nodes} == {"one", "two"}
+    graph_index = next(index for index in snapshot["indexes"] if index["id"] == "graph")
+    assert graph_index["records"] > 0
+
+
+async def test_rehydrate_baseline_then_live_ingest_does_not_double_count() -> None:
+    mesh = MeshState()
+    baseline = [
+        {
+            "type": "github",
+            "label": "GitHub",
+            "dataset": "notes",
+            "documents": 5,
+            "last_indexed_at": "2026-06-20T00:00:00Z",
+            "repos": [],
+        }
+    ]
+
+    await mesh.rehydrate(CONFIG, sources=baseline)
+    # Second call must be a no-op: the _rehydrated guard prevents baselines stacking.
+    await mesh.rehydrate(CONFIG, sources=baseline)
+    await mesh.record_ingest(
+        CONFIG,
+        IngestResult(True, "accepted", "notes", ("ops",)),
+        data="Runbook: rotate keys",
+        dataset="notes",
+        tags=["ops"],
+    )
+    snapshot = await mesh.snapshot(CONFIG)
+
+    # Counters are not seeded, so a live ingest just adds 1 — the baseline never
+    # double-counts the github/repo data the next live sync will re-ingest.
+    assert snapshot["stats"]["documents"] == 1
+    assert snapshot["stats"]["indexed_chunks"] == 1
+
+
+async def test_rehydrate_reads_state_files_and_tolerates_missing(tmp_path: Path) -> None:
+    github = tmp_path / "github_sync_state.json"
+    github.write_text(
+        json.dumps(
+            {
+                "org": "acme",
+                "last_checked_at": "2026-06-21T00:00:00Z",
+                "repos": {"acme/one": {}, "acme/two": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    linear = tmp_path / "linear_sync_state.json"
+    linear.write_text(
+        json.dumps(
+            {
+                "issues": [{"id": 1}, {"id": 2}, {"id": 3}],
+                "last_synced_at": "2026-06-24T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = CitadelConfig(
+        tenant_id="test",
+        default_dataset="notes",
+        github_sync_state_path=str(github),
+        # Repo-content state file is intentionally absent — must be tolerated.
+        repo_content_sync_state_path=str(tmp_path / "missing_repo_state.json"),
+        linear_sync_state_path=str(linear),
+    )
+    mesh = MeshState()
+
+    await mesh.rehydrate(config)
+    snapshot = await mesh.snapshot(config)
+
+    # Counters are not seeded; last_indexed_at + the graph projection carry the
+    # persistent state. Missing repo-content file is tolerated (contributes nothing).
+    assert snapshot["stats"]["documents"] == 0
+    assert snapshot["stats"]["indexed_chunks"] == 0
+    assert snapshot["stats"]["last_indexed_at"] == "2026-06-24T00:00:00Z"
+    source_nodes = [node for node in snapshot["nodes"] if node["type"] == "source"]
+    assert source_nodes  # github + linear sources projected from persistent state
 
 
 async def test_timeline_tracks_chunks_and_resume_filters() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2397,3 +2397,39 @@ def test_promotion_run_disabled_returns_status_and_audits() -> None:
     events = app.state.access_store.snapshot()["audit_events"]
     runs = [e for e in events if e["action"] == "promotion.run"]
     assert runs and runs[-1]["success"] is True
+
+
+def test_lifespan_rehydrates_mesh_from_source_state(tmp_path: Path) -> None:
+    github = tmp_path / "github_sync_state.json"
+    github.write_text(
+        json.dumps(
+            {
+                "org": "acme",
+                "last_checked_at": "2026-06-22T00:00:00Z",
+                "repos": {"acme/one": {}, "acme/two": {}, "acme/three": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(
+        tenant_id="test",
+        default_dataset="notes",
+        github_sync_state_path=str(github),
+        repo_content_sync_state_path=str(tmp_path / "absent_repo_state.json"),
+        linear_sync_state_path=str(tmp_path / "absent_linear_state.json"),
+    )
+    app.state.citadel = citadel
+
+    # Entering the TestClient context triggers the lifespan, which builds and seeds
+    # the mesh exactly once before serving requests.
+    with TestClient(app):
+        mesh = app.state.mesh
+
+    assert mesh._rehydrated is True
+    # Counters are not seeded (avoids double-counting live github/repo re-ingests);
+    # last_indexed_at + the source graph projection carry the persistent state.
+    assert mesh.documents == 0
+    assert mesh.indexed_chunks == 0
+    assert mesh.last_indexed_at == "2026-06-22T00:00:00Z"
+    assert any(node["type"] == "source" for node in mesh.nodes.values())


### PR DESCRIPTION
Fixes the recurring "the graph reset again" confusion. Root cause: `MeshState` is in-memory, so a web-service **restart** zeroes the `/api/mesh` snapshot even though the persistent knowledge graph + source state survive.

- `MeshState.rehydrate(config)` runs once in the FastAPI lifespan (best-effort, never blocks startup): re-projects lightweight **source/repository graph nodes** (keyed by id → a later live sync overwrites, not duplicates) and seeds **`last_indexed_at`** from the cheap github/repo-content/linear state JSON.
- **Deliberately does NOT seed the `documents`/`indexed_chunks` counters** — github/repo syncs already flow through `record_ingest`, so seeding them would **double-count** (an adversarial review caught exactly this in the first cut; fixed here).
- `snapshot()` unchanged → zero per-request cost.

4 tests (projection + last_indexed_at, no-double-count, missing-state tolerance, lifespan wiring). Full suite **368 passing**, ruff clean.