### PR TITLE
feat(ui): Masumi-brand dashboard + consolidate nav to 6 items

### DIFF
--- a/brand.md
+++ b/brand.md
@@ -50,9 +50,24 @@ promotion. See [`CONTEXT.md`](CONTEXT.md) for the full domain glossary.
 
 ---
 
-## Web UI palette — _deferred_
+## Web UI palette — _set 2026-06-29_
 
-The web dashboard still uses a restrained neutral operations palette and no
-custom typography. To set up a full web brand palette + typography at any time,
-run `/brand-design` (or say "pick brand colors"); it will detect this deferred
-state and proceed directly to setup. _Deferred at: 2026-05-20._
+The web dashboard is themed to **Masumi Network's brand** — magenta `#FA008C`
+on a dark, faint-emerald-neutral base. Tokens live in `kb/static/styles.css`
+`:root`; everything derives from them.
+
+| Role | Token | Value | Rationale |
+|---|---|---|---|
+| Brand accent | `--primary` | `#FA008C` | Masumi's declared `theme-color` (masumi.network) |
+| Accent hover/glow | `--primary-strong` | `#FF5CB0` | lighter magenta |
+| Success / indexed | `--success` | `#34D399` | emerald — day-to-day "healthy/indexed" status |
+| Info / search | `--info` | `#22D3EE` | cyan — nod to Citadel's CLI brand |
+| Danger | `--danger` | `#FA140A` | Masumi's own red |
+| Warning / pending | `--warning` | `#FBBF24` | amber |
+| Surfaces | `--bg` … `--surface` | `#0B0F0E` → `#131B18` | dark, faint emerald-neutral tint |
+
+Magenta carries brand identity (active nav, primary actions, links); emerald
+reads as the "indexed / healthy" status across the timeline. The sidebar is 6
+items (Overview · Search · Knowledge · Activity · Write · Admin); merged groups
+expose sub-pages via a content sub-tab bar. Typography unchanged (Inter body;
+monospace reserved for data — timestamps, IDs, reasons).

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -119,6 +119,60 @@ const searchResultStatus = document.getElementById("searchResultStatus");
 const pageButtons = Array.from(document.querySelectorAll("[data-page-target]"));
 const pages = Array.from(document.querySelectorAll("[data-page]"));
 const roleOrder = { reader: 1, writer: 2, admin: 3 };
+
+// Grouped navigation: the sidebar shows 6 top-level items; merged groups expose
+// their sub-pages as a content sub-tab bar that drives the same setPage()
+// switching. Each group's `nav` is the sidebar button (data-page-target) that
+// represents it, so that button stays lit on any of the group's sub-pages.
+const NAV_GROUPS = [
+  { nav: "knowledge", tabs: [
+    { page: "knowledge", label: "Graph" },
+    { page: "sources", label: "Sources" },
+  ] },
+  { nav: "events", tabs: [
+    { page: "events", label: "Timeline" },
+    { page: "conflicts", label: "Conflicts" },
+  ] },
+  { nav: "ingest", tabs: [
+    { page: "ingest", label: "New note" },
+    { page: "feedback", label: "Feedback" },
+  ] },
+  { nav: "agents", tabs: [
+    { page: "agents", label: "Agents" },
+    { page: "access", label: "Access" },
+    { page: "audit", label: "Audit" },
+    { page: "settings", label: "Settings" },
+  ] },
+];
+const pageToGroup = {};
+NAV_GROUPS.forEach((group) => {
+  group.tabs.forEach((tab) => {
+    pageToGroup[tab.page] = group;
+  });
+});
+const subtabBar = document.getElementById("subtabBar");
+
+function renderSubtabs(activePage) {
+  if (!subtabBar) return;
+  const group = pageToGroup[activePage];
+  subtabBar.innerHTML = "";
+  if (!group) {
+    subtabBar.hidden = true;
+    return;
+  }
+  group.tabs.forEach((tab) => {
+    const targetPage = pages.find((page) => page.dataset.page === tab.page);
+    const minRole = (targetPage && targetPage.dataset.minRole) || "reader";
+    if (!canUse(minRole)) return;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `subtab${tab.page === activePage ? " active" : ""}`;
+    button.textContent = tab.label;
+    button.addEventListener("click", () => setPage(tab.page));
+    subtabBar.append(button);
+  });
+  subtabBar.hidden = subtabBar.children.length < 2;
+}
 const sensitiveDetailPattern = /(token|secret|password|authorization|body|content|text|query)$/i;
 
 // force-graph instance + render state. Selection/highlight live here so the
@@ -435,9 +489,19 @@ function setPage(name) {
     page.hidden = page.dataset.page !== resolvedName;
     page.classList.toggle("page-active", page.dataset.page === resolvedName);
   });
+  // Sidebar buttons reflect the active *group* (so e.g. the Admin button stays
+  // lit on the Audit sub-page); in-content [data-page-target] buttons keep
+  // exact-match highlighting.
+  const activeGroup = pageToGroup[resolvedName];
+  const activeNavTarget = activeGroup ? activeGroup.nav : name;
   pageButtons.forEach((button) => {
-    button.classList.toggle("active", button.dataset.pageTarget === name && allowed);
+    const isNavLink = button.classList.contains("nav-link");
+    const match = isNavLink
+      ? button.dataset.pageTarget === activeNavTarget
+      : button.dataset.pageTarget === name;
+    button.classList.toggle("active", match && allowed);
   });
+  renderSubtabs(resolvedName);
   if (allowed && window.location.hash !== `#${name}`) {
     window.history.replaceState(null, "", `#${name}`);
   }
@@ -603,6 +667,11 @@ function timelineEventItem(event) {
   const statusClass = timelineStatusClass(event, timeline);
   const metrics = formatMetrics(timeline.metrics);
   const meta = [timeline.dataset, timeline.source, metrics].filter(Boolean).join(" - ");
+  // Surface the rejection/error reason that the server already records on the
+  // event payload (mesh.record_ingest -> details.reason) but the card never showed.
+  // Skip "accepted" so normal indexed events stay clean.
+  const rawReason = event.details && event.details.reason;
+  const reason = rawReason && rawReason !== "accepted" ? String(rawReason) : null;
   const button = document.createElement("button");
   button.type = "button";
   button.className = `event-item timeline-event-button${selected ? " is-selected" : ""}`;
@@ -616,6 +685,7 @@ function timelineEventItem(event) {
       </span>
       <span class="event-message">${escapeHtml(event.message || humanizeToken(event.type))}</span>
       <span class="event-details">${escapeHtml(meta || formatDetails(event.details || {}))}</span>
+      ${reason ? `<span class="event-reason">reason: ${escapeHtml(reason)}</span>` : ""}
     </span>
     <span class="status-chip ${statusClass}">${escapeHtml(timeline.status || event.type)}</span>
   `;

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -29,59 +29,30 @@
       <div class="shell">
         <aside class="sidebar" aria-label="Workspace navigation">
           <nav class="side-nav" aria-label="Workspace pages">
-            <div class="nav-section-label">Vault</div>
             <button class="nav-link" data-page-target="overview" aria-label="Overview" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
               <span class="nav-label">Overview</span>
-            </button>
-            <button class="nav-link" data-page-target="knowledge" aria-label="Knowledge" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-              <span class="nav-label">Knowledge</span>
             </button>
             <button class="nav-link" data-page-target="search" aria-label="Search" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
               <span class="nav-label">Search</span>
             </button>
-            <button class="nav-link" data-page-target="ingest" aria-label="New note" data-min-role="writer" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
-              <span class="nav-label">New note</span>
-            </button>
-            <button class="nav-link" data-page-target="feedback" aria-label="Feedback" data-min-role="writer" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-              <span class="nav-label">Feedback</span>
-            </button>
-
-            <div class="nav-section-label">Sync</div>
-            <button class="nav-link" data-page-target="sources" aria-label="Sources" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-              <span class="nav-label">Sources</span>
-            </button>
-            <button class="nav-link" data-page-target="conflicts" aria-label="Conflicts" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-              <span class="nav-label">Conflicts</span>
-              <span id="conflictNavBadge" class="nav-badge" hidden>0</span>
+            <button class="nav-link" data-page-target="knowledge" aria-label="Knowledge" type="button">
+              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+              <span class="nav-label">Knowledge</span>
             </button>
             <button class="nav-link" data-page-target="events" aria-label="Activity" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
               <span class="nav-label">Activity</span>
+              <span id="conflictNavBadge" class="nav-badge" hidden>0</span>
             </button>
-
-            <div class="nav-section-label" data-min-role="admin">Admin</div>
-            <button class="nav-link" data-page-target="agents" aria-label="Agents" data-min-role="admin" type="button">
+            <button class="nav-link" data-page-target="ingest" aria-label="Write" data-min-role="writer" type="button">
+              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+              <span class="nav-label">Write</span>
+            </button>
+            <button class="nav-link" data-page-target="agents" aria-label="Admin" data-min-role="admin" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>
-              <span class="nav-label">Agents</span>
-            </button>
-            <button class="nav-link" data-page-target="audit" aria-label="Audit" data-min-role="admin" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-              <span class="nav-label">Audit</span>
-            </button>
-            <button class="nav-link" data-page-target="access" aria-label="Access" data-min-role="admin" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m3 3L22 7l-3-3"/></svg>
-              <span class="nav-label">Access</span>
-            </button>
-            <button class="nav-link" data-page-target="settings" aria-label="Settings" data-min-role="admin" type="button">
-              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-              <span class="nav-label">Settings</span>
+              <span class="nav-label">Admin</span>
             </button>
           </nav>
 
@@ -117,6 +88,7 @@
         </aside>
 
         <main class="workspace">
+          <nav id="subtabBar" class="subtab-bar" aria-label="Section tabs" hidden></nav>
           <section class="page page-active" data-page="overview" aria-labelledby="overviewTitle">
             <div class="page-heading hero-heading">
               <div>

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -19,11 +19,12 @@
   /* Text */
   --text: #eaf1ee;
   --muted: #a3b3ab;
-  --quiet: #6b7a73;
+  --quiet: #7d8b82;
 
   /* Accent — Masumi brand magenta (#FA008C) */
   --primary: #fa008c;
   --primary-strong: #ff5cb0;
+  --primary-deep: #cc0073;
   --primary-soft: rgba(250, 0, 140, 0.16);
   --primary-border: rgba(250, 0, 140, 0.45);
   --primary-text: #ffffff;
@@ -823,8 +824,8 @@ pre {
   justify-content: space-between;
   gap: 12px;
   padding: 12px 14px;
-  border-bottom: 1px solid rgba(232, 97, 95, 0.32);
-  background: rgba(232, 97, 95, 0.08);
+  border-bottom: 1px solid rgba(250, 20, 10, 0.32);
+  background: rgba(250, 20, 10, 0.08);
 }
 
 .inline-alert p {
@@ -1325,8 +1326,8 @@ pre {
 .dashboard-event-card.issue-card,
 .event-item.issue-card,
 .issue-card {
-  border-color: rgba(232, 97, 95, 0.42);
-  background: rgba(232, 97, 95, 0.07);
+  border-color: rgba(250, 20, 10, 0.42);
+  background: rgba(250, 20, 10, 0.07);
 }
 
 /* ---------- Conflicts ---------- */
@@ -1462,9 +1463,9 @@ pre {
   flex-direction: column;
   gap: 4px;
   padding: 10px 12px;
-  border: 1px solid rgba(110, 203, 141, 0.3);
+  border: 1px solid rgba(52, 211, 153, 0.3);
   border-radius: var(--radius);
-  background: rgba(110, 203, 141, 0.06);
+  background: rgba(52, 211, 153, 0.06);
   color: var(--muted);
   font-size: 12px;
 }
@@ -1637,7 +1638,7 @@ textarea[aria-invalid="true"] {
 }
 
 .primary-button:hover {
-  background: var(--primary-strong);
+  background: var(--primary-deep);
 }
 
 .primary-button:disabled,
@@ -1688,20 +1689,20 @@ textarea[aria-invalid="true"] {
 .status-active,
 .status-enabled,
 .status-synced {
-  border-color: rgba(110, 203, 141, 0.36);
-  background: rgba(110, 203, 141, 0.08);
+  border-color: rgba(52, 211, 153, 0.36);
+  background: rgba(52, 211, 153, 0.08);
   color: var(--success);
 }
 
 .status-standby {
-  border-color: rgba(214, 184, 109, 0.35);
-  background: rgba(214, 184, 109, 0.08);
+  border-color: rgba(251, 191, 36, 0.35);
+  background: rgba(251, 191, 36, 0.08);
   color: var(--warning);
 }
 
 .status-error {
-  border-color: rgba(232, 97, 95, 0.4);
-  background: rgba(232, 97, 95, 0.08);
+  border-color: rgba(250, 20, 10, 0.4);
+  background: rgba(250, 20, 10, 0.08);
   color: var(--danger);
 }
 
@@ -2053,13 +2054,13 @@ textarea[aria-invalid="true"] {
 }
 
 .toast-error {
-  border-color: rgba(232, 97, 95, 0.5);
-  background: rgba(232, 97, 95, 0.12);
+  border-color: rgba(250, 20, 10, 0.5);
+  background: rgba(250, 20, 10, 0.12);
 }
 
 .toast-success {
-  border-color: rgba(110, 203, 141, 0.45);
-  background: rgba(110, 203, 141, 0.1);
+  border-color: rgba(52, 211, 153, 0.45);
+  background: rgba(52, 211, 153, 0.1);
 }
 
 .toast-leaving {

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -4,36 +4,36 @@
 :root {
   color-scheme: dark;
 
-  /* Surfaces */
-  --bg: #1e1e1e;
-  --chrome: #202020;
-  --surface: #242424;
-  --surface-raised: #262626;
-  --surface-hover: #2a2a2a;
-  --field: #1c1c1c;
+  /* Surfaces — Masumi-aligned dark with a faint emerald-neutral tint */
+  --bg: #0b0f0e;
+  --chrome: #0e1311;
+  --surface: #131b18;
+  --surface-raised: #16201b;
+  --surface-hover: #18241f;
+  --field: #0e1512;
 
   /* Borders */
-  --border: #333333;
-  --border-strong: #3f3f3f;
+  --border: #1e2a25;
+  --border-strong: #294039;
 
   /* Text */
-  --text: #dadada;
-  --muted: #b3b3b3;
-  --quiet: #999999;
+  --text: #eaf1ee;
+  --muted: #a3b3ab;
+  --quiet: #6b7a73;
 
-  /* Accent (Obsidian purple) */
-  --primary: #a882ff;
-  --primary-strong: #c4b1ff;
-  --primary-soft: rgba(168, 130, 255, 0.14);
-  --primary-border: rgba(168, 130, 255, 0.42);
-  --primary-text: #161221;
-  --focus: #c4b1ff;
+  /* Accent — Masumi brand magenta (#FA008C) */
+  --primary: #fa008c;
+  --primary-strong: #ff5cb0;
+  --primary-soft: rgba(250, 0, 140, 0.16);
+  --primary-border: rgba(250, 0, 140, 0.45);
+  --primary-text: #ffffff;
+  --focus: #ff5cb0;
 
-  /* Semantic status */
-  --danger: #e8615f;
-  --warning: #d6b86d;
-  --success: #6ecb8d;
-  --info: #7dd4c0;
+  /* Semantic status — emerald success, cyan info (Citadel CLI heritage), Masumi red */
+  --danger: #fa140a;
+  --warning: #fbbf24;
+  --success: #34d399;
+  --info: #22d3ee;
 
   /* Shape, motion, type */
   --radius: 6px;
@@ -384,6 +384,38 @@ pre {
   padding: 16px;
   overflow-y: auto;
   background: var(--bg);
+}
+
+.subtab-bar {
+  display: flex;
+  gap: 2px;
+  width: 100%;
+  max-width: 1320px;
+  margin: 0 auto 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.subtab {
+  padding: 8px 14px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 550;
+  cursor: pointer;
+  transition: color var(--speed) ease-out, border-color var(--speed) ease-out;
+}
+
+.subtab:hover {
+  color: var(--text);
+}
+
+.subtab.active {
+  color: var(--primary-strong);
+  border-bottom-color: var(--primary);
 }
 
 .page {
@@ -1074,6 +1106,18 @@ pre {
 .event-details {
   margin-top: 2px;
   overflow-wrap: anywhere;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.event-reason {
+  display: inline-block;
+  align-self: start;
+  margin-top: 5px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--warning);
   font-family: var(--mono);
   font-size: 11px;
 }
@@ -2027,7 +2071,7 @@ textarea[aria-invalid="true"] {
 
 .skeleton {
   border-radius: var(--radius);
-  background: linear-gradient(90deg, #242424 0%, #2d2d2d 50%, #242424 100%);
+  background: linear-gradient(90deg, #131b18 0%, #1d2a24 50%, #131b18 100%);
   background-size: 220% 100%;
 }
 


### PR DESCRIPTION
Rebrands the web dashboard to Masumi's brand and consolidates the 14-item sidebar to 6.

## What
- **Palette** -> Masumi magenta `#FA008C` brand, emerald `#34D399` success/indexed, cyan `#22D3EE` info (Citadel CLI heritage), Masumi red `#FA140A`, on a dark emerald-neutral base. All status/toast/alert tints swapped to the new tokens.
- **Nav** -> 6 items (Overview / Search / Knowledge / Activity / Write / Admin); merged groups (Knowledge+Sources, Activity+Conflicts, Write=Note+Feedback, Admin=Agents/Access/Audit/Settings) exposed via a content sub-tab bar that drives the existing setPage().
- **Reject reason** -> timeline cards now surface details.reason (e.g. duplicate_in_process) that the server already recorded but the UI dropped.
- **a11y** -> --primary-deep for button-hover contrast; --quiet lifted for AA.
- brand.md updated (web palette was 'deferred').

## Verification
Adversarial pre-ship review (wiring / role-gating / CSS / regression): **CLEAN_TO_SHIP**, no blockers. Wiring + role-gating traced correct end-to-end; the CSS mediums it found are fixed in the follow-up commit. Not browser-tested by CI; validated statically + live on the dev node.