### PR TITLE
fix(mcp): thread caller token into citadel:// resource reads (#29)

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -967,7 +967,7 @@ def create_mcp_server(
     @mcp.resource("citadel://session")
     def session_resource() -> str:
         """Current Citadel role, actor, and capabilities."""
-        return json.dumps(resolve_client(None).get("/api/session"), indent=2, default=str)
+        return json.dumps(resolve_client(mcp.get_context()).get("/api/session"), indent=2, default=str)
 
     @mcp.resource("citadel://discovery")
     def discovery_resource() -> str:
@@ -977,17 +977,17 @@ def create_mcp_server(
     @mcp.resource("citadel://sources")
     def sources_resource() -> str:
         """Configured source-learning status."""
-        return json.dumps(resolve_client(None).get("/api/learning-agent"), indent=2, default=str)
+        return json.dumps(resolve_client(mcp.get_context()).get("/api/learning-agent"), indent=2, default=str)
 
     @mcp.resource("citadel://indexes")
     def indexes_resource() -> str:
         """Current Citadel index status."""
-        return json.dumps(resolve_client(None).get("/api/indexes"), indent=2, default=str)
+        return json.dumps(resolve_client(mcp.get_context()).get("/api/indexes"), indent=2, default=str)
 
     @mcp.resource("citadel://events/recent")
     def recent_events_resource() -> str:
         """Recent mesh events."""
-        mesh = resolve_client(None).get("/api/mesh")
+        mesh = resolve_client(mcp.get_context()).get("/api/mesh")
         return json.dumps({"events": mesh.get("events", [])}, indent=2, default=str)
 
     @mcp.prompt()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -151,6 +151,46 @@ def test_discovery_resource_reads_public_manifest_only() -> None:
     assert client.gets == []
 
 
+def test_authed_resource_uses_caller_token_on_hosted_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    # Hosted (HTTP) transport has no fallback client, so an authed resource MUST
+    # read the caller's bearer token from the live request context. Regression
+    # for #29: the resource handlers passed resolve_client(None) and always
+    # raised "No access token" on the hosted /mcp endpoint while tools worked.
+    server = create_mcp_server()
+
+    fake_ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(
+                headers={"authorization": "Bearer ctdl_resourcetoken"}
+            )
+        )
+    )
+    monkeypatch.setattr(server, "get_context", lambda: fake_ctx)
+
+    captured: dict[str, Any] = {}
+
+    class StubClient:
+        def __init__(self, *, base_url: str | None = None, access_token: str = "") -> None:
+            captured["token"] = access_token
+
+        def get(self, path: str, **kwargs: Any) -> dict[str, Any]:
+            captured["path"] = path
+            return {"ok": True, "path": path}
+
+    monkeypatch.setattr(mcp_server, "CitadelHttpClient", StubClient)
+
+    resource = asyncio.run(server._resource_manager.get_resource("citadel://indexes"))
+    payload = json.loads(resource.fn())
+
+    assert captured["token"] == "ctdl_resourcetoken"
+    assert captured["path"] == "/api/indexes"
+    assert payload == {"ok": True, "path": "/api/indexes"}
+
+
 def test_search_clamps_top_k_and_tracks_tool_name() -> None:
     client = FakeHttpClient()
     server = create_mcp_server(client)


### PR DESCRIPTION
## Problem (#29)
The four authenticated MCP resource handlers (`citadel://session`, `sources`, `indexes`, `events/recent`) called `resolve_client(None)`. On the hosted `/mcp` transport there is no fallback client, so every resource read raised `No access token` — while the equivalent `citadel_*` tools (which receive the live `ctx`) worked.

## Fix
Pass `mcp.get_context()` (the live request context) to `resolve_client`, so the caller's bearer token is extracted from the request headers exactly like the tool path. stdio transport still falls back to the env-configured client.

## Tests
New `test_authed_resource_uses_caller_token_on_hosted_transport` simulates the hosted, fallback-less path and asserts the caller token flows to the client (the old code raised). Full suite green (544 passed).

Closes #29