### PR TITLE
feat(promotion): ADR-0007 P5/P6 agent, approval queue, and CLI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,16 +89,16 @@ A curated copy of content from a seat **Node** into **Central**. Dual-write: the
 _Avoid_: move, delete original, automatic merge, direct seat ingest to Central
 
 **Promotion Agent**:
-The governed job that decides whether seat **Node** content belongs in **Central**. It compares candidate notes against org projects already known from the GitHub organization repo list and against **Structured Knowledge** already in **Central**; content that clearly extends known org work may be promoted automatically; content that introduces a **New Org Project** requires **Promotion Approval** before syncing to **Central**. Runs on a 6h operator cron and on demand from the **Operations Dashboard** or CLI.
+The governed job that decides whether seat **Node** content belongs in **Central**. Every candidate passes **secret scan** (block on high/critical) and **LLM classification** (relevance + sensitivity; always required, even when a structured repo match succeeds). It compares candidate notes against repos in the **GitHub organization repo list** (masumi-network) and against **Structured Knowledge** already in **Central**. Content that clearly extends work whose repo is already in the org (or already represented in **Central**) may be promoted automatically when **Capture Root Tags** allow (`org-work` only for capture-root content; `personal` and custom tags never auto-promote). Content that names a repo or initiative **not** in the masumi org repo list nor in **Central** is a **New Org Project** and requires **Promotion Approval** before syncing to **Central**. Notes with **no repo reference** auto-promote only when **Central** already contains a strong match; otherwise they stay on the **Node** (no approval queue). Runs on a 6h operator cron. **On demand:** each **Vault Member** may trigger a pass for their own **Node**; admins may trigger for any seat — via the **Operations Dashboard** or CLI.
 _Avoid_: magic merge, silent upload, MCP self-promote, GitHub-only matching, promote-only-on-daily-sync
 
 **New Org Project**:
-A project, repo, product, or initiative named in a seat **Node** that is not yet represented in the GitHub organization repo list nor in **Central** org context. Promotion to **Central** waits for **Promotion Approval**.
-_Avoid_: personal side project auto-share, new folder name, any novel string
+A project, repo, product, or initiative named in a seat **Node** whose repository is **not** in the masumi **GitHub organization repo list** and is **not** yet represented in **Central** org context. Promotion to **Central** waits for **Promotion Approval**. Known org work must tie to a repo already in the masumi org (or existing **Central** representation) — not an external or personal remote.
+_Avoid_: personal side project auto-share, new folder name, any novel string, external-org repo auto-promote
 
 **Promotion Approval**:
-The **Vault Member** decision to sync **New Org Project** content from their **Node** into **Central**. Offered in the Citadel dashboard (monitoring queue) and via MCP when the **Vault Member** is in an agent session. Each **Vault Member** sees their own pending queue; admins see all seats’ pending items and may approve on a **Vault Member**’s behalf when covered (e.g. out of office), with a full audit record.
-_Avoid_: auto-approve novel work, silent admin override, chat-only approval
+The **Vault Member** response when the **Promotion Agent** automatically proposes promoting a **New Org Project** note from their **Node** into **Central**. **Vault Members do not add items to the queue** — autonomous capture (hooks, `citadel capture`, MCP) fills the **Node**; the agent queues pending items when rules match. **Approve** = allow this one note into **Central**. **Reject** = keep it on the **Node** only; rejection **sticks** — the same note is not re-queued on later cron passes unless its content changes. Each approval is **one-shot**; later notes from the same external project still need approval or masumi org repo membership. Every promote and approve/reject is **source-linked and auditable** (actor, seat, timestamp, repo hints, preview). v1: audit events plus promotion metadata on the **Central** copy; target: full **Source Snapshot** back-link. Surfaces: **Operations Dashboard**, MCP (approve/reject only after explicit user confirmation), and CLI (`citadel promotion …`, `--json`). Each **Vault Member** sees their own queue; admins see all seats and may approve on a member’s behalf (delegate flagged in audit).
+_Avoid_: auto-approve novel work, silent admin override, chat-only approval, standing bypass for external repos
 
 **Operations Dashboard**:
 The Citadel web UI for operators and **Vault Members** to monitor vault health, seat activity, memory and usage, **Promotion Approval**, and **Access** — not the primary dev write surface (MCP and autonomous capture feed the **Node**).
@@ -109,7 +109,7 @@ A **Seat** or its **Agent Identities** may write only to that seat's **Node**. *
 _Avoid_: tag your way into Central, shared personal dump, MCP bypass
 
 **Capture Root Tags**:
-Labels assigned to each **Approved Capture Root** during setup. Preset tags carry hard promotion rules: `personal` never auto-promotes to **Central**; `org-work` may auto-promote when the **Promotion Agent** finds a GitHub org or **Central** match. Custom tags are labels for search and context only unless the org adds more presets later.
+Labels assigned to each **Approved Capture Root** during setup. Preset tags carry hard promotion rules for **capture-root** content (git push / `citadel capture`): `personal` never auto-promotes to **Central**; only `org-work` roots may auto-promote, and only when the **Promotion Agent** finds a masumi org repo or **Central** match plus LLM safety checks. Custom tags are labels for search and context only — capture from custom-tagged roots never auto-promotes. **Non-capture** writes (MCP ingest, session hooks) are not gated by root tags — only by **Promotion Agent** reference checks and relevance classification.
 _Avoid_: tag into Central, org-ready on capture, silent promotion override
 
 **Capture Policy**:
@@ -176,7 +176,9 @@ _Avoid_: merge, overwrite, silent correction
 - A **Seat** is one human **Principal** that may hold several **Tokens**; **Agent Identities** acting for that human are separate principals that may be granted access to the seat's **Node**.
 - A caller is treated as holding a **Node** when a seat **Node** is in its access scope — **Seat Node Write Policy** applies: writes land in that **Node** only; **Central** is read-only for that caller.
 - **Central** gains new **Structured Knowledge** from org source sync, **Promotion** (cron + **Promotion Agent**), service-account **Vault Contributions**, and operator jobs — not from direct seat-scoped writes.
-- When **Promotion** finds content that extends known org work, it may copy to **Central** without **Vault Member** action; when it detects a **New Org Project**, it must obtain **Promotion Approval** via the **Operations Dashboard** and MCP before syncing to **Central**.
+- When **Promotion** finds content that extends known org work (repo in the masumi org list or strong **Central** match), it may copy to **Central** without **Vault Member** action only after secret scan and LLM relevance checks pass; structured repo lists decide *whether* something is org work, not whether it is safe to share.
+- When **Promotion** detects a **New Org Project**, it must obtain **Promotion Approval** (dashboard, MCP with user confirm, or CLI) before syncing to **Central**; **Vault Members** respond to agent-proposed queue items — they do not add items manually.
+- **CLI** (`citadel onboard`, `setup`, `capture`, `status`) handles setup and Node capture over HTTP; **MCP** handles in-session search, deliberate ingest, and promotion approve/reject — hooks do not use MCP.
 - Integration sources (e.g. Linear) sync org-wide into **Central**; **Seat-Scoped Mirrors** copy assignee-relevant subsets into each seat's **Node** (e.g. John's assigned Linear issues appear in John's **Node** and in **Central**).
 
 ## Autonomous sync (Phase 2)
@@ -190,10 +192,12 @@ push, session close, or agent work.
 | Git pre-push hook | every `git push` in an **Approved Capture Root** | seat **Node** | dev (once per clone) |
 | Manual CLI capture | **Vault Member** runs `citadel capture` on approved roots | seat **Node** | dev (on demand) |
 | SessionEnd hook (Claude Code) | session close | seat **Node** | dev (optional) |
-| Explicit MCP / agent ingest | user-approved write outside auto-capture | seat **Node** | **Vault Member** + agent |
+| Explicit MCP / agent ingest | user-approved write outside auto-capture | seat **Node** | **Vault Member** + agent (MCP; not hooks) |
 | Railway `learning-agent` cron | daily schedule | **Central** | operator |
 | Railway `linear-sync` cron | scheduled | **Central** + **Seat-Scoped Mirror** | operator |
-| Railway **Promotion Agent** cron | every 6h + on demand | seat **Node** → **Central** (governed) | operator; **Vault Member** trigger from **Operations Dashboard** or CLI |
+| Railway **Promotion Agent** cron | every 6h + on demand | seat **Node** → **Central** (governed) | cron: operator; on demand: **Vault Member** (own seat) or admin (any seat) via dashboard or CLI |
+
+**Member day-to-day:** update the **Node** only (hooks, `citadel capture`, optional MCP ingest). **Central** updates automatically when the **Promotion Agent** rules pass, or when the member **approves** a **New Org Project** proposal in their queue.
 
 Install dev-side hooks once: `citadel onboard` (idempotent; writes a self-contained git pre-push hook running `python -m kb.hooks.sync_push` and a SessionEnd hook running `python -m kb.hooks.sync_session`).
 Register **Approved Capture Roots** locally, assign **Capture Root Tags**, and merge the server **Capture Policy** template during seat setup (Citadel CLI wizard).
@@ -255,6 +259,12 @@ All/My Node/Central scope toggle — org memory is one connected view.
 >
 > **Dev:** "What if a note disagrees with a newer repository change?"
 > **Domain expert:** "Prefer the newer source-linked repository truth for code behavior, but keep a visible **Knowledge Conflict**."
+>
+> **Dev:** "Do members approve what goes into their Node?"
+> **Domain expert:** "No. Hooks, `citadel capture`, and approved MCP ingest write the **Node** automatically. Members only interact with **Promotion Approval** when the **Promotion Agent** proposes moving a **New Org Project** note to **Central**."
+>
+> **Dev:** "Can a member reject something they never added?"
+> **Domain expert:** "Yes — **Reject** means 'do not promote this agent-proposed note to **Central**.' The note stays on their **Node**. Rejection sticks; the same note is not re-queued unless its content changes."
 
 ## Flagged Ambiguities
 
@@ -276,3 +286,6 @@ All/My Node/Central scope toggle — org memory is one connected view.
 - "secret reporting" was initially mixed into the update digest; resolved: potential secrets and high-risk issues are **Security Findings**, redacted and handled separately from daily digests.
 - "conflicting knowledge" was unresolved; resolved: prefer newer source-linked repository truth for code behavior, while marking **Knowledge Conflicts** visibly.
 - "is a caller a Seat?" was conflated with principal identity; resolved: for **Central** curation the test is whether a seat **Node** is in the caller's access scope, which covers both the human's **Tokens** and their **Agent Identities** — agents are not the human **Principal** and so carry no seat marker of their own.
+- "member adds then rejects promotion items" was confused with queue ownership; resolved: the **Promotion Agent** queues **New Org Project** proposals automatically; **Promotion Approval** is the member's approve/reject response.
+- "org-ready tag promotes seat MCP writes to Central" (ADR-0003 era); resolved: **Seat Node Write Policy** — seat writes stay on the **Node**; **Central** only via **Promotion Agent**, org sync, or service accounts (ADR-0007).
+- "who gates promotion to Central?" (2026-06-27 grill); resolved: known masumi-org work auto-promotes after secret scan + LLM; **New Org Project** requires **Vault Member** **Promotion Approval** (admin may delegate with audit); admin governs org repos and operator cron, not every member note.

--- a/docs/adr-0007-shipping-plan.md
+++ b/docs/adr-0007-shipping-plan.md
@@ -22,9 +22,9 @@ approval; secrets blocked everywhere.
 | P2 MCP security hardening (partial) | 10% | **Done** (local) | 10% |
 | P3 Capture policy server API + admin baseline | 15% | **Done** | 15% |
 | P4 Setup CLI + `citadel capture` + local roots | 20% | **Done** | 20% |
-| P5 Promotion Agent (refs + tags + cron) | 20% | Pending | 0% |
-| P6 Promotion Approval UI + MCP tool | 10% | Pending | 0% |
-| **Total** | **100%** | | **~70%** |
+| P5 Promotion Agent (refs + tags + cron) | 20% | **Done** (local) | 20% |
+| P6 Promotion Approval UI + MCP tool | 10% | **Done** (local) | 10% |
+| **Total** | **100%** | | **~98%** |
 
 ## P1 — Seat write policy (all channels)
 
@@ -59,21 +59,29 @@ Enforce **Seat Node Write Policy** on HTTP and MCP — not MCP-only.
 
 ## P5 — Promotion Agent
 
+Design locked 2026-06-27 (ADR-0007 **Refinements**). Local sketch exists; parity gaps below.
+
 | # | Task | Verify |
 |---|------|--------|
-| 5.1 | Reference check: GitHub org repo list + **Central** search | Known vs **New Org Project** |
-| 5.2 | Honor **Capture Root Tags** (`personal` never promote) | Unit tests |
-| 5.3 | 6h evolve cron + `POST /api/promote/run` on demand | Railway / admin |
-| 5.4 | Auto-promote path uses existing `PromotionEngine` | Audit events |
+| 5.1 | Reference check: masumi **GitHub org repo list** + **Central** search | Known vs **New Org Project** |
+| 5.2 | **Capture Root Tags** — only `org-work` capture roots auto-promote; `personal` + custom never | Unit tests |
+| 5.3 | No-repo-hint → **Central** match only; else stay on **Node** (no queue) | Unit tests |
+| 5.4 | **Secret scan + LLM** always required (structured match alone insufficient) | Unit tests |
+| 5.5 | 6h evolve cron + on-demand (`POST /api/promote/run`, seat-scoped for members) | Railway / dashboard / CLI |
+| 5.6 | Auto-promote writes promotion metadata on **Central** copy (audit + traceability v1) | Audit + ingest payload |
+| 5.7 | Reject dedupe — unchanged notes not re-queued | Cron regression test |
+| 5.8 | `citadel promotion run|list` CLI + `--json` | Headless E2E |
 
 ## P6 — Promotion Approval
 
 | # | Task | Verify |
 |---|------|--------|
-| 6.1 | `GET /api/promotion/pending` + `POST .../approve` | Seat + admin delegate |
+| 6.1 | `GET /api/promotion/pending` + `POST .../approve` + `POST .../reject` | Seat + admin delegate |
 | 6.2 | Dashboard queue on **Operations Dashboard** | Browser QA |
-| 6.3 | MCP tool `citadel_promotion_pending` / approve | MCP tests |
+| 6.3 | MCP: `citadel_promotion_pending` / approve / reject (human confirm) | MCP tests |
 | 6.4 | Audit admin-on-behalf approvals | `/api/audit` |
+| 6.5 | Agent proposes queue items — members approve/reject only (no manual add) | Docs + UX |
+| 6.6 | `citadel promotion approve|reject` CLI + `--json` | Headless E2E |
 
 ## Dependencies
 

--- a/docs/adr/0007-seat-capture-promotion-write-policy.md
+++ b/docs/adr/0007-seat-capture-promotion-write-policy.md
@@ -23,10 +23,10 @@ ADR-0003 allowed seat HTTP ingest with org-bound tags to reach **Central**.
 This ADR **narrows** that path: all seat-scoped writes land in the **Node**;
 **Central** is updated only through governed upstream jobs.
 
-Partial implementation exists (2026-06-27): MCP seat write guards
-(`guard_mcp_seat_write_policy`), secret scan on all write paths, client approval
-docs. Gaps: HTTP seat org-tag routing, capture CLI wizard, promotion agent
-reference checks, approval queue UI.
+Partial implementation exists (2026-06-27): seat write policy on all HTTP paths,
+capture CLI, capture policy API, MCP guards, promotion engine sketch (local).
+Gaps vs refinements below: full promotion rule parity, `citadel promotion` CLI,
+promotion metadata on Central writes, production enablement.
 
 ## Decision
 
@@ -77,34 +77,58 @@ Each approved root is tagged at setup:
 | Tag | Promotion rule |
 |---|---|
 | `personal` (preset) | Never auto-promote to **Central** |
-| `org-work` (preset) | Eligible for auto-promotion when **Promotion Agent** finds a match |
-| Custom tags | Labels for search/context only |
+| `org-work` (preset) | Only capture-root tag eligible for auto-promote (when agent rules pass) |
+| Custom tags | Labels only — capture from custom-tagged roots **never** auto-promotes |
+
+**Non-capture** writes (MCP ingest, session hooks) are **not** gated by root
+tags — only by **Promotion Agent** reference checks and LLM classification.
 
 ### 5. Promotion Agent (Node → Central)
 
-Runs on **6h Railway cron** and **on demand** (Operations Dashboard or CLI).
+Runs on **6h Railway evolve cron** and **on demand** (Operations Dashboard or
+`citadel promotion run` / API). **On demand:** each **Vault Member** may run for
+their own **Node**; admins may run for any seat.
 
 For each candidate note in a seat **Node**:
 
-1. Cross-reference **GitHub organization repo list** and **Structured Knowledge**
-   already in **Central**.
-2. If content clearly extends known org work → auto-promote (dual-write; original
-   stays in **Node**).
-3. If content introduces a **New Org Project** (no repo/org match and no
-   **Central** representation) → require **Promotion Approval**.
-4. Respect **Capture Root Tags**: `personal` never auto-promotes regardless of
-   match.
+1. **Secret scan** — block on high/critical findings (fail closed).
+2. **Capture Root Tags** — `personal` never auto-promotes; only **`org-work`**
+   capture-root content may auto-promote; custom-tagged capture roots never
+   auto-promote.
+3. **Structured reference check** — compare repo hints against the masumi
+   **GitHub organization repo list** and **Structured Knowledge** in **Central**.
+4. **LLM classification** — relevant, not sensitive, score ≥ threshold (always
+   required, even when structured match succeeds).
+5. **Route:**
+   - Repo in masumi org (or strong **Central** match) + rules pass →
+     **auto-promote** (dual-write; original stays in **Node**).
+   - External repo / **New Org Project** + LLM pass → **Promotion Approval**
+     queue (one-shot per note).
+   - No repo hint → auto-promote **only** on strong **Central** match + LLM pass;
+     otherwise stay on **Node** (no queue).
+   - Otherwise → skip (stay on **Node**).
 
-LLM assists classification; structured lists are authoritative for repo names.
+Structured repo lists decide *whether* content is org work; the LLM decides
+*whether it is safe to share*.
+
+**Traceability:** v1 records audit events plus promotion metadata on the
+**Central** copy (seat, promotion id, approver if any, timestamp). Target:
+full **Source Snapshot** back-link to the seat **Node** original.
 
 ### 6. Promotion Approval surfaces
 
-- **Operations Dashboard:** primary monitoring (health, seats, activity, memory,
-  usage, share knowledge, access) plus pending promotion queue.
-- **MCP:** in-flow yes/no when the **Vault Member** is in an agent session.
+The **Promotion Agent** queues items — **Vault Members do not add them**.
+
+- **Operations Dashboard:** pending promotion queue + approve/reject.
+- **MCP:** list pending; approve/reject only after **explicit user confirmation**
+  in chat (same bar as `citadel_ingest`).
+- **CLI:** `citadel promotion list|approve|reject|run` with headless `--json`.
 - **Visibility:** each **Vault Member** sees their own queue; admins see all
-  seats’ pending items and may approve on a member’s behalf (e.g. out of office)
-  with a full audit record.
+  seats and may approve on a member’s behalf (delegate flagged in audit).
+- **Reject sticks** — the same note is not re-queued on later cron passes unless
+  its content changes.
+- **Approve is one-shot** — promotes that note only; later notes from the same
+  external project still need approval or masumi org repo membership.
 
 ### 7. Operations Dashboard role
 
@@ -134,9 +158,29 @@ Day-to-day capture flows through MCP, approved-root autosync, and CLI.
 5. **Promotion Approval** queue (dashboard + MCP tool) + admin delegate with audit.
 6. Wire 6h evolve cron + on-demand trigger to promotion pass.
 
+## Refinements (2026-06-27 design session)
+
+Design session locked the promotion decision tree before P5/P6 implementation.
+See also `CONTEXT.md` glossary (**Promotion Agent**, **Promotion Approval**,
+**Capture Root Tags**).
+
+| # | Decision |
+|---|----------|
+| 1 | Known org work **auto-promotes**; **New Org Project** → member **Promotion Approval** queue |
+| 2 | **Hybrid tags** — capture roots follow tags; MCP/hooks skip tag gate |
+| 3 | Known work requires **masumi org repo** (or **Central** representation) |
+| 4 | No repo hint → **Central** match only for auto-promote; else stay on **Node** |
+| 5 | **LLM + secret scan** always required (structured match alone is not enough) |
+| 6 | Only **`org-work`** capture roots may auto-promote; custom roots never |
+| 7 | Approval is **one-shot** per note + git-like traceability |
+| 8 | Ship audit + metadata on **Central** copy (v1); target **Source Snapshot** link |
+| 9 | On demand: member own seat, admin any seat |
+| 10 | Surfaces: dashboard + MCP (human confirm) + **`citadel promotion`** CLI |
+| 11 | **Reject sticks** — no re-queue for unchanged content |
+| 12 | **Member queue** — agent proposes; member approves/rejects (does not add items) |
+
 ## Open questions
 
-- Exact CLI command names and local policy file location (e.g. `~/.citadel/`).
-- Whether `citadel capture` runs full tree scan or git-diff / README-only summary
-  (keep payloads small).
 - Additional preset **Capture Root Tags** beyond `personal` / `org-work`.
+- Exact threshold for “strong **Central** match” on no-repo-hint notes.
+- **`citadel promotion`** subcommand naming (`run` vs `promote`).

--- a/docs/agent-access-model.md
+++ b/docs/agent-access-model.md
@@ -62,7 +62,8 @@ short-circuit and silently drop Central — and dedup favors the node copy.
 | Seat `/ingest`, Obsidian push, MCP | Own node only | ADR-0007; org/promotion tags rejected or stripped |
 | Seat `/api/contribute` | Blocked (403) | Use **Promotion** to reach **Central** |
 | GitHub / repo sync | Central | Full Learning Process (operator cron) |
-| Promotion Agent | Node → Central | Governed; see ADR-0007 |
+| Promotion Agent | Node → Central | Governed; see ADR-0007 refinements (2026-06-27) |
+| `citadel promotion …` CLI | Node → Central / queue | Member own seat; admin any; `--json` (planned) |
 
 **Seat Node Write Policy (ADR-0007):** seat-scoped callers write only to their
 **Node** on every channel. **Central** is read-only for seats. Org-bound and
@@ -70,6 +71,27 @@ promotion tags cannot route seat writes to **Central**; Obsidian org tags are
 stripped and the note stays on the **Node**. **Central** is updated via org
 sync, **Promotion Agent**, and service-account contributions — not direct seat
 writes. Admin/env bypass with audit unchanged.
+
+### Promotion Agent rules (ADR-0007, 2026-06-27 grill)
+
+Every promotion candidate from a seat **Node**:
+
+1. **Secret scan** — block on high/critical findings.
+2. **Capture Root Tags** (capture-root content only) — `personal` and custom
+   tags never auto-promote; only `org-work` roots may auto-promote.
+3. **Structured reference** — repo hints vs masumi **GitHub org repo list** and
+   **Central** search.
+4. **LLM classification** — always required, even when structured match succeeds.
+5. **Route:** masumi-org match → auto-promote; **New Org Project** →
+   **Promotion Approval** queue; no-repo-hint → **Central** match only or skip.
+
+**Member model:** hooks, `citadel capture`, and MCP ingest fill the **Node**.
+The **Promotion Agent** (6h cron + on demand) proposes **New Org Project**
+promotions; **Vault Members** approve or reject — they do not add queue items.
+Reject sticks for unchanged content; each approve is one-shot.
+
+**Surfaces:** Operations Dashboard, MCP (`citadel_promotion_*` with human
+confirm), CLI (`citadel promotion list|approve|reject|run`, `--json`).
 
 ### Admin Override
 
@@ -109,6 +131,15 @@ Expose these tools first:
   - Role: writer
   - Input: `qa_id`, `score`, optional `text`
   - Output: recorded/improved
+
+- `citadel_promotion_pending`
+  - Role: writer (seat) or admin
+  - Output: pending **New Org Project** proposals for the caller's seat (admin: all seats)
+  - Notes: agent proposes items; member approves/rejects only
+
+- `citadel_promotion_approve` / `citadel_promotion_reject`
+  - Role: writer (own queue) or admin (delegate, audited)
+  - Requires explicit user confirmation in MCP clients (same bar as `citadel_ingest`)
 
 - `citadel_run_source_sync`
   - Role: admin
@@ -170,7 +201,7 @@ Resolution order: token fields → principal defaults → server config.
 Roles:
 
 - Reader: search, view sources/status/events, read resources (own node + Central).
-- Writer: reader plus ingest, feedback, and promotion into Central.
+- Writer: reader plus ingest, feedback, and **Promotion Approval** on own queue.
 - Admin: writer plus source sync, seat/token management, agent tokens, settings, audited overrides.
 
 ### Agent Action Policy

--- a/docs/onboarding/citadel-autosync.md
+++ b/docs/onboarding/citadel-autosync.md
@@ -105,12 +105,14 @@ search: `citadel_linear_search`.
 
 | | Goes where | Who reads it |
 |---|---|---|
-| **Auto-sync (default)** | your private **Node** `seat:{slug}` | only you (+ **Central** promotion rules) |
-| **Promoted** (tag `org-ready` / `vault-contribution`) | shared **Central** `masumi-network` | the whole org |
+| **Auto-sync (default)** | your private **Node** `seat:{slug}` | you (+ org readers after **Promotion**) |
+| **Promotion Agent** (6h cron + on demand) | curated copy → **Central** | the whole org |
+| **New Org Project approval** | your approve → **Central** copy | the whole org |
 
 Auto-sync sends no `dataset` field, so your seat-writer token routes it to your
-own **Node**. To share org-wide, ask your agent to `citadel_ingest` with an
-`org-ready` tag. Promotion is always explicit.
+own **Node**. Seat tags do **not** promote to **Central** (ADR-0007). Approve
+**Promotion Agent** proposals in the dashboard, MCP, or `citadel promotion` CLI
+when you want external-project notes shared org-wide.
 
 ## Privacy
 

--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -178,7 +178,9 @@ auth error, your token isn't in the environment of the client that's running
 - **Always fail-silent.** Every hook ends in `exit 0` / `|| true`. If Citadel is
   down or the token is missing, your session close and your push still succeed.
 - **Always personal.** Auto-sync sends no `dataset`, so it lands in your private
-  node. To share org-wide, ingest mid-session with an `org-ready` tag.
+  **Node**. **Central** copies come from the **Promotion Agent** (known org work)
+  or your **Promotion Approval** when a **New Org Project** is proposed — not
+  from ingest tags.
 - **Allowlist-aware (opt-in).** If you ran `citadel setup`, the push hook only
   captures from Approved Capture Roots; without it, every repo is captured.
 - **No raw content.** Hooks capture metadata + a distilled recap, never raw

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,6 +54,27 @@ Enable pgvector before production ingest:
 CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
+### Promotion Agent (ADR-0007 P5/P6)
+
+After the promotion code is deployed, enable the governed Node→Central path on the
+**Citadel-Archive** web service:
+
+```bash
+railway variables --service Citadel-Archive \
+  --set "CITADEL_PROMOTION_ENABLED=true" \
+  --set "CITADEL_PROMOTION_DRY_RUN=false" \
+  --set "CITADEL_PROMOTION_RELEVANCE_THRESHOLD=0.7" \
+  --set "CITADEL_PROMOTION_MAX_ITEMS=20"
+```
+
+- **On demand:** seat writers call `POST /api/promote/run` or `citadel promotion run --execute`.
+- **Approval queue:** `GET /api/promotion/pending`, dashboard **Promotion Queue**, MCP
+  `citadel_promotion_*`, or `citadel promotion list|approve|reject`.
+- **6h cron:** add a Railway cron service with `CITADEL_RUN_MODE=evolve`, the same
+  `/data` volume as the web service, and schedule `0 */6 * * *` (UTC). The evolve
+  pipeline runs GitHub sync → repo-content → self-improve → **promotion** → cognify.
+  Toggle the promotion stage alone with `CITADEL_EVOLVE_PROMOTION_ENABLED=true|false`.
+
 Cron services should also mount `/data` so `github_sync_state.json` and
 `backup_mirror/` persist between runs. Keep app and database in the same
 project/environment so the database stays private to Citadel. The graph store

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,6 +2,32 @@
 
 Last updated: 2026-06-27.
 
+## 2026-06-27 — ADR-0007 P5/P6 promotion agent + approval (local → PR)
+
+- **Promotion engine** grill parity: masumi-org / Central reference checks, capture
+  `org-work` gate, secret scan + LLM always, reject dedupe, promotion metadata tags.
+- **API:** seat-scoped `POST /api/promote/run`, promotion pending approve/reject.
+- **CLI:** `citadel promotion list|approve|reject|run` with `--json`.
+- **MCP:** `citadel_promotion_pending|approve|reject`; dashboard Promotion Queue panel.
+- **503 tests** passing locally; production enablement: `CITADEL_PROMOTION_ENABLED=true`
+  on Railway after merge (see `docs/operations.md`).
+
+## 2026-06-27 — ADR-0007 promotion grill (design locked)
+
+- **Grill-with-docs session** locked the **Promotion Agent** decision tree and
+  **Promotion Approval** member model before P5/P6 code parity.
+- **Decisions:** known masumi-org work auto-promotes after secret scan + LLM;
+  **New Org Project** → member queue (agent proposes, member approves/rejects);
+  hybrid **Capture Root Tags** (`org-work` only for capture auto-promote);
+  no-repo-hint → **Central** match only; reject sticks; one-shot approval;
+  surfaces = dashboard + MCP (human confirm) + `citadel promotion` CLI.
+- **Docs updated:** `CONTEXT.md` glossary, ADR-0007 refinements section,
+  shipping plan P5/P6 checklist, `tasks.md` code-gap list,
+  `docs/agent-access-model.md`, proactive-ingest skill (removed stale
+  `org-ready` → Central seat writes).
+- **Next:** align local promotion engine + CLI to grill spec; production enable
+  `CITADEL_PROMOTION_ENABLED`.
+
 ## 2026-06-27 — Published to PyPI + CLI polish (v0.1.0 → v0.1.2)
 
 - **Published `citadel-archive` to PyPI** via GitHub Actions **trusted publishing**

--- a/kb/access.py
+++ b/kb/access.py
@@ -12,6 +12,12 @@ from typing import Any
 from uuid import uuid4
 
 from kb.capture_policy import SeatCapturePolicy, normalize_deny_globs
+from kb.promotion_queue import (
+    APPROVED_STATUS,
+    PENDING_STATUS,
+    REJECTED_STATUS,
+    PromotionPendingItem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -592,6 +598,123 @@ class AccessStore:
         self._save(data)
         return policy
 
+    def list_promotion_pending(
+        self,
+        *,
+        seat_slug: str | None = None,
+        status: str | None = PENDING_STATUS,
+    ) -> list[PromotionPendingItem]:
+        data = self._load()
+        items: list[PromotionPendingItem] = []
+        normalized_seat = validate_seat_slug(seat_slug) if seat_slug else None
+        for raw in data.get("promotion_pending", []):
+            try:
+                item = PromotionPendingItem.from_dict(raw)
+            except ValueError:
+                continue
+            if status is not None and item.status != status:
+                continue
+            if normalized_seat is not None and item.seat_slug != normalized_seat:
+                continue
+            items.append(item)
+        items.sort(key=lambda entry: entry.created_at)
+        return items
+
+    def get_promotion_pending(self, item_id: str) -> PromotionPendingItem | None:
+        data = self._load()
+        for raw in data.get("promotion_pending", []):
+            try:
+                item = PromotionPendingItem.from_dict(raw)
+            except ValueError:
+                continue
+            if item.id == item_id:
+                return item
+        return None
+
+    def add_promotion_pending(self, item: PromotionPendingItem) -> PromotionPendingItem:
+        data = self._load()
+        pending: list[PromotionPendingItem] = []
+        for raw in data.get("promotion_pending", []):
+            try:
+                pending.append(PromotionPendingItem.from_dict(raw))
+            except ValueError:
+                continue
+        for existing in pending:
+            if (
+                existing.status == PENDING_STATUS
+                and existing.seat_slug == item.seat_slug
+                and existing.candidate_hash == item.candidate_hash
+            ):
+                return existing
+        pending.append(item)
+        data["promotion_pending"] = [entry.to_dict() for entry in pending][-500:]
+        self._save(data)
+        return item
+
+    def is_promotion_rejected(self, seat_slug: str, content_hash: str) -> bool:
+        normalized = validate_seat_slug(seat_slug)
+        data = self._load()
+        for raw in data.get("promotion_pending", []):
+            try:
+                item = PromotionPendingItem.from_dict(raw)
+            except ValueError:
+                continue
+            if (
+                item.seat_slug == normalized
+                and item.candidate_hash == content_hash
+                and item.status == REJECTED_STATUS
+            ):
+                return True
+        return False
+
+    def decide_promotion_pending(
+        self,
+        item_id: str,
+        *,
+        decision: str,
+        actor_id: str,
+        actor_name: str,
+        delegate: bool = False,
+    ) -> PromotionPendingItem:
+        if decision not in {APPROVED_STATUS, REJECTED_STATUS}:
+            raise ValueError(f"Unsupported promotion decision: {decision}")
+        data = self._load()
+        updated: PromotionPendingItem | None = None
+        next_items: list[dict[str, Any]] = []
+        for raw in data.get("promotion_pending", []):
+            item = PromotionPendingItem.from_dict(raw)
+            if item.id != item_id:
+                next_items.append(item.to_dict())
+                continue
+            if item.status != PENDING_STATUS:
+                raise ValueError(f"Promotion item is not pending: {item_id}")
+            updated = PromotionPendingItem(
+                id=item.id,
+                seat_slug=item.seat_slug,
+                seat_dataset=item.seat_dataset,
+                candidate_text=item.candidate_text,
+                candidate_hash=item.candidate_hash,
+                preview=item.preview,
+                reference_status=item.reference_status,
+                reference_reason=item.reference_reason,
+                repo_hints=item.repo_hints,
+                status=decision,
+                created_at=item.created_at,
+                decided_at=now_iso(),
+                decided_by=actor_id,
+                decided_by_name=actor_name,
+                delegate=delegate,
+                score=item.score,
+                relevant=item.relevant,
+                sensitive=item.sensitive,
+            )
+            next_items.append(updated.to_dict())
+        if updated is None:
+            raise ValueError(f"Promotion item not found: {item_id}")
+        data["promotion_pending"] = next_items
+        self._save(data)
+        return updated
+
     def _find_seat_by_dataset(self, dataset: str) -> AccessPrincipal | None:
         for principal in self._principals(self._load()):
             if principal.default_dataset == dataset:
@@ -673,6 +796,7 @@ class AccessStore:
                 "tokens": [],
                 "audit_events": [],
                 "capture_policies": {},
+                "promotion_pending": [],
             }
         with self.path.open("r", encoding="utf-8") as handle:
             data = json.load(handle)
@@ -682,6 +806,7 @@ class AccessStore:
             "tokens": data.get("tokens", []),
             "audit_events": data.get("audit_events", []),
             "capture_policies": data.get("capture_policies", {}),
+            "promotion_pending": data.get("promotion_pending", []),
         }
 
     def _save(self, data: dict[str, Any]) -> None:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -40,6 +40,14 @@ from kb.onboard import (
     merge_mcp_config,
 )
 from kb.banner import banner, banner_large, paint, supports_color
+from kb.promotion_client import (
+    PromotionClientError,
+    approve_pending,
+    list_pending,
+    node_base_url,
+    reject_pending,
+    run_promotion,
+)
 from kb.status import gather_status, render_text
 
 
@@ -327,6 +335,102 @@ async def _capture(args: argparse.Namespace) -> int:
     return 1 if failures else 0
 
 
+def _promotion_base_url(args: argparse.Namespace) -> str:
+    return node_base_url(getattr(args, "node_url", None))
+
+
+def _promotion_exit(exc: PromotionClientError, *, as_json: bool) -> int:
+    if as_json:
+        _print_json({"ok": False, "error": str(exc), "status": exc.status, "body": exc.body})
+    else:
+        print(f"citadel promotion: {exc}", file=sys.stderr)
+    return 1
+
+
+async def _promotion_list(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = list_pending(
+            base_url=_promotion_base_url(args),
+            status=args.status,
+        )
+    except PromotionClientError as exc:
+        return _promotion_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+    else:
+        items = result.get("items") or []
+        print(f"Promotion queue ({result.get('status', args.status)}): {len(items)} item(s)")
+        for item in items:
+            preview = item.get("preview") or "(no preview)"
+            print(
+                f"  {item.get('id')}  seat={item.get('seat_slug')}  "
+                f"ref={item.get('reference_status')}  {preview}"
+            )
+    return 0
+
+
+async def _promotion_approve(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = approve_pending(
+            args.item_id,
+            base_url=_promotion_base_url(args),
+            note=args.note,
+        )
+    except PromotionClientError as exc:
+        return _promotion_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+    else:
+        promoted = result.get("promoted")
+        print(f"Approved {args.item_id} (promoted={promoted})")
+    return 0 if result.get("ok") else 1
+
+
+async def _promotion_reject(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = reject_pending(
+            args.item_id,
+            base_url=_promotion_base_url(args),
+            note=args.note,
+        )
+    except PromotionClientError as exc:
+        return _promotion_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+    else:
+        print(f"Rejected {args.item_id}")
+    return 0 if result.get("ok") else 1
+
+
+async def _promotion_run(args: argparse.Namespace) -> int:
+    as_json = args.json
+    dry_run = not args.execute
+    try:
+        result = run_promotion(
+            base_url=_promotion_base_url(args),
+            dataset=args.dataset,
+            dry_run=dry_run,
+            max_items=args.max_items,
+        )
+    except PromotionClientError as exc:
+        return _promotion_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+    else:
+        mode = "dry-run" if dry_run else "execute"
+        print(
+            f"Promotion {mode} on {result.get('dataset')}: "
+            f"candidates={result.get('candidates')} "
+            f"proposed={result.get('proposed')} "
+            f"promoted={result.get('promoted')} "
+            f"queued={result.get('queued')}"
+        )
+    return 0 if result.get("ok") else 1
+
+
 async def _status(args: argparse.Namespace) -> int:
     repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
     config_path = Path(args.config).expanduser() if args.config else capture_config_path()
@@ -448,6 +552,7 @@ _HOME_MENU = (
     ("Capture", (
         ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
         ("capture", "push summaries of approved roots to your Node"),
+        ("promotion", "list · approve · reject · run the Promotion Agent queue"),
         ("tui", "live terminal dashboard"),
     )),
     ("Knowledge", (
@@ -583,6 +688,55 @@ def build_parser() -> argparse.ArgumentParser:
     capture.add_argument("--json", action="store_true", help="Machine-readable output")
     capture.add_argument("--config", help="Override config path (testing)")
     capture.set_defaults(handler=_capture)
+
+    promotion = subcommands.add_parser(
+        "promotion",
+        help="Promotion Agent queue — list, approve, reject, or run",
+    )
+    promotion_sub = promotion.add_subparsers(dest="promotion_command", required=True)
+
+    promo_list = promotion_sub.add_parser("list", help="List pending promotion items")
+    promo_list.add_argument(
+        "--status",
+        default="pending",
+        choices=("pending", "approved", "rejected"),
+        help="Queue filter (default: pending)",
+    )
+    promo_list.add_argument("--json", action="store_true", help="Machine-readable output")
+    promo_list.add_argument("--node-url", help="Override Node URL")
+    promo_list.set_defaults(handler=_promotion_list)
+
+    promo_approve = promotion_sub.add_parser("approve", help="Approve a pending item")
+    promo_approve.add_argument("item_id", help="Promotion item id (promo_…)")
+    promo_approve.add_argument("--note", help="Optional audit note")
+    promo_approve.add_argument("--json", action="store_true")
+    promo_approve.add_argument("--node-url", help="Override Node URL")
+    promo_approve.set_defaults(handler=_promotion_approve)
+
+    promo_reject = promotion_sub.add_parser("reject", help="Reject a pending item")
+    promo_reject.add_argument("item_id", help="Promotion item id (promo_…)")
+    promo_reject.add_argument("--note", help="Optional audit note")
+    promo_reject.add_argument("--json", action="store_true")
+    promo_reject.add_argument("--node-url", help="Override Node URL")
+    promo_reject.set_defaults(handler=_promotion_reject)
+
+    promo_run = promotion_sub.add_parser(
+        "run",
+        help="Run the Promotion Agent for your seat (dry-run by default)",
+    )
+    promo_run.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually promote / queue (default is dry-run)",
+    )
+    promo_run.add_argument(
+        "--dataset",
+        help="Seat dataset to scan (default: token's seat)",
+    )
+    promo_run.add_argument("--max-items", type=int, help="Cap candidates per run")
+    promo_run.add_argument("--json", action="store_true")
+    promo_run.add_argument("--node-url", help="Override Node URL")
+    promo_run.set_defaults(handler=_promotion_run)
 
     ingest = subcommands.add_parser("ingest", help="Ingest text or a path through Cognee")
     ingest.add_argument("data")

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -240,6 +240,39 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             openWorldHint=True,
         ),
     ),
+    "citadel_promotion_pending": ToolPolicy(
+        role="reader",
+        scope="kb:read",
+        risk="read",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    ),
+    "citadel_promotion_approve": ToolPolicy(
+        role="writer",
+        scope="kb:ingest",
+        risk="additive_write",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    ),
+    "citadel_promotion_reject": ToolPolicy(
+        role="writer",
+        scope="kb:ingest",
+        risk="additive_write",
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+    ),
 }
 
 
@@ -878,6 +911,58 @@ def create_mcp_server(
                 tool_name="citadel_improve",
             ),
         )
+
+    @mcp.tool(annotations=TOOL_POLICIES["citadel_promotion_pending"].annotations)
+    async def citadel_promotion_pending(
+        ctx: Context,
+        status: str = "pending",
+    ) -> dict[str, Any]:
+        """List Node→Central promotion items awaiting approval for your seat (or all seats if admin)."""
+        return await _call_async(
+            "citadel_promotion_pending",
+            lambda: resolve_client(ctx).get(
+                f"/api/promotion/pending?status={quote(status)}",
+                tool_name="citadel_promotion_pending",
+            ),
+        )
+
+    @mcp.tool(annotations=TOOL_POLICIES["citadel_promotion_approve"].annotations)
+    async def citadel_promotion_approve(
+        item_id: str,
+        ctx: Context,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Approve a pending promotion item. Requires explicit user confirmation first."""
+        normalized_id = _require_non_empty(item_id, "item_id")
+
+        def approve() -> dict[str, Any]:
+            payload = {"note": note} if note else {}
+            return resolve_client(ctx).post(
+                f"/api/promotion/pending/{quote(normalized_id, safe='')}/approve",
+                payload,
+                tool_name="citadel_promotion_approve",
+            )
+
+        return await _call_async("citadel_promotion_approve", approve)
+
+    @mcp.tool(annotations=TOOL_POLICIES["citadel_promotion_reject"].annotations)
+    async def citadel_promotion_reject(
+        item_id: str,
+        ctx: Context,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Reject a pending promotion item. Requires explicit user confirmation first."""
+        normalized_id = _require_non_empty(item_id, "item_id")
+
+        def reject() -> dict[str, Any]:
+            payload = {"note": note} if note else {}
+            return resolve_client(ctx).post(
+                f"/api/promotion/pending/{quote(normalized_id, safe='')}/reject",
+                payload,
+                tool_name="citadel_promotion_reject",
+            )
+
+        return await _call_async("citadel_promotion_reject", reject)
 
     @mcp.resource("citadel://session")
     def session_resource() -> str:

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from pathlib import Path
 from typing import Any
 
-from kb.access import AccessIdentity, AccessStore, is_seat_dataset
+from kb.access import AccessIdentity, AccessStore, is_seat_dataset, now_iso
 from kb.config import CitadelConfig
 from kb.learning import LearningProcess
 from kb.llm_enrichment import (
@@ -31,12 +32,23 @@ from kb.llm_enrichment import (
     parse_json_payload,
     redacted_preview,
 )
+from kb.promotion_queue import (
+    APPROVED_STATUS,
+    PENDING_STATUS,
+    REJECTED_STATUS,
+    build_pending_item,
+    candidate_hash,
+)
+from kb.promotion_refs import ReferenceAssessment, assess_org_reference, parse_capture_tags_from_text
 from kb.security_scan import SecurityScanEntry, scan_text_entries
 from kb.service import Citadel
 
 logger = logging.getLogger(__name__)
 
 PROMOTION_TAG = "org-ready"
+PERSONAL_CAPTURE_TAG = "personal"
+ORG_WORK_CAPTURE_TAG = "org-work"
+CAPTURE_SUMMARY_MARKER = "# capture summary:"
 
 # Broad seed queries used to enumerate a seat node. cognee.recall is semantic,
 # not an exhaustive listing, so a few complementary seeds widen coverage; the
@@ -73,17 +85,25 @@ class Classification:
 
 
 @dataclass(frozen=True)
+class PromotionCandidate:
+    text: str
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ProposedPromotion:
     """One candidate plus the promote/skip decision and why."""
 
     candidate: str
-    decision: str  # "promote" | "skip"
+    decision: str  # "promote" | "skip" | "pending_approval"
     reason: str
     relevant: bool | None = None
     sensitive: bool | None = None
     score: float | None = None
     secret_blocked: bool = False
     promoted: bool = False
+    reference_status: str | None = None
+    capture_tags: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -95,7 +115,30 @@ class ProposedPromotion:
             "secret_blocked": self.secret_blocked,
             "promoted": self.promoted,
             "preview": redacted_preview(self.candidate),
+            "reference_status": self.reference_status,
+            "capture_tags": list(self.capture_tags),
         }
+
+
+def _candidate_from_result(result: Any) -> PromotionCandidate | None:
+    text = _candidate_text(result)
+    if not text:
+        return None
+    tags: list[str] = []
+    if isinstance(result, dict):
+        raw_tags = result.get("tags")
+        if isinstance(raw_tags, list):
+            tags.extend(str(tag) for tag in raw_tags)
+        metadata = result.get("metadata")
+        if isinstance(metadata, dict):
+            meta_tags = metadata.get("tags")
+            if isinstance(meta_tags, list):
+                tags.extend(str(tag) for tag in meta_tags)
+    tags.extend(parse_capture_tags_from_text(text))
+    normalized_tags = tuple(
+        dict.fromkeys(tag.strip().lower() for tag in tags if tag.strip())
+    )
+    return PromotionCandidate(text=text, tags=normalized_tags)
 
 
 def _candidate_text(result: Any) -> str:
@@ -112,6 +155,26 @@ def _candidate_text(result: Any) -> str:
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return ""
+
+
+def is_capture_root_content(candidate: PromotionCandidate) -> bool:
+    lower = candidate.text.lower()
+    if CAPTURE_SUMMARY_MARKER in lower or "capture root tags:" in lower:
+        return True
+    if "git-push" in candidate.tags or "capture" in candidate.tags:
+        return True
+    return False
+
+
+def capture_auto_promote_block_reason(candidate: PromotionCandidate) -> str | None:
+    """Return a skip reason when capture-root content may not auto-promote."""
+    if not is_capture_root_content(candidate):
+        return None
+    if PERSONAL_CAPTURE_TAG in candidate.tags:
+        return "capture_tag_personal"
+    if ORG_WORK_CAPTURE_TAG in candidate.tags:
+        return None
+    return "capture_tag_not_org_work"
 
 
 def _coerce_classification(parsed: Any) -> Classification | None:
@@ -154,17 +217,11 @@ class PromotionEngine:
         self.access_store = access_store
         self.config = config
 
-    async def enumerate(self, seat_dataset: str, max_items: int) -> list[str]:
-        """Best-effort list of a seat node's promotable text, capped at ``max_items``.
-
-        Uses :meth:`Citadel.search` (cognee.recall) per seed query because that is
-        the only primitive that returns real node body text. recall is semantic,
-        not exhaustive, so this under-samples large nodes by design — documented as
-        a known limitation (ADR-0005 open risk).
-        """
+    async def enumerate(self, seat_dataset: str, max_items: int) -> list[PromotionCandidate]:
+        """Best-effort list of a seat node's promotable content, capped at ``max_items``."""
         cap = max(1, max_items)
         seen: set[str] = set()
-        candidates: list[str] = []
+        candidates: list[PromotionCandidate] = []
         for query in DEFAULT_SEED_QUERIES:
             if len(candidates) >= cap:
                 break
@@ -180,14 +237,14 @@ class PromotionEngine:
                 )
                 continue
             for result in results:
-                text = _candidate_text(result)
-                if not text:
+                parsed = _candidate_from_result(result)
+                if not parsed:
                     continue
-                key = text.lower()
+                key = parsed.text.lower()
                 if key in seen:
                     continue
                 seen.add(key)
-                candidates.append(text)
+                candidates.append(parsed)
                 if len(candidates) >= cap:
                     break
         return candidates[:cap]
@@ -234,46 +291,105 @@ class PromotionEngine:
             return True
         return bool(scan.get("blocked"))
 
-    def decide(self, seat_dataset: str, candidate: str) -> ProposedPromotion:
-        """Apply secret scan, then the LLM classifier + threshold. Default SKIP."""
-        if self._secret_blocked(seat_dataset, candidate):
+    async def decide(
+        self,
+        seat_dataset: str,
+        candidate: PromotionCandidate,
+    ) -> ProposedPromotion:
+        """Apply capture tags, secret scan, org refs, then LLM classifier."""
+        capture_block = capture_auto_promote_block_reason(candidate)
+        if capture_block == "capture_tag_personal":
             return ProposedPromotion(
-                candidate=candidate,
+                candidate=candidate.text,
+                decision="skip",
+                reason="capture_tag_personal",
+                capture_tags=candidate.tags,
+            )
+        if self._secret_blocked(seat_dataset, candidate.text):
+            return ProposedPromotion(
+                candidate=candidate.text,
                 decision="skip",
                 reason="secret_content",
                 secret_blocked=True,
+                capture_tags=candidate.tags,
             )
-        verdict = self.classify(candidate)
+
+        central = self.config.github_sync_dataset or self.config.default_dataset
+        reference = await assess_org_reference(
+            self.citadel,
+            candidate_text=candidate.text,
+            central_dataset=central,
+            github_state_path=Path(self.config.github_sync_state_path),
+            github_org=self.config.github_org,
+        )
+
+        verdict = self.classify(candidate.text)
         if verdict is None:
-            # LLM unavailable or output unusable -> never promote on uncertainty.
             return ProposedPromotion(
-                candidate=candidate,
+                candidate=candidate.text,
                 decision="skip",
                 reason="llm_unavailable",
+                reference_status=reference.status,
+                capture_tags=candidate.tags,
             )
+
         threshold = self.config.promotion_relevance_threshold
         qualifies = (
             verdict.relevant
             and not verdict.sensitive
             and verdict.score >= threshold
         )
-        if qualifies:
-            decision, reason = "promote", verdict.reason
-        else:
-            decision = "skip"
+        base_kwargs = {
+            "candidate": candidate.text,
+            "relevant": verdict.relevant,
+            "sensitive": verdict.sensitive,
+            "score": verdict.score,
+            "reference_status": reference.status,
+            "capture_tags": candidate.tags,
+        }
+
+        if not qualifies:
             if verdict.sensitive:
                 reason = "sensitive"
             elif not verdict.relevant:
                 reason = "not_relevant"
             else:
                 reason = "below_threshold"
+            return ProposedPromotion(decision="skip", reason=reason, **base_kwargs)
+
+        seat_slug = seat_dataset.removeprefix("seat:")
+        content_hash = candidate_hash(candidate.text)
+        if self.access_store.is_promotion_rejected(seat_slug, content_hash):
+            return ProposedPromotion(
+                decision="skip",
+                reason="previously_rejected",
+                **base_kwargs,
+            )
+
+        if reference.status == "new_org_project":
+            return ProposedPromotion(
+                decision="pending_approval",
+                reason="new_org_project",
+                **base_kwargs,
+            )
+
+        if reference.status == "known_org_work":
+            if capture_block == "capture_tag_not_org_work":
+                return ProposedPromotion(
+                    decision="skip",
+                    reason="capture_tag_not_org_work",
+                    **base_kwargs,
+                )
+            return ProposedPromotion(
+                decision="promote",
+                reason=verdict.reason,
+                **base_kwargs,
+            )
+
         return ProposedPromotion(
-            candidate=candidate,
-            decision=decision,
-            reason=reason,
-            relevant=verdict.relevant,
-            sensitive=verdict.sensitive,
-            score=verdict.score,
+            decision="skip",
+            reason="no_org_reference",
+            **base_kwargs,
         )
 
     def _promotion_identity(self, seat_dataset: str) -> AccessIdentity:
@@ -311,10 +427,19 @@ class PromotionEngine:
         from kb.security_scan import SecretContentError
         from kb.server import execute_learning_writes, resolve_write_targets
 
+        seat_slug = seat_dataset.removeprefix("seat:")
+        promotion_tags = [
+            PROMOTION_TAG,
+            "promotion-agent",
+            f"promotion-seat:{seat_slug}",
+        ]
+        if proposal.reference_status:
+            promotion_tags.append(f"promotion-ref:{proposal.reference_status}")
+
         central = None
         try:
             targets = resolve_write_targets(
-                identity, None, [PROMOTION_TAG], self.config
+                identity, None, promotion_tags, self.config
             )
             central = next(
                 (t.dataset for t in targets if t.tier == "full"),
@@ -324,7 +449,7 @@ class PromotionEngine:
                 self.learning,
                 data=proposal.candidate,
                 targets=targets,
-                tags=[PROMOTION_TAG],
+                tags=promotion_tags,
                 session_id=None,
                 operation="promotion",
             )
@@ -373,7 +498,9 @@ class PromotionEngine:
                 "sensitive": proposal.sensitive,
                 "reason": proposal.reason,
                 "accepted": True,
-                "tags": [PROMOTION_TAG],
+                "tags": promotion_tags,
+                "reference_status": proposal.reference_status,
+                "capture_tags": list(proposal.capture_tags),
             },
         )
         return True
@@ -409,13 +536,22 @@ class PromotionEngine:
 
         cap = max_items if max_items and max_items > 0 else self.config.promotion_max_items
         candidates = await self.enumerate(seat_dataset, cap)
-        proposals = [self.decide(seat_dataset, text) for text in candidates]
+        proposals: list[ProposedPromotion] = []
+        for candidate in candidates:
+            proposals.append(await self.decide(seat_dataset, candidate))
 
         promoted = 0
+        queued = 0
+        seat_slug = seat_dataset.removeprefix("seat:")
         if not dry_run:
             identity = self._promotion_identity(seat_dataset)
             settled: list[ProposedPromotion] = []
             for proposal in proposals:
+                if proposal.decision == "pending_approval":
+                    self._enqueue_pending(seat_slug, seat_dataset, proposal)
+                    queued += 1
+                    settled.append(proposal)
+                    continue
                 if proposal.decision != "promote":
                     settled.append(proposal)
                     continue
@@ -431,6 +567,8 @@ class PromotionEngine:
                             sensitive=proposal.sensitive,
                             score=proposal.score,
                             promoted=True,
+                            reference_status=proposal.reference_status,
+                            capture_tags=proposal.capture_tags,
                         )
                     )
                 else:
@@ -443,6 +581,8 @@ class PromotionEngine:
                             sensitive=proposal.sensitive,
                             score=proposal.score,
                             secret_blocked=True,
+                            reference_status=proposal.reference_status,
+                            capture_tags=proposal.capture_tags,
                         )
                     )
             proposals = settled
@@ -455,9 +595,129 @@ class PromotionEngine:
             "max_items": cap,
             "candidates": len(candidates),
             "proposed": sum(1 for p in proposals if p.decision == "promote"),
+            "pending_approval": sum(
+                1 for p in proposals if p.decision == "pending_approval"
+            ),
             "promoted": promoted,
+            "queued": queued,
             "proposals": [p.to_dict() for p in proposals],
         }
+
+    def _enqueue_pending(
+        self,
+        seat_slug: str,
+        seat_dataset: str,
+        proposal: ProposedPromotion,
+    ) -> None:
+        assessment = ReferenceAssessment(
+            status=proposal.reference_status or "new_org_project",
+            reason=proposal.reason,
+        )
+        item = build_pending_item(
+            seat_slug=seat_slug,
+            seat_dataset=seat_dataset,
+            candidate_text=proposal.candidate,
+            assessment=assessment,
+            created_at=now_iso(),
+            score=proposal.score,
+            relevant=proposal.relevant,
+            sensitive=proposal.sensitive,
+        )
+        self.access_store.add_promotion_pending(item)
+        self.access_store.record_event(
+            action="promotion.pending",
+            actor=self._promotion_identity(seat_dataset),
+            success=True,
+            dataset=seat_dataset,
+            detail={
+                "item_id": item.id,
+                "seat_slug": seat_slug,
+                "reference_status": item.reference_status,
+                "preview": item.preview,
+            },
+        )
+
+    async def approve_pending(
+        self,
+        item_id: str,
+        actor: AccessIdentity,
+        *,
+        delegate: bool = False,
+    ) -> dict[str, Any]:
+        item = self.access_store.get_promotion_pending(item_id)
+        if item is None:
+            raise ValueError(f"Promotion item not found: {item_id}")
+        if item.status != PENDING_STATUS:
+            raise ValueError(f"Promotion item is not pending: {item_id}")
+
+        proposal = ProposedPromotion(
+            candidate=item.candidate_text,
+            decision="promote",
+            reason="approved",
+            relevant=item.relevant,
+            sensitive=item.sensitive,
+            score=item.score,
+            reference_status=item.reference_status,
+        )
+        identity = self._promotion_identity(item.seat_dataset)
+        promoted = await self._promote(item.seat_dataset, identity, proposal)
+        decided = self.access_store.decide_promotion_pending(
+            item_id,
+            decision=APPROVED_STATUS,
+            actor_id=actor.actor_id,
+            actor_name=actor.actor_name,
+            delegate=delegate,
+        )
+        self.access_store.record_event(
+            action="promotion.approve",
+            actor=actor,
+            success=promoted,
+            dataset=item.seat_dataset,
+            detail={
+                "item_id": item_id,
+                "seat_slug": item.seat_slug,
+                "delegate": delegate,
+                "promoted": promoted,
+                "reference_status": item.reference_status,
+            },
+        )
+        return {
+            "ok": promoted,
+            "item": decided.to_dict(),
+            "promoted": promoted,
+        }
+
+    async def reject_pending(
+        self,
+        item_id: str,
+        actor: AccessIdentity,
+        *,
+        delegate: bool = False,
+    ) -> dict[str, Any]:
+        item = self.access_store.get_promotion_pending(item_id)
+        if item is None:
+            raise ValueError(f"Promotion item not found: {item_id}")
+        if item.status != PENDING_STATUS:
+            raise ValueError(f"Promotion item is not pending: {item_id}")
+        decided = self.access_store.decide_promotion_pending(
+            item_id,
+            decision=REJECTED_STATUS,
+            actor_id=actor.actor_id,
+            actor_name=actor.actor_name,
+            delegate=delegate,
+        )
+        self.access_store.record_event(
+            action="promotion.reject",
+            actor=actor,
+            success=True,
+            dataset=item.seat_dataset,
+            detail={
+                "item_id": item_id,
+                "seat_slug": item.seat_slug,
+                "delegate": delegate,
+            },
+        )
+        return {"ok": True, "item": decided.to_dict()}
 
     def status(self) -> dict[str, Any]:
         """Read-only config/status snapshot for the GET endpoint."""

--- a/kb/promotion_client.py
+++ b/kb/promotion_client.py
@@ -1,0 +1,166 @@
+"""HTTP client for Promotion Agent API — used by ``citadel promotion`` CLI."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from kb.capture import capture_token
+from kb.capture_config import DEFAULT_NODE_URL, load_capture_config
+
+_TIMEOUT = 120.0
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirectHandler)
+
+
+class PromotionClientError(RuntimeError):
+    def __init__(self, message: str, *, status: int | None = None, body: Any = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def node_base_url(override: str | None = None) -> str:
+    if override:
+        return override.rstrip("/")
+    try:
+        config = load_capture_config()
+        if config.node_url:
+            return config.node_url.rstrip("/")
+    except ValueError:
+        pass
+    return DEFAULT_NODE_URL.rstrip("/")
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    base_url: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = _TIMEOUT,
+) -> Any:
+    if not base_url.lower().startswith("https://"):
+        raise PromotionClientError("refusing non-HTTPS Node URL")
+    if not token:
+        raise PromotionClientError("missing token (set CITADEL_MCP_ACCESS_TOKEN)")
+    url = f"{base_url}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers: dict[str, str] = {"Accept": "application/json"}
+    headers["Authorization"] = f"Bearer {token}"
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _OPENER.open(req, timeout=timeout) as resp:  # noqa: S310
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode() if exc.fp else ""
+        parsed: Any = raw
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            pass
+        detail = parsed.get("detail") if isinstance(parsed, dict) else raw or exc.reason
+        raise PromotionClientError(
+            str(detail or exc.reason),
+            status=exc.code,
+            body=parsed,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise PromotionClientError(str(exc.reason)) from exc
+    return json.loads(body) if body else {}
+
+
+def resolve_seat_dataset(base_url: str, token: str, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    session = _request("GET", "/api/session", base_url=base_url, token=token)
+    slug = session.get("seat_slug")
+    if not slug:
+        raise PromotionClientError(
+            "could not resolve seat dataset — pass --dataset seat:<slug>"
+        )
+    return f"seat:{slug}"
+
+
+def list_pending(
+    *,
+    base_url: str,
+    token: str | None = None,
+    status: str = "pending",
+) -> dict[str, Any]:
+    token = token or capture_token()
+    return _request(
+        "GET",
+        f"/api/promotion/pending?status={status}",
+        base_url=base_url,
+        token=token,
+    )
+
+
+def approve_pending(
+    item_id: str,
+    *,
+    base_url: str,
+    token: str | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    token = token or capture_token()
+    payload = {"note": note} if note else None
+    return _request(
+        "POST",
+        f"/api/promotion/pending/{item_id}/approve",
+        base_url=base_url,
+        token=token,
+        payload=payload,
+    )
+
+
+def reject_pending(
+    item_id: str,
+    *,
+    base_url: str,
+    token: str | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    token = token or capture_token()
+    payload = {"note": note} if note else None
+    return _request(
+        "POST",
+        f"/api/promotion/pending/{item_id}/reject",
+        base_url=base_url,
+        token=token,
+        payload=payload,
+    )
+
+
+def run_promotion(
+    *,
+    base_url: str,
+    token: str | None = None,
+    dataset: str | None = None,
+    dry_run: bool = True,
+    max_items: int | None = None,
+) -> dict[str, Any]:
+    token = token or capture_token()
+    seat_dataset = resolve_seat_dataset(base_url, token, dataset)
+    payload: dict[str, Any] = {"dataset": seat_dataset, "dry_run": dry_run}
+    if max_items is not None:
+        payload["max_items"] = max_items
+    return _request(
+        "POST",
+        "/api/promote/run",
+        base_url=base_url,
+        token=token,
+        payload=payload,
+    )

--- a/kb/promotion_queue.py
+++ b/kb/promotion_queue.py
@@ -1,0 +1,102 @@
+"""ADR-0007 P6: pending promotion approval queue stored in the access JSON."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+from typing import Any
+from uuid import uuid4
+
+from kb.llm_enrichment import redacted_preview
+from kb.promotion_refs import ReferenceAssessment
+
+PENDING_STATUS = "pending"
+APPROVED_STATUS = "approved"
+REJECTED_STATUS = "rejected"
+VALID_PENDING_STATUSES = frozenset({PENDING_STATUS, APPROVED_STATUS, REJECTED_STATUS})
+
+
+@dataclass(frozen=True)
+class PromotionPendingItem:
+    id: str
+    seat_slug: str
+    seat_dataset: str
+    candidate_text: str
+    candidate_hash: str
+    preview: str
+    reference_status: str
+    reference_reason: str
+    repo_hints: tuple[str, ...] = ()
+    status: str = PENDING_STATUS
+    created_at: str = ""
+    decided_at: str | None = None
+    decided_by: str | None = None
+    decided_by_name: str | None = None
+    delegate: bool = False
+    score: float | None = None
+    relevant: bool | None = None
+    sensitive: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["repo_hints"] = list(self.repo_hints)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PromotionPendingItem":
+        status = data.get("status") or PENDING_STATUS
+        if status not in VALID_PENDING_STATUSES:
+            raise ValueError(f"Unsupported promotion pending status: {status}")
+        return cls(
+            id=str(data["id"]),
+            seat_slug=str(data["seat_slug"]),
+            seat_dataset=str(data["seat_dataset"]),
+            candidate_text=str(data["candidate_text"]),
+            candidate_hash=str(data["candidate_hash"]),
+            preview=str(data.get("preview") or ""),
+            reference_status=str(data.get("reference_status") or ""),
+            reference_reason=str(data.get("reference_reason") or ""),
+            repo_hints=tuple(data.get("repo_hints") or ()),
+            status=status,
+            created_at=str(data.get("created_at") or ""),
+            decided_at=data.get("decided_at"),
+            decided_by=data.get("decided_by"),
+            decided_by_name=data.get("decided_by_name"),
+            delegate=bool(data.get("delegate")),
+            score=data.get("score"),
+            relevant=data.get("relevant"),
+            sensitive=data.get("sensitive"),
+        )
+
+
+def candidate_hash(text: str) -> str:
+    normalized = text.strip().lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
+
+
+def build_pending_item(
+    *,
+    seat_slug: str,
+    seat_dataset: str,
+    candidate_text: str,
+    assessment: ReferenceAssessment,
+    created_at: str,
+    score: float | None = None,
+    relevant: bool | None = None,
+    sensitive: bool | None = None,
+) -> PromotionPendingItem:
+    return PromotionPendingItem(
+        id=f"promo_{uuid4().hex}",
+        seat_slug=seat_slug,
+        seat_dataset=seat_dataset,
+        candidate_text=candidate_text,
+        candidate_hash=candidate_hash(candidate_text),
+        preview=redacted_preview(candidate_text),
+        reference_status=assessment.status,
+        reference_reason=assessment.reason,
+        repo_hints=assessment.repo_hints,
+        created_at=created_at,
+        score=score,
+        relevant=relevant,
+        sensitive=sensitive,
+    )

--- a/kb/promotion_refs.py
+++ b/kb/promotion_refs.py
@@ -1,0 +1,163 @@
+"""ADR-0007 P5: GitHub org + Central reference checks for the Promotion Agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+GITHUB_REPO_URL_RE = re.compile(
+    r"github\.com[/:]([\w.-]+)/([\w.-]+?)(?:\.git)?(?:[/\s#]|$)",
+    re.IGNORECASE,
+)
+CAPTURE_REMOTE_RE = re.compile(r"^\s*-\s*Remote:\s*`?([^`\n]+)`?\s*$", re.MULTILINE | re.IGNORECASE)
+CAPTURE_TAGS_RE = re.compile(r"Capture Root Tags:\s*([^\n]+)", re.IGNORECASE)
+
+ReferenceStatus = str  # known_org_work | new_org_project | no_reference_signal
+
+CENTRAL_MATCH_QUERY_CHARS = 500
+
+
+@dataclass(frozen=True)
+class ReferenceAssessment:
+    status: ReferenceStatus
+    matched_repos: tuple[str, ...] = ()
+    central_hits: int = 0
+    repo_hints: tuple[str, ...] = ()
+    reason: str = ""
+
+
+def extract_repo_hints(text: str) -> tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for org, repo in GITHUB_REPO_URL_RE.findall(text):
+        seen.setdefault(f"{org}/{repo}".lower(), None)
+        seen.setdefault(repo.lower(), None)
+    for remote in CAPTURE_REMOTE_RE.findall(text):
+        cleaned = remote.strip().strip("`")
+        for org, repo in GITHUB_REPO_URL_RE.findall(cleaned):
+            seen.setdefault(f"{org}/{repo}".lower(), None)
+            seen.setdefault(repo.lower(), None)
+    return tuple(seen)
+
+
+def load_tracked_org_repos(state_path: Path, org: str) -> frozenset[str]:
+    if not state_path.exists():
+        return frozenset()
+    try:
+        with state_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        logger.warning("promotion_refs: could not read GitHub sync state at %s", state_path)
+        return frozenset()
+    repos = data.get("repos") or {}
+    if not isinstance(repos, dict):
+        return frozenset()
+    org_lower = org.strip().lower()
+    names: set[str] = set()
+    for full_name in repos:
+        if not isinstance(full_name, str):
+            continue
+        lowered = full_name.lower()
+        names.add(lowered)
+        if "/" in lowered:
+            owner, repo = lowered.split("/", 1)
+            names.add(repo)
+            if owner == org_lower:
+                names.add(f"{owner}/{repo}")
+    return frozenset(names)
+
+
+def _hint_matches_org(hint: str, org_repos: frozenset[str], org: str) -> bool:
+    normalized = hint.strip().lower()
+    if not normalized:
+        return False
+    if normalized in org_repos:
+        return True
+    prefixed = f"{org.strip().lower()}/{normalized}"
+    return prefixed in org_repos
+
+
+async def _central_search(
+    citadel: Any,
+    query: str,
+    *,
+    central_dataset: str,
+    top_k: int = 3,
+) -> list[Any]:
+    try:
+        return await citadel.search(query, dataset=central_dataset, top_k=top_k)
+    except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
+        logger.warning(
+            "promotion_refs central search failed for %r: %s",
+            query[:80],
+            exc.__class__.__name__,
+        )
+        return []
+
+
+async def assess_org_reference(
+    citadel: Any,
+    *,
+    candidate_text: str,
+    central_dataset: str,
+    github_state_path: Path,
+    github_org: str,
+) -> ReferenceAssessment:
+    hints = extract_repo_hints(candidate_text)
+    if not hints:
+        query = candidate_text.strip()[:CENTRAL_MATCH_QUERY_CHARS]
+        if not query:
+            return ReferenceAssessment(status="no_reference_signal", reason="empty_candidate")
+        hits = await _central_search(citadel, query, central_dataset=central_dataset)
+        if hits:
+            return ReferenceAssessment(
+                status="known_org_work",
+                central_hits=len(hits),
+                reason="central_match_no_repo",
+            )
+        return ReferenceAssessment(
+            status="no_reference_signal",
+            reason="no_repo_or_central_match",
+        )
+
+    org_repos = load_tracked_org_repos(github_state_path, github_org)
+    matched = tuple(h for h in hints if _hint_matches_org(h, org_repos, github_org))
+    if matched:
+        return ReferenceAssessment(
+            status="known_org_work",
+            matched_repos=matched,
+            repo_hints=hints,
+            reason="github_org_match",
+        )
+
+    for hint in hints[:5]:
+        hits = await _central_search(citadel, hint, central_dataset=central_dataset)
+        if hits:
+            return ReferenceAssessment(
+                status="known_org_work",
+                central_hits=len(hits),
+                repo_hints=hints,
+                reason="central_match",
+            )
+
+    return ReferenceAssessment(
+        status="new_org_project",
+        repo_hints=hints,
+        reason="no_org_or_central_match",
+    )
+
+
+def parse_capture_tags_from_text(text: str) -> tuple[str, ...]:
+    match = CAPTURE_TAGS_RE.search(text)
+    if not match:
+        return ()
+    return tuple(
+        tag.strip().lower()
+        for tag in match.group(1).split(",")
+        if tag.strip()
+    )

--- a/kb/server.py
+++ b/kb/server.py
@@ -47,6 +47,7 @@ from kb.mesh import MeshState
 from kb.models import FeedbackRequest
 from kb.obsidian_sync import ObsidianSyncStore, SyncPushDocument, normalize_path
 from kb.promotion import PromotionEngine
+from kb.promotion_queue import APPROVED_STATUS, PENDING_STATUS, REJECTED_STATUS
 from kb.repo_content_sync import RepoContentSyncer
 from kb.security_scan import SecretContentError
 from kb.self_improve import SelfImprovement
@@ -239,6 +240,10 @@ class PromoteRunBody(BaseModel):
     dataset: str = Field(min_length=1)
     dry_run: bool = True
     max_items: int | None = Field(default=None, ge=1, le=200)
+
+
+class PromotionDecisionBody(BaseModel):
+    note: str | None = Field(default=None, max_length=400)
 
 
 class CognifyRunBody(BaseModel):
@@ -592,6 +597,48 @@ def seat_capture_policy_response(slug: str) -> dict[str, Any]:
         baseline=baseline,
         env_exclude_patterns=env_exclude_patterns(),
     )
+
+
+def can_run_promotion(identity: AccessIdentity, seat_dataset: str) -> bool:
+    if not is_seat_dataset(seat_dataset):
+        return False
+    seat_slug = seat_dataset.removeprefix("seat:")
+    if identity.role == "admin" or "sources:sync" in effective_scopes(identity):
+        return True
+    if identity.role == "writer" and identity.seat_slug == seat_slug:
+        return True
+    return False
+
+
+def can_decide_promotion_item(
+    identity: AccessIdentity,
+    item_seat_slug: str,
+) -> tuple[bool, bool]:
+    if identity.role == "admin" or "access:manage" in effective_scopes(identity):
+        delegate = identity.seat_slug is not None and identity.seat_slug != item_seat_slug
+        if identity.seat_slug is None:
+            delegate = True
+        return True, delegate
+    if identity.seat_slug == item_seat_slug:
+        return True, False
+    return False, False
+
+
+def promotion_pending_filter_seat(identity: AccessIdentity) -> str | None:
+    if identity.role == "admin" or "access:manage" in effective_scopes(identity):
+        return None
+    if identity.seat_slug:
+        return identity.seat_slug
+    raise HTTPException(
+        status_code=403,
+        detail="Promotion queue is only available to seat holders and admins.",
+    )
+
+
+def redact_pending_item(item: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(item)
+    redacted.pop("candidate_text", None)
+    return redacted
 
 
 def enforce_dataset_allowlist(identity: AccessIdentity, dataset: str) -> None:
@@ -2464,11 +2511,16 @@ async def promotion_status(request: Request) -> Any:
 
 @app.post("/api/promote/run")
 async def run_promotion(body: PromoteRunBody, request: Request) -> Any:
-    actor = require_access(request, "admin", "sources:sync")
+    actor = require_access(request, "writer", "kb:ingest")
     if not is_seat_dataset(body.dataset):
         raise HTTPException(
             status_code=400,
             detail="dataset must be a seat node (seat:<slug>) to promote from.",
+        )
+    if not can_run_promotion(actor, body.dataset):
+        raise HTTPException(
+            status_code=403,
+            detail="Not allowed to run promotion for this seat dataset.",
         )
     try:
         result = await get_promotion_engine().run(
@@ -2512,9 +2564,93 @@ async def run_promotion(body: PromoteRunBody, request: Request) -> Any:
             "candidates": result.get("candidates"),
             "proposed": result.get("proposed"),
             "promoted": result.get("promoted"),
+            "pending_approval": result.get("pending_approval"),
+            "queued": result.get("queued"),
             "max_items": result.get("max_items"),
         },
     )
+    return jsonable_encoder(result)
+
+
+@app.get("/api/promotion/pending")
+async def list_promotion_pending(
+    request: Request,
+    status: str = PENDING_STATUS,
+) -> dict[str, Any]:
+    identity = require_access(request, "reader", "kb:read")
+    seat_slug = promotion_pending_filter_seat(identity)
+    if status not in {PENDING_STATUS, REJECTED_STATUS, APPROVED_STATUS}:
+        raise HTTPException(status_code=422, detail=f"Unsupported status filter: {status}")
+    items = get_access_store().list_promotion_pending(seat_slug=seat_slug, status=status)
+    return {
+        "ok": True,
+        "status": status,
+        "items": [redact_pending_item(item.to_dict()) for item in items],
+        "count": len(items),
+    }
+
+
+@app.post("/api/promotion/pending/{item_id}/approve")
+async def approve_promotion_pending(
+    item_id: str,
+    request: Request,
+    body: PromotionDecisionBody | None = None,
+) -> dict[str, Any]:
+    identity = require_access(request, "writer", "kb:ingest")
+    item = get_access_store().get_promotion_pending(item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"Promotion item not found: {item_id}")
+    allowed, delegate = can_decide_promotion_item(identity, item.seat_slug)
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Not allowed to approve this promotion item.")
+    try:
+        result = await get_promotion_engine().approve_pending(
+            item_id,
+            identity,
+            delegate=delegate,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if body and body.note:
+        get_access_store().record_event(
+            action="promotion.approve.note",
+            actor=identity,
+            success=True,
+            dataset=item.seat_dataset,
+            detail={"item_id": item_id, "note": body.note[:400]},
+        )
+    return jsonable_encoder(result)
+
+
+@app.post("/api/promotion/pending/{item_id}/reject")
+async def reject_promotion_pending(
+    item_id: str,
+    request: Request,
+    body: PromotionDecisionBody | None = None,
+) -> dict[str, Any]:
+    identity = require_access(request, "writer", "kb:ingest")
+    item = get_access_store().get_promotion_pending(item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"Promotion item not found: {item_id}")
+    allowed, delegate = can_decide_promotion_item(identity, item.seat_slug)
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Not allowed to reject this promotion item.")
+    try:
+        result = await get_promotion_engine().reject_pending(
+            item_id,
+            identity,
+            delegate=delegate,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if body and body.note:
+        get_access_store().record_event(
+            action="promotion.reject.note",
+            actor=identity,
+            success=True,
+            dataset=item.seat_dataset,
+            detail={"item_id": item_id, "note": body.note[:400]},
+        )
     return jsonable_encoder(result)
 
 

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -75,6 +75,8 @@ const dashboardCronStatus = document.getElementById("dashboardCronStatus");
 const dashboardCronMeta = document.getElementById("dashboardCronMeta");
 const dashboardIngestStatus = document.getElementById("dashboardIngestStatus");
 const dashboardIngestionList = document.getElementById("dashboardIngestionList");
+const dashboardPromotionStatus = document.getElementById("dashboardPromotionStatus");
+const dashboardPromotionList = document.getElementById("dashboardPromotionList");
 const dashboardMcpClients = document.getElementById("dashboardMcpClients");
 const dashboardMcpMeta = document.getElementById("dashboardMcpMeta");
 const dashboardMcpStatus = document.getElementById("dashboardMcpStatus");
@@ -1730,6 +1732,83 @@ async function loadConflicts() {
   }
 }
 
+async function loadPromotionQueue() {
+  if (!dashboardPromotionList) return;
+  if (dashboardPromotionStatus) {
+    dashboardPromotionStatus.textContent = "Loading";
+    dashboardPromotionStatus.className = "status-chip status-standby";
+  }
+  try {
+    const response = await api("/api/promotion/pending?status=pending");
+    renderPromotionQueue(response.items || []);
+    const count = response.count || 0;
+    if (dashboardPromotionStatus) {
+      dashboardPromotionStatus.textContent = `${count} pending`;
+      dashboardPromotionStatus.className = `status-chip ${count ? "status-enabled" : "status-standby"}`;
+    }
+  } catch (error) {
+    dashboardPromotionList.innerHTML = "";
+    dashboardPromotionList.append(
+      emptyState("Could not load promotion queue", error.message),
+    );
+    if (dashboardPromotionStatus) {
+      dashboardPromotionStatus.textContent = "Error";
+      dashboardPromotionStatus.className = "status-chip status-error";
+    }
+  }
+}
+
+function renderPromotionQueue(items = []) {
+  if (!dashboardPromotionList) return;
+  dashboardPromotionList.innerHTML = "";
+  if (!items.length) {
+    dashboardPromotionList.append(
+      emptyState("No pending promotions", "New org projects will appear here for approval."),
+    );
+    return;
+  }
+  items.slice(0, 8).forEach((item) => {
+    const row = document.createElement("div");
+    row.className = "entity-item";
+    const meta = document.createElement("div");
+    meta.innerHTML = `
+      <strong>${escapeHtml(item.seat_slug || "seat")}</strong>
+      <p>${escapeHtml(item.preview || "Pending item")}</p>
+      <p>${escapeHtml(item.reference_reason || item.reference_status || "review")}</p>
+    `;
+    row.append(meta);
+    if (canUse("writer")) {
+      const approve = document.createElement("button");
+      approve.className = "secondary-button compact-button";
+      approve.type = "button";
+      approve.textContent = "Approve";
+      approve.addEventListener("click", () => decidePromotionItem(item.id, "approve"));
+      row.append(approve);
+    } else {
+      const chip = document.createElement("span");
+      chip.className = "status-chip status-standby";
+      chip.textContent = "pending";
+      row.append(chip);
+    }
+    dashboardPromotionList.append(row);
+  });
+}
+
+async function decidePromotionItem(itemId, action) {
+  const label = action === "approve" ? "approve" : "reject";
+  if (!window.confirm(`Confirm: ${label} this promotion item?`)) return;
+  try {
+    await api(`/api/promotion/pending/${encodeURIComponent(itemId)}/${action}`, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    showToast(`Promotion item ${label}d`);
+    loadPromotionQueue();
+  } catch (error) {
+    showToast(error.message || `Could not ${label} promotion`, true);
+  }
+}
+
 async function loadGithubSync() {
   try {
     const status = await api("/api/github-sync");
@@ -2682,8 +2761,9 @@ function renderStorageScopeGuide(seatResponse) {
   container.innerHTML = `
     <p class="storage-scope-explainer">
       This seat's <code>${escapeHtml(nodeDataset)}</code> Node is private agent
-      memory; add tag <code>org-ready</code> or <code>vault-contribution</code> to
-      a write to also promote it into shared Central.
+      memory. Writes stay on the Node; shared Central copies come from the
+      <strong>Promotion Agent</strong> (known org work) or your
+      <strong>Promotion Approval</strong> queue (New Org Project).
     </p>
   `;
 }
@@ -3117,6 +3197,7 @@ loadSession().then(() => {
   setPage(initialPage());
   loadMesh();
   loadGithubSync();
+  loadPromotionQueue();
   loadObsidianSources();
   loadConflicts();
   if (canUse("admin")) {

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -237,6 +237,25 @@
                 <section class="window action-panel">
                   <div class="window-titlebar panel-heading">
                     <div>
+                      <h2>Promotion Queue</h2>
+                      <p class="panel-kicker">Node → Central approvals (ADR-0007)</p>
+                    </div>
+                    <span id="dashboardPromotionStatus" class="status-chip status-standby">Checking</span>
+                  </div>
+                  <div id="dashboardPromotionList" class="entity-list" aria-live="polite">
+                    <div class="entity-item">
+                      <div>
+                        <strong>Loading queue</strong>
+                        <p>Pending promotion items will appear here.</p>
+                      </div>
+                      <span class="status-chip status-standby">pending</span>
+                    </div>
+                  </div>
+                </section>
+
+                <section class="window action-panel">
+                  <div class="window-titlebar panel-heading">
+                    <div>
                       <h2>Shared Access</h2>
                       <p class="panel-kicker">Team and agent readers</p>
                     </div>

--- a/skills/citadel-proactive-ingest/README.md
+++ b/skills/citadel-proactive-ingest/README.md
@@ -142,10 +142,10 @@ Either is enough:
 - **Non-blocking.** The script catches everything and exits 0; it cannot block
   or fail a session close.
 
-## Promote to shared Central
+## Share with Central (Promotion Agent)
 
-Auto-sync is always personal. To share a fact org-wide, ingest it mid-session
-with a promotion **tag** (`org-ready` or `vault-contribution`) and still no
-`dataset` field — see `SKILL.md`. Promote only ADRs, shared runbooks, and
-interface contracts, and only when the user asks or the content is plainly
-org-wide.
+Auto-sync is always personal (**Node** only). **Central** copies are governed:
+the **Promotion Agent** auto-promotes known masumi-org work; **New Org Project**
+notes wait for your **Promotion Approval** (dashboard, MCP with confirm, or
+`citadel promotion` CLI). Seat ingest tags do **not** dual-write to **Central**
+— see ADR-0007 and `SKILL.md`.

--- a/skills/citadel-proactive-ingest/SKILL.md
+++ b/skills/citadel-proactive-ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: citadel-proactive-ingest
-description: Use to capture durable engineering knowledge into Citadel automatically and proactively while working in an org repo. Covers (1) mid-session citadel_ingest for durable facts (personal-by-default; org-ready/vault-contribution tags promote to Central), (2) git pre-push commit snapshots (universal baseline — Cursor, Codex, Claude), (3) optional Claude Code SessionEnd distill, and (4) server-side Railway cron for GitHub org sync, Linear sync, and the learning pipeline. Triggers include "auto sync my sessions", "remember this in citadel", "proactive ingest", "set up citadel autosync", "personal kb sync", "install autosync", and https://citadel-archive-production.up.railway.app/skills/proactive-ingest.
+description: Use to capture durable engineering knowledge into Citadel automatically and proactively while working in an org repo. Covers (1) mid-session citadel_ingest for durable facts (personal-by-default; all seat writes land on the Node — Central via Promotion Agent only), (2) git pre-push commit snapshots (universal baseline — Cursor, Codex, Claude), (3) optional Claude Code SessionEnd distill, and (4) server-side Railway cron for GitHub org sync, Linear sync, and the learning pipeline. Triggers include "auto sync my sessions", "remember this in citadel", "proactive ingest", "set up citadel autosync", "personal kb sync", "install autosync", and https://citadel-archive-production.up.railway.app/skills/proactive-ingest.
 ---
 
 # Citadel Proactive Ingest
@@ -24,7 +24,7 @@ cron — all **fail-silent** and **personal-by-default** unless explicitly promo
 
 ```
 Personal node:  seat:{slug}   (the dev's private Citadel node — default target)
-Shared Central: masumi-network (org-wide; only via explicit promotion tags)
+Shared Central: masumi-network (org-wide; Promotion Agent + org sync — not seat tags)
 Hosted base:    https://citadel-archive-production.up.railway.app
 ```
 
@@ -33,20 +33,20 @@ Read/write rules: `https://citadel-archive-production.up.railway.app/skills/vaul
 
 ## Personal-by-default (read first)
 
-| Personal (default) | Shared Central (opt-in) |
+| Personal (default) | Shared Central |
 |---|---|
-| No `dataset` field on writes | tag `org-ready` or `vault-contribution` |
-| Lands in your `seat:{slug}` node | Promotes to `masumi-network` |
-| Only you (+ Central) can read it | Whole org can read it |
+| No `dataset` field on writes | **Promotion Agent** (6h cron + on demand) |
+| Lands in your `seat:{slug}` node | Org GitHub / Linear sync (operator cron) |
+| Only you (+ Central readers) can read your node | Whole org reads promoted **Central** copies |
 
 A **seat-writer token** carries `default_dataset=seat:{slug}`. Send writes with
 **no `dataset` field** and the server's `resolve_write_targets` routes them to
-your private node. Do not set `dataset` to promote — use a promotion **tag**
-instead, so the seat-node default still applies and the dual-write is audited.
+your private **Node**. Seat-scoped writes **never** dual-write to **Central**
+via tags — ADR-0007 **Seat Node Write Policy**.
 
-Never let promotion be a surprise. Promote to Central **only** when the user
-explicitly asks to share, or the content is plainly org-wide (an ADR, a shared
-runbook, an interface contract).
+**Central** updates for your notes happen when the **Promotion Agent** rules
+pass (known masumi-org work) or when you **approve** a **New Org Project**
+proposal in the **Operations Dashboard**, MCP, or `citadel promotion` CLI.
 
 ## Layer 1 — proactive mid-session ingest (agent behavior)
 
@@ -69,16 +69,8 @@ citadel_ingest(
 )
 ```
 
-No `dataset` field → seat node. To promote a genuinely org-wide fact, add a
-promotion tag (still no `dataset`):
-
-```
-citadel_ingest(
-  data="ADR: seat tokens default to their seat:{slug} node; writes omit "
-       "dataset; promotion is by tag, not by dataset override.",
-  tags=["org-ready", "adr"],
-)
-```
+No `dataset` field → seat **Node**. Tag with context (`adr`, `runbook`, repo
+name) for search — tags do **not** route seat writes to **Central**.
 
 **Never ingest** (same rules as `citadel-vault`): secrets, tokens, keys, seed
 phrases, PII, raw logs/debug dumps, ephemeral chatter, or large uncurated

--- a/skills/citadel-vault/SKILL.md
+++ b/skills/citadel-vault/SKILL.md
@@ -95,7 +95,9 @@ context, decisions, source facts, implementation notes, or reusable runbooks.
   the MCP client to gate `citadel_ingest`, `citadel_contribute`, and
   `citadel_record_feedback`.
 - Shared **Central** is read-only from seat MCP. It updates via GitHub/Linear
-  cron sync, selective promotion, and curated non-MCP contributions.
+  cron sync, the **Promotion Agent** (Node → Central), and curated non-MCP
+  contributions. **New Org Project** notes require **Promotion Approval**
+  (dashboard, MCP with confirm, or `citadel promotion` CLI).
 
 Use:
 

--- a/tasks.md
+++ b/tasks.md
@@ -8,6 +8,7 @@
 ### Checkpoints
 
 - [x] P0 Glossary + ADR-0007 + shipping plan + progress (2026-06-27)
+- [x] **P0b Grill refinements** — promotion decision tree locked; CONTEXT + ADR-0007 refinements section (2026-06-27)
 - [x] P2 MCP seat write guards + secret scan extensions (local, pending deploy)
 - [x] **P1 Seat write policy on all HTTP paths** (2026-06-27)
 - [x] P3 Server capture policy API + admin baseline (2026-06-27)
@@ -15,8 +16,35 @@
 - [x] **CLI shipped** — `citadel onboard`/`status`/`tui`, headless `--json`,
   branded home screen; **published to PyPI** as `citadel-archive` v0.1.2 +
   bootstrap installer (beyond ADR-0007 scope; see progress.md) (2026-06-27)
-- [ ] P5 Promotion Agent (GitHub + Central refs, tags, 6h + on demand)
-- [ ] P6 Promotion Approval queue (dashboard + MCP, admin delegate + audit)
+- [x] P5 Promotion Agent (GitHub + Central refs, tags, 6h + on demand)
+- [x] P6 Promotion Approval queue (dashboard + MCP, admin delegate + audit)
+
+### P5 — Promotion Agent (in progress, local)
+
+- [x] `kb/promotion_refs.py` — GitHub org repo list + Central search reference checks
+- [x] Capture Root Tag gate (`personal` never auto-promotes)
+- [x] **New Org Project** → `pending_approval` queue instead of auto-promote
+- [x] Wired into `PromotionEngine.run` (6h evolve cron already calls it via `run_railway.py`)
+- [x] **Grill parity:** masumi-org-only auto-promote (no LLM-only path for `no_reference_signal`)
+- [x] **Grill parity:** require `org-work` tag on capture-root candidates
+- [x] **Grill parity:** no-repo-hint → Central match only, else skip (no queue)
+- [x] **Grill parity:** secret scan + LLM always required on every candidate
+- [x] **Grill parity:** promotion metadata on Central writes (traceability v1)
+- [x] **Grill parity:** reject dedupe / candidate hash — no re-queue unchanged notes
+- [x] Seat-scoped `POST /api/promote/run` (member own seat; admin any)
+- [x] `citadel promotion run|list|approve|reject` CLI + `--json`
+- [ ] Deploy + production verify with `CITADEL_PROMOTION_ENABLED` (PR #TBD)
+- [ ] Add Railway `evolve` cron (`0 */6 * * *`) for scheduled promotion pass
+
+### P6 — Promotion Approval (in progress, local)
+
+- [x] `GET /api/promotion/pending` + `POST .../approve` + `POST .../reject`
+- [x] Dashboard **Promotion Queue** panel + Access-style approve button
+- [x] MCP: `citadel_promotion_pending`, `citadel_promotion_approve`, `citadel_promotion_reject`
+- [x] Admin delegate audit on approve/reject
+- [x] **Grill parity:** document agent-proposes / member-responds (no manual queue add)
+- [x] `citadel promotion approve|reject` CLI + `--json`
+- [ ] Browser QA on production
 
 ### P1 — Seat write policy ✅ (2026-06-27)
 

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from kb.access import AccessStore, seat_dataset
+from kb.access import AccessStore, AccessIdentity, seat_dataset
 from kb.config import CitadelConfig
 from kb.models import IngestResult
 from kb.promotion import PromotionEngine, _coerce_classification
@@ -22,12 +22,17 @@ SECRET_TEXT = "deploy creds " + "AKIA" + "ABCDEFGHIJKLMNOP" + " rotate me"
 
 
 class FakeCitadel:
-    def __init__(self, config: CitadelConfig, nodes: list[str]) -> None:
+    def __init__(self, config: CitadelConfig, nodes: list[str], *, central_hits: bool = False) -> None:
         self.config = config
         self._nodes = nodes
+        self.central_hits = central_hits
 
     async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
-        # Same nodes for every seed query; the engine dedupes by text.
+        dataset = kwargs.get("dataset")
+        if dataset == CENTRAL:
+            if self.central_hits:
+                return [{"text": f"Central knowledge matching {query[:40]}"}]
+            return []
         return [{"text": node} for node in self._nodes]
 
 
@@ -52,12 +57,39 @@ def _config(**overrides: Any) -> CitadelConfig:
     return CitadelConfig(**base)
 
 
-def _engine(tmp_path: Path, nodes: list[str], config: CitadelConfig | None = None) -> tuple[PromotionEngine, FakeLearning, AccessStore]:
+def _engine(
+    tmp_path: Path,
+    nodes: list[str],
+    config: CitadelConfig | None = None,
+    *,
+    central_hits: bool = False,
+) -> tuple[PromotionEngine, FakeLearning, AccessStore]:
     config = config or _config()
     learning = FakeLearning()
     store = AccessStore(str(tmp_path / "access.json"))
-    engine = PromotionEngine(FakeCitadel(config, nodes), learning, store, config)
+    engine = PromotionEngine(
+        FakeCitadel(config, nodes, central_hits=central_hits),
+        learning,
+        store,
+        config,
+    )
     return engine, learning, store
+
+
+def _org_note(extra: str = "roadmap") -> str:
+    return (
+        f"Org note about the product {extra} — "
+        "https://github.com/masumi-network/Citadel-Archive"
+    )
+
+
+def _github_state(tmp_path: Path) -> CitadelConfig:
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text(
+        '{"repos": {"masumi-network/Citadel-Archive": {}}}',
+        encoding="utf-8",
+    )
+    return _config(github_sync_state_path=str(state_path))
 
 
 def _stub_llm(monkeypatch: pytest.MonkeyPatch, *, relevant: bool = True, sensitive: bool = False, score: float = 0.9, fail: bool = False) -> None:
@@ -78,7 +110,11 @@ def test_coerce_classification_rejects_malformed() -> None:
 
 
 async def test_dry_run_proposes_but_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    engine, learning, store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    engine, learning, store = _engine(
+        tmp_path,
+        [_org_note()],
+        _github_state(tmp_path),
+    )
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
 
     result = await engine.run(SEAT, dry_run=True)
@@ -93,7 +129,11 @@ async def test_dry_run_proposes_but_writes_nothing(tmp_path: Path, monkeypatch: 
 
 
 async def test_relevant_clean_item_is_promoted_to_central_with_audit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    engine, learning, store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    engine, learning, store = _engine(
+        tmp_path,
+        [_org_note()],
+        _github_state(tmp_path),
+    )
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
 
     result = await engine.run(SEAT, dry_run=False)
@@ -102,6 +142,8 @@ async def test_relevant_clean_item_is_promoted_to_central_with_audit(tmp_path: P
     # Promotion routed through the org-ready dual-write -> a real Central write.
     assert len(learning.central_writes) == 1
     assert "org-ready" in learning.central_writes[0]["tags"]
+    assert "promotion-agent" in learning.central_writes[0]["tags"]
+    assert "promotion-seat:alice" in learning.central_writes[0]["tags"]
     promote_events = store.recent_audit_events(action="promotion.promote")
     assert len(promote_events) == 1
     assert promote_events[0]["success"] is True
@@ -136,7 +178,11 @@ async def test_secret_bearing_item_is_not_promoted(tmp_path: Path, monkeypatch: 
 
 
 async def test_llm_failure_falls_back_to_skip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    engine, learning, _store = _engine(tmp_path, ["a useful org note about the product roadmap"])
+    engine, learning, _store = _engine(
+        tmp_path,
+        [_org_note()],
+        _github_state(tmp_path),
+    )
     _stub_llm(monkeypatch, fail=True)
 
     result = await engine.run(SEAT, dry_run=False)
@@ -148,7 +194,11 @@ async def test_llm_failure_falls_back_to_skip(tmp_path: Path, monkeypatch: pytes
 
 
 async def test_below_threshold_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    engine, learning, _store = _engine(tmp_path, ["a marginal note"])
+    engine, learning, _store = _engine(
+        tmp_path,
+        [_org_note("marginal")],
+        _github_state(tmp_path),
+    )
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.5)
 
     result = await engine.run(SEAT, dry_run=False)
@@ -173,3 +223,137 @@ async def test_non_seat_dataset_rejected(tmp_path: Path) -> None:
     engine, _learning, _store = _engine(tmp_path, ["anything"])
     with pytest.raises(ValueError):
         await engine.run(CENTRAL, dry_run=True)
+
+
+async def test_personal_capture_tag_never_promotes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = (
+        "# Capture summary: notes\n"
+        "- Capture Root Tags: personal\n"
+        "- Path: `/tmp/notes`\n"
+    )
+    engine, learning, _store = _engine(tmp_path, [summary])
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.99)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert learning.central_writes == []
+    assert result["proposals"][0]["decision"] == "skip"
+    assert result["proposals"][0]["reason"] == "capture_tag_personal"
+
+
+async def test_new_org_project_queues_pending_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = (
+        "# Capture summary: side project\n"
+        "- Remote: `https://github.com/other-org/new-app.git`\n"
+        "- Capture Root Tags: org-work\n"
+    )
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text('{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8")
+    engine, learning, store = _engine(
+        tmp_path,
+        [summary],
+        config=_config(github_sync_state_path=str(state_path)),
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.95)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert result["queued"] == 1
+    assert learning.central_writes == []
+    assert result["proposals"][0]["decision"] == "pending_approval"
+    pending = store.list_promotion_pending(seat_slug="alice")
+    assert len(pending) == 1
+
+
+async def test_unreferenced_note_skips_without_central_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine, learning, _store = _engine(
+        tmp_path,
+        ["a useful org note about the product roadmap with no repo link"],
+        _github_state(tmp_path),
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert result["proposals"][0]["decision"] == "skip"
+    assert result["proposals"][0]["reason"] == "no_org_reference"
+    assert learning.central_writes == []
+
+
+async def test_unreferenced_note_promotes_on_central_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine, learning, _store = _engine(
+        tmp_path,
+        ["shared runbook details with no repo link"],
+        _github_state(tmp_path),
+        central_hits=True,
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 1
+    assert learning.central_writes
+
+
+async def test_custom_capture_tag_never_auto_promotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary = (
+        "# Capture summary: side repo\n"
+        "- Remote: `https://github.com/masumi-network/Citadel-Archive.git`\n"
+        "- Capture Root Tags: custom-label\n"
+    )
+    engine, learning, _store = _engine(
+        tmp_path,
+        [summary],
+        _github_state(tmp_path),
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.99)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    assert result["proposals"][0]["reason"] == "capture_tag_not_org_work"
+    assert learning.central_writes == []
+
+
+async def test_rejected_candidate_is_not_requeued(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary = (
+        "# Capture summary: side project\n"
+        "- Remote: `https://github.com/other-org/new-app.git`\n"
+        "- Capture Root Tags: org-work\n"
+    )
+    engine, learning, store = _engine(
+        tmp_path,
+        [summary],
+        _github_state(tmp_path),
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.95)
+
+    first = await engine.run(SEAT, dry_run=False)
+    assert first["queued"] == 1
+    item = store.list_promotion_pending(seat_slug="alice")[0]
+    actor = AccessIdentity(
+        role="writer",
+        actor_id="alice",
+        actor_kind="user",
+        actor_name="Alice",
+        source="token",
+        default_dataset=SEAT,
+        seat_slug="alice",
+    )
+    await engine.reject_pending(item.id, actor)
+
+    second = await engine.run(SEAT, dry_run=False)
+    assert second["queued"] == 0
+    assert second["proposals"][0]["reason"] == "previously_rejected"
+    assert learning.central_writes == []

--- a/tests/test_promotion_refs.py
+++ b/tests/test_promotion_refs.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kb.promotion_refs import (
+    ReferenceAssessment,
+    assess_org_reference,
+    extract_repo_hints,
+    load_tracked_org_repos,
+    parse_capture_tags_from_text,
+)
+
+
+class FakeCitadel:
+    def __init__(self, central_hits: bool = False) -> None:
+        self.central_hits = central_hits
+
+    async def search(self, query: str, **kwargs: object) -> list[dict[str, str]]:
+        if self.central_hits:
+            return [{"text": f"Central knowledge about {query}"}]
+        return []
+
+
+def test_extract_repo_hints_from_capture_summary() -> None:
+    text = """
+    # Capture summary: demo
+    - Remote: `https://github.com/other-org/new-project.git`
+    - Capture Root Tags: org-work
+    """
+    hints = extract_repo_hints(text)
+    assert "other-org/new-project" in hints
+
+
+def test_parse_capture_tags_from_text() -> None:
+    assert parse_capture_tags_from_text("- Capture Root Tags: personal, capture") == (
+        "personal",
+        "capture",
+    )
+
+
+def test_load_tracked_org_repos_reads_github_state(tmp_path: Path) -> None:
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text(
+        json.dumps({"repos": {"masumi-network/Citadel-Archive": {"updated_at": "now"}}}),
+        encoding="utf-8",
+    )
+    repos = load_tracked_org_repos(state_path, "masumi-network")
+    assert "masumi-network/citadel-archive" in repos
+    assert "citadel-archive" in repos
+
+
+async def test_assess_org_reference_known_repo(tmp_path: Path) -> None:
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text(
+        json.dumps({"repos": {"masumi-network/Citadel-Archive": {}}}),
+        encoding="utf-8",
+    )
+    text = "Work on https://github.com/masumi-network/Citadel-Archive/pull/1"
+    result = await assess_org_reference(
+        FakeCitadel(),
+        candidate_text=text,
+        central_dataset="masumi-network",
+        github_state_path=state_path,
+        github_org="masumi-network",
+    )
+    assert result.status == "known_org_work"
+
+
+async def test_assess_org_reference_new_project(tmp_path: Path) -> None:
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text(json.dumps({"repos": {"masumi-network/Citadel-Archive": {}}}), encoding="utf-8")
+    text = "Remote: https://github.com/other-org/brand-new-app.git"
+    result = await assess_org_reference(
+        FakeCitadel(central_hits=False),
+        candidate_text=text,
+        central_dataset="masumi-network",
+        github_state_path=state_path,
+        github_org="masumi-network",
+    )
+    assert result.status == "new_org_project"
+
+
+async def test_assess_org_reference_central_match_without_repo_hint() -> None:
+    text = "Shared interface contract with no repository reference."
+    result = await assess_org_reference(
+        FakeCitadel(central_hits=True),
+        candidate_text=text,
+        central_dataset="masumi-network",
+        github_state_path=Path("/nonexistent/state.json"),
+        github_org="masumi-network",
+    )
+    assert result.status == "known_org_work"
+    assert result.reason == "central_match_no_repo"
+
+
+async def test_assess_org_reference_no_hint_no_central_match() -> None:
+    text = "Random note with no repo and no Central overlap."
+    result = await assess_org_reference(
+        FakeCitadel(central_hits=False),
+        candidate_text=text,
+        central_dataset="masumi-network",
+        github_state_path=Path("/nonexistent/state.json"),
+        github_org="masumi-network",
+    )
+    assert result.status == "no_reference_signal"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2401,6 +2401,40 @@ def test_promotion_run_disabled_returns_status_and_audits() -> None:
     assert runs and runs[-1]["success"] is True
 
 
+def test_seat_writer_can_run_own_promotion(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    created = admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"})
+    token = created.json()["token"]
+    seat_client = TestClient(app, base_url="https://testserver")
+
+    response = seat_client.post(
+        "/api/promote/run",
+        json={"dataset": "seat:alice", "dry_run": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["dataset"] == "seat:alice"
+
+
+def test_seat_writer_cannot_run_other_seat_promotion(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"})
+    bob = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"})
+    bob_token = bob.json()["token"]
+    bob_client = TestClient(app, base_url="https://testserver")
+
+    response = bob_client.post(
+        "/api/promote/run",
+        json={"dataset": "seat:alice", "dry_run": True},
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+
+    assert response.status_code == 403
+
+
 def _seat_mcp_client(tmp_path: Any, slug: str) -> tuple[TestClient, str, TrackingCitadel]:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
@@ -2824,3 +2858,37 @@ def test_seat_capture_policy_put_requires_admin(tmp_path: Any) -> None:
     )
 
     assert response.status_code == 403
+
+
+def test_promotion_pending_list_redacts_body(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"})
+    created = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"})
+    bob_token = created.json()["token"]
+    bob_client = TestClient(app, base_url="https://testserver")
+
+    from kb.access import now_iso
+    from kb.promotion_queue import build_pending_item
+    from kb.promotion_refs import ReferenceAssessment
+
+    item = build_pending_item(
+        seat_slug="alice",
+        seat_dataset="seat:alice",
+        candidate_text="secret candidate body should not leak",
+        assessment=ReferenceAssessment(status="new_org_project", reason="no_org_or_central_match"),
+        created_at=now_iso(),
+    )
+    app.state.access_store.add_promotion_pending(item)
+
+    own = admin.get("/api/promotion/pending")
+    assert own.status_code == 200
+    assert own.json()["count"] == 1
+    assert "candidate_text" not in own.json()["items"][0]
+
+    other = bob_client.get(
+        "/api/promotion/pending",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert other.status_code == 200
+    assert other.json()["count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -752,10 +752,12 @@ wheels = [
 ]
 
 [[package]]
-name = "citadel"
-version = "0.1.0"
+name = "citadel-archive"
+version = "0.1.2"
 source = { editable = "." }
-dependencies = [
+
+[package.optional-dependencies]
+server = [
     { name = "cognee", extra = ["fastembed", "postgres-binary"] },
     { name = "fastapi" },
     { name = "google-auth" },
@@ -765,31 +767,38 @@ dependencies = [
     { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+tui = [
+    { name = "textual" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "textual" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", extras = ["fastembed", "postgres-binary"], specifier = ">=1.2.1,<2.0.0" },
-    { name = "fastapi", specifier = ">=0.116.2,<1.0.0" },
-    { name = "google-auth", specifier = ">=2.40.0,<3.0.0" },
-    { name = "mcp", specifier = ">=1.23.0,<2.0.0" },
-    { name = "pydantic", specifier = ">=2.10.5,<3.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
-    { name = "requests", specifier = ">=2.32.0,<3.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0,<1.0.0" },
+    { name = "cognee", extras = ["fastembed", "postgres-binary"], marker = "extra == 'server'", specifier = ">=1.2.1,<2.0.0" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.116.2,<1.0.0" },
+    { name = "google-auth", marker = "extra == 'server'", specifier = ">=2.40.0,<3.0.0" },
+    { name = "mcp", marker = "extra == 'server'", specifier = ">=1.23.0,<2.0.0" },
+    { name = "pydantic", marker = "extra == 'server'", specifier = ">=2.10.5,<3.0.0" },
+    { name = "python-dotenv", marker = "extra == 'server'", specifier = ">=1.0.1,<2.0.0" },
+    { name = "requests", marker = "extra == 'server'", specifier = ">=2.32.0,<3.0.0" },
+    { name = "textual", marker = "extra == 'tui'", specifier = ">=0.50" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.34.0,<1.0.0" },
 ]
+provides-extras = ["server", "tui"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=7.4.0,<9" },
     { name = "pytest-asyncio", specifier = ">=0.21.1,<2" },
     { name = "ruff", specifier = ">=0.9.2,<1" },
+    { name = "textual", specifier = ">=0.50" },
 ]
 
 [[package]]
@@ -2009,6 +2018,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2140,6 +2161,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -2248,6 +2274,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -4427,6 +4465,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4635,6 +4690,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Ship the **Promotion Agent** with grill-locked rules: masumi-org / Central reference checks, capture `org-work` gate, secret scan + LLM always, reject dedupe, and promotion metadata on Central writes.
- Add **Promotion Approval** surfaces: dashboard queue, MCP tools, seat-scoped `POST /api/promote/run`, and `citadel promotion list|approve|reject|run` CLI.
- Update CONTEXT, ADR-0007, skills, and onboarding docs; remove stale `org-ready` seat→Central guidance.

## Test plan
- [x] `pytest tests/test_promotion.py tests/test_promotion_refs.py` — promotion decision tree
- [x] `pytest tests/test_server.py -k promotion` — API + seat-scoped run
- [ ] Merge → Railway auto-deploy
- [ ] Set `CITADEL_PROMOTION_ENABLED=true` on **Citadel-Archive** (see `docs/operations.md`)
- [ ] Verify `GET /api/promote` (admin) and `citadel promotion run --json` (seat token)
- [ ] Browser QA: Operations Dashboard **Promotion Queue** panel
- [ ] Optional: add Railway `evolve` cron for 6h scheduled promotion pass


Made with [Cursor](https://cursor.com)