### PR TITLE
docs(0.2.1): align changelog/progress/README/skills with shipped CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] — 2026-06-29
+
+### Added
+
+- **`citadel ingest` cognifies inline by default** — server-side cognify on the
+  ingest path so the note is immediately searchable. `--no-cognify` skips it
+  (faster; data appears in search later). Ingest prints the destination + scope
+  (private seat vs shared org dataset).
+- **`citadel seat token <slug>`** — mint a fresh seat-scoped token for an
+  **existing** seat (re-link a lost/rotated token), distinct from `seat create`.
+- **Write-scope clarity on every mint** — `seat create`, `seat token`, and
+  `token create` each print the token's write-scope; `token create` warns that
+  standalone tokens are **not** seat-scoped.
+- **`citadel doctor` (+`--fix`)** — diagnoses setup drift (token-in-rc-not-env,
+  MCP/capture Node mismatch, missing hooks/`.mcp.json`, Node-rejected token);
+  `--fix` repairs the safe ones.
+- **`citadel onboard` token verify + identity panel** — verifies the pasted
+  token against the Node and shows seat / role / access before wiring anything.
+
+### Changed
+
+- **`citadel ingest` / `citadel search` are HTTP-backed by default** — they
+  route to your seat via the token (no `[server]` extra needed). `--local` runs
+  the in-process server stack instead (needs `[server]`). Both keep `--json`.
+- **Friendlier failure modes** — narrow-terminal truncation, friendly errors for
+  bare subcommand groups / typos / missing args, and clean Ctrl-C (exit 130).
+- **`install.sh` upgrade path** uses `pipx install --force … --pip-args=--no-cache-dir`
+  so upgrades never pull a stale cached wheel.
+
+### Removed
+
+- **TUI removed entirely** — there is no `citadel tui` command and the `[tui]`
+  (textual) extra is dropped. Its data moved into `citadel status` as a
+  "Knowledge mesh" section (documents / nodes / edges / searches).
+
+### Server
+
+- **`/ingest` gained an inline `cognify` flag** so the Node can cognify on the
+  ingest request (backing `citadel ingest`'s default).
+- **Evolve auto-sync interval shortened 6h → 1h** (`CITADEL_EVOLVE_INTERVAL_SECONDS=3600`):
+  GitHub / Linear / repo sync + cognify now run hourly.
+
+## [0.2.0] — 2026-06-29
+
+### Added
+
+- **Guided first-run onboarding** — bare `citadel` on an interactive TTY
+  auto-enters onboarding once, then shows the home screen on later runs. Skip
+  with `--no-onboard` / `CITADEL_NO_ONBOARD`; `install.sh` runs onboarding via
+  `/dev/tty`.
+- **Multi-tool MCP wiring** — `citadel mcp add <tool>` / `citadel mcp list`.
+  Auto-writes Cursor, Codex, Gemini, and Windsurf (token stays in the shell rc
+  via an env reference) and prints a paste-in snippet for Claude user-scope,
+  Cline, and Zed (which store the token in plaintext). Pi has no native MCP
+  (info note only).
+- **Admin `seat` / `token` commands** (need `CITADEL_ADMIN_KEY`) —
+  `citadel seat create "Name" slug` mints a seat + a seat-scoped writer token
+  (a teammate ingests only into their `seat:slug`); `citadel seat list`;
+  `citadel token create` mints standalone/service-account tokens and
+  `citadel token revoke <id>` revokes by id.
+- **`citadel onboard --node-url`** — target a custom Node during onboarding. The
+  onboard now also installs the Claude `SessionStart` hook alongside the
+  existing `SessionEnd` hook, the git pre-push hook, and `.mcp.json`.
+- **`citadel --version` / `citadel version`**.
+
+### Changed
+
+- **Stdlib CLI UX overhaul** — shared ✓/✗ glyphs, an animated cyan spinner +
+  banner reveal, and hardened argparse error/exit handling across the CLI.
+
 ## [0.1.3] — 2026-06-28
 
 ### Added
@@ -83,6 +153,8 @@ self-hosted Organization Vault server.
   references it as `${CITADEL_MCP_ACCESS_TOKEN}` and it is never echoed.
 - The pre-push allowlist fails **closed** on a corrupt config.
 
+[0.2.1]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.2.1
+[0.2.0]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.2.0
 [0.1.3]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.3
 [0.1.2]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.2
 [0.1.1]: https://github.com/masumi-network/Citadel-Archive/releases/tag/v0.1.1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -42,8 +42,7 @@ Pushing the `v*` tag triggers the workflow: it builds the sdist + wheel, runs
 ```bash
 pipx install citadel-archive          # the lightweight client CLI
 citadel --help
-# extras:
-pipx install "citadel-archive[tui]"    # + live `citadel tui` dashboard
+# extra:
 pip  install "citadel-archive[server]" # + run the Node/MCP server
 ```
 
@@ -59,5 +58,6 @@ uv pip install --system twine && python -m twine check dist/*
 - **Version is the source of truth in `pyproject.toml`** — the tag must match
   (`v0.1.1` → `version = "0.1.1"`). PyPI rejects re-uploading an existing
   version, so always bump before tagging.
-- The base package depends only on `python-dotenv`; `[server]` and `[tui]` pull
-  the heavy stacks on demand. Keep that split when adding dependencies.
+- The base package has zero third-party dependencies (pure stdlib); the
+  `[server]` extra pulls the heavy stack on demand. Keep that split when adding
+  dependencies.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ evolves only through governed promotion and org sync.
 
 ```bash
 pipx install citadel-archive          # the `citadel` command (zero-dep client)
+# upgrade: pipx install --force citadel-archive --pip-args=--no-cache-dir
 
 citadel onboard                       # token + hooks + MCP + capture roots (idempotent)
 citadel status                        # connection · identity · local setup  (--json for agents)
@@ -108,10 +109,13 @@ decisions live in [`docs/adr/`](docs/adr/).
 
 ```bash
 citadel onboard                       # one-command setup
-citadel status [--json]               # health + identity + local setup
+citadel doctor [--fix]                # diagnose (and repair) your local setup
+citadel status [--json]               # health + identity + local setup + knowledge mesh
 citadel capture [--dry-run] [--json]  # push summaries of Approved Capture Roots
-citadel search "what did we decide about the vault?"
-citadel ingest "A durable note" --tag decision
+citadel search "what did we decide about the vault?"   # HTTP-backed via your seat (--json)
+citadel ingest "A durable note" --tag decision         # → your seat Node, cognified inline
+citadel mcp add cursor                # wire another coding tool to the hosted MCP
+citadel seat create "Jane Dev" jane   # admin: mint a seat + its seat-scoped writer token
 ```
 
 ### MCP (hosted)

--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -17,10 +17,17 @@ Mint a **seat-writer** token for the teammate. Seat-writer tokens route every
 capture to that teammate's private node (`seat:{slug}`) — they cannot read or
 write anyone else's node, and they get no admin powers.
 
+```bash
+# Admin (CITADEL_ADMIN_KEY set): mint the seat + its seat-scoped writer token
+citadel seat create "Jane Dev" jane    # prints a ctdl_… token scoped to seat:jane
+
+# Lost the token later? Re-mint a fresh one for the existing seat:
+citadel seat token jane
 ```
-Open:  https://citadel-archive-production.up.railway.app/skills/connect
-       (admin → "Create seat" → role: writer → copy the ctdl_… token)
-```
+
+(The web Access page —
+`https://citadel-archive-production.up.railway.app/skills/connect` — does the
+same thing if you'd rather click.)
 
 Hand the token to the teammate over a private channel. It is a secret — treat
 it like a password.
@@ -33,6 +40,7 @@ Install the CLI, then run onboard from the repo:
 
 ```bash
 pipx install citadel-archive     # the `citadel` command (lightweight, zero-dep client)
+# upgrade: pipx install --force citadel-archive --pip-args=--no-cache-dir
 citadel onboard
 ```
 
@@ -147,8 +155,8 @@ in scripts/CI.
 ## Verify (30 seconds)
 
 ```bash
-citadel status        # connection + identity + local setup (expect all ●); --json for agents
-# or:  citadel tui    # live dashboard (needs the [tui] extra)
+citadel status        # connection + identity + local setup + knowledge mesh (expect all ●); --json for agents
+# or:  citadel doctor # diagnose setup issues; --fix repairs the safe ones
 
 # Token works + MCP search returns results:
 #   in Claude Code, ask: "use citadel_search to find what we decided about the vault"

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -2,6 +2,59 @@
 
 Last updated: 2026-06-29.
 
+## 2026-06-29 — v0.2.0 + v0.2.1: CLI DX overhaul shipped (PyPI + Railway)
+
+The client got a top-to-bottom UX pass and shipped as `citadel-archive` 0.2.0
+then 0.2.1 — **published to PyPI, deployed to Railway, cut as a GitHub release.**
+What changed for users:
+
+- **Seat-scoped ingest that actually works, with inline cognify.** `citadel
+  ingest` (and `citadel search`) are now HTTP-backed by default — they route to
+  your seat via the token, no `[server]` extra needed (`--local` still runs the
+  in-process stack). `ingest` cognifies **inline server-side** so the note is
+  searchable immediately (`--no-cognify` to skip), and prints its destination +
+  scope (private seat vs shared org dataset). `--json` on both.
+- **Richer `citadel status`.** Absorbed the old TUI's data into a "Knowledge
+  mesh" section (documents / nodes / edges / searches) — no separate command to
+  launch.
+- **`citadel doctor` (+ `--fix`).** Diagnoses setup drift — token-in-rc-not-env,
+  MCP/capture Node mismatch, missing hooks/`.mcp.json`, Node-rejected token — and
+  repairs the safe ones.
+- **Seat / token minting.** `citadel seat create "Name" slug` mints a seat + a
+  seat-scoped writer token (a teammate ingests ONLY into their `seat:slug`);
+  `citadel seat token <slug>` mints a FRESH token for an EXISTING seat (re-link a
+  lost token); `citadel token create` is for standalone/service-account tokens
+  (warns it is NOT seat-scoped); `citadel token revoke <id>`. Every mint prints
+  its write-scope; the seat token is the per-user "API key". Admin commands need
+  `CITADEL_ADMIN_KEY`.
+- **First-run onboarding.** Bare `citadel` on an interactive TTY auto-enters
+  onboarding once, then shows the home screen (`--no-onboard` /
+  `CITADEL_NO_ONBOARD` to skip; `install.sh` runs it via `/dev/tty`). `citadel
+  onboard` verifies the pasted token, shows seat/role/access, and installs
+  token→shell rc + git pre-push hook + Claude SessionEnd **and** SessionStart
+  hooks + `.mcp.json` (+ optional capture roots); `--node-url` targets a custom
+  Node.
+- **Multi-tool MCP.** `citadel mcp add <tool>` / `citadel mcp list` auto-write
+  Cursor, Codex, Gemini, Windsurf (token stays in the shell rc via an env
+  reference); print a paste-in snippet for Claude user-scope, Cline, Zed (those
+  store the token in plaintext). Pi has no native MCP (info note only).
+- **Friendlier UX.** Shared ✓/✗ glyphs, animated cyan spinner + banner reveal,
+  narrow-terminal truncation, friendly errors for bare subcommand groups / typos
+  / missing args, clean Ctrl-C (exit 130), `--version`.
+- **TUI removed entirely.** No more `citadel tui`, no `[tui]`/textual extra. The
+  zero-dep stdlib client install is just `pipx install citadel-archive`. Upgrade
+  with `pipx install --force citadel-archive --pip-args=--no-cache-dir` (plain
+  `pipx upgrade` can pull a stale cached wheel).
+- **One server change.** The Node's evolve auto-sync interval was shortened
+  **6h → 1h** (`CITADEL_EVOLVE_INTERVAL_SECONDS=3600`), and the `/ingest` endpoint
+  gained the inline `cognify` flag that the new CLI ingest relies on. Autonomous
+  ingestion stays: SessionEnd hook (session → seat) + git pre-push hook (commit
+  metadata → seat) + the hourly evolve cycle (GitHub/Linear/repo sync + cognify);
+  personal-by-default → seat, promote to shared via `citadel promotion`.
+
+**Deferred NEXT project:** event-driven sync — GitHub/Linear webhooks +
+incremental cognify (replace the hourly poll with push-triggered ingest).
+
 ## 2026-06-29 (continued) — Cognee 1.2.2, Linear live, smoke verified, release closed
 
 The remaining release tasks are done (verified via the live admin key through

--- a/skills/citadel-proactive-ingest/README.md
+++ b/skills/citadel-proactive-ingest/README.md
@@ -30,7 +30,7 @@ the MCP server (`.mcp.json`), and the capture roots. No vendored skill directory
 is needed.
 
 ```bash
-pipx install citadel-archive   # lightweight `citadel` CLI (extras: [tui], [server])
+pipx install citadel-archive   # lightweight `citadel` CLI (zero-dep client; extra: [server])
 citadel onboard                # idempotent — safe to re-run
 ```
 

--- a/skills/citadel-proactive-ingest/SKILL.md
+++ b/skills/citadel-proactive-ingest/SKILL.md
@@ -35,7 +35,7 @@ Read/write rules: `https://citadel-archive-production.up.railway.app/skills/vaul
 
 | Personal (default) | Shared Central |
 |---|---|
-| No `dataset` field on writes | **Promotion Agent** (6h cron + on demand) |
+| No `dataset` field on writes | **Promotion Agent** (hourly evolve cron + on demand) |
 | Lands in your `seat:{slug}` node | Org GitHub / Linear sync (operator cron) |
 | Only you (+ Central readers) can read your node | Whole org reads promoted **Central** copies |
 
@@ -189,13 +189,13 @@ org-wide source material.
 | `learning-agent` (or `github-sync`) | GitHub org digest → Central | Daily (`0 8 * * *` UTC) |
 | `linear-sync` | Linear workspace → Central; assignee issues **Seat-Scoped Mirror** → each **Node** | Daily or hourly (operator choice) |
 | `pipeline` (also `all`/`cron`) | GitHub sync + skills refresh + self-improve + backup mirror (each stage env-toggleable) | Daily |
-| `evolve` | Self-evolving cycle: github sync → repo-content → self-improve → promotion → Linear sync → cognify (each `CITADEL_EVOLVE_*`-toggleable) | Every 6h via the in-process scheduler in the web service (`CITADEL_EVOLVE_SCHEDULER_ENABLED`) — not a separate Railway service (promotion/cognify need the web's single-writer Kuzu volume) |
+| `evolve` | Self-evolving cycle: github sync → repo-content → self-improve → promotion → Linear sync → cognify (each `CITADEL_EVOLVE_*`-toggleable) | Every 1h via the in-process scheduler in the web service (`CITADEL_EVOLVE_SCHEDULER_ENABLED`, `CITADEL_EVOLVE_INTERVAL_SECONDS=3600`) — not a separate Railway service (promotion/cognify need the web's single-writer Kuzu volume) |
 | `backup-mirror` | Vault Backup Mirror manifest export | Daily |
 
 Key env vars (Railway cron service / web service — not dev shells):
 
 - `CITADEL_LINEAR_API_KEY` — required for `linear-sync` (and the evolve Linear stage)
-- `CITADEL_EVOLVE_SCHEDULER_ENABLED` / `CITADEL_EVOLVE_INTERVAL_SECONDS` — the 6h in-process evolve scheduler (web service)
+- `CITADEL_EVOLVE_SCHEDULER_ENABLED` / `CITADEL_EVOLVE_INTERVAL_SECONDS` — the hourly in-process evolve scheduler (web service; default `3600`)
 - `CITADEL_LINEAR_USER_MAP` — optional JSON map Linear user id → seat slug
 - `CITADEL_GITHUB_ORG`, `CITADEL_GITHUB_SYNC_*` — GitHub org sync scope
 - `CITADEL_PIPELINE_*_ENABLED` — toggle individual pipeline stages

--- a/skills/citadel-vault/SKILL.md
+++ b/skills/citadel-vault/SKILL.md
@@ -147,7 +147,7 @@ when testing learning-agent or backup-mirror runs. If the client asks for
 approval, present the exact tool and expected effect.
 
 **Do not trigger admin sync proactively.** The daily Railway `learning-agent`
-cron handles GitHub org sync, and an **in-process 6h evolve scheduler** (in the
+cron handles GitHub org sync, and an **in-process hourly evolve scheduler** (in the
 web service) runs the self-evolving cycle — github sync → repo-content → self
 improve → promotion → Linear sync → cognify — keeping **Central**, the graph, and
 promotions current on its own. Only call `citadel_run_learning_agent`,
@@ -164,7 +164,7 @@ no per-capture dev steps:
 | Git pre-push hook | every `git push` | seat **Node** | none — automatic |
 | SessionEnd hook (Claude Code) | session close | seat **Node** | none — automatic |
 | Railway `learning-agent` cron | daily schedule | **Central** | read via `citadel_search` |
-| In-process evolve scheduler (web) | every 6h | **Central** graph + promotion + Linear | `citadel_search`, `citadel_get_mesh`, `citadel_linear_search` |
+| In-process evolve scheduler (web) | every 1h | **Central** graph + promotion + Linear | `citadel_search`, `citadel_get_mesh`, `citadel_linear_search` |
 
 Install dev-side hooks once: `citadel onboard` (writes the git pre-push and
 SessionEnd hooks that run `python -m kb.hooks.sync_push` / `python -m kb.hooks.sync_session`).


### PR DESCRIPTION
Docs-only follow-up to the shipped v0.2.1. No code or version change.

- **CHANGELOG**: adds the missing **[0.2.0]** and **[0.2.1]** entries (the file jumped from 0.1.3).
- **docs/progress.md**: new 2026-06-29 section for the CLI DX overhaul + the event-driven-sync next step.
- **README** + **docs/onboarding/teammate-rollout.md**: current command list, force/no-cache upgrade, `seat create` teammate flow, removed TUI.
- **PUBLISHING.md**: drops the removed `[tui]` extra; base is zero-dep now.
- **skills** (citadel-vault, citadel-proactive-ingest): evolve interval 6h→1h, drop `[tui]`.

A doc-sweep agent had also strayed into a dashboard re-theme (brand.md / static/*) — those were reverted; this PR is docs/skills only.