### PR TITLE
fix(cli): exit nonzero on cognify failures (#31)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -294,6 +294,14 @@ class CogneePublicClient:
         reports as processed).
         """
         self._prepare_cognee_environment()
+        # Fail loud on a missing LLM key. cognee swallows LLMAPIKeyNotSetError
+        # inside its pipeline and returns normally, so a keyless cognify would
+        # otherwise report success while indexing nothing (false-green exit 0).
+        if not os.getenv("LLM_API_KEY"):
+            raise RuntimeError(
+                "LLM_API_KEY (or OPENROUTER_API_KEY) is not set; cognify requires an "
+                "LLM key to extract the knowledge graph."
+            )
         import cognee
 
         await self._ensure_cognee_ready(cognee)

--- a/kb/service.py
+++ b/kb/service.py
@@ -204,7 +204,10 @@ class Citadel:
             verification["ok"] = bool(verification["search_hit"] or graph_grew)
 
         return {
-            "ok": True,
+            # Surface the verify canary verdict at the top level so the CLI exit
+            # code (and API callers) go red when an end-to-end check fails,
+            # instead of always reporting ok=True (false-green).
+            "ok": True if verification is None else bool(verification["ok"]),
             "dataset": target_dataset,
             "graph_before": before,
             "graph_after": after,

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -133,6 +133,18 @@ async def test_cognee_public_client_does_not_pass_external_metadata_keyword(
 
 
 @pytest.mark.asyncio
+async def test_cognify_raises_without_llm_key(monkeypatch: Any) -> None:
+    """cognify must fail loud (not false-green) when no LLM key is configured."""
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    client = CogneePublicClient()
+
+    with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+        await client.cognify(datasets=["notes"])
+
+
+@pytest.mark.asyncio
 async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
     """Durable writes never route through cognee's session cache.
 
@@ -343,6 +355,7 @@ async def test_cognee_public_client_falls_back_when_session_has_no_data(
 
 @pytest.mark.asyncio
 async def test_cognee_public_client_cognify_wraps_cognee_cognify(monkeypatch: Any) -> None:
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
     received: dict[str, Any] = {}
 
     async def run_startup_migrations() -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -207,12 +207,34 @@ async def test_cognify_dataset_verify_ingests_marker_and_confirms_hit() -> None:
     assert result["verification"]["search_hit"] is True
     assert result["verification"]["graph_grew"] is True
     assert result["verification"]["ok"] is True
+    assert result["ok"] is True
     # verify is a superset: recovery cognify + an explicit cognify of the marker
     # (remember does not cognify inline on the modern Cognee path).
     assert fake.cognify_calls == [
         {"datasets": ["masumi-network"], "force": False},
         {"datasets": ["masumi-network"], "force": False},
     ]
+
+
+@pytest.mark.asyncio
+async def test_cognify_dataset_verify_failure_propagates_top_level_ok() -> None:
+    """A failed verify canary must set top-level ok=False (CLI exit code)."""
+
+    class StuckCognee(FakeCognee):
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            return []  # the marker is never retrievable
+
+        async def cognify(self, **kwargs: Any) -> dict[str, Any]:
+            self.cognify_calls.append(kwargs)
+            return {"cognified": True}  # ...and the graph never grows
+
+    fake = StuckCognee()
+    kb = Citadel(CitadelConfig(default_dataset="masumi-network"), cognee=fake)
+
+    result = await kb.cognify_dataset(verify=True)
+
+    assert result["verification"]["ok"] is False
+    assert result["ok"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem (#31)
`citadel cognify` exited 0 on hard failures:
1. cognee swallows `LLMAPIKeyNotSetError` inside its pipeline, so a keyless cognify returned normally → exit 0.
2. `cognify_dataset` always returned top-level `ok: True`, so a failed `--verify` canary still exited 0 (`_result_exit` only reads top-level `ok`).

## Fix
- `cognee_client.cognify` raises a clear error when no LLM key is configured (the CLI wraps it into a clean line + exit 1).
- `cognify_dataset` top-level `ok` now reflects `verification.ok` when `--verify` runs.

## Tests
New: LLM-key guard raises; verify-failure propagates top-level `ok: False`. Full suite green (546 passed).

Closes #31