### PR TITLE
fix(version): single-source version from kb.__version__ (node 0+unknown)

### DIFF
--- a/kb/__init__.py
+++ b/kb/__init__.py
@@ -10,11 +10,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+# Single source of truth for the package version. pyproject reads this via
+# hatchling dynamic versioning, and server discovery / the CLI fall back to it
+# when the package is not dist-installed (the Railway node runs from source, so
+# importlib.metadata.version raises there). Keeps server + CLI from drifting.
+__version__ = "0.2.1"
+
 if TYPE_CHECKING:
     from kb.config import CitadelConfig
     from kb.service import Citadel
 
-__all__ = ["Citadel", "CitadelConfig"]
+__all__ = ["Citadel", "CitadelConfig", "__version__"]
 
 
 def __getattr__(name: str) -> Any:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -1408,7 +1408,7 @@ def build_parser() -> argparse.ArgumentParser:
     try:
         _version = _pkg_version("citadel-archive")
     except PackageNotFoundError:
-        _version = "0+unknown"
+        from kb import __version__ as _version
     parser.add_argument("--version", action="version", version=f"citadel {_version}")
     parser.add_argument(
         "--no-onboard",

--- a/kb/server.py
+++ b/kb/server.py
@@ -188,13 +188,14 @@ async def lifespan(app: FastAPI) -> Any:
             await _stop_evolve_scheduler(evolve_task)
 
 
-# Single-source the service version from the installed package metadata so the
-# /.well-known/citadel.json discovery field and the CLI never drift (the
-# hardcoded "0.1.0" misled operators into thinking the node ran stale code).
+# Single-source the service version so /.well-known/citadel.json and the CLI
+# never drift. Prefer installed package metadata; fall back to the in-source
+# kb.__version__ because the Railway node runs from source (not dist-installed),
+# where importlib.metadata raises and a hardcoded version would mislead.
 try:
     _SERVICE_VERSION = _pkg_version("citadel-archive")
 except PackageNotFoundError:
-    _SERVICE_VERSION = "0+unknown"
+    from kb import __version__ as _SERVICE_VERSION
 
 app = FastAPI(
     title="Citadel Archive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citadel-archive"
-version = "0.2.1"
+dynamic = ["version"]
 description = "Citadel — a self-hosted Organization Vault and seat-capture CLI built on Cognee."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -49,6 +49,9 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "kb/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["kb"]


### PR DESCRIPTION
## Problem (follow-up to #37)
PR #55 sourced the version from `importlib.metadata`, but the Railway node runs from source (not dist-installed), so `importlib.metadata.version` raised and discovery reported `0+unknown` (verified live).

## Fix
- Add `kb.__version__` as the single source of truth.
- `pyproject` reads it via hatchling dynamic versioning (`[tool.hatch.version] path = "kb/__init__.py"`), so the dist version can't drift from source.
- Server discovery and the CLI fall back to `kb.__version__` when the package isn't dist-installed, so the node reports its real version (0.2.1) instead of `0+unknown`.

## Tests
Full suite green (546 passed); `kb.__version__` resolves to 0.2.1; `_SERVICE_VERSION` resolves.

Refs #37