### PR TITLE
Complete #47: stop per-ingest background cognify colliding across processes

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -8,6 +8,24 @@ from urllib.parse import unquote, urlparse
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to detached background cognify tasks so the loop does not GC them
+# mid-flight (and so they can be awaited/observed in tests).
+_BACKGROUND_COGNIFY_TASKS: set[Any] = set()
+
+
+def _suppress_inline_cognify() -> bool:
+    """True when this process must ADD only and never cognify (Kuzu write).
+
+    Set on the evolve Phase-1 subprocess so it cannot write Kuzu while the web
+    process owns the single writer (#47); the web cognifies in Phase 2.
+    """
+    return os.getenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 
 class CogneeGateway(Protocol):
     async def remember(
@@ -209,23 +227,50 @@ class CogneePublicClient:
         # longer diverts the write away from the durable path.
         data = self._data_with_metadata(data, metadata)
 
-        if hasattr(cognee, "remember"):
-            # Cognify in the background so the write returns promptly. cognee's
-            # default inline cognify runs the LLM graph-extraction synchronously,
-            # which blocked interactive ingest long enough to time out the MCP /
-            # HTTP request. run_in_background stages the add+cognify as a task on
-            # the server loop (the sole Kuzu writer) and returns immediately.
-            return await cognee.remember(
-                data, dataset_name=dataset_name, run_in_background=True
-            )
+        # Add is a fast write to the relational + vector stores; it does NOT touch
+        # the Kuzu graph (cognify is the graph write). Metadata rides in the
+        # DataItem (external_metadata) via _data_with_metadata, never as an add()
+        # keyword — cognee rejects external_metadata as a kwarg.
+        added = await cognee.add(data, dataset_name=dataset_name)
 
-        kwargs = {"dataset_name": dataset_name}
-        if metadata:
-            kwargs["metadata"] = metadata
+        # The cognify is a single-writer Kuzu write, so it must be coordinated (#47).
+        # We previously used cognee.remember(run_in_background=True), but that
+        # fire-and-forget cognify is NOT behind our writer lock and fires in EVERY
+        # process — so the evolve Phase-1 subprocess and the web cognified Kuzu at
+        # the same time, the hourly "Lock is held by PID N" crash.
+        #
+        # 1) In the Phase-1 evolve subprocess (CITADEL_SUPPRESS_INLINE_COGNIFY=true)
+        #    we ADD ONLY and never write Kuzu — the web cognifies everything in
+        #    Phase 2 as the sole writer.
+        # 2) Otherwise we schedule our OWN background cognify that serializes on the
+        #    writer lock (kept non-blocking for the caller, #56), so concurrent
+        #    in-process ingests and the evolve scheduler never collide.
+        if _suppress_inline_cognify():
+            return {"added": added, "cognify": "suppressed"}
+        self._schedule_background_cognify(dataset_name)
+        return {"added": added, "background_cognify": True}
 
-        added = await cognee.add(data, **kwargs)
-        cognified = await cognee.cognify(datasets=[dataset_name])
-        return {"added": added, "cognified": cognified}
+    def _schedule_background_cognify(self, dataset_name: str) -> None:
+        """Schedule a tracked, writer-lock-guarded cognify so ingest stays fast.
+
+        Replaces cognee's fire-and-forget run_in_background cognify with one that
+        acquires our writer lock (via cognify()) — serializing the Kuzu write and
+        surfacing failures instead of swallowing them (#47/#56).
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop (sync caller); nothing to schedule
+
+        async def _run() -> None:
+            try:
+                await self.cognify(datasets=[dataset_name])
+            except Exception:  # noqa: BLE001 - background task: log, never crash the loop
+                logger.exception("background cognify for dataset %s failed", dataset_name)
+
+        task = loop.create_task(_run())
+        _BACKGROUND_COGNIFY_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_COGNIFY_TASKS.discard)
 
     async def recall(
         self,

--- a/kb/server.py
+++ b/kb/server.py
@@ -229,6 +229,10 @@ async def _evolve_scheduler_loop(interval_seconds: int) -> None:
                     **os.environ,
                     "CITADEL_RUN_MODE": "evolve",
                     "CITADEL_EVOLVE_COGNIFY_ENABLED": "false",
+                    # Add-only in Phase 1: the per-ingest background cognify is a
+                    # Kuzu write, so suppress it here and let the web cognify in
+                    # Phase 2 as the sole writer — no cross-process collision (#47).
+                    "CITADEL_SUPPRESS_INLINE_COGNIFY": "true",
                 },
             )
             code = await proc.wait()

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -43,18 +43,19 @@ async def test_cognee_public_client_runs_startup_migrations_once(monkeypatch: An
     async def run_startup_migrations() -> None:
         calls.append("migrate")
 
-    async def remember(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    async def add(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return {"ok": True}
 
     async def recall(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
         return [{"ok": True}]
 
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")  # add-only, no bg task
     monkeypatch.setitem(
         sys.modules,
         "cognee",
         SimpleNamespace(
             run_startup_migrations=run_startup_migrations,
-            remember=remember,
+            add=add,
             recall=recall,
         ),
     )
@@ -77,15 +78,16 @@ async def test_cognee_public_client_creates_database_and_retries_migrations(
         if calls == ["migrate"]:
             raise RuntimeError("missing enum")
 
-    async def remember(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    async def add(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return {"ok": True}
 
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")  # add-only, no bg task
     monkeypatch.setitem(
         sys.modules,
         "cognee",
         SimpleNamespace(
             run_startup_migrations=run_startup_migrations,
-            remember=remember,
+            add=add,
         ),
     )
     client = CogneePublicClient()
@@ -109,27 +111,27 @@ async def test_cognee_public_client_does_not_pass_external_metadata_keyword(
     async def run_startup_migrations() -> None:
         return None
 
-    async def remember(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    async def add(*args: Any, **kwargs: Any) -> dict[str, Any]:
         received["args"] = args
         received["kwargs"] = kwargs
         return {"ok": True}
 
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")  # add-only, no bg task
     monkeypatch.setitem(
         sys.modules,
         "cognee",
         SimpleNamespace(
             run_startup_migrations=run_startup_migrations,
-            remember=remember,
+            add=add,
         ),
     )
     client = CogneePublicClient()
 
     await client.remember("note", dataset_name="notes", tags=("github", "daily-sync"))
 
-    assert received["kwargs"] == {
-        "dataset_name": "notes",
-        "run_in_background": True,
-    }
+    # metadata rides in the DataItem, never as an add() keyword (external_metadata
+    # is rejected by cognee.add); only dataset_name is passed.
+    assert received["kwargs"] == {"dataset_name": "notes"}
 
 
 @pytest.mark.asyncio
@@ -295,7 +297,7 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
     async def run_startup_migrations() -> None:
         return None
 
-    async def remember(data: Any, **kwargs: Any) -> dict[str, Any]:
+    async def add(data: Any, **kwargs: Any) -> dict[str, Any]:
         captured["data"] = data
         captured["kwargs"] = kwargs
         return {"ok": True}
@@ -303,32 +305,64 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
     monkeypatch.setitem(
         sys.modules,
         "cognee",
-        SimpleNamespace(
-            run_startup_migrations=run_startup_migrations,
-            remember=remember,
-        ),
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, add=add),
     )
+    # Suppress the background cognify so the test is deterministic (and so a real
+    # cognify isn't scheduled against the mock); the bypass assertion is on add.
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")
     client = CogneePublicClient()
 
     # Even with a session_id supplied, the write must NOT be diverted into the
-    # session cache: no session_id reaches cognee.remember, and the payload is
+    # session cache: no session_id reaches cognee.add, and the payload is
     # DataItem-wrapped (carrying citadel_tags) for the permanent graph.
-    await client.remember(
+    result = await client.remember(
         "real digest",
         dataset_name="masumi-network",
         session_id="masumi-github-daily",
         tags=("github",),
     )
     assert "session_id" not in captured["kwargs"]
-    # Durable path: no session routing, and cognify runs in the background so the
-    # write returns promptly instead of blocking on inline LLM cognify.
-    assert captured["kwargs"] == {
-        "dataset_name": "masumi-network",
-        "run_in_background": True,
-    }
+    assert captured["kwargs"] == {"dataset_name": "masumi-network"}
     assert isinstance(captured["data"], DataItem)
     assert captured["data"].data == "real digest"
     assert captured["data"].external_metadata == {"citadel_tags": ["github"]}
+    assert result == {"added": {"ok": True}, "cognify": "suppressed"}
+
+
+@pytest.mark.asyncio
+async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: Any) -> None:
+    # #47: outside the suppress flag, remember adds then schedules OUR background
+    # cognify (lock-guarded), not cognee's fire-and-forget run_in_background.
+    import asyncio
+
+    import kb.cognee_client as cc
+
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    cognified: list[Any] = []
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def add(data: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        cognified.append(list(datasets))
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, add=add, cognify=cognify),
+    )
+    client = CogneePublicClient()
+
+    result = await client.remember("note", dataset_name="seat:sarthi", tags=())
+    assert result == {"added": {"ok": True}, "background_cognify": True}
+    # Drain the scheduled background cognify and confirm it ran via cognify().
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    assert cognified == [["seat:sarthi"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -123,6 +123,8 @@ async def test_evolve_scheduler_loop_runs_subprocess_then_cognifies(monkeypatch:
     # Phase 1: heavy stages in a subprocess with cognify disabled (frees the lock).
     assert sub_envs[0]["CITADEL_RUN_MODE"] == "evolve"
     assert sub_envs[0]["CITADEL_EVOLVE_COGNIFY_ENABLED"] == "false"
+    # ...and add-only so its per-ingest background cognify never writes Kuzu (#47).
+    assert sub_envs[0]["CITADEL_SUPPRESS_INLINE_COGNIFY"] == "true"
     # Phase 2: cognify ran in-loop after the subprocess.
     assert len(cognify_calls) >= 2
     # The verify canary verdict is recorded for /readyz (#27).


### PR DESCRIPTION
Completes the #47 fix from PR #64. Active root-cause analysis (prompted by the cleanup dry-run showing 105 `Session ID: masumi-github-daily/masumi-repo-content … Answer: [DataItem]` nodes) found the deployed fix was incomplete:

`remember()` called `cognee.remember(run_in_background=True)`, which fires a background cognify (a single-writer **Kuzu write**) on **every ingest, in every process**. `CITADEL_EVOLVE_COGNIFY_ENABLED=false` only disables the explicit cognify *stage*, so the Phase-1 evolve subprocess and the web cognified Kuzu concurrently → the hourly **"Lock is held by PID N"** crash. PR #64's writer lock / scheduler-holds-lock / cross-process guard never touched this `cognee.remember` path.

## Fix
`remember()` now `cognee.add`s inline (relational + vector only — not a Kuzu write), then:
- **Phase-1 subprocess** (`CITADEL_SUPPRESS_INLINE_COGNIFY=true`): ADD ONLY, never writes Kuzu — the web cognifies everything in Phase 2 as the sole writer.
- **otherwise**: schedules our own background cognify through `cognify()` (writer-lock guarded), replacing cognee's fire-and-forget so concurrent in-process ingests + the scheduler serialize and failures surface.

Both building blocks are prod-proven: `cognee.add` is the existing fallback-path call; `self.cognify` is the same lock-guarded path `/api/cognify` and inline ingest cognify already use. Metadata still rides in the `DataItem`, never as an `add()` keyword.

## Tests (599 pass)
remember bypasses the session cache via add; suppress flag → add-only; otherwise a lock-guarded background cognify is scheduled and runs; the scheduler spawns the subprocess with the suppress flag.

Note: also requires `CITADEL_SUPPRESS_INLINE_COGNIFY` to NOT be set on the web service (only the scheduler sets it on the subprocess). After deploy I'll ingest a test note to confirm the add+cognify path still makes content searchable.