### PR TITLE
Stop reading cognee's session cache — the real source of [DataItem] in search (#15/#52)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -27,6 +27,22 @@ def _suppress_inline_cognify() -> bool:
     }
 
 
+def _session_recall_enabled() -> bool:
+    """Whether to read cognee's per-session QA cache before the durable store.
+
+    The session cache is the deprecated, pre-#54 corrupt path: it stored writes as
+    the literal "[DataItem]" placeholder and is no longer written to (durable
+    writes go to the chunk/vector store). Reading it first only resurfaces that
+    stale garbage in search/linear_search (#15/#52/#26), so it is OFF by default.
+    """
+    return os.getenv("CITADEL_COGNEE_SESSION_RECALL", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 class CogneeGateway(Protocol):
     async def remember(
         self,
@@ -284,7 +300,11 @@ class CogneePublicClient:
         import cognee
 
         await self._ensure_cognee_ready(cognee)
-        if session_id and hasattr(cognee, "recall"):
+        # The per-session QA cache is the deprecated pre-#54 path and now serves only
+        # stale "[DataItem]" scaffolds, so it is OFF by default — durable recall goes
+        # straight to the chunk/vector store (#15/#52). Re-enable per-session reads
+        # with CITADEL_COGNEE_SESSION_RECALL=true only if the cache is ever repaired.
+        if session_id and hasattr(cognee, "recall") and _session_recall_enabled():
             try:
                 session_results = await cognee.recall(
                     query,

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -401,9 +401,10 @@ async def test_cognee_public_client_uses_chunk_search_by_default(monkeypatch: An
 
 
 @pytest.mark.asyncio
-async def test_cognee_public_client_returns_session_recall_before_chunk_search(
-    monkeypatch: Any,
-) -> None:
+async def test_session_recall_off_by_default_and_opt_in(monkeypatch: Any) -> None:
+    # #15/#52: the per-session QA cache served stale "[DataItem]" garbage, so the
+    # session-scoped recall is OFF by default — search goes straight to the durable
+    # chunk store. It only runs when CITADEL_COGNEE_SESSION_RECALL is set.
     received: dict[str, Any] = {}
 
     async def run_startup_migrations() -> None:
@@ -429,11 +430,19 @@ async def test_cognee_public_client_returns_session_recall_before_chunk_search(
     )
     client = CogneePublicClient()
 
+    # Default OFF: the session cache is never read; the durable chunk search runs.
+    monkeypatch.delenv("CITADEL_COGNEE_SESSION_RECALL", raising=False)
     result = await client.recall("note", dataset="notes", session_id="source-session")
+    assert result == [{"source": "graph"}]
+    assert "recall" not in received  # session QA cache never touched
+    assert "search" in received
 
+    # Opt-in: session recall runs first only when explicitly enabled.
+    received.clear()
+    monkeypatch.setenv("CITADEL_COGNEE_SESSION_RECALL", "true")
+    result = await client.recall("note", dataset="notes", session_id="source-session")
     assert result == [{"source": "session"}]
     assert received["recall"]["kwargs"]["scope"] == "session"
-    assert received["recall"]["kwargs"]["session_id"] == "source-session"
     assert "search" not in received
 
 
@@ -498,6 +507,8 @@ async def test_cognee_public_client_falls_back_when_session_has_no_data(
     )
     client = CogneePublicClient()
 
+    # The session-recall fallback only applies when session recall is opted in.
+    monkeypatch.setenv("CITADEL_COGNEE_SESSION_RECALL", "true")
     result = await client.recall("note", dataset="notes", session_id="source-session")
 
     assert result == [{"source": "chunks"}]


### PR DESCRIPTION
Live prod testing of the #15 graph cleanup exposed the **actual** root cause. The `[DataItem]` search hits are not graph or vector-chunk content — their shape is `{question, answer: "[DataItem]", qa_id, source: "session"}`: cognee's **per-session QA cache**. `recall()` did a `scope="session"` recall **first** and returned it wholesale when non-empty, short-circuiting the durable chunk search.

PR #54 stopped *writing* that cache, but recall still *read* it — so every search/`linear_search` resurfaced the stale pre-#54 scaffolds (the read side of #15/#52/#26). The graph-node cleanup deleted the wrong store.

## Fix
Gate the session-scoped recall behind `CITADEL_COGNEE_SESSION_RECALL` (default **OFF**) so durable recall goes straight to the chunk/vector store. No data deletion, no risk to real content — the cache just stops being read. Opt back in only if the cache is ever repaired.

## Tests (600 pass)
Session recall is skipped by default (chunk search runs, cache untouched) and only runs when the flag is set.

After deploy I'll re-run the prod searches and confirm zero `[DataItem]` hits.