### PR TITLE
fix(evolve/linear/search): one-loop evolve (#69) + coalesced Linear resync (#46) + search timing (#50)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from time import perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 
@@ -43,6 +44,24 @@ def _session_recall_enabled() -> bool:
     }
 
 
+def _search_timing_enabled() -> bool:
+    """Whether to log a per-search wall-time breakdown (#50, node profiling).
+
+    Off by default; set ``CITADEL_SEARCH_TIMING=true`` to emit setup vs recall vs
+    total elapsed ms per search at INFO so the ~6-9s node latency can be attributed
+    on the live node later. Embedding + vector recall + cognee's per-read history
+    writes all happen INSIDE the single ``cognee.search`` call, so they are lumped
+    into the ``recall`` bucket — splitting them further needs cognee-internal
+    instrumentation, not something the client boundary can see.
+    """
+    return os.getenv("CITADEL_SEARCH_TIMING", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 class CogneeGateway(Protocol):
     async def remember(
         self,
@@ -51,7 +70,11 @@ class CogneeGateway(Protocol):
         dataset_name: str,
         session_id: str | None = None,
         tags: tuple[str, ...] = (),
+        defer_cognify: bool = False,
     ) -> Any:
+        ...
+
+    def schedule_cognify(self, datasets: list[str]) -> None:
         ...
 
     async def recall(
@@ -226,6 +249,7 @@ class CogneePublicClient:
         dataset_name: str,
         session_id: str | None = None,
         tags: tuple[str, ...] = (),
+        defer_cognify: bool = False,
     ) -> Any:
         self._prepare_cognee_environment()
         import cognee
@@ -263,6 +287,13 @@ class CogneePublicClient:
         #    in-process ingests and the evolve scheduler never collide.
         if _suppress_inline_cognify():
             return {"added": added, "cognify": "suppressed"}
+        if defer_cognify:
+            # The caller (e.g. a bulk Linear resync) coalesces ONE cognify over every
+            # dataset it touched at the end, instead of scheduling one-per-write — a
+            # 200-issue resync otherwise fires 200 background cognifies that storm the
+            # writer lock and starve the request (#46/#52). Add-only here; the caller
+            # calls schedule_cognify() once when the batch is done.
+            return {"added": added, "cognify": "deferred"}
         self._schedule_background_cognify(dataset_name)
         return {"added": added, "background_cognify": True}
 
@@ -273,6 +304,20 @@ class CogneePublicClient:
         acquires our writer lock (via cognify()) — serializing the Kuzu write and
         surfacing failures instead of swallowing them (#47/#56).
         """
+        self.schedule_cognify([dataset_name])
+
+    def schedule_cognify(self, datasets: list[str]) -> None:
+        """Schedule ONE tracked, writer-lock-guarded background cognify.
+
+        Lets a bulk writer (the Linear resync) coalesce a single cognify over every
+        dataset it touched instead of one-per-write, so the request is not starved by
+        a storm of per-issue cognifies (#46/#52). The single cognify still serializes
+        on the writer lock (single Kuzu writer, #47) and logs — never crashes — on
+        failure. No-op with no running loop (sync caller) or no datasets.
+        """
+        wanted = list(dict.fromkeys(datasets))  # de-dup, preserve order
+        if not wanted:
+            return
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -280,9 +325,9 @@ class CogneePublicClient:
 
         async def _run() -> None:
             try:
-                await self.cognify(datasets=[dataset_name])
+                await self.cognify(datasets=wanted)
             except Exception:  # noqa: BLE001 - background task: log, never crash the loop
-                logger.exception("background cognify for dataset %s failed", dataset_name)
+                logger.exception("background cognify for datasets %s failed", wanted)
 
         task = loop.create_task(_run())
         _BACKGROUND_COGNIFY_TASKS.add(task)
@@ -296,10 +341,13 @@ class CogneePublicClient:
         session_id: str | None = None,
         top_k: int = 10,
     ) -> list[Any]:
+        timing = _search_timing_enabled()
+        t_start = perf_counter() if timing else 0.0
         self._prepare_cognee_environment()
         import cognee
 
         await self._ensure_cognee_ready(cognee)
+        t_ready = perf_counter() if timing else 0.0
         # The per-session QA cache is the deprecated pre-#54 path and now serves only
         # stale "[DataItem]" scaffolds, so it is OFF by default — durable recall goes
         # straight to the chunk/vector store (#15/#52). Re-enable per-session reads
@@ -322,7 +370,7 @@ class CogneePublicClient:
         query_type = self._configured_search_type(cognee)
         if query_type is None and hasattr(cognee, "recall"):
             try:
-                return await cognee.recall(
+                results = await cognee.recall(
                     query,
                     datasets=[dataset],
                     session_id=session_id,
@@ -330,9 +378,24 @@ class CogneePublicClient:
                 )
             except Exception as exc:
                 if self._is_no_data_error(exc):
-                    return []
-                raise
+                    results = []
+                else:
+                    raise
+            if timing:
+                self._log_search_timing(
+                    t_start, t_ready, dataset=dataset, top_k=top_k, query_type=None
+                )
+            return results
 
+        # NOTE (#50): we deliberately do NOT pass cognee's only_context=True here.
+        # For the CHUNKS query_type this node uses, only_context flips the return
+        # value from the list-of-chunk-payload dicts the callers rely on
+        # (result_provenance/_citadel envelope, dedup, drill-down) to a single
+        # newline-joined string — a real shape change (verified against cognee 1.2.2
+        # source). It also would NOT remove the write-per-read: for CHUNKS cognee
+        # persists no session QA at all, and the per-search writes that remain
+        # (log_query/log_result history) are unconditional and not gated by
+        # only_context. See the timing instrument to attribute the residual latency.
         search_kwargs = {
             "query_text": query,
             "datasets": [dataset],
@@ -342,11 +405,43 @@ class CogneePublicClient:
         if query_type is not None:
             search_kwargs["query_type"] = query_type
         try:
-            return await cognee.search(**search_kwargs)
+            results = await cognee.search(**search_kwargs)
         except Exception as exc:
             if self._is_no_data_error(exc):
-                return []
-            raise
+                results = []
+            else:
+                raise
+        if timing:
+            self._log_search_timing(
+                t_start, t_ready, dataset=dataset, top_k=top_k, query_type=query_type
+            )
+        return results
+
+    def _log_search_timing(
+        self,
+        t_start: float,
+        t_ready: float,
+        *,
+        dataset: str,
+        top_k: int,
+        query_type: Any,
+    ) -> None:
+        """Emit one setup/recall/total wall-time line for a search (#50).
+
+        ``setup`` = env prep + cognee import + startup migrations; ``recall`` = the
+        single cognee search/recall call (embedding + vector recall + cognee's
+        per-read history writes, not separable from here); ``total`` = both.
+        """
+        now = perf_counter()
+        logger.info(
+            "search timing: setup=%.1fms recall=%.1fms total=%.1fms dataset=%s top_k=%s query_type=%s",
+            (t_ready - t_start) * 1000.0,
+            (now - t_ready) * 1000.0,
+            (now - t_start) * 1000.0,
+            dataset,
+            top_k,
+            getattr(query_type, "name", query_type),
+        )
 
     async def graph_data(self) -> tuple[list[Any], list[Any]]:
         """Return raw nodes and edges from Cognee's graph engine.

--- a/kb/learning.py
+++ b/kb/learning.py
@@ -83,6 +83,7 @@ class LearningProcess:
         run_improve: bool = False,
         detect_conflicts: bool = True,
         tier: Literal["full", "light"] = "full",
+        defer_cognify: bool = False,
     ) -> LearningOutcome:
         """Filter, optionally enrich/chunk, ingest, record mesh activity,
         detect conflicts, and optionally run improvement for one piece of
@@ -128,6 +129,7 @@ class LearningProcess:
                     dataset=dataset,
                     tags=chunk_tags,
                     session_id=session_id,
+                    defer_cognify=defer_cognify,
                 )
             except Exception as exc:
                 if self.mesh:

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -321,7 +321,7 @@ class LinearSyncer:
             ]
         return []
 
-    async def run(self, *, force: bool = False) -> dict[str, Any]:
+    async def run(self, *, force: bool = False, await_cognify: bool = False) -> dict[str, Any]:
         if not self.config.linear_api_key:
             return {"ok": False, "enabled": False, "reason": "linear_api_key_missing"}
 
@@ -408,7 +408,11 @@ class LinearSyncer:
                     "linear-issue",
                     "linear-sync",
                     f"linear:{issue.identifier}",
-                    issue.team_key or "linear",
+                    # Team as a structured, filterable metadata tag so Central issues
+                    # are discoverable by team (e.g. "what is the marketing team
+                    # working on?"). The human team NAME also rides in the note body
+                    # (format_issue_note) for semantic search.
+                    f"team:{issue.team_key}" if issue.team_key else "linear",
                 ],
                 session_id=session_id,
                 operation="linear_sync",
@@ -427,7 +431,7 @@ class LinearSyncer:
                     "linear-assignee",
                     "linear-issue",
                     f"linear:{issue.identifier}",
-                    issue.team_key or "linear",
+                    f"team:{issue.team_key}" if issue.team_key else "linear",
                 ],
                 session_id=f"linear-{mirror_dataset.removeprefix(SEAT_DATASET_PREFIX)}",
                 operation="linear_mirror",
@@ -440,10 +444,24 @@ class LinearSyncer:
 
         # One coalesced cognify over Central + every seat mirror we wrote — unless
         # inline cognify is suppressed (the evolve Phase-1 subprocess is add-only and
-        # the web cognifies in Phase 2 as the sole Kuzu writer, #47). Backgrounded, so
-        # the request returns without waiting on the graph write.
+        # the web cognifies in Phase 2 as the sole Kuzu writer, #47).
         if not _suppress_inline_cognify():
-            self.citadel.cognee.schedule_cognify([central_dataset, *mirrors.keys()])
+            cognify_datasets = list(dict.fromkeys([central_dataset, *mirrors.keys()]))
+            if await_cognify:
+                # Standalone CITADEL_RUN_MODE=linear-sync: AWAIT the single coalesced
+                # cognify so a manual forced run actually indexes the issues, instead
+                # of scheduling a task that asyncio.run cancels on teardown. Best-effort
+                # — the writes already landed in Postgres, so a cognify failure (e.g. a
+                # cross-process Kuzu lock if the web is writing, #47) is logged, not
+                # raised; the next evolve pass folds the data into the graph.
+                try:
+                    await self.citadel.cognee.cognify(datasets=cognify_datasets)
+                except Exception:  # noqa: BLE001 - writes succeeded; cognify is a follow-on
+                    logger.exception("Linear sync coalesced cognify failed")
+            else:
+                # On-demand endpoint / evolve: background it so the request returns
+                # without waiting on the graph write.
+                self.citadel.cognee.schedule_cognify(cognify_datasets)
 
         payload = {
             "version": STATE_VERSION,

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -17,6 +17,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from kb.access import CENTRAL_DATASET, SEAT_DATASET_PREFIX, AccessStore, seat_dataset
+from kb.cognee_client import _suppress_inline_cognify
 from kb.learning import LearningProcess
 from kb.service import Citadel
 
@@ -376,6 +377,12 @@ class LinearSyncer:
         central_dataset = self.config.linear_sync_dataset or CENTRAL_DATASET
         session_id = self.config.linear_sync_session
 
+        # Coalesce cognify (#46/#52): a full resync writes the digest + ~200 issues +
+        # seat mirrors. Each write used to schedule its OWN background cognify, so
+        # the on-demand POST /api/linear-sync/run fired ~200 Kuzu-writing cognifies
+        # that stormed the writer lock and starved the request into a timeout. Write
+        # ADD-ONLY here (defer_cognify=True) and schedule ONE cognify over every
+        # dataset touched after the loop instead.
         digest = format_workspace_digest(issues)
         central_outcome = await learning.learn(
             digest,
@@ -385,6 +392,7 @@ class LinearSyncer:
             operation="linear_sync",
             run_improve=self.config.linear_sync_run_improve,
             tier="full",
+            defer_cognify=True,
         )
 
         mirrored = 0
@@ -406,6 +414,7 @@ class LinearSyncer:
                 operation="linear_sync",
                 run_improve=False,
                 tier="light",
+                defer_cognify=True,
             )
             mirror_dataset = resolve_mirror_dataset(issue, email_index, linear_user_map=user_map)
             if not mirror_dataset:
@@ -424,9 +433,17 @@ class LinearSyncer:
                 operation="linear_mirror",
                 run_improve=False,
                 tier="light",
+                defer_cognify=True,
             )
             mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
             mirrored += 1
+
+        # One coalesced cognify over Central + every seat mirror we wrote — unless
+        # inline cognify is suppressed (the evolve Phase-1 subprocess is add-only and
+        # the web cognifies in Phase 2 as the sole Kuzu writer, #47). Backgrounded, so
+        # the request returns without waiting on the graph write.
+        if not _suppress_inline_cognify():
+            self.citadel.cognee.schedule_cognify([central_dataset, *mirrors.keys()])
 
         payload = {
             "version": STATE_VERSION,

--- a/kb/service.py
+++ b/kb/service.py
@@ -61,6 +61,7 @@ class Citadel:
         dataset: str | None = None,
         tags: Iterable[str] | None = None,
         session_id: str | None = None,
+        defer_cognify: bool = False,
     ) -> IngestResult:
         target_dataset = dataset or self.config.default_dataset
         merged_tags = merge_tags(self.config.default_tags, tags)
@@ -86,6 +87,7 @@ class Citadel:
             dataset_name=target_dataset,
             session_id=session_id,
             tags=merged_tags,
+            defer_cognify=defer_cognify,
         )
         return IngestResult(True, "accepted", target_dataset, merged_tags, result)
 

--- a/scripts/run_github_sync.py
+++ b/scripts/run_github_sync.py
@@ -7,7 +7,6 @@ non-zero when the scheduler should mark the run as failed.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -15,6 +14,8 @@ import sys
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+
+from scripts.stage_loop import run_async
 
 logging.basicConfig(
     level=logging.INFO,
@@ -266,7 +267,10 @@ def run() -> int:
             return 1
     else:
         logger.info("Starting scheduled GitHub sync in-process")
-        result = asyncio.run(
+        # run_async, not asyncio.run: in the evolve chain this shares the one stage
+        # loop so cognee's cached engine is not bound to a throwaway loop (#69).
+        # Standalone (no shared loop) it falls back to asyncio.run.
+        result = run_async(
             _run_local(
                 force=force,
                 dry_run=dry_run,

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -25,11 +25,12 @@ Modes (via ``CITADEL_RUN_MODE``):
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import sys
 from typing import Callable
+
+from scripts.stage_loop import run_async, stage_loop
 
 logger = logging.getLogger("citadel.pipeline")
 
@@ -89,7 +90,7 @@ def _repo_content_sync_stage() -> int:
     from kb.repo_content_sync import RepoContentSyncer
     from kb.service import Citadel
 
-    result = asyncio.run(RepoContentSyncer(Citadel.from_env()).run())
+    result = run_async(RepoContentSyncer(Citadel.from_env()).run())
     if not result.get("ok"):
         return 1
     if result.get("enabled") is False:
@@ -109,7 +110,7 @@ def _cognify_mode(*, verify: bool) -> int:
     from kb.service import Citadel
 
     dataset = os.getenv("CITADEL_COGNIFY_DATASET") or None
-    result = asyncio.run(Citadel.from_env().cognify_dataset(dataset=dataset, verify=verify))
+    result = run_async(Citadel.from_env().cognify_dataset(dataset=dataset, verify=verify))
     logger.info(
         "Cognify finished: dataset=%s graph_before=%s graph_after=%s grew=%s verify=%s",
         result.get("dataset"),
@@ -262,7 +263,7 @@ def _promotion_stage() -> int:
             promoted += result.get("promoted") or 0
         return promoted, failures
 
-    promoted, failures = asyncio.run(_run())
+    promoted, failures = run_async(_run())
     logger.info(
         "Promotion stage finished: seats=%s promoted=%s failures=%s dry_run=%s",
         len(seats),
@@ -327,7 +328,13 @@ def _linear_sync_stage() -> int:
         access_store = AccessStore(citadel.config.access_store_path)
         result = await LinearSyncer(citadel, access_store=access_store).run(force=False)
         if not result.get("ok"):
-            logger.error("Linear sync stage failed: %s", result.get("reason"))
+            # Surface the actual failure reason + detail, not just the stage name in
+            # the _run_stages `failed=linear_sync` summary (#46).
+            logger.error(
+                "Linear sync stage failed: reason=%s error=%s",
+                result.get("reason"),
+                result.get("error"),
+            )
             return 1
         logger.info(
             "Linear sync stage finished: issues=%s mirrored=%s",
@@ -336,7 +343,7 @@ def _linear_sync_stage() -> int:
         )
         return 0
 
-    return asyncio.run(_run())
+    return run_async(_run())
 
 
 def evolve_stages() -> list[tuple[str, bool, Callable[[], int]]]:
@@ -441,7 +448,16 @@ def run_pipeline() -> int:
 
 
 def run_evolve() -> int:
-    return _run_stages(evolve_stages(), label="Evolve")
+    # One shared event loop for the whole chain: cognee caches its async DB engine
+    # on the first loop and raises "got Future attached to a different loop" on any
+    # later loop, so every cognee-touching stage (github_sync, repo_content_sync,
+    # self_improve, promotion, linear_sync) must run on the SAME loop or all but the
+    # first silently fail while the pass still exits 0 (#69). Pipeline mode keeps its
+    # per-stage loops: it is not the evolve subprocess and does not set
+    # CITADEL_SUPPRESS_INLINE_COGNIFY, so a shared loop there could let one stage's
+    # background cognify straddle into the next stage.
+    with stage_loop():
+        return _run_stages(evolve_stages(), label="Evolve")
 
 
 def run(mode: str | None = None) -> int:
@@ -476,7 +492,11 @@ def run(mode: str | None = None) -> int:
                 access_store=access_store,
             ).run(force=True)
             if not result.get("ok"):
-                logger.error("Linear sync failed: %s", result.get("reason"))
+                logger.error(
+                    "Linear sync failed: reason=%s error=%s",
+                    result.get("reason"),
+                    result.get("error"),
+                )
                 return 1
             logger.info(
                 "Linear sync finished: issues=%s mirrored=%s",
@@ -485,7 +505,7 @@ def run(mode: str | None = None) -> int:
             )
             return 0
 
-        return asyncio.run(_run())
+        return run_async(_run())
     print(f"Unsupported CITADEL_RUN_MODE: {resolved_mode}", file=sys.stderr)
     return 1
 

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -487,10 +487,13 @@ def run(mode: str | None = None) -> int:
         async def _run() -> int:
             citadel = Citadel.from_env()
             access_store = AccessStore(citadel.config.access_store_path)
+            # Standalone forced sync: AWAIT the coalesced cognify so a manual run
+            # actually indexes the issues (the scheduled background cognify would be
+            # cancelled when this asyncio.run loop tears down at process exit) (#46).
             result = await LinearSyncer(
                 citadel,
                 access_store=access_store,
-            ).run(force=True)
+            ).run(force=True, await_cognify=True)
             if not result.get("ok"):
                 logger.error(
                     "Linear sync failed: reason=%s error=%s",

--- a/scripts/run_self_improve.py
+++ b/scripts/run_self_improve.py
@@ -8,7 +8,6 @@ falls back to an in-process pass otherwise.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -16,6 +15,8 @@ import sys
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+
+from scripts.stage_loop import run_async
 
 logging.basicConfig(
     level=logging.INFO,
@@ -147,7 +148,9 @@ def run() -> int:
             return 1
     else:
         logger.info("Starting scheduled self-improvement in-process")
-        result = asyncio.run(_run_local(dry_run=dry_run))
+        # run_async shares the evolve chain's single loop so cognee's cached engine
+        # is not bound to a throwaway loop (#69); standalone it is asyncio.run.
+        result = run_async(_run_local(dry_run=dry_run))
 
     if result.get("ok") is False:
         logger.error("Self-improvement pass failed: %s", result)

--- a/scripts/stage_loop.py
+++ b/scripts/stage_loop.py
@@ -1,0 +1,67 @@
+"""One shared event loop for a multi-stage entrypoint run (#69).
+
+Cognee caches its async DB engine (the asyncpg pool) on the FIRST event loop that
+touches it and raises ``RuntimeError: got Future attached to a different loop`` on
+any later loop. The evolve cron chains several cognee-touching stages
+(``github_sync`` → ``repo_content_sync`` → ``self_improve`` → ``promotion`` →
+``linear_sync``), and each used to run its body in its own ``asyncio.run()`` — so
+only the first stage's loop worked and every later cognee stage failed silently
+(the pass still exited 0). A worker thread and a fresh subprocess both hit this;
+the only fix is to run every cognee-touching stage body on the SAME loop.
+
+``stage_loop()`` installs one shared :class:`asyncio.Runner` for the duration of a
+stage sequence; ``run_async()`` runs a coroutine on it (via ``runner.run``) so all
+stages share one loop and cognee binds its engine exactly once. Callers with no
+active shared loop (standalone jobs, unit tests) fall back to ``asyncio.run``, so
+behaviour is unchanged outside the shared-loop context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Coroutine, Iterator
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+# The single Runner installed by stage_loop() for the current stage sequence.
+# None outside a shared-loop context, where run_async() falls back to asyncio.run.
+_RUNNER: asyncio.Runner | None = None
+
+
+def run_async(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run *coro* on the shared stage loop if one is active, else ``asyncio.run``.
+
+    Every cognee-touching stage body funnels through here so the whole stage
+    sequence shares one loop (#69). With no shared loop active this is a drop-in
+    for ``asyncio.run`` — standalone jobs and unit tests keep their prior
+    per-call-loop behaviour.
+    """
+    runner = _RUNNER
+    if runner is None:
+        return asyncio.run(coro)
+    return runner.run(coro)
+
+
+@contextlib.contextmanager
+def stage_loop() -> Iterator[None]:
+    """Install one shared event loop for the enclosed stage sequence (#69).
+
+    Every ``run_async`` call inside the block runs on this single loop, so cognee
+    binds its cached async engine once and never trips the "Future attached to a
+    different loop" error between stages. Nested use reuses the outer loop. On
+    exit the :class:`asyncio.Runner` cancels any leftover tasks and closes the
+    loop, mirroring ``asyncio.run`` cleanup.
+    """
+    global _RUNNER
+    if _RUNNER is not None:
+        # Already inside a shared-loop context; reuse the outer loop.
+        yield
+        return
+    with asyncio.Runner() as runner:
+        _RUNNER = runner
+        try:
+            yield
+        finally:
+            _RUNNER = None

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -386,6 +386,42 @@ async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: A
 
 
 @pytest.mark.asyncio
+async def test_schedule_cognify_runs_one_cognify_over_all_datasets(monkeypatch: Any) -> None:
+    # #46/#52: the coalesced cognify is ONE background task over every dataset the
+    # bulk write touched (de-duplicated), not one-per-write.
+    import asyncio
+
+    import kb.cognee_client as cc
+
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    cognified: list[list[str]] = []
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        cognified.append(list(datasets))
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient()
+
+    client.schedule_cognify(["central", "seat:a", "central"])  # duplicate central
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    assert cognified == [["central", "seat:a"]]  # one cognify, de-duplicated
+
+    # No datasets → no task scheduled.
+    cognified.clear()
+    client.schedule_cognify([])
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    assert cognified == []
+
+
+@pytest.mark.asyncio
 async def test_cognee_public_client_uses_chunk_search_by_default(monkeypatch: Any) -> None:
     received: dict[str, Any] = {}
 
@@ -562,6 +598,75 @@ async def test_cognee_public_client_cognify_wraps_cognee_cognify(monkeypatch: An
 
     assert result == {"cognified": True}
     assert received["kwargs"] == {"datasets": ["masumi-network"], "incremental_loading": True}
+
+
+@pytest.mark.asyncio
+async def test_recall_does_not_pass_only_context(monkeypatch: Any) -> None:
+    # #50: cognee's only_context=True flips the CHUNKS result from the list-of-dicts
+    # the callers rely on (result_provenance/_citadel envelope, dedup, drill-down) to
+    # a single newline-joined string, and does NOT suppress the per-read history write
+    # for CHUNKS. So it must never be passed on the read path — the result shape stays.
+    received: dict[str, Any] = {}
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def search(**kwargs: Any) -> list[dict[str, Any]]:
+        received["search"] = kwargs
+        return [{"ok": True}]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            SearchType=SimpleNamespace(CHUNKS="chunks"),
+            run_startup_migrations=run_startup_migrations,
+            search=search,
+        ),
+    )
+    client = CogneePublicClient()
+
+    result = await client.recall("note", dataset="notes")
+
+    assert result == [{"ok": True}]  # list-of-dicts shape preserved
+    assert "only_context" not in received["search"]
+
+
+@pytest.mark.asyncio
+async def test_search_timing_logs_only_when_enabled(monkeypatch: Any, caplog: Any) -> None:
+    # #50: an opt-in, lightweight per-search wall-time line (setup/recall/total) so the
+    # residual node latency can be attributed later. Off by default, INFO when enabled.
+    import logging
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def search(**kwargs: Any) -> list[dict[str, Any]]:
+        return [{"ok": True}]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            SearchType=SimpleNamespace(CHUNKS="chunks"),
+            run_startup_migrations=run_startup_migrations,
+            search=search,
+        ),
+    )
+    client = CogneePublicClient()
+
+    monkeypatch.delenv("CITADEL_SEARCH_TIMING", raising=False)
+    with caplog.at_level(logging.INFO, logger="kb.cognee_client"):
+        await client.recall("note", dataset="notes")
+    assert "search timing:" not in caplog.text  # silent by default
+
+    caplog.clear()
+    monkeypatch.setenv("CITADEL_SEARCH_TIMING", "true")
+    with caplog.at_level(logging.INFO, logger="kb.cognee_client"):
+        await client.recall("note", dataset="notes", top_k=7)
+    assert "search timing:" in caplog.text
+    assert "query_type=chunks" in caplog.text
+    assert "top_k=7" in caplog.text
 
 
 def test_cognee_public_client_derives_db_env_from_database_url(monkeypatch: Any) -> None:

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -120,6 +120,7 @@ async def test_linear_sync_ingests_central_and_mirror(
         run_improve: bool = False,
         detect_conflicts: bool = True,
         tier: str = "full",
+        defer_cognify: bool = False,
     ) -> Any:
         ingests.append(
             {
@@ -128,6 +129,7 @@ async def test_linear_sync_ingests_central_and_mirror(
                 "operation": operation,
                 "tier": tier,
                 "data": data[:80],
+                "defer_cognify": defer_cognify,
             }
         )
 
@@ -140,6 +142,12 @@ async def test_linear_sync_ingests_central_and_mirror(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    # #46: the resync must coalesce ONE cognify over the datasets it touched
+    # (Central + mirrors) instead of one-per-issue — capture it here.
+    scheduled: list[list[str]] = []
+    monkeypatch.setattr(
+        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+    )
 
     syncer = LinearSyncer(
         citadel,
@@ -152,6 +160,10 @@ async def test_linear_sync_ingests_central_and_mirror(
     assert result["mirrored_count"] == 1
     assert any(item["dataset"] == "masumi-network" for item in ingests)
     assert any(item["dataset"] == seat_dataset("john") for item in ingests)
+    # Every write is add-only (deferred), and exactly one coalesced cognify is
+    # scheduled over Central + the seat mirror.
+    assert all(item["defer_cognify"] is True for item in ingests)
+    assert scheduled == [["masumi-network", seat_dataset("john")]]
     assert syncer.issues_for_scope(scope="my", seat_dataset_name=seat_dataset("john"))
     assert len(syncer.issues_for_scope(scope="org", seat_dataset_name=None)) == 2
 
@@ -182,6 +194,7 @@ async def test_linear_sync_writes_each_issue_to_central(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
     syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
 
     result = await syncer.run(force=True)
@@ -236,6 +249,7 @@ async def test_linear_sync_auto_maps_assignee_by_member_email(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
     syncer = LinearSyncer(
         citadel, client=FakeLinearClient(issues, users=members), access_store=store
     )
@@ -245,6 +259,40 @@ async def test_linear_sync_auto_maps_assignee_by_member_email(
     assert result["auto_mapped_assignees"] == 1
     assert result["mirrored_count"] == 1
     assert seat_dataset("john") in result["mirrors"]
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_defers_coalesced_cognify_when_inline_suppressed(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #46/#47: in the evolve Phase-1 subprocess (CITADEL_SUPPRESS_INLINE_COGNIFY=true)
+    # the resync is add-only and the web cognifies in Phase 2 as the sole Kuzu
+    # writer — so the coalesced cognify must NOT be scheduled here.
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+
+    async def fake_learn(self: Any, data: str, **_: Any) -> Any:
+        class Outcome:
+            class ingest:
+                accepted = True
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    scheduled: list[list[str]] = []
+    monkeypatch.setattr(
+        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+    )
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
+
+    result = await syncer.run(force=True)
+    assert result["ok"] is True
+    assert scheduled == []  # suppressed: Phase 2 cognifies, not the subprocess
 
 
 @pytest.mark.asyncio

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -208,6 +208,10 @@ async def test_linear_sync_writes_each_issue_to_central(
     assert "linear:ENG-2" in id_tags
     # The full description reaches Central, not just the title.
     assert any("Implement workspace sync." in i["data"] for i in central_issue_writes)
+    # Each Central issue carries a structured team tag so issues are filterable by
+    # team (both sample issues are on team ENG).
+    team_tags = {tag for i in central_issue_writes for tag in i["tags"] if tag.startswith("team:")}
+    assert team_tags == {"team:ENG"}
 
 
 @pytest.mark.asyncio
@@ -293,6 +297,47 @@ async def test_linear_sync_defers_coalesced_cognify_when_inline_suppressed(
     result = await syncer.run(force=True)
     assert result["ok"] is True
     assert scheduled == []  # suppressed: Phase 2 cognifies, not the subprocess
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_awaits_coalesced_cognify_when_requested(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #46/standalone: CITADEL_RUN_MODE=linear-sync passes await_cognify=True so a
+    # manual forced run AWAITS the single coalesced cognify (indexing the issues)
+    # instead of scheduling a task that asyncio.run cancels on teardown.
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+
+    async def fake_learn(self: Any, data: str, **_: Any) -> Any:
+        class Outcome:
+            class ingest:
+                accepted = True
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    awaited: list[list[str]] = []
+    scheduled: list[list[str]] = []
+
+    async def fake_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        awaited.append(list(datasets))
+        return {"ok": True}
+
+    monkeypatch.setattr(citadel.cognee, "cognify", fake_cognify)
+    monkeypatch.setattr(
+        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+    )
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
+
+    result = await syncer.run(force=True, await_cognify=True)
+    assert result["ok"] is True
+    assert awaited == [["masumi-network"]]  # awaited inline over Central (no mirrors)
+    assert scheduled == []  # awaited, not backgrounded
 
 
 @pytest.mark.asyncio

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -431,3 +431,51 @@ def test_cognify_via_api_posts_to_endpoint(monkeypatch: Any) -> None:
 def test_cognify_via_api_fails_without_admin_key(monkeypatch: Any) -> None:
     monkeypatch.delenv("CITADEL_ADMIN_KEY", raising=False)
     assert run_railway._cognify_via_api("http://localhost:8080", force=False) == 1
+
+
+# --- Evolve single-loop restructure (#69) ----------------------------------
+
+
+def test_stage_loop_shares_one_event_loop() -> None:
+    # #69: cognee binds its async engine to the first loop, so every cognee-touching
+    # stage body must run on ONE shared loop. run_async provides it; outside a shared
+    # loop it falls back to asyncio.run (a fresh loop per call, the old behaviour).
+    import asyncio
+
+    from scripts.stage_loop import run_async, stage_loop
+
+    async def running_loop() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    with stage_loop():
+        first = run_async(running_loop())
+        second = run_async(running_loop())
+    assert first is second  # both stage bodies ran on the SAME loop object
+
+    # With no shared loop active, run_async still works (asyncio.run fallback).
+    assert run_async(running_loop()) is not None
+
+
+def test_evolve_runs_cognee_stage_bodies_on_one_loop(monkeypatch: Any) -> None:
+    # #69 (integration): the whole evolve chain shares one loop, so two stage bodies
+    # dispatched through run_async observe the SAME running loop — the fix that stops
+    # "got Future attached to a different loop" on every cognee stage after the first.
+    import asyncio
+
+    _clear_evolve_env(monkeypatch)
+    seen: list[int] = []
+
+    async def _record() -> int:
+        seen.append(id(asyncio.get_running_loop()))
+        return 0
+
+    monkeypatch.setattr(run_railway, "_github_sync_stage", lambda: 0)
+    monkeypatch.setattr(run_railway, "_repo_content_sync_stage", lambda: run_railway.run_async(_record()))
+    monkeypatch.setattr(run_railway, "_self_improve_stage", lambda: 0)
+    monkeypatch.setattr(run_railway, "_promotion_stage", lambda: 0)
+    monkeypatch.setattr(run_railway, "_linear_sync_stage", lambda: run_railway.run_async(_record()))
+    monkeypatch.setattr(run_railway, "_cognify_stage", lambda: 0)
+
+    assert run_railway.run("evolve") == 0
+    assert len(seen) == 2
+    assert seen[0] == seen[1]  # repo_content_sync and linear_sync shared one loop


### PR DESCRIPTION
Three post-verification fixes from the read-side sprint (#69, #46, #50), unit-tested on this branch (607 pass / 1 pre-existing env fail).

#69 evolve loop-binding: the evolve chain ran each stage in its own asyncio.run(); cognee binds its async engine to the first loop and fails on later loops, so github_sync and linear_sync failed every pass while the run still exited 0. New scripts/stage_loop.py runs the whole evolve chain on one shared Runner. Pipeline mode keeps per-stage loops on purpose (it does not set suppress-inline).

#46 Linear resync: POST /api/linear-sync/run scheduled ~200 per-issue cognifies that starved the request. Now add-only writes plus ONE coalesced, writer-lock-guarded cognify per batch. Standalone linear-sync awaits its cognify; the evolve subprocess stays add-only. Failure reason is surfaced. Each issue is tagged with its Linear team on the Central write.

#50 search latency: only_context was verified unsafe for the CHUNKS query type (flips the return to a joined string, breaking _citadel provenance, and does not remove the write-per-read), so it is not applied. Added opt-in CITADEL_SEARCH_TIMING to attribute setup/recall/total per search on the node. Latency fix awaits node profiling.

Node verification after deploy:
- #69: one evolve pass logs github_sync ok + linear_sync ok, no Future-attached-to-a-different-loop.
- #46: force resync returns 200 within budget, mirror_count over 0, search stays responsive.
- #50: set CITADEL_SEARCH_TIMING=true and read the search timing lines.