### PR TITLE
fix(ingest): cognify in the background so writes return promptly

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -192,7 +192,14 @@ class CogneePublicClient:
         data = self._data_with_metadata(data, metadata)
 
         if hasattr(cognee, "remember"):
-            return await cognee.remember(data, dataset_name=dataset_name)
+            # Cognify in the background so the write returns promptly. cognee's
+            # default inline cognify runs the LLM graph-extraction synchronously,
+            # which blocked interactive ingest long enough to time out the MCP /
+            # HTTP request. run_in_background stages the add+cognify as a task on
+            # the server loop (the sole Kuzu writer) and returns immediately.
+            return await cognee.remember(
+                data, dataset_name=dataset_name, run_in_background=True
+            )
 
         kwargs = {"dataset_name": dataset_name}
         if metadata:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -128,6 +128,7 @@ async def test_cognee_public_client_does_not_pass_external_metadata_keyword(
 
     assert received["kwargs"] == {
         "dataset_name": "notes",
+        "run_in_background": True,
     }
 
 
@@ -189,7 +190,12 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
         tags=("github",),
     )
     assert "session_id" not in captured["kwargs"]
-    assert captured["kwargs"] == {"dataset_name": "masumi-network"}
+    # Durable path: no session routing, and cognify runs in the background so the
+    # write returns promptly instead of blocking on inline LLM cognify.
+    assert captured["kwargs"] == {
+        "dataset_name": "masumi-network",
+        "run_in_background": True,
+    }
     assert isinstance(captured["data"], DataItem)
     assert captured["data"].data == "real digest"
     assert captured["data"].external_metadata == {"citadel_tags": ["github"]}


### PR DESCRIPTION
## Problem
PR #54 fixed the `[DataItem]` corruption by routing durable writes through cognee's permanent `add()`+`cognify()` path. But cognee's default cognify runs LLM graph-extraction **synchronously**, so interactive `citadel_ingest` (MCP) now blocks long enough to time out — verified on the production node (the server still completed the write; the marker was searchable as real text).

## Fix
Pass `run_in_background=True` to `cognee.remember`, so it stages the add+cognify as a task on the server event loop (the sole Kuzu writer) and returns immediately. Interactive ingest returns promptly; indexing completes shortly after.

## Tests
Full suite green (543 passed); updated the `remember` kwargs assertions.

Refs #32, #44