### PR TITLE
Auto-map Linear assignees to seats by email (#46)

### DIFF
--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -107,6 +107,15 @@ query Issues($first: Int!, $after: String) {
 """
 
 
+USERS_QUERY = """
+query Users($first: Int!) {
+  users(first: $first) {
+    nodes { id name email active }
+  }
+}
+"""
+
+
 class LinearClient:
     def __init__(self, *, api_key: str, timeout: float = 30.0) -> None:
         self.api_key = api_key
@@ -166,6 +175,15 @@ class LinearClient:
             if not cursor:
                 break
         return issues
+
+    def fetch_users(self, *, max_users: int = 250) -> list[dict[str, Any]]:
+        """List workspace members (id/name/email) for assignee→seat auto-mapping."""
+        data = self.query(USERS_QUERY, {"first": min(max(max_users, 1), 250)})
+        block = data.get("users") if isinstance(data.get("users"), dict) else {}
+        nodes = block.get("nodes")
+        if not isinstance(nodes, list):
+            return []
+        return [node for node in nodes if isinstance(node, dict) and node.get("id")]
 
 
 def format_issue_note(issue: LinearIssue) -> str:
@@ -326,7 +344,33 @@ class LinearSyncer:
             if self.access_store
             else {}
         )
-        user_map = self.config.linear_user_map
+        # Auto-resolve assignee_id -> seat by matching Linear members' emails to
+        # seat emails, using the node's own Linear key (#46). This populates seat
+        # mirrors without a manual CITADEL_LINEAR_USER_MAP, and works even when the
+        # per-issue assignee.email is null (a common non-admin-key limitation) —
+        # the id is matched instead. Explicit config map entries always win.
+        user_map = dict(self.config.linear_user_map)
+        auto_mapped = 0
+        if self.access_store:
+            email_to_slug = {
+                email: dataset.removeprefix(SEAT_DATASET_PREFIX)
+                for email, dataset in email_index.items()
+            }
+            try:
+                members = await asyncio.to_thread(self._client().fetch_users)
+            except LinearAPIError as exc:
+                members = []
+                logger.warning(
+                    "Linear member fetch failed; mirrors fall back to assignee email/config map: %s",
+                    exc,
+                )
+            for member in members:
+                member_id = member.get("id")
+                member_email = (member.get("email") or "").strip().lower()
+                if member_id and member_email and member_email in email_to_slug:
+                    if member_id not in user_map:
+                        user_map[member_id] = email_to_slug[member_email]
+                        auto_mapped += 1
 
         learning = LearningProcess(self.citadel)
         central_dataset = self.config.linear_sync_dataset or CENTRAL_DATASET
@@ -399,6 +443,10 @@ class LinearSyncer:
             "enabled": True,
             "issue_count": len(issues),
             "mirrored_count": mirrored,
+            # Diagnostics for #46: how many assignees were auto-mapped to seats by
+            # email. 0 with issues present usually means the Linear key cannot read
+            # member emails — set CITADEL_LINEAR_USER_MAP explicitly in that case.
+            "auto_mapped_assignees": auto_mapped,
             "central_ingested": central_outcome.ingest.accepted,
             "mirrors": mirrors,
             "last_synced_at": payload["last_synced_at"],

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -18,13 +18,19 @@ from kb.service import Citadel
 
 
 class FakeLinearClient(LinearClient):
-    def __init__(self, issues: list[dict[str, Any]]) -> None:
+    def __init__(
+        self, issues: list[dict[str, Any]], users: list[dict[str, Any]] | None = None
+    ) -> None:
         super().__init__(api_key="test-key")
         self._issues = issues
+        self._users = users or []
 
     def fetch_issues(self, *, max_issues: int) -> list[LinearIssue]:
         parsed = [LinearIssue.from_node(item) for item in self._issues]
         return [item for item in parsed if item][:max_issues]
+
+    def fetch_users(self, *, max_users: int = 250) -> list[dict[str, Any]]:
+        return self._users
 
 
 @pytest.fixture
@@ -189,6 +195,56 @@ async def test_linear_sync_writes_each_issue_to_central(
     assert "linear:ENG-2" in id_tags
     # The full description reaches Central, not just the title.
     assert any("Implement workspace sync." in i["data"] for i in central_issue_writes)
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_auto_maps_assignee_by_member_email(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    # #46: when the issue payload omits assignee.email, resolve the mirror by
+    # matching the assignee id against the Linear members list (id->email) vs seats.
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+    store = AccessStore(config.access_store_path)
+    store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
+
+    issues = [
+        {
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            "title": "x",
+            "description": "d",
+            "url": "u",
+            "priority": 1,
+            "updatedAt": "2026-06-25T10:00:00Z",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "ENG", "name": "Eng"},
+            "assignee": {"id": "linear-user-john", "name": "John", "email": None},  # no email
+        }
+    ]
+    members = [{"id": "linear-user-john", "name": "John Doe", "email": "john@example.com", "active": True}]
+
+    async def fake_learn(self: Any, data: str, **_: Any) -> Any:
+        class Outcome:
+            class ingest:
+                accepted = True
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    syncer = LinearSyncer(
+        citadel, client=FakeLinearClient(issues, users=members), access_store=store
+    )
+
+    result = await syncer.run(force=True)
+    assert result["ok"] is True
+    assert result["auto_mapped_assignees"] == 1
+    assert result["mirrored_count"] == 1
+    assert seat_dataset("john") in result["mirrors"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Completes #46. `mirror_count` stayed 0 because `resolve_mirror_dataset` matched `assignee.email` → seat email, but a non-admin Linear key typically can't return assignee emails on issues, so nothing matched — and the workaround was a hand-written `CITADEL_LINEAR_USER_MAP`.

The node already holds the Linear key (in Railway), so resolve it automatically: `LinearClient.fetch_users()` lists workspace members and the sync builds `assignee_id → seat_slug` by matching each member's email to a seat email. This:
- populates seat mirrors with **no manual config**,
- works even when per-issue `assignee.email` is null (matches by id instead),
- keeps explicit `CITADEL_LINEAR_USER_MAP` entries winning,
- reports `auto_mapped_assignees` in the run result — `0` with issues present ⇒ the key can't read member emails either ⇒ set the map explicitly.

Tests: an issue with a null assignee email still mirrors to the seat via the members list; existing email/config paths unchanged. Full suite 600 passed.

After deploy I'll trigger a forced resync and check `/api/linear-sync` for `mirror_count` + `auto_mapped_assignees`.