### PR TITLE
docs: CLI brand + onboarding flow (banner, headless, bundled hooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,15 +217,32 @@ curl -fsS -X POST "$CITADEL_BASE_URL/api/contribute" \
 
 ### Teammate CLI (lightweight)
 
+```
+  ▙ ▟ ▙ ▟ ▙ ▟ ▙ ▟
+  ███████████████   CITADEL
+  ██ ▟▀▙   ▟▀▙ ██   the organization vault
+  ██ █ █   █ █ ██
+  ███████████████
+```
+
 ```bash
 pipx install citadel-archive            # the `citadel` command (onboard/status/capture)
 pipx install "citadel-archive[tui]"     # + the live `citadel tui` dashboard
-citadel onboard                         # one-command setup; then `citadel status`
+
+citadel onboard                         # one-command setup: token + hooks + MCP + capture roots
+citadel status                          # connection + identity + local setup (●/○); --json for agents
 ```
 
-The base install is a small, stdlib-first client. The server stack is an extra
-(`citadel-archive[server]`). Publishing is automated — see
-[`PUBLISHING.md`](PUBLISHING.md).
+`citadel onboard` is idempotent and self-contained — it installs the git
+pre-push + Claude Code `SessionEnd` autosync hooks (bundled `kb.hooks.*`, no
+vendored skill), writes the seat token to your shell rc (masked), adds the MCP
+server, and offers Approved Capture Roots. Every teammate command is **headless**
+(`--json`) so AI coding agents (Claude / Codex / Cursor) and CI can drive it.
+
+The base install is a small, **zero-dependency**, stdlib-first client. The server
+stack is an extra (`citadel-archive[server]`); the live dashboard is
+`citadel-archive[tui]`. Publishing is automated — see
+[`PUBLISHING.md`](PUBLISHING.md). Brand: [`brand.md`](brand.md).
 
 ### Server / development
 

--- a/brand.md
+++ b/brand.md
@@ -1,15 +1,58 @@
-# Brand - Citadel
+# Brand — Citadel
 
-_Status: deferred_
+Citadel's brand currently lives in the **CLI** (`citadel-archive`). The web-UI
+color palette and typography remain deferred (see the note at the bottom); the
+terminal is the shipped brand surface.
 
-The user chose to defer brand setup. This project is currently using a restrained neutral operations palette and no custom typography. The `frontend-design-guidelines` skill will quietly use defaults and will not prompt again.
+## The mark — castle banner
 
-To set up a real brand palette, typography, and voice at any time, run:
+A compact crenellated fortress: battlements, walls, two windows. Shown on bare
+`citadel`, and as the header of `citadel status` and `citadel onboard` on a TTY.
 
-    /brand-design
+```
+  ▙ ▟ ▙ ▟ ▙ ▟ ▙ ▟
+  ███████████████   CITADEL
+  ██ ▟▀▙   ▟▀▙ ██   the organization vault
+  ██ █ █   █ █ ██
+  ███████████████
+```
 
-or say: "pick brand colors"
+- **Wordmark:** `CITADEL` (bold).
+- **Tagline:** `the organization vault` (dim).
+- Source of truth: [`kb/banner.py`](kb/banner.py).
 
-When `brand-design` runs, it will detect this deferred state, skip the "confirm overwrite" step, and proceed directly to the full brand setup. The resulting palette will be applied to the UI assets and this file will be replaced with the real brand documentation.
+## Terminal palette (ANSI)
 
-_Deferred at: 2026-05-20_
+| Element | Style |
+|---|---|
+| Castle walls | cyan (`\033[36m`) |
+| Wordmark | bold + cyan |
+| Tagline | dim |
+| Status OK `●` | green |
+| Status fail `○` | red |
+| Verdict ("Not fully connected") | yellow |
+
+Color is **TTY-aware**: applied only on a real terminal, and suppressed when
+output is piped, under `--json`, or when `NO_COLOR` / `TERM=dumb` is set — so
+headless/agent output stays clean and parseable. (`banner.supports_color`.)
+
+## Voice
+
+Terse, operational, honest. The CLI mirrors the system's guarantees in how it
+speaks:
+
+- **Personal-by-default** — capture lands in your private Node unless explicitly promoted.
+- **Fail-silent** — hooks never block your `git push` or session close.
+- **No surprises** — masked tokens, explicit exit codes, errors on stderr.
+
+Words we use: Node, Central, seat, Approved Capture Roots, Capture Root Tags,
+promotion. See [`CONTEXT.md`](CONTEXT.md) for the full domain glossary.
+
+---
+
+## Web UI palette — _deferred_
+
+The web dashboard still uses a restrained neutral operations palette and no
+custom typography. To set up a full web brand palette + typography at any time,
+run `/brand-design` (or say "pick brand colors"); it will detect this deferred
+state and proceed directly to setup. _Deferred at: 2026-05-20._

--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -32,14 +32,23 @@ it like a password.
 Install the CLI, then run onboard from the repo:
 
 ```bash
-pipx install citadel-archive     # the `citadel` command (lightweight client)
+pipx install citadel-archive     # the `citadel` command (lightweight, zero-dep client)
 citadel onboard
 ```
 
+```
+  ▙ ▟ ▙ ▟ ▙ ▟ ▙ ▟
+  ███████████████   CITADEL
+  ██ ▟▀▙   ▟▀▙ ██   the organization vault     ← citadel onboard / status
+  ██ █ █   █ █ ██
+  ███████████████
+```
+
 This runs all of the steps below for you — pastes your token into your shell rc
-(once, masked), installs the git-push + SessionEnd hooks, adds the Citadel MCP
-server, and offers to set up Approved Capture Roots. Idempotent; safe to re-run.
-`--no-mcp` for capture-only; `--non-interactive --token …` for scripts. See the
+(once, masked), installs the bundled git-push + SessionEnd hooks (`kb.hooks.*`,
+no vendoring), adds the Citadel MCP server, and offers to set up Approved
+Capture Roots. Idempotent; safe to re-run. `--no-mcp` for capture-only;
+`--non-interactive --json --token …` for agents/CI. See the
 [`citadel-onboard`](../../skills/citadel-onboard/SKILL.md) skill.
 
 The manual steps below are what `onboard` does under the hood (and the path if

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,6 +2,22 @@
 
 Last updated: 2026-06-27.
 
+## 2026-06-27 — Teammate CLI shipped to prod (PR #11 merged + deployed)
+
+- **Published-ready CLI** `citadel-archive` (command stays `citadel`): zero-dep
+  client base; `[server]` / `[tui]` extras. `citadel onboard` (one-command,
+  idempotent, self-contained bundled hooks), `citadel status` / `citadel tui`
+  (dashboard replacement), `citadel setup` / `citadel capture`.
+- **Headless** `--json` on onboard/setup/capture/status — agent- and CI-drivable
+  (token from env, never argv); clean stdout, exit codes.
+- **Brand:** castle banner + TTY-aware color (`kb/banner.py`); see `brand.md`.
+- **Adversarial audit** (35 agents): 14 findings fixed feat-by-feat — incl. a
+  HIGH TUI Rich-markup injection/crash, onboard foreign-hook backup + token
+  rotation + shell-quote safety, status corrupt-config safety.
+- **Merged PR #11 → main → Railway auto-deploy verified** (commit a53b1bb live,
+  uvicorn up, /healthz 200, authed session OK). 484 tests, ruff + twine clean.
+- Pending: PyPI publish (one-time trusted-publisher setup + `git tag v0.1.0`).
+
 ## 2026-06-27 — ADR-0007 design + security tightening
 
 - **Design session (grill-with-docs):** locked **Seat Node Write Policy** — all

--- a/skills/citadel-onboard/SKILL.md
+++ b/skills/citadel-onboard/SKILL.md
@@ -6,16 +6,17 @@ description: One-command teammate onboarding for Citadel. Use when a teammate wa
 # Citadel Onboard
 
 `citadel onboard` collapses the whole teammate rollout into **one idempotent
-command**. Install the CLI, then run it from a repo that has
-`skills/citadel-proactive-ingest/` vendored (the hooks live there).
+command**. Install the CLI and run it from your repo — the autosync hooks are
+**bundled in the package** (`kb.hooks.*`), so no vendored skill directory is needed.
 
 ```bash
 pipx install citadel-archive    # the `citadel` command (or [tui]/[server] extras)
 citadel onboard
 ```
 
-It walks these steps, merging into existing config (never clobbering) and safe
-to re-run:
+On a terminal you'll see the Citadel castle banner (cyan walls, bold wordmark);
+`--json`/piped output is always plain. It walks these steps, merging into
+existing config (never clobbering) and safe to re-run:
 
 | Step | What it does | Required? |
 |---|---|---|


### PR DESCRIPTION
Documentation-only follow-up to the merged teammate CLI (PR #11). No code changes.

- **brand.md** — documents the real CLI brand (castle banner, wordmark/tagline, TTY-aware ANSI palette, voice). The web-UI palette stays deferred (noted).
- **README** — Teammate CLI section shows the banner + `onboard → status` flow; zero-dep client + headless `--json` + brand.md link.
- **citadel-onboard skill** — fixes the stale "needs vendored skill" line (hooks are bundled in `kb.hooks.*`) + branded-banner note.
- **teammate-rollout** — banner in the fast path; bundled hooks; `--json` for agents/CI.
- **progress.md** — dated entry for the shipped + deployed CLI.