### PR TITLE
feat: bootstrap installer (offers to install Python if missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ citadel onboard                       # token + hooks + MCP + capture roots (ide
 citadel status                        # connection · identity · local setup  (--json for agents)
 ```
 
+> **No Python yet?** The bootstrap installer checks for Python 3.10+, **asks
+> before installing it** if it's missing, then sets up pipx + the CLI:
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/masumi-network/Citadel-Archive/main/install.sh | sh
+> ```
+> (`citadel` is a Python tool; pipx keeps its interpreter isolated so you don't
+> manage Python yourself. Add `-s -- -y` to skip prompts, `--dry-run` to preview.)
+
 ```
   ▙ ▟ ▙ ▟ ▙ ▟ ▙ ▟
   ███████████████   CITADEL

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Citadel bootstrap installer.
+#
+# Ensures Python 3.10+ and pipx are present — offering to install Python if it
+# isn't — then installs the `citadel` CLI from PyPI. Runs without Python (it is
+# the thing that puts Python there), so it's the entry point for a fresh machine.
+#
+#   curl -fsSL https://raw.githubusercontent.com/masumi-network/Citadel-Archive/main/install.sh | sh
+#   # skip prompts:  ... | sh -s -- -y
+#   # preview only:   ... | sh -s -- --dry-run
+
+set -eu
+
+PKG="citadel-archive"
+ASSUME_YES=0
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -n|--dry-run) DRY_RUN=1 ;;
+    -h|--help) printf 'Usage: install.sh [-y|--yes] [-n|--dry-run]\n'; exit 0 ;;
+    *) printf 'unknown option: %s\n' "$arg" >&2; exit 2 ;;
+  esac
+done
+
+say()  { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+have() { command -v "$1" >/dev/null 2>&1; }
+# Only ever called with our own literal command strings (no external input).
+run()  { if [ "$DRY_RUN" = 1 ]; then say "  [dry-run] $*"; else eval "$*"; fi; }
+
+# Prompt y/n on the real terminal even when this script is piped via `curl | sh`
+# (where stdin is the script, not the user). No tty -> default to "no".
+ask() {
+  [ "$ASSUME_YES" = 1 ] && return 0
+  # Try to open the controlling terminal; if it can't be opened (CI, no tty),
+  # decline silently rather than auto-installing.
+  if { printf '%s [y/N] ' "$1" > /dev/tty; } 2>/dev/null; then
+    IFS= read -r ans < /dev/tty 2>/dev/null || ans=""
+    case "$ans" in [Yy]|[Yy][Ee][Ss]) return 0 ;; esac
+  fi
+  return 1
+}
+
+PYTHON=""
+detect_python() {
+  for py in python3 python; do
+    if have "$py" && "$py" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 10) else 1)' 2>/dev/null; then
+      PYTHON="$py"
+      return 0
+    fi
+  done
+  return 1
+}
+
+install_python() {
+  os="$(uname -s)"
+  case "$os" in
+    Darwin)
+      if have brew; then run "brew install python@3.12"
+      else warn "Homebrew not found. Install it from https://brew.sh (or Python 3.10+ from https://python.org), then re-run."; return 1; fi ;;
+    Linux)
+      if have apt-get; then run "sudo apt-get update" && run "sudo apt-get install -y python3 python3-pip python3-venv"
+      elif have dnf; then run "sudo dnf install -y python3 python3-pip"
+      elif have pacman; then run "sudo pacman -S --noconfirm python python-pip"
+      else warn "No supported package manager (apt/dnf/pacman). Install Python 3.10+ manually."; return 1; fi ;;
+    *)
+      warn "Unsupported OS '$os'. Install Python 3.10+ from https://python.org, then re-run."; return 1 ;;
+  esac
+}
+
+say "Citadel installer"
+
+if ! detect_python; then
+  say "Python 3.10+ is required but was not found on this system."
+  if ask "Install Python now?"; then
+    install_python || { warn "Could not install Python automatically — see the message above."; exit 1; }
+    if [ "$DRY_RUN" != 1 ] && ! detect_python; then
+      warn "Python still not found after install. Open a new shell and re-run this installer."
+      exit 1
+    fi
+  else
+    say "Okay — install Python 3.10+ yourself, then re-run this installer."
+    exit 1
+  fi
+fi
+if [ -n "$PYTHON" ]; then say "Using $("$PYTHON" --version 2>&1)"; else say "Using the freshly installed Python"; fi
+
+if have pipx; then
+  PIPX="pipx"
+else
+  say "Installing pipx…"
+  run "${PYTHON:-python3} -m pip install --user pipx"
+  run "${PYTHON:-python3} -m pipx ensurepath"
+  PIPX="${PYTHON:-python3} -m pipx"
+fi
+
+say "Installing ${PKG}…"
+run "$PIPX install $PKG"
+
+say ""
+say "Done. Next:"
+say "  citadel onboard     # set up this repo (token + hooks + MCP + capture roots)"
+say "  citadel status      # check the connection"
+say ""
+say "If 'citadel' isn't found, open a new shell so your PATH picks it up."


### PR DESCRIPTION
Adds `install.sh` — the `curl … | sh` entry point for a fresh machine that may not have Python.

`pipx install citadel-archive` can't run without Python, so the "install Python? y/N" prompt has to live in a shell script that runs *before* Python exists. This is that script.

- Detects Python 3.10+; if missing, **prompts before installing** it via brew/apt/dnf/pacman (reads `/dev/tty` so the prompt works under `curl | sh`; declines safely with no tty).
- Ensures pipx → `pipx install citadel-archive`.
- `-y` skip prompts · `--dry-run` preview · `--help`.

```bash
curl -fsSL https://raw.githubusercontent.com/masumi-network/Citadel-Archive/main/install.sh | sh
```

Syntax-clean (sh + dash); verified dry-run / decline-without-tty / `-y`. README updated.