### PR TITLE
Purge garbage from the chunk vector store too (#15)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -366,10 +366,12 @@ class CogneePublicClient:
         return list(nodes), list(edges)
 
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:
-        """Delete nodes by id from the graph store (admin cleanup, #15).
+        """Delete nodes by id from BOTH the graph and the chunk vector store (#15).
 
-        Serializes on the writer lock like cognify, since deletion is a graph
-        write on the single Kuzu writer (#47). Returns the count requested.
+        The same UUID identifies a DocumentChunk in the Kuzu graph AND in the
+        DocumentChunk_text vector collection that CHUNKS search reads — so deleting
+        only the graph node leaves the chunk searchable. Remove both. Serializes on
+        the writer lock like cognify (single Kuzu writer, #47).
         """
         if not node_ids:
             return 0
@@ -382,7 +384,26 @@ class CogneePublicClient:
         engine = await get_graph_engine()
         async with self.writer_lock:
             await engine.delete_nodes(node_ids)
+            await self._delete_vector_points(node_ids)
         return len(node_ids)
+
+    async def _delete_vector_points(self, node_ids: list[str]) -> None:
+        """Drop the same ids from the chunk vector collection (best-effort, #15)."""
+        try:
+            from uuid import UUID
+
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            ids: list[Any] = []
+            for node_id in node_ids:
+                try:
+                    ids.append(UUID(str(node_id)))
+                except (ValueError, TypeError, AttributeError):
+                    continue
+            if ids:
+                await get_vector_engine().delete_data_points("DocumentChunk_text", ids)
+        except Exception:  # noqa: BLE001 - vector cleanup is best-effort
+            logger.warning("vector-store cleanup delete skipped/failed", exc_info=True)
 
     async def get_document(self, document_id: str) -> dict[str, Any] | None:
         """Resolve a search-hit node id back to its stored chunk text (#28).

--- a/kb/service.py
+++ b/kb/service.py
@@ -303,14 +303,40 @@ class Citadel:
         nodes, _ = await self.cognee.graph_data()
         candidates: list[dict[str, Any]] = []
         counts: dict[str, int] = {}
+        seen: set[str] = set()
+
+        def _add(node_id: Any, kind: str, text: Any) -> None:
+            cid = str(node_id)
+            if cid in seen:
+                return
+            seen.add(cid)
+            candidates.append({"id": cid, "kind": kind, "preview": _normalize_text(text)[:120]})
+            counts[kind] = counts.get(kind, 0) + 1
+
         for node_id, properties in nodes:
             kind = _legacy_garbage_kind(node_id, properties)
-            if kind is None:
+            if kind is not None:
+                props = properties if isinstance(properties, dict) else {}
+                _add(node_id, kind, props.get("text") or props.get("name") or node_id)
+
+        # The same garbage was also cognified into the chunk vector store, which the
+        # graph scan can't see once the graph node is gone. Sweep it via search so
+        # orphaned [DataItem]/marker chunks are caught and purged too (#15).
+        for probe in ("[DataItem]", "COGNIFY_TEST_MARKER", "Session ID Question Answer"):
+            try:
+                hits = await self.search(probe, dataset=self.config.default_dataset, top_k=100)
+            except Exception:  # noqa: BLE001 - sweep is best-effort
                 continue
-            props = properties if isinstance(properties, dict) else {}
-            preview = _normalize_text(props.get("text") or props.get("name") or node_id)[:120]
-            candidates.append({"id": str(node_id), "kind": kind, "preview": preview})
-            counts[kind] = counts.get(kind, 0) + 1
+            for hit in hits:
+                if not isinstance(hit, dict):
+                    continue
+                hit_id = hit.get("id")
+                text = hit.get("text") or hit.get("answer") or ""
+                if hit_id:
+                    kind = _legacy_garbage_kind(hit_id, {"text": text})
+                    if kind is not None:
+                        _add(hit_id, kind, text)
+
         deleted = 0
         if not dry_run and candidates:
             deleted = await self.cognee.delete_graph_nodes([c["id"] for c in candidates])

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -191,16 +191,27 @@ async def test_improve_raises_without_llm_key(monkeypatch: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_graph_nodes_calls_engine(monkeypatch: Any) -> None:
-    # #15: delete_graph_nodes forwards ids to the graph engine.
+async def test_delete_graph_nodes_clears_graph_and_vector(monkeypatch: Any) -> None:
+    # #15: delete_graph_nodes removes ids from BOTH the graph and the chunk vector
+    # collection (search reads the vector store, so graph-only deletion isn't enough).
+    from uuid import UUID
+
     captured: dict[str, Any] = {}
 
-    class FakeEngine:
+    class FakeGraphEngine:
         async def delete_nodes(self, node_ids: list[str]) -> None:
-            captured["ids"] = list(node_ids)
+            captured["graph"] = list(node_ids)
 
-    async def get_graph_engine() -> FakeEngine:
-        return FakeEngine()
+    class FakeVectorEngine:
+        async def delete_data_points(self, collection: str, ids: list[UUID]) -> None:
+            captured["collection"] = collection
+            captured["vector"] = list(ids)
+
+    async def get_graph_engine() -> FakeGraphEngine:
+        return FakeGraphEngine()
+
+    def get_vector_engine() -> FakeVectorEngine:
+        return FakeVectorEngine()
 
     async def run_startup_migrations() -> None:
         return None
@@ -213,6 +224,11 @@ async def test_delete_graph_nodes_calls_engine(monkeypatch: Any) -> None:
         "cognee.infrastructure.databases.graph",
         SimpleNamespace(get_graph_engine=get_graph_engine),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee.infrastructure.databases.vector",
+        SimpleNamespace(get_vector_engine=get_vector_engine),
+    )
 
     client = CogneePublicClient()
     monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
@@ -222,8 +238,12 @@ async def test_delete_graph_nodes_calls_engine(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(client, "_ensure_cognee_ready", _ready)
 
-    assert await client.delete_graph_nodes(["a", "b"]) == 2
-    assert captured["ids"] == ["a", "b"]
+    uuid_a = "9dbe579d-eccb-51b6-9bba-13982cbaf69f"
+    uuid_b = "43fdc0c1-b319-51d3-8fc2-2b670c2acc54"
+    assert await client.delete_graph_nodes([uuid_a, uuid_b]) == 2
+    assert captured["graph"] == [uuid_a, uuid_b]
+    assert captured["collection"] == "DocumentChunk_text"
+    assert captured["vector"] == [UUID(uuid_a), UUID(uuid_b)]
     assert await client.delete_graph_nodes([]) == 0  # no-op
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -373,6 +373,29 @@ async def test_cleanup_legacy_nodes_dry_run_then_delete() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cleanup_sweeps_orphaned_vector_chunks() -> None:
+    # #15: garbage cognified into the chunk vector store is found via the search
+    # sweep even when its graph node is already gone (graph is empty here).
+    class SweepGateway(_GraphGateway):
+        def __init__(self) -> None:
+            super().__init__([])  # empty graph
+
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            return [
+                {"id": "chunk-1", "text": "Session ID: x\n\nQuestion: \n\nAnswer: [DataItem]"},
+                {"id": "real-1", "text": "A genuine note about payments."},
+            ]
+
+    gw = SweepGateway()
+    kb = Citadel(CitadelConfig(), cognee=gw)
+
+    res = await kb.cleanup_legacy_nodes(dry_run=False)
+    assert "chunk-1" in gw.deleted  # garbage chunk purged via the sweep
+    assert "real-1" not in gw.deleted  # real content untouched
+    assert res["counts_by_kind"].get("dataitem", 0) >= 1
+
+
+@pytest.mark.asyncio
 async def test_cognify_verify_deletes_its_marker_node() -> None:
     # #15 backprop: the verify canary must not leave a marker node behind.
     class MarkerGateway(_GraphGateway):


### PR DESCRIPTION
Follow-up to the session-recall fix. The session scaffolds were cognified into both the Kuzu graph AND the `DocumentChunk_text` vector collection, so the graph-only cleanup left searchable garbage chunks (e.g. `43fdc0c1`). `delete_graph_nodes` now also deletes the same ids from `DocumentChunk_text`, and `cleanup_legacy_nodes` adds a search sweep to re-discover chunks orphaned from the graph. Full suite 601 passed. After deploy I'll re-run the admin cleanup to purge the remaining chunk garbage and confirm search is clean.