### PR TITLE
feat: branded home screen for bare `citadel` (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] — 2026-06-27
+
+### Added
+
+- **Branded home screen** — bare `citadel` now shows the large castle hero
+  (figlet `CITADEL`) plus a curated, colorized command menu, replacing the raw
+  argparse usage dump.
+- **`install.sh` bootstrap** — `curl … | sh` entry point that detects Python
+  3.10+, **asks before installing it** if missing (brew/apt/dnf/pacman), then
+  installs pipx + the CLI.
+
 ## [0.1.0] — 2026-06-27
 
 First published release. Ships the lightweight teammate CLI alongside the
@@ -46,4 +57,5 @@ self-hosted Organization Vault server.
   references it as `${CITADEL_MCP_ACCESS_TOKEN}` and it is never echoed.
 - The pre-push allowlist fails **closed** on a corrupt config.
 
+[0.1.1]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.1
 [0.1.0]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.0

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -25,6 +25,22 @@ _LABELS: dict[int, tuple[str, tuple[str, ...]]] = {
     2: ("the organization vault", ("dim",)),
 }
 
+# Large hero — a figlet "CITADEL" framed in a crenellated fortress. Used on the
+# bare `citadel` home screen; the compact `banner()` is the in-command header.
+_HERO = r"""
+     ▛▜   ▛▜   ▛▜   ▛▜   ▛▜   ▛▜   ▛▜
+    ▕══════════════════════════════════▏
+    ▕   ____  _ _____ _   ___  ___ _    ▏
+    ▕  / ___|| |_   _/ \ |   \| __| |   ▏
+    ▕ | |__  | | | |/ _ \| |) | _|| |__ ▏
+    ▕  \___| |_| |_/_/ \_\___/|___|____|▏
+    ▕══════════════════════════════════▏
+    ▕    ▟▀▙       ▟▀▙       ▟▀▙        ▏
+    ▕▄▄▄▄█ █▄▄▄▄▄▄▄█ █▄▄▄▄▄▄▄█ █▄▄▄▄▄▄▄▄▏
+"""
+_HERO_LINES = tuple(_HERO.strip("\n").splitlines())
+_HERO_WORDMARK_ROWS = frozenset({2, 3, 4, 5})  # the figlet letter rows
+
 _ANSI = {
     "reset": "\033[0m",
     "bold": "\033[1m",
@@ -55,6 +71,15 @@ def paint(text: str, *styles: str, enable: bool = True) -> str:
         return text
     codes = "".join(_ANSI.get(style, "") for style in styles)
     return f"{codes}{text}{_ANSI['reset']}" if codes else text
+
+
+def banner_large(*, color: bool = True) -> str:
+    """The big hero: a figlet CITADEL in a castle frame (cyan walls, bold letters)."""
+    out: list[str] = []
+    for index, line in enumerate(_HERO_LINES):
+        styles = ("bold", "cyan") if index in _HERO_WORDMARK_ROWS else ("cyan",)
+        out.append(paint(line, *styles, enable=color))
+    return "\n".join(out)
 
 
 def banner(*, color: bool = True) -> str:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -37,7 +37,7 @@ from kb.onboard import (
     merge_claude_settings,
     merge_mcp_config,
 )
-from kb.banner import banner, supports_color
+from kb.banner import banner, banner_large, paint, supports_color
 from kb.status import gather_status, render_text
 
 
@@ -438,6 +438,38 @@ async def _onboard(args: argparse.Namespace) -> int:
     return 0
 
 
+_HOME_MENU = (
+    ("Get started", (
+        ("onboard", "one-command setup — token · hooks · MCP · capture roots"),
+        ("status", "connection · identity · local setup    (--json for agents)"),
+    )),
+    ("Capture", (
+        ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
+        ("capture", "push summaries of approved roots to your Node"),
+        ("tui", "live terminal dashboard"),
+    )),
+    ("Knowledge", (
+        ("search", "search the Organization Vault"),
+        ("ingest", "add a durable note to your Node"),
+    )),
+)
+
+
+def _print_home() -> None:
+    color = supports_color()
+    print(banner_large(color=color))
+    print()
+    print("  " + paint("the organization vault", "dim", enable=color))
+    print()
+    for title, rows in _HOME_MENU:
+        print("  " + paint(title, "bold", enable=color))
+        for name, desc in rows:
+            label = paint(name.ljust(9), "cyan", enable=color)
+            print(f"    {label} {paint(desc, 'dim', enable=color)}")
+        print()
+    print("  " + paint("Run `citadel <command> --help` for details.", "dim", enable=color))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="citadel")
     # Not required: bare `citadel` shows the banner + command list instead of an error.
@@ -605,10 +637,8 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
     if not getattr(args, "command", None):
-        # Bare `citadel` → branded banner + the command list.
-        print(banner(color=supports_color()))
-        print()
-        parser.print_help()
+        # Bare `citadel` → branded home screen (hero + curated command menu).
+        _print_home()
         raise SystemExit(0)
     # Handlers may return an int exit code (capture/setup); others return None.
     raise SystemExit(asyncio.run(args.handler(args)) or 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citadel-archive"
-version = "0.1.0"
+version = "0.1.1"
 description = "Citadel — a self-hosted Organization Vault and seat-capture CLI built on Cognee."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 import io
 
-from kb.banner import banner, paint, supports_color
+from kb.banner import banner, banner_large, paint, supports_color
+
+
+def test_banner_large_has_castle_and_figlet() -> None:
+    plain = banner_large(color=False)
+    assert "▛▜" in plain          # crenellations
+    assert "▕══" in plain         # castle frame
+    assert "____" in plain        # figlet CITADEL
+    assert "\033[" not in plain
+    colored = banner_large(color=True)
+    assert "\033[1m" in colored and "\033[36m" in colored  # bold figlet + cyan walls
 
 
 def test_banner_plain_has_wordmark_and_no_ansi() -> None:

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -35,14 +35,16 @@ def test_setup_json_emits_pure_config(tmp_path: Path, capsys) -> None:
     assert out["roots"][0]["tags"] == ["org-work"]
 
 
-def test_bare_citadel_shows_banner(monkeypatch, capsys) -> None:
+def test_bare_citadel_shows_home_screen(monkeypatch, capsys) -> None:
     monkeypatch.setattr(sys, "argv", ["citadel"])
     with pytest.raises(SystemExit) as exc:
         kb.cli.main()
     assert exc.value.code == 0
     out = capsys.readouterr().out
-    assert "CITADEL" in out
-    assert "status" in out  # command list
+    assert "the organization vault" in out         # hero tagline
+    assert "▛▜" in out                              # castle hero art
+    assert "onboard" in out and "status" in out     # curated command menu
+    assert "Get started" in out                     # grouped menu
 
 
 def test_setup_json_never_prompts_even_on_tty(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
Make bare `citadel` a proper branded home screen instead of the raw argparse usage dump.

- **Large castle hero** (figlet `CITADEL` framed in a fortress) via `banner_large()` — cyan walls, bold letters, TTY-aware (plain under `--json`/pipe).
- **Curated command menu** — grouped (Get started / Capture / Knowledge), colorized, with one-line descriptions. No more `{status,tui,...}` dump.
- Bumps to **0.1.1** + CHANGELOG (also records the `install.sh` bootstrap from #14).

485 tests, ruff clean.