### PR TITLE
feat(cli): UX overhaul — guided onboarding, multi-tool MCP, doctor, seat/token

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,23 +101,28 @@ run "$PIPX install $PKG"
 
 if [ "$DRY_RUN" = 1 ]; then
   say ""
-  say "  [dry-run] would show the citadel home screen here"
+  say "  [dry-run] would launch: citadel onboard   (guided setup)"
   exit 0
 fi
 
-# End on the brand: show the home screen if `citadel` is reachable this session.
 CITADEL_BIN="$(command -v citadel 2>/dev/null || true)"
 if [ -z "$CITADEL_BIN" ] && [ -x "$HOME/.local/bin/citadel" ]; then
   CITADEL_BIN="$HOME/.local/bin/citadel"
 fi
 
 say ""
-if [ -n "$CITADEL_BIN" ]; then
-  "$CITADEL_BIN" || true
-  say ""
-  say "Next:  citadel onboard     # set up this repo (token · hooks · MCP · capture)"
-else
+if [ -z "$CITADEL_BIN" ]; then
   say "Done. Open a new shell so your PATH updates, then run:"
   say "  citadel             # the home screen"
   say "  citadel onboard     # set up this repo"
+# Land directly in guided onboarding when a controlling terminal is reachable
+# (even under `curl | sh`, where this script's stdin is the pipe). The
+# `< /dev/tty` redirect hands the wizard the user's keyboard. With -y or no tty
+# (CI), fall back to printing the home screen + a next-step hint instead.
+elif [ "$ASSUME_YES" != 1 ] && { : > /dev/tty; } 2>/dev/null; then
+  "$CITADEL_BIN" onboard < /dev/tty || true
+else
+  "$CITADEL_BIN" --no-onboard || true
+  say ""
+  say "Next:  citadel onboard     # set up this repo (token · hooks · MCP · capture)"
 fi

--- a/kb/access_client.py
+++ b/kb/access_client.py
@@ -1,0 +1,150 @@
+"""HTTP client for the Access admin API — backs ``citadel seat`` / ``citadel token``.
+
+The admin key is read ONLY from ``CITADEL_ADMIN_KEY`` in the environment — never
+a CLI argument, because argv leaks via ``ps`` and shell history. All calls are
+HTTPS-only and never follow redirects. A freshly minted token is returned to the
+caller exactly once; this module never logs or persists it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from kb.capture_config import DEFAULT_NODE_URL, load_capture_config
+
+ADMIN_KEY_ENV = "CITADEL_ADMIN_KEY"
+_TIMEOUT = 60.0
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirectHandler)
+
+
+class AccessClientError(RuntimeError):
+    def __init__(self, message: str, *, status: int | None = None, body: Any = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def admin_key() -> str:
+    """The admin bootstrap key from the environment, or a clean error."""
+    key = (os.getenv(ADMIN_KEY_ENV) or "").strip()
+    if not key:
+        raise AccessClientError(
+            f"missing admin key — set {ADMIN_KEY_ENV} in the environment "
+            "(never pass an admin key on the command line)"
+        )
+    return key
+
+
+def node_base_url(override: str | None = None) -> str:
+    if override:
+        return override.rstrip("/")
+    try:
+        config = load_capture_config()
+        if config.node_url:
+            return config.node_url.rstrip("/")
+    except ValueError:
+        pass
+    return DEFAULT_NODE_URL.rstrip("/")
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    base_url: str,
+    key: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = _TIMEOUT,
+) -> Any:
+    if not base_url.lower().startswith("https://"):
+        raise AccessClientError("refusing non-HTTPS Node URL")
+    url = f"{base_url}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {key}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _OPENER.open(req, timeout=timeout) as resp:  # noqa: S310
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode() if exc.fp else ""
+        parsed: Any = raw
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            pass
+        detail = parsed.get("detail") if isinstance(parsed, dict) else raw or exc.reason
+        raise AccessClientError(str(detail or exc.reason), status=exc.code, body=parsed) from exc
+    except urllib.error.URLError as exc:
+        raise AccessClientError(str(exc.reason)) from exc
+    return json.loads(body) if body else {}
+
+
+def list_seats(*, base_url: str, key: str | None = None) -> dict[str, Any]:
+    return _request("GET", "/api/access/seats", base_url=base_url, key=key or admin_key())
+
+
+def create_seat(
+    *,
+    base_url: str,
+    name: str,
+    slug: str,
+    email: str | None = None,
+    role: str = "writer",
+    issue_token: bool = True,
+    token_name: str | None = None,
+    key: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": name,
+        "slug": slug,
+        "role": role,
+        "issue_token": issue_token,
+    }
+    if email:
+        payload["email"] = email
+    if token_name:
+        payload["token_name"] = token_name
+    return _request("POST", "/api/access/seats", base_url=base_url, key=key or admin_key(), payload=payload)
+
+
+def create_token(
+    *,
+    base_url: str,
+    name: str,
+    role: str = "reader",
+    kind: str = "service_account",
+    default_dataset: str | None = None,
+    default_session: str | None = None,
+    allowed_datasets: list[str] | None = None,
+    expires_at: str | None = None,
+    key: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"name": name, "role": role, "kind": kind}
+    if default_dataset:
+        payload["default_dataset"] = default_dataset
+    if default_session:
+        payload["default_session"] = default_session
+    if allowed_datasets:
+        payload["allowed_datasets"] = allowed_datasets
+    if expires_at:
+        payload["expires_at"] = expires_at
+    return _request("POST", "/api/access/tokens", base_url=base_url, key=key or admin_key(), payload=payload)
+
+
+def revoke_token(token_id: str, *, base_url: str, key: str | None = None) -> dict[str, Any]:
+    return _request(
+        "POST", f"/api/access/tokens/{token_id}/revoke", base_url=base_url, key=key or admin_key()
+    )

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -51,14 +51,30 @@ _ANSI = {
     "yellow": "\033[33m",
 }
 
+# Semantic status glyphs — one shared vocabulary across home/status/onboard so
+# the surfaces read like one product. Shape (not just color) carries pass/fail,
+# so the signal survives NO_COLOR and low-DPI terminals where a filled vs hollow
+# dot is indistinguishable.
+OK = "✓"
+FAIL = "✗"
+WARN = "!"
+SKIP = "⊘"
+BULLET = "•"
+
 
 def supports_color(stream: IO[str] | None = None) -> bool:
-    """True only on a real TTY that hasn't opted out (NO_COLOR / dumb term)."""
+    """True on a real TTY (or when forced) that hasn't opted out.
+
+    Opt-outs (NO_COLOR / TERM=dumb) win over force flags. FORCE_COLOR /
+    CLICOLOR_FORCE then enable color even when piped (e.g. `… | less -R`).
+    """
     stream = stream if stream is not None else sys.stdout
     if os.getenv("NO_COLOR"):
         return False
     if os.getenv("TERM") == "dumb":
         return False
+    if os.getenv("FORCE_COLOR") or os.getenv("CLICOLOR_FORCE"):
+        return True
     try:
         return bool(stream.isatty())
     except (AttributeError, ValueError):
@@ -71,6 +87,16 @@ def paint(text: str, *styles: str, enable: bool = True) -> str:
         return text
     codes = "".join(_ANSI.get(style, "") for style in styles)
     return f"{codes}{text}{_ANSI['reset']}" if codes else text
+
+
+def glyph(ok: bool) -> str:
+    """The bare pass/fail glyph (✓ / ✗) — shape carries the signal sans color."""
+    return OK if ok else FAIL
+
+
+def mark(ok: bool, *, enable: bool = True) -> str:
+    """The status glyph painted green (pass) or red (fail)."""
+    return paint(glyph(ok), "green" if ok else "red", enable=enable)
 
 
 def banner_large(*, color: bool = True) -> str:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -4,13 +4,18 @@ import argparse
 import asyncio
 import difflib
 import functools
+import getpass
+import http.client
 import json
 import os
 import re
 import sys
+import threading
 import urllib.error
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -39,7 +44,14 @@ from kb.onboard import (
     merge_claude_settings,
     merge_mcp_config,
 )
-from kb.banner import banner, banner_large, paint, supports_color
+from kb.banner import SKIP, banner, banner_large, mark, paint, supports_color
+from kb.access_client import (
+    AccessClientError,
+    create_seat,
+    create_token,
+    list_seats,
+    revoke_token,
+)
 from kb.promotion_client import (
     PromotionClientError,
     approve_pending,
@@ -55,6 +67,44 @@ def _print_json(value: Any) -> None:
     print(json.dumps(value, default=str, indent=2))
 
 
+class _Spinner:
+    """A minimal stdlib spinner on stderr (so stdout stays clean/parseable).
+
+    Active only when stderr is a real TTY; a no-op otherwise (CI, pipes, --json),
+    so it never pollutes captured output.
+    """
+
+    _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        self.enable = sys.stderr.isatty()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _run(self) -> None:
+        i = 0
+        while not self._stop.is_set():
+            frame = self._FRAMES[i % len(self._FRAMES)]
+            sys.stderr.write(f"\r{frame} {self.message}")
+            sys.stderr.flush()
+            i += 1
+            self._stop.wait(0.1)
+
+    def __enter__(self) -> "_Spinner":
+        if self.enable:
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=0.5)
+            sys.stderr.write("\r\033[K")  # erase the spinner line
+            sys.stderr.flush()
+
+
 def _needs_server(
     fn: Callable[[argparse.Namespace], Awaitable[Any]],
 ) -> Callable[[argparse.Namespace], Awaitable[Any]]:
@@ -62,19 +112,36 @@ def _needs_server(
 
     @functools.wraps(fn)
     async def wrapper(args: argparse.Namespace) -> Any:
+        cmd = getattr(args, "command", "") or ""
         try:
             return await fn(args)
         except ImportError as exc:
             missing = getattr(exc, "name", None) or str(exc)
             print(
-                f"`citadel {getattr(args, 'command', '')}` needs the server extra:\n"
-                "  pip install 'citadel-archive[server]'\n"
+                f"`citadel {cmd}` needs the server extra:\n"
+                "  pip install 'citadel-archive[server]'"
+                "    (pipx: pipx install --force 'citadel-archive[server]')\n"
                 f"  (missing dependency: {missing})",
                 file=sys.stderr,
             )
             return 2
+        except Exception as exc:
+            # Operational failure (network, cognee, bad dataset): a clean stderr
+            # line and a nonzero exit — never a raw traceback dumped at the user.
+            print(f"citadel {cmd}: {exc}", file=sys.stderr)
+            return 1
 
     return wrapper
+
+
+def _result_exit(value: Any) -> int:
+    """Exit 1 when a result payload carries ``ok: False``; else 0.
+
+    Closes the 'JSON says failed but exit 0' gap without each handler having to
+    special-case it. Values without an ``ok`` key (lists, plain results) → 0.
+    """
+    data = value if isinstance(value, dict) else getattr(value, "__dict__", {})
+    return 1 if isinstance(data, dict) and data.get("ok") is False else 0
 
 
 @_needs_server
@@ -89,10 +156,65 @@ async def _ingest(args: argparse.Namespace) -> None:
         session_id=args.session,
     )
     _print_json(result.__dict__)
+    return _result_exit(result)
+
+
+def _render_search(results: list[Any], query: str) -> None:
+    color = supports_color()
+    if not results:
+        print(paint(f'No results for "{query}".', "dim", enable=color))
+        return
+    print(f'{len(results)} result(s) for "{query}":\n')
+    for index, item in enumerate(results, 1):
+        if isinstance(item, dict):
+            text = (
+                item.get("text") or item.get("content") or item.get("summary")
+                or item.get("title") or item.get("name") or json.dumps(item, default=str)
+            )
+        else:
+            text = str(item)
+        text = " ".join(str(text).split())
+        snippet = text[:300] + ("…" if len(text) > 300 else "")
+        print(f"  {paint(f'{index}.', 'cyan', enable=color)} {snippet}")
+
+
+async def _search(args: argparse.Namespace) -> int:
+    """Search the Organization Vault over HTTP (the Node), like MCP citadel_search.
+
+    Zero-dep: hits the Node's /search with the seat token, so base-install
+    teammates can query the same vault their agent sees. `--local` runs the
+    in-process server stack instead (needs the [server] extra).
+    """
+    if getattr(args, "local", False):
+        return await _search_local(args)
+    base_url = node_base_url(getattr(args, "node_url", None))
+    token = capture_token()
+    if not token:
+        print(
+            "citadel search: no token — set CITADEL_MCP_ACCESS_TOKEN or run `citadel onboard`.",
+            file=sys.stderr,
+        )
+        return 1
+    from kb.status import search_node
+
+    try:
+        results = await asyncio.to_thread(search_node, base_url, token, args.query, args.top_k)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:200] if exc.fp else exc.reason
+        print(f"citadel search: HTTP {exc.code} {detail}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
+        print(f"citadel search: {exc}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        _print_json(results)
+    else:
+        _render_search(results, args.query)
+    return 0
 
 
 @_needs_server
-async def _search(args: argparse.Namespace) -> None:
+async def _search_local(args: argparse.Namespace) -> int:
     from kb.service import Citadel
 
     kb = Citadel.from_env()
@@ -103,6 +225,7 @@ async def _search(args: argparse.Namespace) -> None:
         top_k=args.top_k,
     )
     _print_json(results)
+    return _result_exit(results)
 
 
 @_needs_server
@@ -121,6 +244,7 @@ async def _feedback(args: argparse.Namespace) -> None:
         )
     )
     _print_json(result.__dict__)
+    return _result_exit(result)
 
 
 @_needs_server
@@ -130,6 +254,7 @@ async def _improve(args: argparse.Namespace) -> None:
     kb = Citadel.from_env()
     result = await kb.improve(dataset=args.dataset, session_ids=args.session_id)
     _print_json(result)
+    return _result_exit(result)
 
 
 @_needs_server
@@ -139,6 +264,7 @@ async def _cognify(args: argparse.Namespace) -> None:
     kb = Citadel.from_env()
     result = await kb.cognify_dataset(dataset=args.dataset, verify=args.verify)
     _print_json(result)
+    return _result_exit(result)
 
 
 @_needs_server
@@ -159,6 +285,7 @@ async def _sync_github(args: argparse.Namespace) -> None:
     )
     result = await syncer.run(force=args.force, dry_run=args.dry_run)
     _print_json(result)
+    return _result_exit(result)
 
 
 @_needs_server
@@ -169,6 +296,7 @@ async def _sync_repo_content(args: argparse.Namespace) -> None:
     syncer = RepoContentSyncer(Citadel.from_env())
     result = await syncer.run(force=args.force, dry_run=args.dry_run)
     _print_json(result)
+    return _result_exit(result)
 
 
 @_needs_server
@@ -183,6 +311,7 @@ async def _learn(args: argparse.Namespace) -> None:
         include_digest_preview=not args.hide_digest_preview,
     )
     _print_json(result)
+    return _result_exit(result)
 
 
 def _parse_root_arg(raw: str) -> tuple[str, tuple[str, ...]]:
@@ -259,9 +388,10 @@ async def _setup(args: argparse.Namespace) -> int:
     written = save_capture_config(
         config, path=config_path, updated_at=datetime.now(timezone.utc).isoformat()
     )
-    if not getattr(args, "json", False):
+    if getattr(args, "json", False):
+        _print_json(load_capture_config(config_path).to_dict())
+    else:
         print(f"\nSaved {len(config.roots)} approved root(s) to {written}")
-    _print_json(load_capture_config(config_path).to_dict())
     return 0
 
 
@@ -330,8 +460,7 @@ async def _capture(args: argparse.Namespace) -> int:
                 print(f"FAIL {root.path}: {exc}", file=sys.stderr)
     if as_json:
         _print_json({"ok": failures == 0, "results": results})
-    else:
-        _print_json(results)
+    # Human mode already printed a per-root OK/FAIL line during the loop.
     return 1 if failures else 0
 
 
@@ -431,6 +560,197 @@ async def _promotion_run(args: argparse.Namespace) -> int:
     return 0 if result.get("ok") else 1
 
 
+def _access_exit(exc: AccessClientError, *, as_json: bool) -> int:
+    if as_json:
+        _print_json({"ok": False, "error": str(exc), "status": exc.status, "body": exc.body})
+    else:
+        print(f"citadel: {exc}", file=sys.stderr)
+    return 1
+
+
+def _print_minted_token(token: str, api_token: dict[str, Any], *, color: bool) -> None:
+    """Print a freshly minted token once, with a store-it-now warning."""
+    print()
+    print(paint("  Token (shown once — copy it now, it cannot be retrieved later):", "yellow", enable=color))
+    print("    " + paint(token, "bold", enable=color))
+    meta = f"  id={api_token.get('id')}  role={api_token.get('role')}"
+    print(paint(meta, "dim", enable=color))
+    print(paint("  Share over a private channel; the teammate pastes it into `citadel onboard`.", "dim", enable=color))
+
+
+async def _seat_list(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = list_seats(base_url=node_base_url(args.node_url))
+    except AccessClientError as exc:
+        return _access_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+        return 0
+    color = supports_color()
+    seats = result.get("seats") or []
+    print(f"Seats ({len(seats)}):")
+    for seat in seats:
+        disabled = paint("  [disabled]", "red", enable=color) if seat.get("disabled") else ""
+        slug = paint(str(seat.get("seat_slug") or "—"), "cyan", enable=color)
+        print(
+            f"  {slug}  {seat.get('name', '')}  role={seat.get('role')}  "
+            f"tokens={seat.get('active_token_count', 0)}{disabled}"
+        )
+    return 0
+
+
+async def _seat_create(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = create_seat(
+            base_url=node_base_url(args.node_url),
+            name=args.name,
+            slug=args.slug,
+            email=args.email,
+            role=args.role,
+            issue_token=not args.no_token,
+        )
+    except AccessClientError as exc:
+        return _access_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+        return 0
+    color = supports_color()
+    principal = result.get("principal", {})
+    print(
+        paint(
+            f"Seat created: {principal.get('seat_slug')}  (dataset {principal.get('default_dataset')})",
+            "green",
+            enable=color,
+        )
+    )
+    token = result.get("token")
+    if token:
+        _print_minted_token(token, result.get("api_token", {}), color=color)
+    else:
+        print("  (no token issued — re-run without --no-token to mint one)")
+    return 0
+
+
+async def _token_create(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = create_token(
+            base_url=node_base_url(args.node_url),
+            name=args.name,
+            role=args.role,
+            kind=args.kind,
+            default_dataset=args.dataset,
+            expires_at=args.expires_at,
+        )
+    except AccessClientError as exc:
+        return _access_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+        return 0
+    color = supports_color()
+    print(paint(f"Token created  (principal {result.get('principal', {}).get('id')})", "green", enable=color))
+    if result.get("token"):
+        _print_minted_token(result["token"], result.get("api_token", {}), color=color)
+    return 0
+
+
+async def _token_revoke(args: argparse.Namespace) -> int:
+    as_json = args.json
+    try:
+        result = revoke_token(args.token_id, base_url=node_base_url(args.node_url))
+    except AccessClientError as exc:
+        return _access_exit(exc, as_json=as_json)
+    if as_json:
+        _print_json(result)
+        return 0
+    print(f"Revoked {args.token_id}")
+    return 0 if result.get("ok") else 1
+
+
+def _indent(text: str, prefix: str = "    ") -> str:
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
+def _wire_detected_tools(node_url: str, *, color: bool) -> None:
+    """Interactive: offer to add Citadel's MCP server to each detected tool.
+
+    Write-tier tools (token stays in the rc via an env reference) are merged on
+    confirmation; snippet-tier tools print a paste-in block on request; Pi gets
+    a note. Used only on an interactive `citadel onboard`.
+    """
+    from kb import tool_detect
+
+    detected = tool_detect.detect()
+    if not detected:
+        return
+    print("\n" + paint("Coding tools", "bold", enable=color))
+    for name in detected:
+        spec = tool_detect.SPECS[name]
+        if spec.mode == "write":
+            answer = input(f"  Add Citadel MCP to {spec.label}? [Y/n]: ").strip().lower()
+            if answer not in ("", "y", "yes"):
+                continue
+            result = tool_detect.apply(name, node_url=node_url)
+            sigil = mark(result.action != "error", enable=color)
+            print(f"  {sigil} {spec.label}  {paint(f'{result.action} · {result.detail}', 'dim', enable=color)}")
+        elif spec.mode == "snippet":
+            answer = input(f"  Show paste-in MCP snippet for {spec.label}? [y/N]: ").strip().lower()
+            if answer not in ("y", "yes"):
+                continue
+            result = tool_detect.apply(name, node_url=node_url)
+            print(paint(f"    → {spec.config_hint}", "dim", enable=color))
+            print(_indent(result.snippet or ""))
+        else:  # note (e.g. Pi)
+            result = tool_detect.apply(name, node_url=node_url)
+            print(f"  {paint('•', 'dim', enable=color)} {spec.label}: {paint(result.detail, 'dim', enable=color)}")
+
+
+async def _mcp_add(args: argparse.Namespace) -> int:
+    from kb import tool_detect
+
+    node_url = node_base_url(args.node_url)
+    color = supports_color()
+    targets = tool_detect.ALL_TOOLS if args.tool == "all" else [args.tool]
+    rc = 0
+    for name in targets:
+        if name not in tool_detect.SPECS:
+            print(f"citadel mcp add: unknown tool {name!r} "
+                  f"(choose from: {', '.join(tool_detect.ALL_TOOLS)}, all)", file=sys.stderr)
+            rc = 1
+            continue
+        spec = tool_detect.SPECS[name]
+        result = tool_detect.apply(name, node_url=node_url)
+        if spec.mode == "write":
+            ok = result.action != "error"
+            rc = rc or (0 if ok else 1)
+            print(f"  {mark(ok, enable=color)} {spec.label}  "
+                  f"{paint(f'{result.action} · {result.detail}', 'dim', enable=color)}")
+        elif spec.mode == "snippet":
+            print(paint(f"{spec.label} — paste into {spec.config_hint}:", "bold", enable=color))
+            print(_indent(result.snippet or ""))
+        else:
+            print(f"{spec.label}: {result.detail}")
+    return rc
+
+
+async def _mcp_list(args: argparse.Namespace) -> int:
+    from kb import tool_detect
+
+    color = supports_color()
+    detected = tool_detect.detect()
+    if not detected:
+        print("No known coding tools detected.")
+        return 0
+    print(f"Detected coding tools ({len(detected)}):")
+    for name in detected:
+        spec = tool_detect.SPECS[name]
+        mode = {"write": "auto-write", "snippet": "snippet", "note": "note"}[spec.mode]
+        print(f"  {paint(name.ljust(9), 'cyan', enable=color)} {mode:<10} {paint(spec.config_hint, 'dim', enable=color)}")
+    return 0
+
+
 async def _status(args: argparse.Namespace) -> int:
     repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
     config_path = Path(args.config).expanduser() if args.config else capture_config_path()
@@ -440,23 +760,149 @@ async def _status(args: argparse.Namespace) -> int:
         node_url = args.node_url or DEFAULT_NODE_URL
     token = capture_token() or None
 
-    report = await asyncio.to_thread(
-        gather_status,
-        node_url,
-        token,
-        repo=repo,
-        config_path=config_path,
-        with_search=not args.no_search,
-        with_recent=not args.no_recent,
-    )
+    async def _gather() -> Any:
+        return await asyncio.to_thread(
+            gather_status,
+            node_url,
+            token,
+            repo=repo,
+            config_path=config_path,
+            with_search=not args.no_search,
+            with_recent=not args.no_recent,
+        )
+
     if args.json:
+        report = await _gather()
         _print_json(report.to_dict())
     else:
+        # The search check can take ~15s cold — spin so it doesn't look hung.
+        with _Spinner("Checking Citadel…"):
+            report = await _gather()
         use_color = supports_color()
         print(banner(color=use_color))
         print()
         print(render_text(report, color=use_color))
     return 0 if report.healthy else 1
+
+
+def _mcp_node_url(path: Path) -> str | None:
+    """The Node base URL wired into .mcp.json (citadel server), sans /mcp/ suffix."""
+    try:
+        servers = json.loads(path.read_text()).get("mcpServers", {})
+        url = (servers.get("citadel") or {}).get("url", "")
+    except (OSError, ValueError, AttributeError):
+        return None
+    for suffix in ("/mcp/", "/mcp"):
+        if url.endswith(suffix):
+            return url[: -len(suffix)]
+    return url or None
+
+
+async def _doctor(args: argparse.Namespace) -> int:
+    """Diagnose common Citadel misconfigs and (with --fix) repair the safe ones."""
+    repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
+    config_path = Path(args.config).expanduser() if args.config else capture_config_path()
+    try:
+        cap_node = load_capture_config(config_path).node_url
+    except ValueError:
+        cap_node = None
+    node_url = args.node_url or cap_node or DEFAULT_NODE_URL
+    token = capture_token() or None
+    as_json = getattr(args, "json", False)
+    color = supports_color() and not as_json
+
+    async def _gather() -> Any:
+        return await asyncio.to_thread(
+            gather_status, node_url, token, repo=repo, config_path=config_path,
+            with_search=False, with_recent=False,
+        )
+
+    if as_json:
+        report = await _gather()
+    else:
+        with _Spinner("Diagnosing Citadel…"):
+            report = await _gather()
+    checks = {c.name: c for c in report.checks}
+
+    issues: list[dict[str, Any]] = []
+    env_token = bool(os.getenv(TOKEN_ENV))
+    rc_path = detect_shell_rc()
+    try:
+        rc_has = rc_path.exists() and f"{TOKEN_ENV}=" in rc_path.read_text()
+    except OSError:
+        rc_has = False
+    if not env_token and rc_has:
+        issues.append({"problem": f"token is in {rc_path} but not this shell's env",
+                       "fix": f"source {rc_path}  (or open a new shell)"})
+    elif not env_token and not rc_has:
+        issues.append({"problem": "no seat token configured", "fix": "citadel onboard"})
+
+    node = checks.get("node")
+    if node and not node.ok:
+        issues.append({"problem": f"Node unreachable at {node_url} ({node.detail})",
+                       "fix": "check the Node URL / network"})
+    auth = checks.get("auth")
+    # Only call it a token rejection when the Node is actually reachable — when
+    # the Node is down, auth fails too, and we must not tell the user to rotate
+    # a perfectly valid token.
+    if node and node.ok and token and auth and not auth.ok:
+        issues.append({"problem": f"Node rejected the token ({auth.detail})",
+                       "fix": "token revoked/expired or wrong Node — re-mint (`citadel seat create`) or re-onboard"})
+
+    mcp_node = _mcp_node_url(repo / ".mcp.json")
+    if mcp_node and cap_node and mcp_node.rstrip("/") != cap_node.rstrip("/"):
+        issues.append({"problem": f".mcp.json Node ({mcp_node}) disagrees with capture config ({cap_node})",
+                       "fix": f"citadel onboard --node-url {cap_node}"})
+
+    if checks.get("pre_push_hook") and not checks["pre_push_hook"].ok:
+        issues.append({"problem": "git pre-push autosync hook missing", "fix": "citadel doctor --fix", "kind": "pre_push"})
+    if checks.get("session_hook") and not checks["session_hook"].ok:
+        issues.append({"problem": "Claude SessionEnd/SessionStart hooks missing", "fix": "citadel doctor --fix", "kind": "session"})
+    if checks.get("mcp") and not checks["mcp"].ok:
+        issues.append({"problem": ".mcp.json missing the citadel MCP server", "fix": "citadel doctor --fix", "kind": "mcp"})
+
+    fixed: list[str] = []
+    if getattr(args, "fix", False):
+        for issue in issues:
+            kind = issue.get("kind")
+            try:
+                if kind == "pre_push":
+                    if not install_pre_push_hook(repo).startswith("skipped"):
+                        fixed.append("pre-push hook")
+                elif kind == "session":
+                    merge_claude_settings(repo / ".claude" / "settings.json")
+                    fixed.append("Claude hooks")
+                elif kind == "mcp":
+                    merge_mcp_config(repo / ".mcp.json", node_url)
+                    fixed.append("MCP server")
+            except (ValueError, OSError):
+                pass
+
+    if as_json:
+        _print_json({
+            "ok": not issues,
+            "node_url": node_url,
+            "issues": [{k: v for k, v in i.items() if k != "kind"} for i in issues],
+            "fixed": fixed,
+        })
+        return 1 if issues else 0
+
+    print(banner(color=color))
+    print()
+    if not issues:
+        print(paint("✓ No problems found.", "green", enable=color))
+        return 0
+    print(paint(f"Found {len(issues)} issue(s):", "yellow", enable=color))
+    for issue in issues:
+        print(f"  {mark(False, enable=color)} {issue['problem']}")
+        print(f"      {paint('fix: ' + issue['fix'], 'dim', enable=color)}")
+    if fixed:
+        print()
+        print(paint(f"Applied: {', '.join(fixed)}. Re-run `citadel doctor` to confirm.", "green", enable=color))
+    elif any(i.get("kind") for i in issues):
+        print()
+        print(paint("Run `citadel doctor --fix` to apply the auto-fixable ones.", "dim", enable=color))
+    return 1
 
 
 async def _tui(args: argparse.Namespace) -> int:
@@ -483,14 +929,42 @@ async def _tui(args: argparse.Namespace) -> int:
     return 0
 
 
+def _humanize_status(status: str) -> tuple[str, bool, bool]:
+    """Map a raw onboard step status → (human text, ok, skipped).
+
+    Step functions return machine tokens like ``skipped:not-git``; humans should
+    never see those. Skipped steps are not failures (they render with ⊘).
+    """
+    if status.startswith("skipped:"):
+        reason = status.split(":", 1)[1].replace("-", " ")
+        reason = {"not git": "not a git repo"}.get(reason, reason)
+        return f"skipped ({reason})", True, True
+    return status, True, False
+
+
 async def _onboard(args: argparse.Namespace) -> int:
     repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
     as_json = getattr(args, "json", False)
     interactive = sys.stdin.isatty() and not args.non_interactive and not as_json
+    color = supports_color() and not as_json
+    node_url = (getattr(args, "node_url", None) or DEFAULT_NODE_URL).rstrip("/")
+
+    if interactive:
+        print(banner(color=color))
 
     token = (args.token or os.environ.get(TOKEN_ENV) or "").strip()
     if not token and interactive:
-        token = input("Paste your Citadel seat token (ctdl_…): ").strip()
+        # Guide the new user to the token instead of dead-ending on an error.
+        print(
+            f"\nGet your seat token from the Citadel dashboard:  "
+            f"{paint(node_url, 'cyan', enable=color)}\n"
+            "  (log in with the admin key → Create Seat → copy the ctdl_… token)\n"
+        )
+        try:
+            # getpass: the pasted secret is not echoed to the screen/scrollback.
+            token = getpass.getpass("Paste your Citadel seat token (ctdl_…): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
     if not token:
         print(
             "citadel onboard: no token — pass --token or set CITADEL_MCP_ACCESS_TOKEN.",
@@ -505,10 +979,26 @@ async def _onboard(args: argparse.Namespace) -> int:
         steps.append(("git pre-push hook", install_pre_push_hook(repo)))
         steps.append(("SessionEnd hook", merge_claude_settings(repo / ".claude" / "settings.json")))
         if not args.no_mcp:
-            steps.append(("MCP server (.mcp.json)", merge_mcp_config(repo / ".mcp.json")))
+            steps.append(("MCP server (.mcp.json)", merge_mcp_config(repo / ".mcp.json", node_url)))
     except ValueError as exc:
         print(f"citadel onboard: {exc}", file=sys.stderr)
         return 1
+
+    # A custom --node-url is persisted to the capture config so MCP and capture
+    # target the same Node (no split-brain). Done before the roots wizard, which
+    # preserves node_url when it re-saves.
+    if getattr(args, "node_url", None):
+        try:
+            cfg_path = capture_config_path()
+            existing = load_capture_config(cfg_path)
+            save_capture_config(
+                CaptureConfig(node_url=node_url, roots=existing.roots, version=existing.version),
+                path=cfg_path,
+                updated_at=datetime.now(timezone.utc).isoformat(),
+            )
+            steps.append((f"node url → {cfg_path}", node_url))
+        except ValueError:
+            pass
 
     want_capture = not args.no_capture and interactive
     if want_capture:
@@ -520,6 +1010,9 @@ async def _onboard(args: argparse.Namespace) -> int:
                 cfg, path=cfg_path, updated_at=datetime.now(timezone.utc).isoformat()
             )
             steps.append((f"capture roots → {cfg_path}", f"{len(cfg.roots)} root(s)"))
+
+    if interactive and not getattr(args, "no_tools", False):
+        _wire_detected_tools(node_url, color=color)
 
     if as_json:
         _print_json(
@@ -533,10 +1026,16 @@ async def _onboard(args: argparse.Namespace) -> int:
         )
         return 0
 
-    print(banner(color=supports_color()))
+    if not interactive:
+        print(banner(color=color))
     print(f"\nCitadel onboarding for {repo}  (token {mask_token(token)}):")
     for label, status in steps:
-        print(f"  • {label}: {status}")
+        text, ok, skipped = _humanize_status(status)
+        sigil = paint(SKIP, "yellow", enable=color) if skipped else mark(ok, enable=color)
+        print(f"  {sigil} {label}  {paint(text, 'dim', enable=color)}")
+    done = sum(1 for _, status in steps if not status.startswith("skipped"))
+    print()
+    print(paint(f"Citadel configured — {done}/{len(steps)} steps wired.", "green", enable=color))
     print(
         f"\nNext: restart your shell (or `source {rc_path}`), then in your agent ask:\n"
         '  "use citadel_search to find what we decided about the vault"'
@@ -547,7 +1046,8 @@ async def _onboard(args: argparse.Namespace) -> int:
 _HOME_MENU = (
     ("Get started", (
         ("onboard", "one-command setup — token · hooks · MCP · capture roots"),
-        ("status", "connection · identity · local setup    (--json for agents)"),
+        ("status", "connection · identity · local setup (--json for agents)"),
+        ("doctor", "diagnose setup problems · --fix to repair"),
     )),
     ("Capture", (
         ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
@@ -559,7 +1059,37 @@ _HOME_MENU = (
         ("search", "search the Organization Vault"),
         ("ingest", "add a durable note to your Node"),
     )),
+    ("Connect & admin", (
+        ("mcp", "add Citadel MCP to Claude · Cursor · Codex · …"),
+        ("seat", "create · list seats and mint tokens (admin)"),
+        ("token", "create · revoke standalone tokens (admin)"),
+    )),
 )
+
+
+def _already_onboarded() -> bool:
+    """Network-free check: has the user ever completed onboarding?
+
+    Onboarding is "done" once the token is wired (any one ⇒ onboarded), checked
+    offline so the home screen and the first-run gate stay instant and work
+    without the Node:
+      1. CITADEL_MCP_ACCESS_TOKEN in the environment (current shell)
+      2. an ``export CITADEL_MCP_ACCESS_TOKEN=`` line in the shell rc — the signal
+         that survives a fresh post-install shell, where the env var isn't set yet
+
+    A capture config alone is NOT a signal: ``citadel setup`` writes one without
+    ever wiring a token, so counting it would falsely suppress first-run
+    onboarding and show "✓ set up" with no token.
+    """
+    if os.environ.get(TOKEN_ENV):
+        return True
+    try:
+        rc = detect_shell_rc()
+        if rc.exists() and f"{TOKEN_ENV}=" in rc.read_text():
+            return True
+    except OSError:
+        pass
+    return False
 
 
 def _print_home() -> None:
@@ -567,11 +1097,24 @@ def _print_home() -> None:
     print(banner_large(color=color))
     print()
     print("  " + paint("the organization vault", "dim", enable=color))
+    if _already_onboarded():
+        state = mark(True, enable=color) + " " + paint("set up", "green", enable=color)
+    else:
+        state = (
+            mark(False, enable=color)
+            + " "
+            + paint("not set up", "red", enable=color)
+            + paint(" — run ", "dim", enable=color)
+            + paint("citadel onboard", "cyan", enable=color)
+        )
+    print("  " + state)
     print()
+    # Pad command names to the widest, so descriptions form a clean column.
+    pad = max(len(name) for _, rows in _HOME_MENU for name, _ in rows) + 2
     for title, rows in _HOME_MENU:
         print("  " + paint(title, "bold", enable=color))
         for name, desc in rows:
-            label = paint(name.ljust(9), "cyan", enable=color)
+            label = paint(name.ljust(pad), "cyan", enable=color)
             print(f"    {label} {paint(desc, 'dim', enable=color)}")
         print()
     print("  " + paint("Run `citadel <command> --help` for details.", "dim", enable=color))
@@ -608,6 +1151,16 @@ class CitadelParser(argparse.ArgumentParser):
 
 def build_parser() -> argparse.ArgumentParser:
     parser = CitadelParser(prog="citadel")
+    try:
+        _version = _pkg_version("citadel-archive")
+    except PackageNotFoundError:
+        _version = "0+unknown"
+    parser.add_argument("--version", action="version", version=f"citadel {_version}")
+    parser.add_argument(
+        "--no-onboard",
+        action="store_true",
+        help="Skip first-run onboarding on bare `citadel` (also via CITADEL_NO_ONBOARD)",
+    )
     # Not required: bare `citadel` shows the banner + command list instead of an error.
     subcommands = parser.add_subparsers(dest="command")
 
@@ -622,6 +1175,17 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--no-search", action="store_true", help="Skip the search smoke check")
     status.add_argument("--no-recent", action="store_true", help="Skip recent-activity fetch")
     status.set_defaults(handler=_status)
+
+    doctor = subcommands.add_parser(
+        "doctor",
+        help="Diagnose setup problems and suggest (or --fix) repairs",
+    )
+    doctor.add_argument("--fix", action="store_true", help="Apply safe auto-fixes (hooks, .mcp.json)")
+    doctor.add_argument("--json", action="store_true", help="Machine-readable output")
+    doctor.add_argument("--node-url", help="Override Node URL")
+    doctor.add_argument("--repo", help="Repo to check (default: git toplevel or cwd)")
+    doctor.add_argument("--config", help="Override capture config path")
+    doctor.set_defaults(handler=_doctor)
 
     tui = subcommands.add_parser(
         "tui",
@@ -639,9 +1203,16 @@ def build_parser() -> argparse.ArgumentParser:
     onboard.add_argument("--token", help="Seat token (else prompt, or use env)")
     onboard.add_argument("--repo", help="Repo root (default: git toplevel or cwd)")
     onboard.add_argument("--shell-rc", help="Shell rc file for the token export")
+    onboard.add_argument(
+        "--node-url",
+        help="Node URL to wire into MCP/capture (default: the built-in Node)",
+    )
     onboard.add_argument("--no-mcp", action="store_true", help="Skip writing .mcp.json")
     onboard.add_argument(
         "--no-capture", action="store_true", help="Skip Approved Capture Roots setup"
+    )
+    onboard.add_argument(
+        "--no-tools", action="store_true", help="Skip detecting/adding MCP to other coding tools"
     )
     onboard.add_argument(
         "--non-interactive", action="store_true", help="No prompts; requires --token"
@@ -738,6 +1309,81 @@ def build_parser() -> argparse.ArgumentParser:
     promo_run.add_argument("--node-url", help="Override Node URL")
     promo_run.set_defaults(handler=_promotion_run)
 
+    seat = subcommands.add_parser(
+        "seat",
+        help="Manage seats (admin — reads the admin key from CITADEL_ADMIN_KEY)",
+    )
+    seat_sub = seat.add_subparsers(dest="seat_command", required=True)
+
+    seat_list = seat_sub.add_parser("list", help="List seats, roles, and active token counts")
+    seat_list.add_argument("--json", action="store_true", help="Machine-readable output")
+    seat_list.add_argument("--node-url", help="Override Node URL")
+    seat_list.set_defaults(handler=_seat_list)
+
+    seat_create = seat_sub.add_parser(
+        "create", help="Create a seat and mint its writer token (printed once)"
+    )
+    seat_create.add_argument("name", help='Human name, e.g. "Alice Smith"')
+    seat_create.add_argument("slug", help="Seat slug, e.g. alice (a-z, 0-9, hyphen)")
+    seat_create.add_argument("--email", help="Optional contact email")
+    seat_create.add_argument(
+        "--role", default="writer", choices=("writer", "reader"), help="Seat role (default: writer)"
+    )
+    seat_create.add_argument(
+        "--no-token", action="store_true", help="Create the seat without issuing a token"
+    )
+    seat_create.add_argument("--json", action="store_true", help="Machine-readable output")
+    seat_create.add_argument("--node-url", help="Override Node URL")
+    seat_create.set_defaults(handler=_seat_create)
+
+    token = subcommands.add_parser(
+        "token",
+        help="Manage standalone tokens (admin — reads CITADEL_ADMIN_KEY)",
+    )
+    token_sub = token.add_subparsers(dest="token_command", required=True)
+
+    token_create = token_sub.add_parser(
+        "create", help="Issue a standalone (service-account) token, printed once"
+    )
+    token_create.add_argument("name", help="Token name/label")
+    token_create.add_argument(
+        "--role", default="reader", choices=("reader", "writer", "admin"),
+        help="Token role (default: reader)",
+    )
+    token_create.add_argument(
+        "--kind", default="service_account", choices=("service_account", "user"),
+        help="Principal kind (default: service_account)",
+    )
+    token_create.add_argument("--dataset", help="Default dataset for the token")
+    token_create.add_argument("--expires-at", help="ISO 8601 expiry timestamp (optional)")
+    token_create.add_argument("--json", action="store_true", help="Machine-readable output")
+    token_create.add_argument("--node-url", help="Override Node URL")
+    token_create.set_defaults(handler=_token_create)
+
+    token_revoke = token_sub.add_parser("revoke", help="Revoke a token by id (token_…)")
+    token_revoke.add_argument("token_id", help="Token id to revoke (token_…)")
+    token_revoke.add_argument("--json", action="store_true", help="Machine-readable output")
+    token_revoke.add_argument("--node-url", help="Override Node URL")
+    token_revoke.set_defaults(handler=_token_revoke)
+
+    mcp = subcommands.add_parser(
+        "mcp",
+        help="Add the Citadel MCP server to your other coding tools",
+    )
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+
+    mcp_add = mcp_sub.add_parser(
+        "add", help="Add Citadel MCP to a tool (or 'all') — writes config or prints a snippet"
+    )
+    mcp_add.add_argument(
+        "tool", help="Tool to wire: claude, cursor, codex, gemini, windsurf, cline, zed, pi, or all"
+    )
+    mcp_add.add_argument("--node-url", help="Override Node URL")
+    mcp_add.set_defaults(handler=_mcp_add)
+
+    mcp_list = mcp_sub.add_parser("list", help="List detected coding tools and how each is wired")
+    mcp_list.set_defaults(handler=_mcp_list)
+
     ingest = subcommands.add_parser("ingest", help="Ingest text or a path through Cognee")
     ingest.add_argument("data")
     ingest.add_argument("--dataset")
@@ -745,11 +1391,18 @@ def build_parser() -> argparse.ArgumentParser:
     ingest.add_argument("--tag", action="append", default=[])
     ingest.set_defaults(handler=_ingest)
 
-    search = subcommands.add_parser("search", help="Search the Organization Vault")
-    search.add_argument("query")
-    search.add_argument("--dataset")
-    search.add_argument("--session")
-    search.add_argument("--top-k", type=int, default=10)
+    search = subcommands.add_parser("search", help="Search the Organization Vault (via the Node)")
+    search.add_argument("query", help="Search query")
+    search.add_argument("--top-k", type=int, default=10, help="Max results (default: 10)")
+    search.add_argument("--json", action="store_true", help="Machine-readable output")
+    search.add_argument("--node-url", help="Override Node URL")
+    search.add_argument(
+        "--local",
+        action="store_true",
+        help="Search the local server stack instead of the Node (needs the server extra)",
+    )
+    search.add_argument("--dataset", help="(--local only) dataset to search")
+    search.add_argument("--session", help="(--local only) session id")
     search.set_defaults(handler=_search)
 
     feedback = subcommands.add_parser("feedback", help="Attach feedback to a Cognee QA entry")
@@ -822,7 +1475,17 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
     if not getattr(args, "command", None):
-        # Bare `citadel` → branded home screen (hero + curated command menu).
+        # Bare `citadel`: on a brand-new interactive install, drop straight into
+        # guided onboarding once; afterwards show the branded home screen. The
+        # opt-outs (--no-onboard / CITADEL_NO_ONBOARD / any non-TTY) keep cron,
+        # CI, agents, and pipes safe — they never block on a prompt.
+        opted_out = bool(os.getenv("CITADEL_NO_ONBOARD")) or getattr(args, "no_onboard", False)
+        interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        if interactive and not opted_out and not _already_onboarded():
+            onboard_args = parser.parse_args(["onboard"])
+            asyncio.run(onboard_args.handler(onboard_args))
+            print()
+        # Branded home screen (hero + curated command menu).
         _print_home()
         raise SystemExit(0)
     # Handlers may return an int exit code (capture/setup); others return None.

--- a/kb/hooks/sync_start.py
+++ b/kb/hooks/sync_start.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Warm-start context for Citadel — SessionStart hook.
+
+Invoked by a Claude Code ``SessionStart`` hook (matcher ``startup|resume``).
+Fetches a compact "recent in the vault" digest from the developer's Citadel node
+and prints it to stdout, which Claude Code injects as session context — so a new
+session opens already aware of recent org activity, without the agent having to
+query for it. This is the read-side counterpart to the ``SessionEnd`` distiller
+(``kb/hooks/sync_session.py``).
+
+Design contract (reviewers verify these invariants):
+
+* **Token from env only.** ``CITADEL_MCP_ACCESS_TOKEN`` is read solely from the
+  environment and never printed (the digest is recent *contribution* metadata,
+  not the token).
+* **Fail-silent / non-blocking.** Any problem -> exit 0 with NO output, so the
+  hook can never delay or break session start, nor inject an error.
+* **Quiet when empty.** Injects ONLY when there is recent activity; an empty or
+  unreachable vault prints nothing, so it is never noise-for-nothing.
+* **HTTPS only, no redirects.** The token is never sent over plaintext.
+* **Stdlib only.**
+
+Hook payload (read from STDIN as JSON): ``session_id``, ``transcript_path``,
+``cwd``, ``hook_event_name``, ``source`` — all unused here (we just drain it).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from typing import Any
+
+DEFAULT_BASE_URL = "https://citadel-archive-production.up.railway.app"
+TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
+HTTP_TIMEOUT_SECONDS = 5
+RECENT_LIMIT = 8
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so a 3xx (esp. https->http) can't leak the token."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+urllib.request.install_opener(urllib.request.build_opener(_NoRedirectHandler))
+
+
+def _base_url() -> str:
+    configured = os.getenv("CITADEL_BASE_URL")
+    return configured.rstrip("/") if configured else DEFAULT_BASE_URL
+
+
+def read_hook_payload(stream: Any) -> dict[str, Any]:
+    """Parse the hook JSON from STDIN defensively; return {} on any problem."""
+    try:
+        raw = stream.read()
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def fetch_recent(base_url: str, token: str, *, limit: int = RECENT_LIMIT) -> list[dict[str, Any]]:
+    if not base_url.lower().startswith("https://"):
+        raise ValueError("refusing non-HTTPS Citadel base URL")
+    url = f"{base_url}/api/contributions/recent?mine=true&limit={limit}"
+    request = urllib.request.Request(  # noqa: S310 - https asserted above
+        url,
+        method="GET",
+        headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        body = response.read().decode()
+    data = json.loads(body) if body else {}
+    items = data.get("contributions") if isinstance(data, dict) else None
+    return items if isinstance(items, list) else []
+
+
+def format_digest(items: list[dict[str, Any]]) -> str:
+    """A short, plain-text digest. Stdout is injected verbatim as context."""
+    lines = ["# Citadel vault — recent activity", ""]
+    for item in items[:RECENT_LIMIT]:
+        if not isinstance(item, dict):
+            continue
+        when = str(item.get("created_at") or item.get("timestamp") or "")[:10]
+        label = item.get("title") or item.get("action") or item.get("detail") or "—"
+        label = " ".join(str(label).split())[:120]
+        lines.append(f"- {when}  {label}" if when else f"- {label}")
+    return "\n".join(lines)
+
+
+def run(stream_in: Any) -> int:
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    try:
+        read_hook_payload(stream_in)  # drain stdin; fields unused
+        token = os.getenv(TOKEN_ENV)
+        if not token:
+            return 0
+        items = fetch_recent(_base_url(), token)
+        if not items:
+            return 0  # nothing to inject -> stay silent
+        sys.stdout.write(format_digest(items) + "\n")
+    except Exception:
+        # Fail-silent: never block session start, never surface the token.
+        return 0
+    return 0
+
+
+def main() -> None:
+    sys.exit(run(sys.stdin))
+
+
+if __name__ == "__main__":
+    main()

--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -25,8 +25,10 @@ TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
 MCP_SERVER_NAME = "citadel"
 PUSH_MODULE = "kb.hooks.sync_push"
 SESSION_MODULE = "kb.hooks.sync_session"
-# Used both to install the SessionEnd hook and to detect it on re-run.
+START_MODULE = "kb.hooks.sync_start"
+# Used both to install the hooks and to detect them on re-run.
 _SESSION_HOOK_MARKER = SESSION_MODULE
+_START_HOOK_MARKER = START_MODULE
 
 
 def _hook_python() -> str:
@@ -86,6 +88,28 @@ def _session_hook(python: str | None = None) -> dict[str, Any]:
         "timeout": 20,
         "allowedEnvVars": [TOKEN_ENV],
     }
+
+
+def _session_start_hook(python: str | None = None) -> dict[str, Any]:
+    py = python or _hook_python()
+    return {
+        "type": "command",
+        "command": f'"{py}" -m {START_MODULE}',
+        "timeout": 10,
+        "allowedEnvVars": [TOKEN_ENV],
+    }
+
+
+def _event_has_marker(event_list: list[Any], marker: str) -> bool:
+    """True if any hook group in the event list runs a command containing marker."""
+    return any(
+        isinstance(group, dict)
+        and any(
+            isinstance(hook, dict) and marker in str(hook.get("command", ""))
+            for hook in group.get("hooks", [])
+        )
+        for group in event_list
+    )
 
 
 def pre_push_hook_script(python: str | None = None) -> str:
@@ -157,7 +181,12 @@ def merge_mcp_config(path: Path, base_url: str = DEFAULT_NODE_URL) -> str:
 
 
 def merge_claude_settings(path: Path, python: str | None = None) -> str:
-    """Merge the SessionEnd hook into .claude/settings.json without duplicating it."""
+    """Merge the SessionEnd + SessionStart hooks into .claude/settings.json.
+
+    SessionEnd distills the closing session to the dev's node; SessionStart
+    injects a recent-activity digest. Both are idempotent (detected by module
+    marker) so the merge never duplicates them on re-run.
+    """
     data = _load_json_object(path)
     hooks = data.setdefault("hooks", {})
     if not isinstance(hooks, dict):
@@ -165,18 +194,16 @@ def merge_claude_settings(path: Path, python: str | None = None) -> str:
     session_end = hooks.setdefault("SessionEnd", [])
     if not isinstance(session_end, list):
         raise ValueError(f"corrupt {path}: hooks.SessionEnd must be an array")
+    session_start = hooks.setdefault("SessionStart", [])
+    if not isinstance(session_start, list):
+        raise ValueError(f"corrupt {path}: hooks.SessionStart must be an array")
 
-    has_marker = any(
-        isinstance(group, dict)
-        and any(
-            isinstance(hook, dict) and _SESSION_HOOK_MARKER in str(hook.get("command", ""))
-            for hook in group.get("hooks", [])
-        )
-        for group in session_end
-    )
     changed = False
-    if not has_marker:
+    if not _event_has_marker(session_end, _SESSION_HOOK_MARKER):
         session_end.append({"hooks": [_session_hook(python)]})
+        changed = True
+    if not _event_has_marker(session_start, _START_HOOK_MARKER):
+        session_start.append({"matcher": "startup|resume", "hooks": [_session_start_hook(python)]})
         changed = True
     allowed = data.setdefault("httpHookAllowedEnvVars", [])
     if not isinstance(allowed, list):

--- a/kb/status.py
+++ b/kb/status.py
@@ -148,6 +148,33 @@ def check_search(base_url: str, token: str | None, *, timeout: float = _SEARCH_T
     return Check("search", ok=True, detail=f"{count} result(s)", data={"count": count})
 
 
+def search_node(
+    base_url: str,
+    token: str,
+    query: str,
+    top_k: int = 10,
+    *,
+    timeout: float = _SEARCH_TIMEOUT,
+) -> list[dict[str, Any]]:
+    """POST a query to the Node's /search (the same endpoint MCP citadel_search uses).
+
+    Zero-dep, HTTPS-only. The Node resolves the dataset from the token's seat, so
+    callers pass only query + top_k. Returns the results list (``results`` or the
+    legacy ``matches`` key), or [] if the shape is unexpected.
+    """
+    data = _request(
+        "POST",
+        f"{base_url.rstrip('/')}/search",
+        token=token,
+        payload={"query": query, "top_k": top_k},
+        timeout=timeout,
+    )
+    results = data.get("results")
+    if results is None:
+        results = data.get("matches")
+    return results if isinstance(results, list) else []
+
+
 def check_local_setup(repo: Path, config_path: Path | None = None) -> list[Check]:
     checks: list[Check] = []
     checks.append(
@@ -242,21 +269,48 @@ def gather_status(
     )
 
 
-_DOT_OK = "●"
-_DOT_BAD = "○"
+# Checks split into two sections; everything not here is "Local setup".
+_CONNECTIVITY = ("node", "auth", "search")
+# Human labels — the raw snake_case names read like debug output.
+_CHECK_LABELS = {
+    "node": "Node",
+    "auth": "Auth",
+    "search": "Search",
+    "token": "Token",
+    "mcp": "MCP server",
+    "pre_push_hook": "Pre-push hook",
+    "session_hook": "SessionEnd hook",
+    "capture_roots": "Capture roots",
+}
 
 
 def render_text(report: StatusReport, *, color: bool = False) -> str:
-    from kb.banner import paint
+    from kb.banner import mark, paint
 
     ident = report.identity
     seat = ident.get("seat_slug") or ident.get("actor") or "—"
     role = ident.get("role") or "—"
-    lines = [f"seat: {paint(str(seat), 'bold', enable=color)}   role: {role}", ""]
-    for check in report.checks:
-        dot = paint(_DOT_OK, "green", enable=color) if check.ok else paint(_DOT_BAD, "red", enable=color)
+    lines = [
+        f"seat: {paint(str(seat), 'bold', enable=color)}   role: {role}",
+        paint(f"node: {report.node_url}", "dim", enable=color),
+        "",
+    ]
+
+    def _row(check: Check) -> str:
+        label = _CHECK_LABELS.get(check.name, check.name)
         latency = f"  ({check.latency_ms}ms)" if check.latency_ms is not None else ""
-        lines.append(f"  {dot} {check.name:<16} {check.detail}{latency}")
+        return f"  {mark(check.ok, enable=color)} {label:<16} {check.detail}{latency}"
+
+    conn = [c for c in report.checks if c.name in _CONNECTIVITY]
+    local = [c for c in report.checks if c.name not in _CONNECTIVITY]
+    if conn:
+        lines.append(paint("Connectivity", "bold", enable=color))
+        lines.extend(_row(c) for c in conn)
+        lines.append("")
+    if local:
+        lines.append(paint("Local setup", "bold", enable=color))
+        lines.extend(_row(c) for c in local)
+
     if report.recent:
         lines.append("")
         lines.append("Recent activity")
@@ -264,9 +318,26 @@ def render_text(report: StatusReport, *, color: bool = False) -> str:
             when = item.get("created_at") or item.get("timestamp") or ""
             label = item.get("title") or item.get("action") or item.get("detail") or "—"
             lines.append(f"  · {str(when)[:19]}  {label}")
+
     lines.append("")
-    if report.healthy:
+    total = len(report.checks)
+    ok_count = sum(1 for c in report.checks if c.ok)
+    failing = [_CHECK_LABELS.get(c.name, c.name) for c in report.checks if not c.ok]
+    if report.healthy and not failing:
         lines.append(paint("All systems go.", "green", enable=color))
+    elif report.healthy:
+        # Connected to the Node, but some local setup is still incomplete.
+        lines.append(paint("All systems go.", "green", enable=color))
+        lines.append(
+            paint(f"  setup incomplete ({ok_count}/{total}) — {', '.join(failing)}", "yellow", enable=color)
+        )
     else:
-        lines.append(paint("Not fully connected — try `citadel onboard`.", "yellow", enable=color))
+        lines.append(
+            paint(
+                f"Not fully connected ({ok_count}/{total} ok) — check: "
+                f"{', '.join(failing)}.  Try `citadel onboard`.",
+                "yellow",
+                enable=color,
+            )
+        )
     return "\n".join(lines)

--- a/kb/status_tui.py
+++ b/kb/status_tui.py
@@ -14,10 +14,10 @@ from textual import work
 from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header, Static
 
-from kb.status import StatusReport, gather_status
+from kb.status import _CHECK_LABELS, StatusReport, gather_status
 
-_OK = "[green]●[/]"
-_BAD = "[red]○[/]"
+_OK = "[green]✓[/]"
+_BAD = "[red]✗[/]"
 
 
 def _identity_markup(report: StatusReport) -> str:
@@ -36,8 +36,9 @@ def _checks_markup(report: StatusReport) -> str:
     lines = ["[b]Connection & setup[/]"]
     for check in report.checks:
         dot = _OK if check.ok else _BAD
+        label = _CHECK_LABELS.get(check.name, check.name)
         latency = f"  [dim]({check.latency_ms}ms)[/]" if check.latency_ms is not None else ""
-        lines.append(f"  {dot} {escape(check.name):<16} {escape(check.detail)}{latency}")
+        lines.append(f"  {dot} {escape(label):<16} {escape(check.detail)}{latency}")
     return "\n".join(lines)
 
 

--- a/kb/tool_detect.py
+++ b/kb/tool_detect.py
@@ -1,0 +1,257 @@
+"""Detect installed coding tools and wire Citadel's MCP server into each.
+
+Citadel's MCP is a hosted, remote, streamable-HTTP server (``<node>/mcp/`` with
+an ``Authorization: Bearer <ctdl_token>`` header). Tools differ in two ways that
+matter here:
+
+  * config location + format — JSON (Cursor, Gemini, Windsurf, Cline, Zed,
+    Claude user scope) vs TOML (Codex);
+  * whether the tool expands an env var inside the header, so the token can stay
+    only in the shell rc, vs needing the literal token written into the file.
+
+v1 AUTO-WRITES only the tools that keep the secret in the rc via an env
+reference (Cursor → ``${env:VAR}``, Codex → ``bearer_token_env_var``). Every
+other tool is offered as a copy-paste snippet so the user controls where a
+plaintext token lands (Claude project scope is already wired by
+``citadel onboard`` via ``.mcp.json``; the snippet here is the user-scope
+option). Pi has no native MCP, so it gets an informational note only.
+
+All facts (config paths, field names, env-interpolation support) were verified
+against current tool docs in June 2026; re-check when a tool changes its schema.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from kb.capture_config import DEFAULT_NODE_URL
+from kb.onboard import TOKEN_ENV
+
+HOME = Path.home()
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    label: str
+    mode: str  # "write" | "snippet" | "note"
+    config_hint: str
+
+
+# Order here is the order tools are offered during onboarding.
+SPECS: dict[str, ToolSpec] = {
+    "claude": ToolSpec("claude", "Claude Code (user scope)", "snippet", "~/.claude.json (or `claude mcp add`)"),
+    "cursor": ToolSpec("cursor", "Cursor", "write", "~/.cursor/mcp.json"),
+    "codex": ToolSpec("codex", "Codex CLI", "write", "~/.codex/config.toml"),
+    "gemini": ToolSpec("gemini", "Gemini CLI", "write", "~/.gemini/settings.json"),
+    "windsurf": ToolSpec("windsurf", "Windsurf", "write", "~/.codeium/windsurf/mcp_config.json"),
+    "cline": ToolSpec("cline", "Cline", "snippet", "cline_mcp_settings.json (token in plaintext)"),
+    "zed": ToolSpec("zed", "Zed", "snippet", "~/.config/zed/settings.json (token in plaintext)"),
+    "pi": ToolSpec("pi", "Pi", "note", "(no native MCP)"),
+}
+
+ALL_TOOLS = list(SPECS)
+
+
+@dataclass
+class ToolResult:
+    tool: str
+    action: str  # "wrote" | "unchanged" | "snippet" | "note" | "error"
+    detail: str
+    snippet: str | None = None
+
+
+def _which(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def _exists(*paths: str) -> bool:
+    return any(Path(p).expanduser().exists() for p in paths)
+
+
+def _cline_settings() -> Path:
+    """Cline's MCP settings file in the VS Code globalStorage dir (mac/Linux)."""
+    rel = "globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    mac = HOME / "Library/Application Support/Code/User" / rel
+    if mac.parent.parent.exists():
+        return mac
+    return HOME / ".config/Code/User" / rel
+
+
+def detect() -> list[str]:
+    """Names of installed coding tools we know how to wire, in display order."""
+    found: set[str] = set()
+    if _which("cursor") or _exists("~/.cursor"):
+        found.add("cursor")
+    if _which("codex") or _exists("~/.codex"):
+        found.add("codex")
+    if _which("claude") or _exists("~/.claude.json", "~/.claude"):
+        found.add("claude")
+    if _which("gemini") or _exists("~/.gemini"):
+        found.add("gemini")
+    if _exists("~/.codeium/windsurf"):
+        found.add("windsurf")
+    if _exists("~/.config/zed"):
+        found.add("zed")
+    if _cline_settings().parent.parent.exists():
+        found.add("cline")
+    if _which("pi") or _exists("~/.pi"):
+        found.add("pi")
+    return [t for t in ALL_TOOLS if t in found]
+
+
+def mcp_url(node_url: str) -> str:
+    return f"{node_url.rstrip('/')}/mcp/"
+
+
+def _merge_json_mcp(path: Path, tool: str, servers_key: str, block: dict) -> ToolResult:
+    """Merge a ``citadel`` server into a JSON config, never clobbering siblings."""
+    data: dict = {}
+    if path.exists():
+        try:
+            raw = path.read_text()  # read once; reuse for parse AND backup
+        except OSError as exc:
+            # Unreadable: never overwrite a file we couldn't read/back up.
+            return ToolResult(tool, "error", f"{path}: unreadable ({exc})")
+        try:
+            loaded = json.loads(raw)
+            if not isinstance(loaded, dict):
+                raise ValueError("config root is not a JSON object")
+            data = loaded
+        except ValueError:
+            # Corrupt/foreign: back it up BEFORE overwriting, with restricted perms
+            # (it may hold a third-party token), rather than clobbering blind.
+            backup = path.with_suffix(path.suffix + ".citadel-bak")
+            try:
+                fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(raw)
+            except OSError:
+                pass
+            data = {}
+    servers = data.setdefault(servers_key, {})
+    if not isinstance(servers, dict):
+        return ToolResult(tool, "error", f"{path}: {servers_key} is not an object")
+    if servers.get("citadel") == block:
+        return ToolResult(tool, "unchanged", str(path))
+    servers["citadel"] = block
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2) + "\n")
+    except OSError as exc:
+        return ToolResult(tool, "error", f"{path}: {exc}")
+    return ToolResult(tool, "wrote", str(path))
+
+
+def _wire_codex(url: str) -> ToolResult:
+    """Prefer the `codex mcp add` CLI (no hand-rolled TOML); else marker-append."""
+    if _which("codex"):
+        try:
+            subprocess.run(
+                ["codex", "mcp", "add", "citadel", "--url", url, "--bearer-token-env-var", TOKEN_ENV],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+            return ToolResult("codex", "wrote", "via `codex mcp add`")
+        except (OSError, subprocess.SubprocessError):
+            pass  # fall back to editing config.toml directly
+    path = Path("~/.codex/config.toml").expanduser()
+    marker = "[mcp_servers.citadel]"
+    existing = ""
+    if path.exists():
+        try:
+            existing = path.read_text()
+        except OSError as exc:
+            return ToolResult("codex", "error", f"{path}: {exc}")
+    if marker in existing:
+        return ToolResult("codex", "unchanged", str(path))
+    block = f"\n{marker}\nurl = \"{url}\"\nbearer_token_env_var = \"{TOKEN_ENV}\"\n"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(block)
+    except OSError as exc:
+        return ToolResult("codex", "error", f"{path}: {exc}")
+    return ToolResult("codex", "wrote", str(path))
+
+
+def apply(name: str, *, node_url: str = DEFAULT_NODE_URL) -> ToolResult:
+    """Wire (write tier) or produce a snippet/note (others) for one tool."""
+    spec = SPECS.get(name)
+    if spec is None:
+        return ToolResult(name, "error", f"unknown tool: {name}")
+    url = mcp_url(node_url)
+
+    if name == "cursor":
+        # Cursor expands ${env:VAR} in headers — token stays in the shell rc.
+        return _merge_json_mcp(
+            Path("~/.cursor/mcp.json").expanduser(),
+            "cursor",
+            "mcpServers",
+            {"url": url, "headers": {"Authorization": "Bearer ${env:%s}" % TOKEN_ENV}},
+        )
+    if name == "codex":
+        return _wire_codex(url)
+    if name == "gemini":
+        # Gemini expands $VAR in headers (NOT the ${env:} form) — token stays in rc.
+        return _merge_json_mcp(
+            Path("~/.gemini/settings.json").expanduser(),
+            "gemini",
+            "mcpServers",
+            {"httpUrl": url, "headers": {"Authorization": f"Bearer ${TOKEN_ENV}"}},
+        )
+    if name == "windsurf":
+        # Windsurf expands ${env:VAR} in headers — token stays in rc.
+        return _merge_json_mcp(
+            Path("~/.codeium/windsurf/mcp_config.json").expanduser(),
+            "windsurf",
+            "mcpServers",
+            {"serverUrl": url, "headers": {"Authorization": "Bearer ${env:%s}" % TOKEN_ENV}},
+        )
+    if name == "claude":
+        snippet = (
+            "# Project scope is already wired by `citadel onboard` (.mcp.json).\n"
+            "# To add Citadel at USER scope (every project), run:\n"
+            f'claude mcp add --transport http citadel {url} --scope user '
+            f'--header "Authorization: Bearer ${TOKEN_ENV}"'
+        )
+        return ToolResult("claude", "snippet", spec.config_hint, snippet)
+    if name == "cline":
+        # `type` MUST be the camelCase "streamableHttp" or Cline falls back to
+        # legacy SSE and 405s. No header env-interpolation → literal token.
+        snippet = json.dumps(
+            {
+                "mcpServers": {
+                    "citadel": {
+                        "type": "streamableHttp",
+                        "url": url,
+                        "headers": {"Authorization": "Bearer <paste your ctdl_ token>"},
+                        "disabled": False,
+                        "autoApprove": [],
+                    }
+                }
+            },
+            indent=2,
+        )
+        return ToolResult("cline", "snippet", spec.config_hint, snippet)
+    if name == "zed":
+        # No header env-interpolation in Zed yet → literal token in settings.json.
+        snippet = json.dumps(
+            {"context_servers": {"citadel": {"url": url, "headers": {"Authorization": "Bearer <paste your ctdl_ token>"}}}},
+            indent=2,
+        )
+        return ToolResult("zed", "snippet", spec.config_hint, snippet)
+    if name == "pi":
+        return ToolResult(
+            "pi",
+            "note",
+            "Pi has no native MCP. With the community pi-mcp-adapter extension it can reach "
+            f"{url} using a Bearer token; otherwise it cannot consume Citadel's MCP.",
+        )
+    return ToolResult(name, "error", f"unknown tool: {name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citadel-archive"
-version = "0.1.3"
+version = "0.2.0"
 description = "Citadel — a self-hosted Organization Vault and seat-capture CLI built on Cognee."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_access_client.py
+++ b/tests/test_access_client.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from typing import Any
+
+import pytest
+
+from kb import access_client as ac
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *a: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_admin_key_missing_raises(monkeypatch) -> None:
+    monkeypatch.delenv(ac.ADMIN_KEY_ENV, raising=False)
+    with pytest.raises(ac.AccessClientError, match="missing admin key"):
+        ac.admin_key()
+
+
+def test_admin_key_from_env(monkeypatch) -> None:
+    monkeypatch.setenv(ac.ADMIN_KEY_ENV, "owner-admin")
+    assert ac.admin_key() == "owner-admin"
+
+
+def test_request_refuses_non_https() -> None:
+    with pytest.raises(ac.AccessClientError, match="non-HTTPS"):
+        ac.list_seats(base_url="http://node.example", key="owner-admin")
+
+
+def test_create_seat_sends_payload_and_auth(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_open(req: Any, timeout: float | None = None) -> _FakeResp:
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode())
+        captured["auth"] = req.headers.get("Authorization")
+        return _FakeResp({"ok": True, "token": "ctdl_new", "principal": {"seat_slug": "alice"}})
+
+    monkeypatch.setattr(ac._OPENER, "open", fake_open)
+    out = ac.create_seat(base_url="https://node.example", name="Alice", slug="alice", key="owner-admin")
+    assert out["token"] == "ctdl_new"
+    assert captured["url"] == "https://node.example/api/access/seats"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"name": "Alice", "slug": "alice", "role": "writer", "issue_token": True}
+    assert captured["auth"] == "Bearer owner-admin"
+
+
+def test_http_error_maps_detail_and_status(monkeypatch) -> None:
+    def fake_open(req: Any, timeout: float | None = None) -> _FakeResp:
+        raise urllib.error.HTTPError(
+            req.full_url,
+            422,
+            "Unprocessable Entity",
+            {},
+            io.BytesIO(json.dumps({"detail": "Seat already exists"}).encode()),
+        )
+
+    monkeypatch.setattr(ac._OPENER, "open", fake_open)
+    with pytest.raises(ac.AccessClientError) as excinfo:
+        ac.create_seat(base_url="https://node.example", name="A", slug="a", key="owner-admin")
+    assert excinfo.value.status == 422
+    assert "already exists" in str(excinfo.value)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from kb.cli import _doctor, _search
+from kb.status import Check, StatusReport
+
+
+def _report(checks: list[Check], *, healthy: bool = True) -> StatusReport:
+    return StatusReport(
+        node_url="https://node.example",
+        healthy=healthy,
+        identity={"seat_slug": "alice", "role": "writer"},
+        checks=checks,
+        recent=[],
+    )
+
+
+def _all_ok() -> list[Check]:
+    return [
+        Check("node", True, "healthy"),
+        Check("auth", True, "valid"),
+        Check("token", True, "…1234"),
+        Check("mcp", True, "present"),
+        Check("pre_push_hook", True, "installed"),
+        Check("session_hook", True, "installed"),
+        Check("capture_roots", True, "none"),
+    ]
+
+
+def test_doctor_clean_reports_ok(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_x")
+    monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(_all_ok()))
+    args = argparse.Namespace(
+        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
+        node_url=None, json=True, fix=False,
+    )
+    rc = asyncio.run(_doctor(args))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True and out["issues"] == []
+
+
+def test_doctor_fix_installs_missing_local_setup(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_x")
+    broken = [
+        Check("node", True, "healthy"),
+        Check("auth", True, "valid"),
+        Check("mcp", False, "not configured"),
+        Check("pre_push_hook", False, "missing"),
+        Check("session_hook", False, "missing"),
+    ]
+    monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(broken))
+    args = argparse.Namespace(
+        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
+        node_url="https://node.example", json=True, fix=True,
+    )
+    rc = asyncio.run(_doctor(args))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1  # issues were found (doctor reports even after fixing)
+    assert set(out["fixed"]) == {"pre-push hook", "Claude hooks", "MCP server"}
+    assert (tmp_path / ".git" / "hooks" / "pre-push").exists()
+    assert (tmp_path / ".claude" / "settings.json").exists()
+    assert (tmp_path / ".mcp.json").exists()
+
+
+def test_search_http_renders_results(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    monkeypatch.setattr("kb.status.search_node", lambda *a, **k: [{"text": "hello vault"}])
+    args = argparse.Namespace(
+        query="hi", top_k=10, json=True, node_url="https://node.example",
+        local=False, dataset=None, session=None,
+    )
+    rc = asyncio.run(_search(args))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out == [{"text": "hello vault"}]
+
+
+def test_search_no_token_exits_one(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli.capture_token", lambda: None)
+    args = argparse.Namespace(
+        query="hi", top_k=10, json=False, node_url=None,
+        local=False, dataset=None, session=None,
+    )
+    rc = asyncio.run(_search(args))
+    assert rc == 1
+    assert "no token" in capsys.readouterr().err

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -131,10 +131,15 @@ def test_merge_claude_settings_adds_then_idempotent(tmp_path: Path) -> None:
     ]
     assert any("kb.hooks.sync_session" in c for c in cmds)
     assert TOKEN_ENV in data["httpHookAllowedEnvVars"]
+    start_groups = data["hooks"]["SessionStart"]
+    start_cmds = [h["command"] for g in start_groups for h in g["hooks"]]
+    assert any("kb.hooks.sync_start" in c for c in start_cmds)
+    assert start_groups[0]["matcher"] == "startup|resume"
 
     assert merge_claude_settings(path, python="/usr/bin/python3") == "unchanged"
     data2 = json.loads(path.read_text())
     assert len(data2["hooks"]["SessionEnd"]) == 1  # not duplicated
+    assert len(data2["hooks"]["SessionStart"]) == 1  # not duplicated
 
 
 def _make_repo(tmp_path: Path) -> Path:
@@ -160,10 +165,11 @@ def test_install_pre_push_hook_not_git(tmp_path: Path) -> None:
 def test_bundled_hooks_are_importable_modules() -> None:
     # The published CLI installs hooks as `python -m kb.hooks.*`; the modules
     # must import and expose a runnable main() with no server deps.
-    from kb.hooks import sync_push, sync_session
+    from kb.hooks import sync_push, sync_session, sync_start
 
     assert callable(sync_push.main)
     assert callable(sync_session.main)
+    assert callable(sync_start.main)
 
 
 def test_pre_push_hook_script_is_failsafe() -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -161,7 +161,7 @@ def test_render_text_smoke() -> None:
     out = render_text(report)
     assert "seat: sarthi" in out
     assert "All systems go." in out
-    assert "●" in out
+    assert "✓" in out
 
 
 def test_status_command_json_and_exit(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_status_tui.py
+++ b/tests/test_status_tui.py
@@ -31,7 +31,7 @@ def test_markup_helpers() -> None:
     report = _report()
     assert "sarthi" in status_tui._identity_markup(report)
     assert "connected" in status_tui._identity_markup(report)
-    assert "node" in status_tui._checks_markup(report)
+    assert "Node" in status_tui._checks_markup(report)
     assert "feat: x" in status_tui._recent_markup(report)
 
 

--- a/tests/test_sync_start.py
+++ b/tests/test_sync_start.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from kb.hooks import sync_start
+
+
+def test_no_token_is_silent_noop(monkeypatch, capsys) -> None:
+    monkeypatch.delenv(sync_start.TOKEN_ENV, raising=False)
+    rc = sync_start.run(io.StringIO("{}"))
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # nothing injected without a token
+
+
+def test_empty_recent_is_silent(monkeypatch, capsys) -> None:
+    monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
+    monkeypatch.setattr(sync_start, "fetch_recent", lambda *a, **k: [])
+    rc = sync_start.run(io.StringIO("{}"))
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # quiet when there is no activity
+
+
+def test_injects_digest_when_recent(monkeypatch, capsys) -> None:
+    monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
+    monkeypatch.setattr(
+        sync_start,
+        "fetch_recent",
+        lambda *a, **k: [{"created_at": "2026-06-29T10:00:00", "title": "Shipped CLI overhaul"}],
+    )
+    rc = sync_start.run(io.StringIO("{}"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Citadel vault — recent activity" in out
+    assert "Shipped CLI overhaul" in out
+    assert "ctdl_x" not in out  # token never leaks into the digest
+
+
+def test_failure_is_swallowed(monkeypatch, capsys) -> None:
+    monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
+
+    def boom(*a, **k):
+        raise RuntimeError("node down")
+
+    monkeypatch.setattr(sync_start, "fetch_recent", boom)
+    assert sync_start.run(io.StringIO("{}")) == 0  # fail-silent, exit 0
+    assert capsys.readouterr().out == ""
+
+
+def test_fetch_recent_refuses_non_https() -> None:
+    with pytest.raises(ValueError, match="non-HTTPS"):
+        sync_start.fetch_recent("http://node.example", "ctdl_x")

--- a/tests/test_tool_detect.py
+++ b/tests/test_tool_detect.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kb import tool_detect as td
+
+NODE = "https://node.example"
+
+
+def test_specs_modes() -> None:
+    for write_tool in ("cursor", "codex", "gemini", "windsurf"):
+        assert td.SPECS[write_tool].mode == "write"
+    for snippet_tool in ("claude", "cline", "zed"):
+        assert td.SPECS[snippet_tool].mode == "snippet"
+    assert td.SPECS["pi"].mode == "note"
+
+
+def test_cursor_merge_preserves_and_idempotent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cur = tmp_path / ".cursor" / "mcp.json"
+    cur.parent.mkdir(parents=True)
+    cur.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}}))
+
+    first = td.apply("cursor", node_url=NODE)
+    assert first.action == "wrote"
+    data = json.loads(cur.read_text())
+    assert "other" in data["mcpServers"]  # sibling server preserved
+    assert data["mcpServers"]["citadel"]["url"] == "https://node.example/mcp/"
+    assert "${env:CITADEL_MCP_ACCESS_TOKEN}" in data["mcpServers"]["citadel"]["headers"]["Authorization"]
+
+    assert td.apply("cursor", node_url=NODE).action == "unchanged"
+
+
+def test_cursor_creates_file_when_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert td.apply("cursor", node_url=NODE).action == "wrote"
+    assert (tmp_path / ".cursor" / "mcp.json").exists()
+
+
+def test_cursor_backs_up_corrupt_config(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cur = tmp_path / ".cursor" / "mcp.json"
+    cur.parent.mkdir(parents=True)
+    cur.write_text("{ not valid json")
+    result = td.apply("cursor", node_url=NODE)
+    assert result.action == "wrote"
+    assert (cur.parent / "mcp.json.citadel-bak").exists()  # original preserved
+    assert "citadel" in json.loads(cur.read_text())["mcpServers"]
+
+
+def test_codex_append_fallback_idempotent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(td, "_which", lambda name: False)  # force the config.toml path
+    first = td.apply("codex", node_url=NODE)
+    assert first.action == "wrote"
+    cfg = (tmp_path / ".codex" / "config.toml").read_text()
+    assert "[mcp_servers.citadel]" in cfg
+    assert 'bearer_token_env_var = "CITADEL_MCP_ACCESS_TOKEN"' in cfg
+    assert td.apply("codex", node_url=NODE).action == "unchanged"
+
+
+def test_gemini_write_uses_httpurl_and_dollar_var(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert td.apply("gemini", node_url=NODE).action == "wrote"
+    entry = json.loads((tmp_path / ".gemini" / "settings.json").read_text())["mcpServers"]["citadel"]
+    assert entry["httpUrl"] == "https://node.example/mcp/"  # httpUrl, not url (SSE)
+    # Gemini expands $VAR, NOT the ${env:} form.
+    assert entry["headers"]["Authorization"] == "Bearer $CITADEL_MCP_ACCESS_TOKEN"
+
+
+def test_windsurf_write_uses_serverurl_and_env_ref(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert td.apply("windsurf", node_url=NODE).action == "wrote"
+    entry = json.loads(
+        (tmp_path / ".codeium" / "windsurf" / "mcp_config.json").read_text()
+    )["mcpServers"]["citadel"]
+    assert entry["serverUrl"] == "https://node.example/mcp/"
+    assert entry["headers"]["Authorization"] == "Bearer ${env:CITADEL_MCP_ACCESS_TOKEN}"
+
+
+def test_snippet_shapes() -> None:
+    cline = td.apply("cline", node_url=NODE)
+    assert '"streamableHttp"' in cline.snippet  # camelCase is load-bearing for Cline
+
+    zed = td.apply("zed", node_url=NODE)
+    assert "context_servers" in zed.snippet and '"source"' not in zed.snippet
+
+    claude = td.apply("claude", node_url=NODE)
+    assert "claude mcp add" in claude.snippet and "--scope user" in claude.snippet
+
+
+def test_pi_is_note_only() -> None:
+    result = td.apply("pi", node_url=NODE)
+    assert result.action == "note"
+    assert "no native MCP" in result.detail
+
+
+def test_unknown_tool_errors() -> None:
+    assert td.apply("nope", node_url=NODE).action == "error"


### PR DESCRIPTION
Full CLI UX overhaul + the token-minting gap closed. Stdlib-only (zero new runtime deps), 538 tests pass, two adversarial review passes (all confirmed findings — 6 total, all LOW — fixed).

## What's in it
- **Terminal UI**: shared `✓/✗/⊘` glyphs (survive `NO_COLOR`), grouped+humanized `status` with node URL + spinner, glyph `onboard` output with `getpass`, home state line + Connect&admin menu, `FORCE_COLOR`.
- **First-run**: bare `citadel` auto-enters onboarding once (guarded by `--no-onboard`/`CITADEL_NO_ONBOARD`/non-tty); `install.sh` runs `citadel onboard < /dev/tty`.
- **Multi-tool MCP** (`kb/tool_detect.py` + `citadel mcp add/list`): auto-writes Cursor, Codex, Gemini, Windsurf (token stays in the rc via env-ref); snippets for Claude user-scope, Cline, Zed (plaintext); Pi note (no native MCP).
- **Admin** (`kb/access_client.py`): `citadel seat create/list`, `citadel token create/revoke` — admin key env-only, token printed once.
- **`citadel doctor`** (+`--fix`), HTTP-backed **`citadel search`** (`--local` for the server path), **warm-start hot cache** SessionStart hook (`kb/hooks/sync_start.py`).
- Server-handler error/exit-code hardening, `--version`, `onboard --node-url`.

Bump `0.1.3` → `0.2.0`.

Note: this is client/CLI surface — it doesn't change the hosted Node's behavior. Reaches end users via a PyPI release.