### PR TITLE
feat(events): GitHub PR-merge webhook + evolve run-mode (ADR-0005 step 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,9 @@ CITADEL_MCP_MAX_INGEST_BYTES=200000
 CITADEL_MCP_ALLOW_INSECURE_HTTP=false
 
 # Railway run mode: web, pipeline (full scheduled run: GitHub org sync,
-# skills refresh, self-improvement, backup mirror), or the single jobs
-# learning-agent/github-sync and backup-mirror.
+# skills refresh, self-improvement, backup mirror), evolve (6h self-evolving
+# cycle, ADR-0005 step 3), or the single jobs learning-agent/github-sync and
+# backup-mirror.
 CITADEL_RUN_MODE=web
 # Pipeline stage toggles. A failed stage never stops later stages; the run
 # exits nonzero only when every enabled stage fails.
@@ -54,6 +55,16 @@ CITADEL_PIPELINE_GITHUB_SYNC_ENABLED=true
 CITADEL_PIPELINE_REPO_CONTENT_SYNC_ENABLED=true
 CITADEL_PIPELINE_SKILLS_REFRESH_ENABLED=true
 CITADEL_PIPELINE_BACKUP_MIRROR_ENABLED=true
+# Evolve cron stage toggles (CITADEL_RUN_MODE=evolve). Same fail-soft semantics
+# as the pipeline: a failed stage never stops later stages and the run exits
+# nonzero only when every enabled stage fails. The 6h cadence is an operator
+# Railway-cron step, not code. Chain: github sync -> repo-content sync ->
+# self-improve -> promotion -> cognify.
+CITADEL_EVOLVE_GITHUB_SYNC_ENABLED=true
+CITADEL_EVOLVE_REPO_CONTENT_SYNC_ENABLED=true
+CITADEL_EVOLVE_SELF_IMPROVE_ENABLED=true
+CITADEL_EVOLVE_PROMOTION_ENABLED=true
+CITADEL_EVOLVE_COGNIFY_ENABLED=true
 # Where the pipeline stores last-seen skill content hashes for change detection.
 CITADEL_SKILLS_STATE_PATH=/data/.citadel/skills_catalog.json
 
@@ -123,6 +134,15 @@ CITADEL_GITHUB_SYNC_SECURITY_SCAN_ENABLED=true
 CITADEL_GITHUB_SYNC_SECURITY_BLOCK_SEVERITY=high
 GITHUB_TOKEN=
 
+# GitHub PR-merge webhook -> non-blocking org re-ingest (ADR-0005 step 3).
+# Disabled by default: POST /api/webhooks/github returns 404 until enabled. When
+# enabled, the raw body is verified against X-Hub-Signature-256 (HMAC-SHA256
+# keyed by the secret) BEFORE parsing; a missing/invalid signature is rejected
+# with 401. Only a closed+merged pull_request triggers work (202); everything
+# else is acknowledged with 204. Set the SAME secret in the GitHub webhook UI.
+CITADEL_GITHUB_WEBHOOK_ENABLED=false
+CITADEL_GITHUB_WEBHOOK_SECRET=
+
 # Content/secret gate on EVERY write path (ADR-0005 step 1): /ingest,
 # /api/contribute, Obsidian sync, autosync, and MCP writers all funnel through
 # the service-layer ingest gate. A finding at or above the block severity is
@@ -137,6 +157,9 @@ CITADEL_CONTENT_SCAN_BLOCK_SEVERITY=high
 # score >= threshold) via the org-ready dual-write. dry_run defaults TRUE
 # (propose only, write nothing); a human sets dry_run=false to actually promote.
 CITADEL_PROMOTION_ENABLED=false
+# Default dry-run for the evolve cron's promotion stage (propose, write nothing).
+# Set false to let the 6h evolve cron actually promote qualifying items.
+CITADEL_PROMOTION_DRY_RUN=true
 CITADEL_PROMOTION_RELEVANCE_THRESHOLD=0.7
 CITADEL_PROMOTION_MAX_ITEMS=20
 

--- a/kb/config.py
+++ b/kb/config.py
@@ -174,9 +174,12 @@ class CitadelConfig:
     github_sync_repo_denylist: tuple[str, ...] = field(default_factory=tuple)
     github_sync_security_scan_enabled: bool = True
     github_sync_security_block_severity: str = "high"
+    github_webhook_enabled: bool = False
+    github_webhook_secret: str = ""
     content_scan_enabled: bool = True
     content_scan_block_severity: str = "high"
     promotion_enabled: bool = False
+    promotion_dry_run: bool = True
     promotion_relevance_threshold: float = 0.7
     promotion_max_items: int = 20
     github_token: str | None = None
@@ -300,6 +303,11 @@ class CitadelConfig:
                 "CITADEL_GITHUB_SYNC_SECURITY_BLOCK_SEVERITY",
                 "high",
             ),
+            github_webhook_enabled=_bool(
+                os.getenv("CITADEL_GITHUB_WEBHOOK_ENABLED"),
+                default=False,
+            ),
+            github_webhook_secret=os.getenv("CITADEL_GITHUB_WEBHOOK_SECRET", ""),
             content_scan_enabled=_bool(
                 os.getenv("CITADEL_CONTENT_SCAN_ENABLED"),
                 default=True,
@@ -311,6 +319,10 @@ class CitadelConfig:
             promotion_enabled=_bool(
                 os.getenv("CITADEL_PROMOTION_ENABLED"),
                 default=False,
+            ),
+            promotion_dry_run=_bool(
+                os.getenv("CITADEL_PROMOTION_DRY_RUN"),
+                default=True,
             ),
             promotion_relevance_threshold=_float(
                 os.getenv("CITADEL_PROMOTION_RELEVANCE_THRESHOLD"),

--- a/kb/server.py
+++ b/kb/server.py
@@ -59,6 +59,11 @@ logger = logging.getLogger(__name__)
 # the caller's ctdl_ bearer token. No clone, no local Python — agents point their
 # MCP client at https://<host>/mcp/ with Authorization: Bearer <token>.
 MCP_ENDPOINT_PATH = "/mcp/"
+
+# Strong refs to detached fire-and-forget tasks (e.g. the webhook re-ingest) so
+# the event loop does not garbage-collect them mid-flight.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
 mcp_server = create_mcp_server()
 mcp_app = mcp_server.streamable_http_app()
 
@@ -1791,6 +1796,110 @@ async def run_github_sync(body: GitHubSyncBody, request: Request) -> Any:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     await mesh_state.record_github_sync(citadel.config, result)
     return jsonable_encoder(result)
+
+
+def verify_github_signature(secret: str, body: bytes, signature_header: str) -> bool:
+    """Constant-time check of GitHub's ``X-Hub-Signature-256`` over the raw body.
+
+    GitHub signs the request body with HMAC-SHA256 keyed by the shared webhook
+    secret and sends ``sha256=<hexdigest>``. A missing/empty/malformed header, an
+    empty secret, or any mismatch returns ``False``. The body is UNTRUSTED; this
+    runs before any parsing.
+    """
+    if not secret or not signature_header:
+        return False
+    prefix = "sha256="
+    if not signature_header.startswith(prefix):
+        return False
+    provided = signature_header[len(prefix):]
+    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(provided, expected)
+
+
+def webhook_identity(dataset: str) -> AccessIdentity:
+    """Synthetic service-account identity for auditing accepted webhook triggers."""
+    return AccessIdentity(
+        role="admin",
+        actor_id="github-webhook",
+        actor_kind="service_account",
+        actor_name="github-webhook",
+        source="env",
+        default_dataset=dataset,
+    )
+
+
+async def _run_webhook_reingest(syncer: GitHubOrgSyncer) -> None:
+    """Background org re-ingest kicked off by an accepted PR-merge webhook.
+
+    Fire-and-forget: the webhook returns 202 immediately (GitHub times out in
+    seconds; the full sync is ~26min) and this runs detached. Never raises.
+    """
+    try:
+        await syncer.run(force=True)
+    except Exception as exc:  # pragma: no cover - depends on GitHub + Cognee runtime.
+        logger.error(
+            "GitHub webhook re-ingest failed: %s: %s",
+            exc.__class__.__name__,
+            exc,
+        )
+
+
+@app.post("/api/webhooks/github")
+async def github_webhook(request: Request) -> Response:
+    """GitHub PR-merge webhook -> non-blocking org re-ingest (ADR-0005 step 3).
+
+    Gated off by default (``github_webhook_enabled`` -> 404 when disabled). The
+    raw body is verified against ``X-Hub-Signature-256`` BEFORE parsing and is
+    treated as untrusted. An invalid/missing signature -> 401. Only a closed,
+    merged ``pull_request`` event triggers work (returns 202); everything else
+    (ping, other events, non-merge closes) is acknowledged with 204 and no work.
+    """
+    config = get_citadel().config
+    if not config.github_webhook_enabled:
+        raise HTTPException(status_code=404, detail="Not found.")
+
+    body = await request.body()
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    if not verify_github_signature(config.github_webhook_secret, body, signature):
+        raise HTTPException(status_code=401, detail="Invalid signature.")
+
+    event = request.headers.get("X-GitHub-Event", "")
+    if event != "pull_request":
+        return Response(status_code=204)
+
+    try:
+        payload = json.loads(body or b"{}")
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    pull_request = payload.get("pull_request")
+    merged = isinstance(pull_request, dict) and pull_request.get("merged") is True
+    if payload.get("action") != "closed" or not merged:
+        return Response(status_code=204)
+
+    repository = payload.get("repository")
+    repo_full_name = repository.get("full_name") if isinstance(repository, dict) else None
+    task = asyncio.create_task(_run_webhook_reingest(get_github_syncer()))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+    get_access_store().record_event(
+        action="github_webhook.merge",
+        actor=webhook_identity(config.github_sync_dataset),
+        success=True,
+        dataset=config.github_sync_dataset,
+        detail={
+            "event": event,
+            "action": "closed",
+            "merged": True,
+            "pr_number": pull_request.get("number"),
+            "repository": repo_full_name,
+            "triggered": "github_sync",
+        },
+    )
+    return Response(status_code=202)
 
 
 @app.get("/api/linear-sync")

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -15,6 +15,10 @@ Modes (via ``CITADEL_RUN_MODE``):
   mirror export. Each stage is toggleable via env, logs a per-stage summary
   line, and a failed stage never stops the stages after it. The process exits
   nonzero only when every enabled stage fails.
+- ``evolve``: the 6h self-evolving cycle (ADR-0005 step 3) — GitHub org sync,
+  repo-content sync, self-improvement, selective seat->Central promotion, and
+  cognify. Same per-stage ``CITADEL_EVOLVE_*`` toggles + fail-soft semantics as
+  ``pipeline``; the 6h cadence is an operator Railway-cron step, not code.
 - ``linear-sync``: sync the Linear workspace to Central and mirror assignee
   issues into seat Nodes (requires ``CITADEL_LINEAR_API_KEY``).
 """
@@ -120,6 +124,75 @@ def _cognify_mode(*, verify: bool) -> int:
     return 0
 
 
+def _cognify_stage() -> int:
+    return _cognify_mode(verify=False)
+
+
+def _promotion_stage() -> int:
+    """Selective seat-node -> Central promotion across every seat (ADR-0005 step 3).
+
+    Reuses :class:`kb.promotion.PromotionEngine`, honoring its opt-in
+    (``CITADEL_PROMOTION_ENABLED``) and dry-run (``CITADEL_PROMOTION_DRY_RUN``,
+    default on) config. Each seat node is promoted independently; a failure on one
+    seat never aborts the others, and the stage only fails when EVERY seat raised.
+    """
+    from kb.access import AccessStore, is_seat_dataset
+    from kb.learning import LearningProcess
+    from kb.promotion import PromotionEngine
+    from kb.service import Citadel
+
+    citadel = Citadel.from_env()
+    config = citadel.config
+    if not config.promotion_enabled:
+        logger.info("Promotion stage skipped: disabled via CITADEL_PROMOTION_ENABLED")
+        return 0
+
+    access_store = AccessStore(config.access_store_path)
+    seats = sorted(
+        {
+            principal.get("default_dataset")
+            for principal in access_store.snapshot()["principals"]
+            if principal.get("seat_slug") and is_seat_dataset(principal.get("default_dataset"))
+        }
+    )
+    if not seats:
+        logger.info("Promotion stage: no seat nodes to promote from")
+        return 0
+
+    engine = PromotionEngine(citadel, LearningProcess(citadel), access_store, config)
+
+    async def _run() -> tuple[int, int]:
+        promoted = 0
+        failures = 0
+        for seat in seats:
+            try:
+                result = await engine.run(seat, dry_run=config.promotion_dry_run)
+            except Exception as exc:
+                logger.error(
+                    "Promotion failed for %s: %s: %s",
+                    seat,
+                    exc.__class__.__name__,
+                    exc,
+                )
+                failures += 1
+                continue
+            promoted += result.get("promoted") or 0
+        return promoted, failures
+
+    promoted, failures = asyncio.run(_run())
+    logger.info(
+        "Promotion stage finished: seats=%s promoted=%s failures=%s dry_run=%s",
+        len(seats),
+        promoted,
+        failures,
+        config.promotion_dry_run,
+    )
+    # One flaky seat must not fail the stage; only a total wipeout counts as failure.
+    if failures and failures == len(seats):
+        return 1
+    return 0
+
+
 def pipeline_stages() -> list[tuple[str, bool, Callable[[], int]]]:
     """(name, enabled, runner) for every pipeline stage, in execution order."""
     return [
@@ -151,11 +224,49 @@ def pipeline_stages() -> list[tuple[str, bool, Callable[[], int]]]:
     ]
 
 
-def run_pipeline() -> int:
+def evolve_stages() -> list[tuple[str, bool, Callable[[], int]]]:
+    """(name, enabled, runner) for the 6h evolve cron, in execution order.
+
+    Mirrors :func:`pipeline_stages` (per-stage env toggles) but chains the
+    self-evolving cycle: github sync -> repo-content sync -> self-improve ->
+    promotion -> cognify. The 6h cadence is an operator Railway-cron step, not
+    code. Each stage carries its own ``CITADEL_EVOLVE_*`` toggle so an operator
+    can disable any link without touching the others.
+    """
+    return [
+        (
+            "github_sync",
+            _bool(os.getenv("CITADEL_EVOLVE_GITHUB_SYNC_ENABLED"), default=True),
+            _github_sync_stage,
+        ),
+        (
+            "repo_content_sync",
+            _bool(os.getenv("CITADEL_EVOLVE_REPO_CONTENT_SYNC_ENABLED"), default=True),
+            _repo_content_sync_stage,
+        ),
+        (
+            "self_improve",
+            _bool(os.getenv("CITADEL_EVOLVE_SELF_IMPROVE_ENABLED"), default=True),
+            _self_improve_stage,
+        ),
+        (
+            "promotion",
+            _bool(os.getenv("CITADEL_EVOLVE_PROMOTION_ENABLED"), default=True),
+            _promotion_stage,
+        ),
+        (
+            "cognify",
+            _bool(os.getenv("CITADEL_EVOLVE_COGNIFY_ENABLED"), default=True),
+            _cognify_stage,
+        ),
+    ]
+
+
+def _run_stages(stages: list[tuple[str, bool, Callable[[], int]]], *, label: str) -> int:
     """Run every enabled stage; continue past failures.
 
     Exit code is nonzero only when all enabled stages fail, so one flaky
-    source never blocks the rest of the scheduled learning work.
+    source never blocks the rest of the scheduled work.
     """
     if not logging.getLogger().handlers:
         logging.basicConfig(
@@ -167,17 +278,18 @@ def run_pipeline() -> int:
     succeeded: list[str] = []
     failed: list[str] = []
     skipped: list[str] = []
-    for name, enabled, runner in pipeline_stages():
+    for name, enabled, runner in stages:
         if not enabled:
             skipped.append(name)
-            logger.info("Pipeline stage %s: skipped (disabled via env)", name)
+            logger.info("%s stage %s: skipped (disabled via env)", label, name)
             continue
-        logger.info("Pipeline stage %s: starting", name)
+        logger.info("%s stage %s: starting", label, name)
         try:
             code = runner()
         except Exception as exc:
             logger.error(
-                "Pipeline stage %s: FAILED with %s: %s",
+                "%s stage %s: FAILED with %s: %s",
+                label,
                 name,
                 exc.__class__.__name__,
                 exc,
@@ -186,13 +298,14 @@ def run_pipeline() -> int:
             continue
         if code == 0:
             succeeded.append(name)
-            logger.info("Pipeline stage %s: ok", name)
+            logger.info("%s stage %s: ok", label, name)
         else:
             failed.append(name)
-            logger.error("Pipeline stage %s: FAILED with exit code %s", name, code)
+            logger.error("%s stage %s: FAILED with exit code %s", label, name, code)
 
     logger.info(
-        "Pipeline finished: succeeded=%s failed=%s skipped=%s",
+        "%s finished: succeeded=%s failed=%s skipped=%s",
+        label,
         ",".join(succeeded) or "none",
         ",".join(failed) or "none",
         ",".join(skipped) or "none",
@@ -200,6 +313,14 @@ def run_pipeline() -> int:
     if failed and not succeeded:
         return 1
     return 0
+
+
+def run_pipeline() -> int:
+    return _run_stages(pipeline_stages(), label="Pipeline")
+
+
+def run_evolve() -> int:
+    return _run_stages(evolve_stages(), label="Evolve")
 
 
 def run(mode: str | None = None) -> int:
@@ -219,6 +340,8 @@ def run(mode: str | None = None) -> int:
         return _cognify_mode(verify=resolved_mode == "cognify-verify")
     if resolved_mode in {"pipeline", "all", "cron"}:
         return run_pipeline()
+    if resolved_mode == "evolve":
+        return run_evolve()
     if resolved_mode == "linear-sync":
         from kb.access import AccessStore
         from kb.linear_sync import LinearSyncer

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -234,3 +234,104 @@ def test_pipeline_mode_aliases_with_everything_disabled(monkeypatch: Any) -> Non
     assert run_railway.run("all") == 0
     assert run_railway.run("cron") == 0
     assert calls == []
+
+
+# --- Evolve run-mode (ADR-0005 step 3) -------------------------------------
+
+_EVOLVE_STAGE_ATTRS = [
+    ("github_sync", "_github_sync_stage"),
+    ("repo_content_sync", "_repo_content_sync_stage"),
+    ("self_improve", "_self_improve_stage"),
+    ("promotion", "_promotion_stage"),
+    ("cognify", "_cognify_stage"),
+]
+
+
+def _patch_evolve_stages(
+    monkeypatch: Any,
+    calls: list[str],
+    *,
+    fail_codes: dict[str, int] | None = None,
+    raise_stage: str | None = None,
+) -> None:
+    fail_codes = fail_codes or {}
+
+    def make_stage(stage_name: str) -> Any:
+        def stage() -> int:
+            calls.append(stage_name)
+            if stage_name == raise_stage:
+                raise RuntimeError(f"{stage_name} exploded")
+            return fail_codes.get(stage_name, 0)
+
+        return stage
+
+    for stage_name, attr in _EVOLVE_STAGE_ATTRS:
+        monkeypatch.setattr(run_railway, attr, make_stage(stage_name))
+
+
+def _clear_evolve_env(monkeypatch: Any) -> None:
+    for name in (
+        "CITADEL_EVOLVE_GITHUB_SYNC_ENABLED",
+        "CITADEL_EVOLVE_REPO_CONTENT_SYNC_ENABLED",
+        "CITADEL_EVOLVE_SELF_IMPROVE_ENABLED",
+        "CITADEL_EVOLVE_PROMOTION_ENABLED",
+        "CITADEL_EVOLVE_COGNIFY_ENABLED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_evolve_runs_all_stages_in_chain_order(monkeypatch: Any) -> None:
+    _clear_evolve_env(monkeypatch)
+    calls: list[str] = []
+    _patch_evolve_stages(monkeypatch, calls)
+
+    assert run_railway.run("evolve") == 0
+    assert calls == [
+        "github_sync",
+        "repo_content_sync",
+        "self_improve",
+        "promotion",
+        "cognify",
+    ]
+
+
+def test_evolve_stage_toggles_disable_individual_stages(monkeypatch: Any) -> None:
+    _clear_evolve_env(monkeypatch)
+    monkeypatch.setenv("CITADEL_EVOLVE_SELF_IMPROVE_ENABLED", "false")
+    monkeypatch.setenv("CITADEL_EVOLVE_PROMOTION_ENABLED", "false")
+    calls: list[str] = []
+    _patch_evolve_stages(monkeypatch, calls)
+
+    assert run_railway.run("evolve") == 0
+    assert calls == ["github_sync", "repo_content_sync", "cognify"]
+
+
+def test_evolve_continues_past_a_failed_stage(monkeypatch: Any) -> None:
+    _clear_evolve_env(monkeypatch)
+    calls: list[str] = []
+    _patch_evolve_stages(monkeypatch, calls, raise_stage="github_sync")
+
+    assert run_railway.run("evolve") == 0
+    assert calls == [
+        "github_sync",
+        "repo_content_sync",
+        "self_improve",
+        "promotion",
+        "cognify",
+    ]
+
+
+def test_evolve_exits_nonzero_only_when_all_enabled_stages_fail(monkeypatch: Any) -> None:
+    _clear_evolve_env(monkeypatch)
+    for name in (
+        "CITADEL_EVOLVE_REPO_CONTENT_SYNC_ENABLED",
+        "CITADEL_EVOLVE_SELF_IMPROVE_ENABLED",
+        "CITADEL_EVOLVE_PROMOTION_ENABLED",
+        "CITADEL_EVOLVE_COGNIFY_ENABLED",
+    ):
+        monkeypatch.setenv(name, "false")
+    calls: list[str] = []
+    _patch_evolve_stages(monkeypatch, calls, raise_stage="github_sync")
+
+    assert run_railway.run("evolve") == 1
+    assert calls == ["github_sync"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 from pathlib import Path
+import secrets
 import tempfile
 from typing import Any
 
 from fastapi.testclient import TestClient
+
+import kb.server as server_module
 
 from kb.access import AccessStore
 from kb.config import CitadelConfig
@@ -2433,3 +2438,207 @@ def test_lifespan_rehydrates_mesh_from_source_state(tmp_path: Path) -> None:
     assert mesh.indexed_chunks == 0
     assert mesh.last_indexed_at == "2026-06-22T00:00:00Z"
     assert any(node["type"] == "source" for node in mesh.nodes.values())
+
+
+# --- GitHub PR-merge webhook (ADR-0005 step 3) -----------------------------
+
+
+class _WebhookSyncer:
+    """Tracks whether the heavy org re-ingest was actually awaited inline."""
+
+    def __init__(self) -> None:
+        self.ran = False
+
+    async def run(self, *, force: bool = False) -> dict[str, Any]:
+        self.ran = True
+        return {"ok": True, "force": force}
+
+
+def _webhook_citadel(secret: str, *, enabled: bool = True) -> FakeCitadel:
+    citadel = FakeCitadel()
+    # Instance attribute shadows the class-level config for this test only.
+    citadel.config = CitadelConfig(
+        tenant_id="test",
+        default_dataset="notes",
+        github_sync_dataset="masumi-network",
+        github_webhook_enabled=enabled,
+        github_webhook_secret=secret,
+    )
+    return citadel
+
+
+def _sign(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _setup_webhook(tmp_path: Path, secret: str, *, enabled: bool = True) -> _WebhookSyncer:
+    app.state.citadel = _webhook_citadel(secret, enabled=enabled)
+    app.state.mesh = MeshState()
+    syncer = _WebhookSyncer()
+    app.state.github_syncer = syncer
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    return syncer
+
+
+def _merge_payload() -> bytes:
+    return json.dumps(
+        {
+            "action": "closed",
+            "pull_request": {"merged": True, "number": 42},
+            "repository": {"full_name": "masumi-network/agent"},
+        }
+    ).encode("utf-8")
+
+
+def test_github_webhook_merged_pr_returns_202_nonblocking_and_audits(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    secret = secrets.token_hex(16)  # built at runtime; no committed secret literal.
+    syncer = _setup_webhook(tmp_path, secret)
+
+    # Capture the re-ingest at scheduling time without running the heavy sync, so
+    # the assertions are deterministic and prove the handler does not block on it.
+    triggered: list[Any] = []
+
+    def fake_reingest(passed: Any) -> Any:
+        triggered.append(passed)
+
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    monkeypatch.setattr(server_module, "_run_webhook_reingest", fake_reingest)
+
+    body = _merge_payload()
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _sign(secret, body),
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 202
+    # Non-blocking: the ~26min org sync is scheduled, never awaited in-request.
+    assert triggered == [syncer]
+    assert syncer.ran is False
+
+    events = app.state.access_store.snapshot()["audit_events"]
+    merge_events = [e for e in events if e["action"] == "github_webhook.merge"]
+    assert len(merge_events) == 1
+    assert merge_events[0]["success"] is True
+    assert merge_events[0]["detail"]["merged"] is True
+    assert merge_events[0]["detail"]["pr_number"] == 42
+    assert merge_events[0]["detail"]["repository"] == "masumi-network/agent"
+    assert merge_events[0]["detail"]["triggered"] == "github_sync"
+
+
+def test_github_webhook_invalid_signature_returns_401(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    secret = secrets.token_hex(16)
+    syncer = _setup_webhook(tmp_path, secret)
+    triggered: list[Any] = []
+    monkeypatch.setattr(
+        server_module, "_run_webhook_reingest", lambda s: triggered.append(s)
+    )
+
+    body = _merge_payload()
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            # Signature computed with the WRONG secret -> must be rejected.
+            "X-Hub-Signature-256": _sign(secrets.token_hex(16), body),
+        },
+    )
+
+    assert response.status_code == 401
+    assert triggered == []
+    assert syncer.ran is False
+    events = app.state.access_store.snapshot()["audit_events"]
+    assert [e for e in events if e["action"] == "github_webhook.merge"] == []
+
+
+def test_github_webhook_missing_signature_returns_401(tmp_path: Path) -> None:
+    secret = secrets.token_hex(16)
+    syncer = _setup_webhook(tmp_path, secret)
+
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=_merge_payload(),
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+
+    assert response.status_code == 401
+    assert syncer.ran is False
+
+
+def test_github_webhook_disabled_returns_404(tmp_path: Path) -> None:
+    secret = secrets.token_hex(16)
+    syncer = _setup_webhook(tmp_path, secret, enabled=False)
+
+    body = _merge_payload()
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=body,
+        # Even a valid signature must 404 while the webhook is disabled.
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _sign(secret, body),
+        },
+    )
+
+    assert response.status_code == 404
+    assert syncer.ran is False
+
+
+def test_github_webhook_non_merge_close_returns_204(tmp_path: Path) -> None:
+    secret = secrets.token_hex(16)
+    syncer = _setup_webhook(tmp_path, secret)
+
+    body = json.dumps(
+        {"action": "closed", "pull_request": {"merged": False, "number": 7}}
+    ).encode("utf-8")
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _sign(secret, body),
+        },
+    )
+
+    assert response.status_code == 204
+    assert syncer.ran is False
+    events = app.state.access_store.snapshot()["audit_events"]
+    assert [e for e in events if e["action"] == "github_webhook.merge"] == []
+
+
+def test_github_webhook_other_event_returns_204(tmp_path: Path) -> None:
+    secret = secrets.token_hex(16)
+    syncer = _setup_webhook(tmp_path, secret)
+
+    body = json.dumps({"zen": "ping", "hook_id": 1}).encode("utf-8")
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post(
+        "/api/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "ping",
+            "X-Hub-Signature-256": _sign(secret, body),
+        },
+    )
+
+    assert response.status_code == 204
+    assert syncer.ran is False


### PR DESCRIPTION
Final core build track (ADR-0005 step 3). **Both features are gated off by default** — merging deploys dormant code.

## Part A — GitHub PR-merge webhook (`POST /api/webhooks/github`)
- Verifies `X-Hub-Signature-256` HMAC **constant-time (`hmac.compare_digest`), before parsing** the untrusted body. Missing/invalid/empty signature → **401** (fail-closed).
- Gated off by default: `CITADEL_GITHUB_WEBHOOK_ENABLED=false` → **404**.
- On a merged `pull_request` → **non-blocking** re-ingest (detached asyncio task, strong-ref'd) → **202** + audit event. Ping / non-merge / other events → **204**.

## Part B — `CITADEL_RUN_MODE=evolve`
Chains github sync → repo-content sync → self-improve → promotion (per seat, opt-in/dry-run) → cognify, with per-stage `CITADEL_EVOLVE_*` toggles and **fail-soft** semantics (a stage failure never stops later stages; nonzero exit only if every enabled stage fails). 6h cadence = operator Railway-cron step.

## Review
Adversarial security review **PASSED** (no auth bypass, no blocking sync). 10 new tests; full suite **378 passing**, ruff clean. Test signatures built at runtime (no committed secret).

## Known follow-ups (low/info — for the hardening pass, not blockers; feature is dormant)
- No HMAC replay protection (GitHub's scheme lacks nonce/timestamp; triggered work is idempotent).
- No concurrency guard (rapid merges could overlap background syncers).
- The background `syncer.run` executes on the event loop — if it does blocking IO it should move to a thread executor before the webhook is enabled in prod.