### PR TITLE
fix(api): clamp search top_k + cap ingest payload size (#49)

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -44,7 +44,7 @@ from kb.knowledge_mesh import KnowledgeMesh
 from kb.learning import LearningOutcome, LearningProcess
 from kb.learning_agent import LearningAgent
 from kb.logging_utils import configure_logging
-from kb.mcp_server import TOOL_POLICIES, create_mcp_server
+from kb.mcp_server import TOOL_POLICIES, _max_ingest_bytes, create_mcp_server
 from kb.mesh import MeshState
 from kb.models import FeedbackRequest
 from kb.obsidian_sync import ObsidianSyncStore, SyncPushDocument, normalize_path
@@ -1342,6 +1342,23 @@ def audit_limit_value(limit: int | None) -> int | None:
             detail=f"Audit limit must be between 1 and {AUDIT_LIMIT_MAX}.",
         )
     return limit
+
+
+def enforce_ingest_size(text: str) -> None:
+    """Reject oversized write payloads at the HTTP boundary.
+
+    Mirrors the MCP write tools' byte cap (kb.mcp_server._validate_ingest_size) so a
+    direct HTTP caller (or autosync) that bypasses the MCP layer cannot push an
+    unbounded body into seat-scoped storage. Shares the MCP limit/env so the two
+    surfaces never drift.
+    """
+    max_bytes = _max_ingest_bytes()
+    byte_count = len(text.encode("utf-8"))
+    if byte_count > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Payload is {byte_count} bytes; limit is {max_bytes} bytes.",
+        )
 
 
 def known_datasets(config: Any) -> list[str]:
@@ -3061,6 +3078,7 @@ async def events(request: Request) -> StreamingResponse:
 @app.post("/ingest")
 async def ingest(body: IngestBody, request: Request) -> Any:
     actor = require_access(request, "writer", "kb:ingest")
+    enforce_ingest_size(body.data)
     citadel = get_citadel()
     learning = get_learning_process()
     write_targets = resolve_write_targets(actor, body.dataset, body.tags, citadel.config)
@@ -3170,6 +3188,7 @@ async def contribute(body: ContributeBody, request: Request) -> Any:
     like any other accepted Source Material.
     """
     actor = require_access(request, "writer", "kb:ingest")
+    enforce_ingest_size(body.content)
     guard_seat_write_policy(
         actor,
         operation="contribute",

--- a/kb/service.py
+++ b/kb/service.py
@@ -20,6 +20,14 @@ from kb.tags import merge_tags
 
 logger = logging.getLogger(__name__)
 
+# Upper bound for search breadth. The HTTP /search route (SearchBody) already rejects
+# top_k outside [1, 100] and the MCP layer clamps to 25, but this is the single
+# chokepoint every read path funnels through (search, the /api/knowledge alias,
+# promotion/learning-agent lookups, the cognify marker probe). Clamping here floors
+# negatives/zero to 1 and caps absurd values so no caller — present, future, or one that
+# bypasses pydantic — can drive an unbounded recall into the search-backend timeout.
+MAX_SEARCH_TOP_K = 100
+
 
 class Citadel:
     def __init__(
@@ -112,6 +120,7 @@ class Citadel:
         session_id: str | None = None,
         top_k: int = 10,
     ) -> list[Any]:
+        top_k = min(max(int(top_k), 1), MAX_SEARCH_TOP_K)
         target_dataset = dataset or self.config.default_dataset
         results = await self.cognee.recall(
             query,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -515,6 +515,21 @@ def test_ingest_inline_cognify_flag() -> None:
     assert with_cognify.json()["cognified"] is True
 
 
+def test_ingest_and_contribute_reject_oversized_payloads(monkeypatch: Any) -> None:
+    monkeypatch.setenv("CITADEL_MCP_MAX_INGEST_BYTES", "16")
+    client = authed_client()
+
+    big = "x" * 50
+    ingest = client.post("/ingest", json={"data": big})
+    contribute = client.post("/api/contribute", json={"title": "T", "content": big})
+    small = client.post("/ingest", json={"data": "ok"})
+
+    assert ingest.status_code == 413
+    assert "limit is 16 bytes" in ingest.json()["detail"]
+    assert contribute.status_code == 413
+    assert small.status_code == 200
+
+
 def test_writer_access_can_ingest_and_feedback_but_not_admin_actions() -> None:
     client = authed_client("test-writer")
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,7 +8,7 @@ import pytest
 from kb.config import CitadelConfig
 from kb.models import FeedbackRequest
 from kb.security_scan import SecretContentError
-from kb.service import Citadel
+from kb.service import MAX_SEARCH_TOP_K, Citadel
 
 
 class FakeCognee:
@@ -235,6 +235,18 @@ async def test_cognify_dataset_verify_failure_propagates_top_level_ok() -> None:
 
     assert result["verification"]["ok"] is False
     assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_clamps_top_k_to_safe_bounds() -> None:
+    fake = FakeCognee()
+    kb = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    huge = await kb.search("anything", top_k=100_000)
+    negative = await kb.search("anything", top_k=-1)
+
+    assert huge[0]["top_k"] == MAX_SEARCH_TOP_K
+    assert negative[0]["top_k"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem (#49, from input-fuzz testing)
1. `top_k` is forwarded unbounded through the shared `Citadel.search` chokepoint — negative/zero/huge values reach the recall backend and the ~100s search timeout (cross-ref #44). Edge guards (MCP clamp, `/search` pydantic) don't cover internal callers.
2. The HTTP `/ingest` and `/api/contribute` routes have no byte cap; only the MCP layer enforces one, so a direct HTTP caller can push an unbounded body into seat storage.

## Fix
- Clamp `top_k` to `[1, 100]` in `Citadel.search` (one place, every read path).
- Add `enforce_ingest_size` (413) on `/ingest` and `/api/contribute`, reusing `kb.mcp_server._max_ingest_bytes` so the HTTP and MCP caps share one source of truth.

## Tests
New: service clamp (huge→100, -1→1); HTTP 413 on oversized `/ingest` and `/api/contribute`, 200 on small. Full suite green (548 passed).

Closes #49