### PR TITLE
fix(sync): surface unauthenticated GitHub state; stop masking 403s (#30, #42)

### DIFF
--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -262,6 +262,7 @@ class GitHubOrgSyncer:
             "tracked_repositories": len(state.get("repos") or {}),
             "seen_events": len(state.get("seen_event_ids") or []),
             "tracked_commit_repositories": len(state.get("commits") or {}),
+            "authenticated": bool(getattr(self.client, "token", None)),
             "include_commits": self.include_commits,
             "include_private": self.include_private,
             "repo_allowlist": list(self.repo_allowlist),
@@ -277,6 +278,13 @@ class GitHubOrgSyncer:
 
     async def run(self, *, force: bool = False, dry_run: bool = False) -> dict[str, Any]:
         checked_at = utc_now()
+        authenticated = bool(getattr(self.client, "token", None))
+        if not authenticated:
+            logger.warning(
+                "GitHub sync for org %s is running UNAUTHENTICATED (no GITHUB_TOKEN); GitHub "
+                "throttles anonymous requests to 60/hr and will 403 across an org-wide sync.",
+                self.org,
+            )
         logger.info(
             "GitHub sync starting for org %s (force=%s, dry_run=%s)", self.org, force, dry_run
         )
@@ -382,6 +390,7 @@ class GitHubOrgSyncer:
         )
         return {
             "ok": True,
+            "authenticated": authenticated,
             "org": self.org,
             "source_url": SOURCE_URL_TEMPLATE.format(org=self.org),
             "checked_at": checked_at,

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -275,6 +275,7 @@ class RepoContentSyncer:
         files = state.get("files") if isinstance(state.get("files"), dict) else {}
         return {
             "ok": True,
+            "authenticated": bool(getattr(self.client, "token", None)),
             "source_type": "github_repo_content",
             "org": self.org,
             "enabled": self.config.repo_content_sync_enabled,
@@ -308,6 +309,12 @@ class RepoContentSyncer:
             }
 
         checked_at = utc_now()
+        authenticated = bool(getattr(self.client, "token", None))
+        if not authenticated:
+            logger.warning(
+                "Repo content sync is running UNAUTHENTICATED (no GITHUB_TOKEN); GitHub "
+                "throttles anonymous requests to 60/hr and will 403 across the repo allowlist.",
+            )
         state = self._load_state()
         tracked: dict[str, Any] = dict(state.get("files") or {})
         root_paths = self.config.repo_content_sync_root_paths or DEFAULT_REPO_CONTENT_ROOT_PATHS
@@ -446,6 +453,13 @@ class RepoContentSyncer:
             state["files"] = tracked
             self._save_state(state)
 
+        repos_errored = [result for result in repo_results if result["errors"]]
+        all_repos_errored = (
+            bool(repo_results)
+            and len(repos_errored) == len(repo_results)
+            and ingested_files == 0
+        )
+
         logger.info(
             "Repo content sync finished: repos=%d ingested=%d skipped=%d blocked=%d dry_run=%s",
             len(repo_results),
@@ -455,11 +469,13 @@ class RepoContentSyncer:
             dry_run,
         )
         return {
-            "ok": True,
+            "ok": not all_repos_errored,
             "enabled": True,
+            "authenticated": authenticated,
             "org": self.org,
             "checked_at": checked_at,
             "repos_scanned": len(repo_results),
+            "repos_errored": len(repos_errored),
             "files_ingested": ingested_files,
             "files_skipped": skipped_files,
             "files_skipped_by_reason": skip_totals,

--- a/kb/server.py
+++ b/kb/server.py
@@ -2256,6 +2256,9 @@ async def _run_webhook_reingest(syncer: GitHubOrgSyncer) -> None:
             exc.__class__.__name__,
             exc,
         )
+        await get_mesh().record_error(
+            get_citadel().config, operation="github_sync", error=str(exc)
+        )
 
 
 @app.post("/api/webhooks/github")

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -410,3 +410,21 @@ async def test_github_sync_security_scan_blocks_secret_metadata(tmp_path: Any) -
     assert result["security_scan"]["highest_severity"] == "high"
     assert citadel.ingest_calls == []
     assert "not-a-real-secret-value" not in serialized_findings
+
+
+@pytest.mark.asyncio
+async def test_github_sync_reports_authenticated_flag(tmp_path: Any) -> None:
+    config = CitadelConfig(
+        github_sync_dataset="masumi-network",
+        github_sync_session="masumi-github-daily",
+        github_sync_state_path=str(tmp_path / "github_state.json"),
+    )
+    client = FakeGitHubClient()
+    syncer = GitHubOrgSyncer(FakeCitadel(config), client=client, org="masumi-network")
+
+    result = await syncer.run()
+    assert result["authenticated"] is False
+    assert (await syncer.status())["authenticated"] is False
+
+    client.token = "ghp_example"  # type: ignore[attr-defined]
+    assert (await syncer.status())["authenticated"] is True

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from kb.config import CitadelConfig
+from kb.github_sync import GitHubAPIError
 from kb.models import IngestResult
 from kb.repo_content_sync import (
     RepoContentFile,
@@ -177,3 +178,36 @@ async def test_repo_content_syncer_respects_disabled_flag() -> None:
     syncer = RepoContentSyncer(FakeCitadel(config), client=FakeRepoContentClient())
     result = await syncer.run()
     assert result["enabled"] is False
+
+
+class FailingRepoContentClient(RepoContentGitHubClient):
+    def __init__(self) -> None:
+        super().__init__(token=None)
+
+    def fetch_default_branch(self, full_name: str) -> str:
+        raise GitHubAPIError(
+            "GitHub API returned 403: API rate limit exceeded for 95.90.238.57"
+        )
+
+
+@pytest.mark.asyncio
+async def test_repo_content_syncer_marks_failure_when_all_repos_error(tmp_path: Path) -> None:
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_state_path=str(tmp_path / "repo_content_sync_state.json"),
+        repo_content_sync_repos=("sokosumi-cli", "sokosumi-docs"),
+    )
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FailingRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+        learning=FakeLearningProcess(),  # type: ignore[arg-type]
+    )
+
+    result = await syncer.run()
+
+    assert result["ok"] is False
+    assert result["authenticated"] is False
+    assert result["repos_errored"] == 2
+    assert result["files_ingested"] == 0
+    assert all(repo["errors"] for repo in result["repositories"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -2620,6 +2621,22 @@ def _webhook_citadel(secret: str, *, enabled: bool = True) -> FakeCitadel:
         github_webhook_secret=secret,
     )
     return citadel
+
+
+def test_webhook_reingest_records_mesh_error_on_failure(tmp_path: Path) -> None:
+    app.state.citadel = _webhook_citadel(secrets.token_hex(16))
+    mesh = MeshState()
+    app.state.mesh = mesh
+
+    class _FailingSyncer:
+        async def run(self, *, force: bool = False) -> dict[str, Any]:
+            raise RuntimeError("GitHub API returned 403: rate limit exceeded")
+
+    asyncio.run(server_module._run_webhook_reingest(_FailingSyncer()))
+
+    # The fire-and-forget webhook re-ingest used to swallow failures to a log
+    # line; it now records the error on the mesh so a 403 is visible.
+    assert mesh.errors == 1
 
 
 def _sign(secret: str, body: bytes) -> str:


### PR DESCRIPTION
## Problem (#30, #42)
Both GitHub syncers call the API unauthenticated when no token is configured (60 req/hr → 403 across an org sync). The failure was masked: no `authenticated` signal; `sync-repo-content` returned `ok:True`/exit 0 even when every repo 403'd (#42); the PR-merge webhook re-ingest swallowed the error to a log line.

## Fix
- `authenticated` flag + loud UNAUTHENTICATED warning in both syncers' `run()`/`status()`.
- `repo_content_sync` returns `ok:False` (CLI/cron exits 1, via `_result_exit`) when all scanned repos errored and nothing ingested.
- `_run_webhook_reingest` records the failure on the mesh (`record_error`), mirroring the manual endpoint.

## Tests
New: github authenticated flag; repo-content marks failure when all repos error; webhook records mesh error. Full suite green (551 passed).

## Deploy note
`citadel sync-repo-content` now **exits 1** when every repo errors (was 0). Setting `GITHUB_TOKEN`/`CITADEL_GITHUB_TOKEN` removes the 403 and the warning.

Closes #30
Closes #42