### PR TITLE
feat(cli): friendly unknown-command error with suggestions (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.2] — 2026-06-27
+
+### Changed
+
+- **Friendly unknown-command error** — a mistyped command (e.g. `citadel stauts`)
+  now shows `✗ unknown command` + a fuzzy "did you mean? `citadel status`"
+  suggestion, instead of the raw argparse usage dump.
+
 ## [0.1.1] — 2026-06-27
 
 ### Added
@@ -57,5 +65,6 @@ self-hosted Organization Vault server.
   references it as `${CITADEL_MCP_ACCESS_TOKEN}` and it is never echoed.
 - The pre-push allowlist fails **closed** on a corrupt config.
 
+[0.1.2]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.2
 [0.1.1]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.1
 [0.1.0]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.0

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import difflib
 import functools
 import json
 import os
+import re
 import sys
 import urllib.error
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 # Lightweight client modules only — the heavy server stack (kb.service,
 # kb.github_sync, …) is imported lazily inside the server handlers so the base
@@ -470,8 +472,37 @@ def _print_home() -> None:
     print("  " + paint("Run `citadel <command> --help` for details.", "dim", enable=color))
 
 
+class CitadelParser(argparse.ArgumentParser):
+    """argparse parser with a friendly, suggestion-aware unknown-command error."""
+
+    def error(self, message: str) -> NoReturn:
+        if "invalid choice:" in message and "argument command" in message:
+            color = supports_color(sys.stderr)
+            bad_match = re.search(r"invalid choice: '([^']*)'", message)
+            bad = bad_match.group(1) if bad_match else ""
+            choices_match = re.search(r"\(choose from (.+)\)\s*$", message)
+            choices = (
+                [c.strip().strip("'\"") for c in choices_match.group(1).split(",")]
+                if choices_match
+                else []
+            )
+            lines = [paint(f"✗ unknown command: {bad!r}", "red", enable=color), ""]
+            matches = difflib.get_close_matches(bad, choices, n=3, cutoff=0.5)
+            if matches:
+                lines.append("  did you mean?")
+                lines += [
+                    "    " + paint(f"citadel {name}", "bold", "cyan", enable=color)
+                    for name in matches
+                ]
+                lines.append("")
+            lines.append("  run " + paint("citadel", "cyan", enable=color) + " to see all commands.")
+            sys.stderr.write("\n".join(lines) + "\n")
+            raise SystemExit(2)
+        super().error(message)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="citadel")
+    parser = CitadelParser(prog="citadel")
     # Not required: bare `citadel` shows the banner + command list instead of an error.
     subcommands = parser.add_subparsers(dest="command")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citadel-archive"
-version = "0.1.1"
+version = "0.1.2"
 description = "Citadel — a self-hosted Organization Vault and seat-capture CLI built on Cognee."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -47,6 +47,23 @@ def test_bare_citadel_shows_home_screen(monkeypatch, capsys) -> None:
     assert "Get started" in out                     # grouped menu
 
 
+def test_unknown_command_suggests_closest(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(["stauts"])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "unknown command" in err
+    assert "citadel status" in err  # fuzzy suggestion
+
+
+def test_unknown_command_no_match_is_clean(capsys) -> None:
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["zzzzz"])
+    err = capsys.readouterr().err
+    assert "unknown command" in err
+    assert "see all commands" in err
+
+
 def test_setup_json_never_prompts_even_on_tty(tmp_path: Path, monkeypatch, capsys) -> None:
     # --json implies non-interactive: must not call input() even with a TTY.
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)


### PR DESCRIPTION
Mistyped commands now get `✗ unknown command` + a fuzzy 'did you mean? `citadel status`' suggestion instead of the raw argparse dump. Falls back cleanly when nothing's close. 487 tests, ruff clean.