### PR TITLE
fix(ingest): inline server-side cognify (writer tokens get immediate search)

### DIFF
--- a/kb/cli.py
+++ b/kb/cli.py
@@ -174,17 +174,22 @@ async def _ingest(args: argparse.Namespace) -> int:
         return 1
     from kb.status import ingest_node
 
+    # Cognify inline (server-side) by default so the note is immediately
+    # searchable; the one request blocks until cognify finishes (--no-cognify skips).
+    cognify = not getattr(args, "no_cognify", False)
+    as_json = getattr(args, "json", False)
+    spinner_msg = "Ingesting + building the graph…" if cognify else "Ingesting to your Node…"
     try:
-        with _Spinner("Ingesting to your Node…"):
-            result = await asyncio.to_thread(ingest_node, base_url, token, args.data, args.tag)
+        with _Spinner(spinner_msg):
+            result = await asyncio.to_thread(ingest_node, base_url, token, args.data, args.tag, cognify)
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:200] if exc.fp else exc.reason
         print(f"citadel ingest: HTTP {exc.code} {detail}", file=sys.stderr)
         return 1
     except TimeoutError:
         print(
-            "citadel ingest: timed out waiting for the Node (it may still be ingesting — "
-            "check with `citadel search` shortly).",
+            "citadel ingest: the Node is still working (cognify can be slow). Your note is "
+            "saved — it'll be searchable shortly; check `citadel search`.",
             file=sys.stderr,
         )
         return 1
@@ -196,44 +201,27 @@ async def _ingest(args: argparse.Namespace) -> int:
     accepted = result.get("accepted", True)
     # A duplicate is a benign, idempotent no-op — not a failure.
     duplicate = (not accepted) and "duplicate" in str(result.get("reason") or "")
-    as_json = getattr(args, "json", False)
+    cognified = result.get("cognified")  # True/False from the Node, or None (not requested / old Node)
     color = supports_color()
     dataset = result.get("dataset") or "your node"
     scope = "your private seat" if str(dataset).startswith("seat:") else "shared org vault"
 
-    # Confirm the write (and WHERE it went) before the slower cognify step.
-    if accepted and not as_json:
-        print(
-            f"  {mark(True, enable=color)} ingested to {paint(dataset, 'cyan', enable=color)}  "
-            f"{paint('(' + scope + ')', 'dim', enable=color)}"
-        )
-
-    # Every ingest cognifies by default so it's immediately searchable (--no-cognify to skip).
-    cognified: bool | None = None
-    if accepted and not getattr(args, "no_cognify", False):
-        from kb.status import cognify_node
-
-        try:
-            with _Spinner("Cognifying (building the graph)…"):
-                await asyncio.to_thread(cognify_node, base_url, token, result.get("dataset"))
-            cognified = True
-        except (
-            TimeoutError, urllib.error.URLError, urllib.error.HTTPError,
-            OSError, ValueError, http.client.HTTPException,
-        ):
-            cognified = False
-
     if as_json:
-        if cognified is not None:
-            result["cognified"] = cognified
         _print_json(result)
         return 0 if (accepted or duplicate) else 1
 
     if accepted:
+        print(
+            f"  {mark(True, enable=color)} ingested to {paint(dataset, 'cyan', enable=color)}  "
+            f"{paint('(' + scope + ')', 'dim', enable=color)}"
+        )
         if cognified is True:
             print(f"  {mark(True, enable=color)} cognified — now searchable")
         elif cognified is False:
-            print(f"  {paint(SKIP, 'yellow', enable=color)} cognify still running on the Node (will finish shortly)")
+            print(f"  {paint(SKIP, 'yellow', enable=color)} ingested, but cognify didn't finish — the next Node sync will pick it up")
+        elif cognify:
+            # Requested cognify but the Node didn't report it (older Node, pre inline-cognify).
+            print(paint("  (graph update will happen on the next Node sync)", "dim", enable=color))
     elif duplicate:
         print(
             f"  {paint(SKIP, 'yellow', enable=color)} already in your vault (duplicate) — nothing new to add"
@@ -670,13 +658,19 @@ def _access_exit(exc: AccessClientError, *, as_json: bool) -> int:
 
 
 def _print_minted_token(token: str, api_token: dict[str, Any], *, color: bool) -> None:
-    """Print a freshly minted token once, with a store-it-now warning."""
+    """Print a freshly minted token once, with its write-scope + adopt steps."""
     print()
     print(paint("  Token (shown once — copy it now, it cannot be retrieved later):", "yellow", enable=color))
     print("    " + paint(token, "bold", enable=color))
-    meta = f"  id={api_token.get('id')}  role={api_token.get('role')}"
-    print(paint(meta, "dim", enable=color))
-    print(paint("  Share over a private channel; the teammate pastes it into `citadel onboard`.", "dim", enable=color))
+    dataset = api_token.get("default_dataset")
+    if dataset and str(dataset).startswith("seat:"):
+        scope = f"ingests go to {dataset} (their private seat) only"
+    elif dataset:
+        scope = f"ingests go to {dataset}"
+    else:
+        scope = "ingests go to the org default dataset — NOT a private seat"
+    print(paint(f"  scope: {scope}  ·  role={api_token.get('role')}", "dim", enable=color))
+    print(paint("  Adopt:  citadel onboard --token <token-above>   ·   share over a private channel", "dim", enable=color))
 
 
 async def _seat_list(args: argparse.Namespace) -> int:
@@ -754,7 +748,6 @@ async def _seat_token(args: argparse.Namespace) -> int:
     )
     if result.get("token"):
         _print_minted_token(result["token"], result.get("api_token", {}), color=color)
-        print(paint("  Adopt it with:  citadel onboard --token <token-above>", "dim", enable=color))
     return 0
 
 
@@ -778,6 +771,17 @@ async def _token_create(args: argparse.Namespace) -> int:
     print(paint(f"Token created  (principal {result.get('principal', {}).get('id')})", "green", enable=color))
     if result.get("token"):
         _print_minted_token(result["token"], result.get("api_token", {}), color=color)
+    # Standalone tokens are NOT seat-scoped — steer teammate tokens to seats.
+    api_token = result.get("api_token", {})
+    if not str(api_token.get("default_dataset") or "").startswith("seat:"):
+        print(
+            paint(
+                "  Note: this is a standalone token (not a private seat). For a teammate, use "
+                "`citadel seat create \"Name\" slug` so their writes land in their own seat.",
+                "yellow",
+                enable=color,
+            )
+        )
     return 0
 
 
@@ -1084,6 +1088,44 @@ def _humanize_status(status: str) -> tuple[str, bool, bool]:
     return status, True, False
 
 
+def _print_banner_animated(text: str, color: bool) -> None:
+    """Reveal the banner line-by-line for a little ceremony (TTY + color only)."""
+    if not (color and sys.stdout.isatty()):
+        print(text)
+        return
+    import time
+
+    for line in text.split("\n"):
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+        time.sleep(0.035)
+
+
+def _render_onboard_identity(auth: Any, node_url: str, color: bool) -> str:
+    """Who this token belongs to — seat, role, access — shown on onboard."""
+    if not getattr(auth, "ok", False):
+        detail = getattr(auth, "detail", "could not verify")
+        return (
+            f"  {mark(False, enable=color)} "
+            + paint(f"token not verified ({detail}) — saved anyway; run `citadel status` to recheck.", "yellow", enable=color)
+        )
+    ident = getattr(auth, "data", None) or {}
+    seat = ident.get("seat_slug") or ident.get("actor") or "—"
+    caps = ident.get("capabilities") or {}
+    access = " · ".join(
+        flag for flag, on in (("read", caps.get("read")), ("write", caps.get("write")), ("admin", caps.get("admin"))) if on
+    ) or "—"
+    writes = f"seat:{seat}" if ident.get("seat_slug") else "shared org dataset"
+    return "\n".join([
+        paint(f"  {mark(True, enable=color)} authenticated", "green", enable=color),
+        f"      seat     {paint(str(seat), 'cyan', enable=color)}",
+        f"      role     {ident.get('role') or '—'}",
+        f"      access   {access}",
+        f"      writes   {writes}",
+        paint(f"      node     {node_url}", "dim", enable=color),
+    ])
+
+
 async def _onboard(args: argparse.Namespace) -> int:
     repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
     as_json = getattr(args, "json", False)
@@ -1092,7 +1134,7 @@ async def _onboard(args: argparse.Namespace) -> int:
     node_url = (getattr(args, "node_url", None) or DEFAULT_NODE_URL).rstrip("/")
 
     if interactive:
-        print(banner(color=color))
+        _print_banner_animated(banner(color=color), color)
 
     token = (args.token or os.environ.get(TOKEN_ENV) or "").strip()
     if not token and interactive:
@@ -1113,6 +1155,15 @@ async def _onboard(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Verify the token + resolve its identity (seat / role / access) to show the
+    # user who they're onboarding as. Interactive-only: keeps scripts/CI offline.
+    auth = None
+    if interactive:
+        from kb.status import check_auth
+
+        with _Spinner("Verifying your token…"):
+            auth = await asyncio.to_thread(check_auth, node_url, token)
 
     rc_path = Path(args.shell_rc).expanduser() if args.shell_rc else detect_shell_rc()
     steps: list[tuple[str, str]] = []
@@ -1170,6 +1221,9 @@ async def _onboard(args: argparse.Namespace) -> int:
 
     if not interactive:
         print(banner(color=color))
+    if auth is not None:
+        print()
+        print(_render_onboard_identity(auth, node_url, color))
     print(f"\nCitadel onboarding for {repo}  (token {mask_token(token)}):")
     for label, status in steps:
         text, ok, skipped = _humanize_status(status)

--- a/kb/server.py
+++ b/kb/server.py
@@ -280,6 +280,10 @@ class IngestBody(BaseModel):
     dataset: str | None = None
     tags: list[str] = Field(default_factory=list)
     session_id: str | None = None
+    # When true, cognify the written dataset inline (server-side, where it holds
+    # the single Kuzu writer) and block until done — so a writer's ingest is
+    # immediately searchable without needing the admin-only cognify endpoint.
+    cognify: bool = False
 
 
 class SearchBody(BaseModel):
@@ -3113,7 +3117,17 @@ async def ingest(body: IngestBody, request: Request) -> Any:
             ),
         },
     )
-    return jsonable_encoder(result)
+    payload = jsonable_encoder(result)
+    # Inline cognify (opt-in) so the just-written data is immediately searchable.
+    # The write already succeeded; a cognify failure must NOT fail the ingest.
+    if body.cognify and result.accepted:
+        try:
+            await citadel.cognify_dataset(dataset=outcome.dataset)
+            payload["cognified"] = True
+        except Exception as exc:  # pragma: no cover - depends on runtime Cognee state
+            logger.error("inline cognify after ingest failed: %s", exc.__class__.__name__)
+            payload["cognified"] = False
+    return payload
 
 
 @app.get("/api/contributions/recent")

--- a/kb/status.py
+++ b/kb/status.py
@@ -189,35 +189,32 @@ def ingest_node(
     token: str,
     data: str,
     tags: list[str] | tuple[str, ...] = (),
+    cognify: bool = False,
     *,
-    timeout: float = _INGEST_TIMEOUT,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
     """POST a note to the Node's /ingest (same endpoint MCP citadel_ingest uses).
 
     Sends no dataset, so the seat token routes the write to the dev's private
-    node (personal-by-default), mirroring the SessionEnd hook. Returns the
-    response (``accepted``, ``reason``, ``dataset``, …).
+    node (personal-by-default), mirroring the SessionEnd hook. With cognify=True
+    the Node builds the graph inline and blocks until done (so the note is
+    immediately searchable). Returns the response (``accepted``, ``reason``,
+    ``dataset``, and ``cognified`` when cognify was requested).
     """
+    payload: dict[str, Any] = {"data": data, "tags": list(tags)}
+    if cognify:
+        payload["cognify"] = True
+    resolved = timeout if timeout is not None else (_COGNIFY_TIMEOUT if cognify else _INGEST_TIMEOUT)
     return _request(
         "POST",
         f"{base_url.rstrip('/')}/ingest",
         token=token,
-        payload={"data": data, "tags": list(tags)},
-        timeout=timeout,
+        payload=payload,
+        timeout=resolved,
     )
 
 
-_COGNIFY_TIMEOUT = 180.0  # building the graph is slow; give it room
-
-
-def cognify_node(
-    base_url: str, token: str, dataset: str | None = None, *, timeout: float = _COGNIFY_TIMEOUT
-) -> dict[str, Any]:
-    """POST /api/cognify/run to materialize ingested data into the graph."""
-    payload: dict[str, Any] = {"dataset": dataset} if dataset else {}
-    return _request(
-        "POST", f"{base_url.rstrip('/')}/api/cognify/run", token=token, payload=payload, timeout=timeout
-    )
+_COGNIFY_TIMEOUT = 180.0  # /ingest cognifies inline; give the combined call room
 
 
 def fetch_mesh(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -> dict[str, Any]:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -134,10 +134,14 @@ def test_ingest_no_token_exits_one(monkeypatch, capsys) -> None:
 
 def test_ingest_cognifies_by_default(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
-    monkeypatch.setattr("kb.status.ingest_node", lambda *a, **k: {"accepted": True, "dataset": "seat:alice"})
-    calls: list = []
-    monkeypatch.setattr("kb.status.cognify_node", lambda *a, **k: calls.append(a) or {"ok": True})
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, **k):
+        seen["cognify"] = cognify  # the Node is asked to cognify inline
+        return {"accepted": True, "dataset": "seat:alice", "cognified": True}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
     rc = asyncio.run(_ingest(_ingest_args(no_cognify=False)))
     assert rc == 0
-    assert calls  # cognify was triggered after a successful ingest
+    assert seen["cognify"] is True
     assert json.loads(capsys.readouterr().out)["cognified"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -503,6 +503,18 @@ def test_reader_access_can_view_and_search_but_not_mutate() -> None:
     assert sync_run.status_code == 403
 
 
+def test_ingest_inline_cognify_flag() -> None:
+    client = authed_client()
+    # Default: no inline cognify, no `cognified` in the response.
+    plain = client.post("/ingest", json={"data": "note one", "tags": []})
+    assert plain.status_code == 200
+    assert "cognified" not in plain.json()
+    # cognify=True → the Node cognifies inline (server-side) and reports it.
+    with_cognify = client.post("/ingest", json={"data": "note two", "tags": [], "cognify": True})
+    assert with_cognify.status_code == 200
+    assert with_cognify.json()["cognified"] is True
+
+
 def test_writer_access_can_ingest_and_feedback_but_not_admin_actions() -> None:
     client = authed_client("test-writer")
 


### PR DESCRIPTION
Follow-up to #21 (still 0.2.1, unpublished). Fixes a real bug found in testing + folds in mint-scope clarity and onboard token verification.

- **Inline cognify on /ingest**: `/api/cognify/run` is admin-only, so `citadel ingest` with a writer/seat token hit a silent 403 (mislabeled 'cognify still running'). Now `/ingest` takes a `cognify` flag and cognifies the written dataset **inline** (in the web process that owns the single Kuzu writer), blocking until done — no admin needed. CLI sends it by default (`--no-cognify` to skip); one request waits for cognify with honest messaging. Cognify failure never fails the write. Degrades gracefully on older Nodes (Pydantic ignores the flag).
- **Mint scope clarity**: every minted token prints whether it writes to a private seat or the shared dataset; `token create` warns it's standalone (use `seat create` for people).
- **onboard**: verifies the pasted token and shows seat/role/access + an animated banner reveal.

542 tests pass, lint clean. No PyPI tag.