### PR TITLE
fix(server): source service version from package metadata (#37)

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -12,6 +12,8 @@ import re
 import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
@@ -186,9 +188,17 @@ async def lifespan(app: FastAPI) -> Any:
             await _stop_evolve_scheduler(evolve_task)
 
 
+# Single-source the service version from the installed package metadata so the
+# /.well-known/citadel.json discovery field and the CLI never drift (the
+# hardcoded "0.1.0" misled operators into thinking the node ran stale code).
+try:
+    _SERVICE_VERSION = _pkg_version("citadel-archive")
+except PackageNotFoundError:
+    _SERVICE_VERSION = "0+unknown"
+
 app = FastAPI(
     title="Citadel Archive",
-    version="0.1.0",
+    version=_SERVICE_VERSION,
     description="Self-hosted Organization Vault wrapper around Cognee.",
     lifespan=lifespan,
 )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -49,10 +49,12 @@ def test_discovery_manifest_is_public_and_verifiable() -> None:
     assert response.headers["cache-control"] == "public, max-age=300"
     payload = response.json()
     assert payload["ok"] is True
+    from kb.server import _SERVICE_VERSION
+
     assert payload["service"] == {
         "name": "Citadel Archive",
         "kind": "organization_vault",
-        "version": "0.1.0",
+        "version": _SERVICE_VERSION,
         "base_url": "https://citadel.example",
     }
     assert payload["public_endpoints"]["discovery"] == (


### PR DESCRIPTION
## Problem (#37, part of #25)
`kb/server.py` hardcoded the FastAPI app `version="0.1.0"`, surfaced via `/.well-known/citadel.json` (`service.version`). It drifted from the installed package and misled operators into thinking the production node ran stale code.

## Fix
Source the version from `importlib.metadata.version("citadel-archive")` (the same mechanism the CLI already uses), with a `0+unknown` fallback. Server discovery and the CLI now read the same source and cannot drift.

## Tests
Full suite green (542 passed). `tests/test_skills.py` now asserts the discovery payload version equals the server's single-sourced `_SERVICE_VERSION` instead of a hardcoded string.

Closes #37