### PR TITLE
feat(sync): marker-based repo auto-join + index AGENTS.md (#34)

### DIFF
--- a/kb/config.py
+++ b/kb/config.py
@@ -196,6 +196,9 @@ class CitadelConfig:
     repo_content_sync_max_files_per_repo: int = 40
     repo_content_sync_max_bytes_per_file: int = 120_000
     repo_content_sync_run_improve: bool = True
+    repo_content_sync_autojoin_enabled: bool = False
+    repo_content_sync_autojoin_markers: tuple[str, ...] = field(default_factory=tuple)
+    repo_content_sync_autojoin_max_repos: int = 100
     contribute_run_improve: bool = False
     organization_digest_enabled: bool = True
     organization_digest_window_hours: int = 24
@@ -381,6 +384,17 @@ class CitadelConfig:
             repo_content_sync_run_improve=_bool(
                 os.getenv("CITADEL_REPO_CONTENT_SYNC_RUN_IMPROVE"),
                 default=True,
+            ),
+            repo_content_sync_autojoin_enabled=_bool(
+                os.getenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_ENABLED"),
+                default=False,
+            ),
+            repo_content_sync_autojoin_markers=tuple(
+                _csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_MARKERS"))
+            ),
+            repo_content_sync_autojoin_max_repos=_int(
+                os.getenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_MAX_REPOS"),
+                default=100,
             ),
             contribute_run_improve=_bool(
                 os.getenv("CITADEL_CONTRIBUTE_RUN_IMPROVE"),

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -25,6 +25,7 @@ from kb.security_scan import SecurityScanEntry, scan_text_entries
 from kb.service import Citadel
 
 __all__ = [
+    "DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS",
     "DEFAULT_REPO_CONTENT_REPOS",
     "DEFAULT_REPO_CONTENT_ROOT_PATHS",
     "DEFAULT_REPO_CONTENT_TREE_EXTENSIONS",
@@ -46,7 +47,7 @@ DEFAULT_REPO_CONTENT_REPOS = (
     "sokosumi-cli",
     "sokosumi-docs",
 )
-DEFAULT_REPO_CONTENT_ROOT_PATHS = ("README.md", "SKILL.md", "CONTEXT.md")
+DEFAULT_REPO_CONTENT_ROOT_PATHS = ("README.md", "AGENTS.md", "SKILL.md", "CONTEXT.md")
 DEFAULT_REPO_CONTENT_TREE_PREFIXES = (
     "skills/",
     "content/docs/",
@@ -54,6 +55,7 @@ DEFAULT_REPO_CONTENT_TREE_PREFIXES = (
     "plugins/",
 )
 DEFAULT_REPO_CONTENT_TREE_EXTENSIONS = (".md", ".mdx", ".txt")
+DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS = ("AGENTS.md", "CONTEXT.md", "SKILL.md")
 
 
 @dataclass(frozen=True)
@@ -229,6 +231,49 @@ def discover_repo_paths(
     return selected
 
 
+def discover_org_repos(
+    client: RepoContentGitHubClient,
+    org: str,
+    *,
+    markers: tuple[str, ...],
+    max_repos: int,
+) -> list[str]:
+    """Auto-join org repos that carry a marker file (e.g. AGENTS.md/CONTEXT.md/
+    SKILL.md) at their root, so the static allowlist never silently lags reality.
+
+    Returns the full names of non-archived repos in ``org`` that have at least one
+    ``markers`` file at their default-branch root. Failures degrade to an empty
+    result rather than aborting the sync.
+    """
+    if not markers or max_repos <= 0:
+        return []
+    try:
+        repos = client.fetch_repos(org, max_repos=max_repos)
+    except GitHubAPIError as exc:
+        logger.warning("Auto-join skipped: could not list repos for org %s: %s", org, exc)
+        return []
+    discovered: list[str] = []
+    for repo in repos:
+        full_name = repo.full_name
+        ref = repo.default_branch
+        if not full_name or repo.archived or not ref:
+            continue
+        for marker in markers:
+            normalized = marker.strip().lstrip("/")
+            if not normalized:
+                continue
+            try:
+                if client.file_exists(full_name, normalized, ref=ref):
+                    discovered.append(full_name)
+                    break
+            except GitHubAPIError as exc:
+                logger.warning(
+                    "Auto-join: marker probe failed for %s/%s: %s", full_name, normalized, exc
+                )
+                continue
+    return discovered
+
+
 class RepoContentSyncer:
     """Fetch allowlisted repository files and cognify them into the vault."""
 
@@ -268,7 +313,25 @@ class RepoContentSyncer:
 
     def _resolved_repos(self) -> list[str]:
         repos = self.config.repo_content_sync_repos or DEFAULT_REPO_CONTENT_REPOS
-        return [resolve_repo_full_name(name, self.org) for name in repos if name.strip()]
+        resolved = [resolve_repo_full_name(name, self.org) for name in repos if name.strip()]
+        if not self.config.repo_content_sync_autojoin_enabled:
+            return resolved
+        markers = (
+            self.config.repo_content_sync_autojoin_markers
+            or DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS
+        )
+        discovered = discover_org_repos(
+            self.client,
+            self.org,
+            markers=markers,
+            max_repos=self.config.repo_content_sync_autojoin_max_repos,
+        )
+        seen = set(resolved)
+        for full_name in discovered:
+            if full_name not in seen:
+                resolved.append(full_name)
+                seen.add(full_name)
+        return resolved
 
     async def status(self) -> dict[str, Any]:
         state = self._load_state()
@@ -281,6 +344,11 @@ class RepoContentSyncer:
             "enabled": self.config.repo_content_sync_enabled,
             "dataset": self.config.repo_content_sync_dataset,
             "session": self.config.repo_content_sync_session,
+            "autojoin_enabled": self.config.repo_content_sync_autojoin_enabled,
+            "autojoin_markers": list(
+                self.config.repo_content_sync_autojoin_markers
+                or DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS
+            ),
             "repos": self._resolved_repos(),
             "root_paths": list(
                 self.config.repo_content_sync_root_paths or DEFAULT_REPO_CONTENT_ROOT_PATHS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,20 @@ def test_from_env_env_vars_still_override(monkeypatch) -> None:
     config = CitadelConfig.from_env()
     assert config.tenant_id == "explicit-org"
     assert config.default_dataset == "explicit-dataset"
+
+
+def test_repo_content_autojoin_env(monkeypatch) -> None:
+    monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_ENABLED", "true")
+    monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_MARKERS", "AGENTS.md, SKILL.md")
+    monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_MAX_REPOS", "25")
+    config = CitadelConfig.from_env(env_file=None)
+    assert config.repo_content_sync_autojoin_enabled is True
+    assert config.repo_content_sync_autojoin_markers == ("AGENTS.md", "SKILL.md")
+    assert config.repo_content_sync_autojoin_max_repos == 25
+
+
+def test_repo_content_autojoin_defaults_off() -> None:
+    config = CitadelConfig()
+    assert config.repo_content_sync_autojoin_enabled is False
+    assert config.repo_content_sync_autojoin_markers == ()
+    assert config.repo_content_sync_autojoin_max_repos == 100

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -10,13 +10,16 @@ from kb.config import CitadelConfig
 from kb.github_sync import GitHubAPIError
 from kb.models import IngestResult
 from kb.repo_content_sync import (
+    DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS,
     RepoContentFile,
     RepoContentGitHubClient,
     RepoContentSyncer,
+    discover_org_repos,
     discover_repo_paths,
     format_repo_content_document,
     resolve_repo_full_name,
 )
+from kb.repository_update import GitHubRepo
 
 
 class FakeCitadel:
@@ -211,3 +214,92 @@ async def test_repo_content_syncer_marks_failure_when_all_repos_error(tmp_path: 
     assert result["repos_errored"] == 2
     assert result["files_ingested"] == 0
     assert all(repo["errors"] for repo in result["repositories"])
+
+
+class FakeAutoJoinClient(RepoContentGitHubClient):
+    """Org with: a marker repo, a markerless repo, and an archived marker repo."""
+
+    def __init__(self) -> None:
+        super().__init__(token=None)
+        self.markers: set[str] = {
+            "masumi-network/masumi-agent-messenger/AGENTS.md",
+            "masumi-network/archived-repo/AGENTS.md",
+            "masumi-network/sokosumi-cli/SKILL.md",
+        }
+
+    def _repo(self, name: str, *, archived: bool = False, branch: str | None = "main") -> GitHubRepo:
+        return GitHubRepo(
+            name=name,
+            full_name=f"masumi-network/{name}",
+            html_url="",
+            description=None,
+            language=None,
+            pushed_at=None,
+            updated_at=None,
+            default_branch=branch,
+            visibility="public",
+            archived=archived,
+            stargazers_count=0,
+            forks_count=0,
+            open_issues_count=0,
+            topics=(),
+            license_name=None,
+        )
+
+    def fetch_repos(self, org: str, *, max_repos: int, include_private: bool = True) -> list[GitHubRepo]:
+        return [
+            self._repo("masumi-agent-messenger"),
+            self._repo("no-markers-here"),
+            self._repo("archived-repo", archived=True),
+            self._repo("sokosumi-cli"),
+        ][:max_repos]
+
+    def file_exists(self, full_name: str, path: str, *, ref: str) -> bool:
+        return f"{full_name}/{path}" in self.markers
+
+
+def test_discover_org_repos_joins_only_non_archived_marker_repos() -> None:
+    joined = discover_org_repos(
+        FakeAutoJoinClient(),
+        "masumi-network",
+        markers=DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS,
+        max_repos=50,
+    )
+    assert joined == [
+        "masumi-network/masumi-agent-messenger",
+        "masumi-network/sokosumi-cli",
+    ]
+
+
+def test_resolved_repos_unions_autojoin_with_dedup() -> None:
+    config = CitadelConfig(
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_autojoin_enabled=True,
+        repo_content_sync_autojoin_markers=("AGENTS.md",),
+        repo_content_sync_autojoin_max_repos=50,
+    )
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeAutoJoinClient(),
+        state_path="unused",
+    )
+    resolved = syncer._resolved_repos()
+    assert resolved == [
+        "masumi-network/sokosumi-cli",
+        "masumi-network/masumi-agent-messenger",
+    ]
+
+
+def test_resolved_repos_autojoin_disabled_skips_discovery() -> None:
+    config = CitadelConfig(repo_content_sync_repos=("sokosumi-cli",))
+
+    fetch_calls: list[int] = []
+
+    class TrackingClient(FakeAutoJoinClient):
+        def fetch_repos(self, org: str, *, max_repos: int, include_private: bool = True) -> list[GitHubRepo]:
+            fetch_calls.append(1)
+            return super().fetch_repos(org, max_repos=max_repos, include_private=include_private)
+
+    syncer = RepoContentSyncer(FakeCitadel(config), client=TrackingClient(), state_path="unused")
+    assert syncer._resolved_repos() == ["masumi-network/sokosumi-cli"]
+    assert fetch_calls == []


### PR DESCRIPTION
## Problem (#34)
Repo-content sync only scanned a static 4-repo sokosumi allowlist, so active org repos shipping `AGENTS.md`/`SKILL.md` (e.g. `masumi-agent-messenger`) were never indexed — silent drift. `AGENTS.md` was referenced nowhere, so it was ingested from no repo at all.

## Fix
- Add `AGENTS.md` to `DEFAULT_REPO_CONTENT_ROOT_PATHS`.
- Add `discover_org_repos`: an opt-in marker-based auto-join that unions org repos carrying `AGENTS.md`/`CONTEXT.md`/`SKILL.md` at root into `_resolved_repos()`, reusing the inherited `fetch_repos` + `file_exists`. Skips archived repos; fails closed (logged) on API errors.
- Three default-off config flags (`CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_*`). Default path is byte-for-byte unchanged — no new network calls until enabled.

## Tests
New: discover joins only non-archived marker repos; union de-dups with explicit-first; disabled (default) makes no discovery call; env parsing + defaults. Full suite green (556 passed).

## Deploy
Set `CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_ENABLED=true` to activate. Existing GitHub token already authorizes org listing.

Closes #34