### PR TITLE
fix(ingest): write durable knowledge to the permanent graph, not the session cache

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -180,19 +180,19 @@ class CogneePublicClient:
 
         await self._ensure_cognee_ready(cognee)
         metadata = {"citadel_tags": list(tags)} if tags else None
+        # Durable knowledge writes always go to cognee's permanent graph
+        # (add+cognify), never its per-session cache. When a session_id was
+        # supplied, cognee routed the write into the session cache, which (a)
+        # stored an unserializable payload as the literal "[DataItem]"
+        # placeholder instead of the real text, (b) never cognified it inline so
+        # ingest reported items_processed:0, and (c) re-embedded a growing
+        # scaffolded "Session ID:/Question:/Answer:" blob every sync cycle.
+        # session_id is still accepted (callers pass it as provenance) but no
+        # longer diverts the write away from the durable path.
         data = self._data_with_metadata(data, metadata)
 
         if hasattr(cognee, "remember"):
-            kwargs: dict[str, Any] = {
-                "dataset_name": dataset_name,
-                "session_id": session_id,
-            }
-            if session_id:
-                kwargs["self_improvement"] = False
-            return await cognee.remember(
-                data,
-                **kwargs,
-            )
+            return await cognee.remember(data, dataset_name=dataset_name)
 
         kwargs = {"dataset_name": dataset_name}
         if metadata:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -128,8 +128,71 @@ async def test_cognee_public_client_does_not_pass_external_metadata_keyword(
 
     assert received["kwargs"] == {
         "dataset_name": "notes",
-        "session_id": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
+    """Durable writes never route through cognee's session cache.
+
+    Passing a session_id used to divert the write into the per-session cache,
+    which stored the payload as the literal "[DataItem]" placeholder, never
+    cognified it (ingest items_processed:0), and re-embedded a growing
+    scaffolded blob each cycle. remember() now always sends the write to the
+    permanent add+cognify path: cognee.remember is called WITHOUT a session_id,
+    and the payload is DataItem-wrapped so citadel_tags metadata survives.
+    """
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class DataItem:
+        data: Any
+        label: Any = None
+        external_metadata: Any = field(default=None)
+        data_id: Any = None
+
+    for parent in ("cognee.tasks", "cognee.tasks.ingestion"):
+        monkeypatch.setitem(sys.modules, parent, SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee.tasks.ingestion.data_item",
+        SimpleNamespace(DataItem=DataItem),
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def remember(data: Any, **kwargs: Any) -> dict[str, Any]:
+        captured["data"] = data
+        captured["kwargs"] = kwargs
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            run_startup_migrations=run_startup_migrations,
+            remember=remember,
+        ),
+    )
+    client = CogneePublicClient()
+
+    # Even with a session_id supplied, the write must NOT be diverted into the
+    # session cache: no session_id reaches cognee.remember, and the payload is
+    # DataItem-wrapped (carrying citadel_tags) for the permanent graph.
+    await client.remember(
+        "real digest",
+        dataset_name="masumi-network",
+        session_id="masumi-github-daily",
+        tags=("github",),
+    )
+    assert "session_id" not in captured["kwargs"]
+    assert captured["kwargs"] == {"dataset_name": "masumi-network"}
+    assert isinstance(captured["data"], DataItem)
+    assert captured["data"].data == "real digest"
+    assert captured["data"].external_metadata == {"citadel_tags": ["github"]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem (#26, #32)
Durable sync/seat writes passed a `session_id` to `cognee.remember`, which diverted them into cognee's per-session cache. That path:
1. stored the payload as the literal `[DataItem]` placeholder instead of the real text (search returned no usable content — #26),
2. never cognified inline, so ingest reported `items_processed: 0` (#32),
3. re-embedded a growing `Session ID:/Question:/Answer:` blob every sync cycle (unbounded index growth — #26).

## Fix
`CogneePublicClient.remember()` now always takes the permanent `add()`+`cognify()` path and DataItem-wraps the payload so `citadel_tags` metadata survives. `session_id` is retained for API compatibility but no longer routes the write into the session cache.

## Tests
Full suite green (543 passed). Updated `tests/test_cognee_client.py` to assert durable writes bypass the session cache (no `session_id` forwarded; payload wrapped).

## Risk
Touches the live ingest→graph path. Verified statically against the installed cognee 1.2.x and via stubbed unit tests; recommend a post-deploy `cognify --verify` canary + a `citadel_search` smoke check on the node.

Closes #26
Closes #32