### PR TITLE
CLI UX: token keep/replace + rotation, checkbox tool select, citadel update, brand hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ All notable changes to `citadel-archive` are documented here. Format follows
   `pipx upgrade --pip-args=--no-cache-dir`, editable/source checkouts are left
   alone (told to `git pull`), anything else gets printed instructions.
 
+- **Checkbox tool selection on onboard** — the coding-tools step is one
+  arrow-key multi-select (↑/↓ · space · enter; numeric fallback off-TTY)
+  instead of a Y/n question per tool, with the spinner while the selection is
+  wired.
+- **Stale-shell auth hint** — when `ingest`/`search`/`capture` get a 401/403
+  and the shell rc holds a different token than the env, the error now says
+  the actual fix: `source ~/.zshrc`.
+
 ### Changed
 
 - **`citadel onboard` token flow** — an already-configured token (env or shell
@@ -28,10 +36,11 @@ All notable changes to `citadel-archive` are documented here. Format follows
   toplevel on onboard, cwd on setup) is offered as a press-Enter default, and a
   root like `/masumi` that doesn't exist offers the home-relative dir that does
   (`~/masumi`) instead of recording a dead root.
-- **New castle art** — the hero is a walled fortress (solid ramparts, lit
-  windows, arched gate) built programmatically so alignment can't drift; the
-  compact banner gains the matching gate; the home screen falls back to the
-  compact banner on narrow terminals and shows the installed version.
+- **Brand-color hero** — the opening art is now just the CITADEL wordmark in
+  brand colors: a Masumi-magenta → cyan gradient on truecolor terminals, bold
+  cyan elsewhere. The compact castle banner (the mark) stays as the in-command
+  header and gains an arched gate; the home screen falls back to it on narrow
+  terminals and shows the installed version.
 
 ## [0.2.1] — 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`citadel token set [TOKEN]`** — set/rotate the seat token this machine uses
+  without re-running onboard: verifies the token against the Node first (a
+  rejected token writes **nothing**; `--skip-verify` overrides), then updates
+  the shell rc in place and reminds you to `source` it.
+- **`citadel update`** (alias `upgrade`) — self-update that answers pipx's
+  "already seems to be installed" dead end: pipx installs run
+  `pipx upgrade --pip-args=--no-cache-dir`, editable/source checkouts are left
+  alone (told to `git pull`), anything else gets printed instructions.
+
+### Changed
+
+- **`citadel onboard` token flow** — an already-configured token (env or shell
+  rc, detected even in a fresh shell) is shown masked with a keep-or-replace
+  prompt instead of being silently reused; verification + the identity panel
+  moved to the *front* of the run; a Node-rejected token offers an immediate
+  re-paste loop instead of "saved anyway" after all the other prompts.
+- **Capture-roots wizard defaults** — the dir you ran `citadel` from (repo
+  toplevel on onboard, cwd on setup) is offered as a press-Enter default, and a
+  root like `/masumi` that doesn't exist offers the home-relative dir that does
+  (`~/masumi`) instead of recording a dead root.
+- **New castle art** — the hero is a walled fortress (solid ramparts, lit
+  windows, arched gate) built programmatically so alignment can't drift; the
+  compact banner gains the matching gate; the home screen falls back to the
+  compact banner on narrow terminals and shows the installed version.
+
 ## [0.2.1] — 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ All notable changes to `citadel-archive` are documented here. Format follows
   moved to the *front* of the run; a Node-rejected token offers an immediate
   re-paste loop instead of "saved anyway" after all the other prompts.
 - **Capture-roots wizard defaults** — the dir you ran `citadel` from (repo
-  toplevel on onboard, cwd on setup) is offered as a press-Enter default, and a
-  root like `/masumi` that doesn't exist offers the home-relative dir that does
-  (`~/masumi`) instead of recording a dead root.
+  toplevel on onboard, cwd on setup) is offered as an explicit press-Enter
+  yes/no (declinable), and a root like `/masumi` that doesn't exist offers the
+  home-relative dir that does (`~/masumi`) instead of recording a dead root.
 - **Brand-color hero** — the opening art is now just the CITADEL wordmark in
   brand colors: a Masumi-magenta → cyan gradient on truecolor terminals, bold
   cyan elsewhere. The compact castle banner (the mark) stays as the in-command

--- a/brand.md
+++ b/brand.md
@@ -19,6 +19,9 @@ A compact crenellated fortress: battlements, walls, two windows. Shown on bare
 
 - **Wordmark:** `CITADEL` (bold).
 - **Tagline:** `the organization vault` (dim).
+- **Opening hero (bare `citadel`):** the figlet `CITADEL` wordmark in brand
+  colors — Masumi magenta `#FA008C` fading to cyan on truecolor terminals
+  (`COLORTERM`), bold cyan elsewhere.
 - Source of truth: [`kb/banner.py`](kb/banner.py).
 
 ## Terminal palette (ANSI)

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -56,13 +56,20 @@ def _lerp_rgb(start: tuple[int, int, int], end: tuple[int, int, int], t: float) 
     return tuple(round(s + (e - s) * t) for s, e in zip(start, end))
 
 
-def _gradient_line(line: str, *, width: int) -> str:
+def _ansi256(rgb: tuple[int, int, int]) -> int:
+    """Nearest xterm-256 color-cube index for an RGB triple."""
+    r, g, b = (round(c / 255 * 5) for c in rgb)
+    return 16 + 36 * r + 6 * g + b
+
+
+def _gradient_line(line: str, *, width: int, truecolor: bool) -> str:
     """Paint one wordmark row with the brand gradient, column by column."""
     out: list[str] = [_ANSI["bold"]]
     for column, char in enumerate(line):
         if char != " ":
-            r, g, b = _lerp_rgb(_BRAND_MAGENTA, _BRAND_CYAN, column / max(width - 1, 1))
-            out.append(f"\033[38;2;{r};{g};{b}m")
+            rgb = _lerp_rgb(_BRAND_MAGENTA, _BRAND_CYAN, column / max(width - 1, 1))
+            code = f"38;2;{rgb[0]};{rgb[1]};{rgb[2]}" if truecolor else f"38;5;{_ansi256(rgb)}"
+            out.append(f"\033[{code}m")
         out.append(char)
     out.append(_ANSI["reset"])
     return "".join(out)
@@ -127,12 +134,15 @@ def mark(ok: bool, *, enable: bool = True) -> str:
 
 def banner_large(*, color: bool = True) -> str:
     """The big hero: the CITADEL wordmark in brand colors — a magenta→cyan
-    gradient on truecolor terminals, bold cyan elsewhere, plain when piped."""
+    gradient (24-bit, or the xterm-256 approximation), bold cyan on basic
+    terminals, plain when piped."""
     width = max(len(line) for line in _WORDMARK)
+    truecolor = supports_truecolor()
+    gradient = truecolor or "256color" in os.getenv("TERM", "")
     out: list[str] = []
     for line in _WORDMARK:
-        if color and supports_truecolor():
-            out.append(_HERO_INDENT + _gradient_line(line, width=width))
+        if color and gradient:
+            out.append(_HERO_INDENT + _gradient_line(line, width=width, truecolor=truecolor))
         else:
             out.append(_HERO_INDENT + paint(line, "bold", "cyan", enable=color))
     return "\n".join(out)

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -10,14 +10,15 @@ import os
 import sys
 from typing import IO
 
-# A crenellated fortress: battlements, walls, two windows. Box-drawing chars
-# render in any modern terminal; we simply omit the banner when not a TTY.
+# A crenellated fortress: battlements, walls, two windows, an arched gate.
+# Box-drawing chars render in any modern terminal; we simply omit the banner
+# when not a TTY.
 _CASTLE_LINES = (
     "  ▙ ▟ ▙ ▟ ▙ ▟ ▙ ▟",
     "  ███████████████",
     "  ██ ▟▀▙   ▟▀▙ ██",
     "  ██ █ █   █ █ ██",
-    "  ███████████████",
+    "  █████▛▀▀▀▜█████",
 )
 # Right-side labels keyed by castle row, each with its ANSI styles.
 _LABELS: dict[int, tuple[str, tuple[str, ...]]] = {
@@ -25,21 +26,52 @@ _LABELS: dict[int, tuple[str, tuple[str, ...]]] = {
     2: ("the organization vault", ("dim",)),
 }
 
-# Large hero — a figlet "CITADEL" framed in a crenellated fortress. Used on the
-# bare `citadel` home screen; the compact `banner()` is the in-command header.
-_HERO = r"""
-     ▛▜   ▛▜   ▛▜   ▛▜   ▛▜   ▛▜   ▛▜
-    ▕══════════════════════════════════▏
-    ▕   ____  _ _____ _   ___  ___ _    ▏
-    ▕  / ___|| |_   _/ \ |   \| __| |   ▏
-    ▕ | |__  | | | |/ _ \| |) | _|| |__ ▏
-    ▕  \___| |_| |_/_/ \_\___/|___|____|▏
-    ▕══════════════════════════════════▏
-    ▕    ▟▀▙       ▟▀▙       ▟▀▙        ▏
-    ▕▄▄▄▄█ █▄▄▄▄▄▄▄█ █▄▄▄▄▄▄▄█ █▄▄▄▄▄▄▄▄▏
-"""
-_HERO_LINES = tuple(_HERO.strip("\n").splitlines())
-_HERO_WORDMARK_ROWS = frozenset({2, 3, 4, 5})  # the figlet letter rows
+# Large hero — a figlet "CITADEL" inside a walled fortress: merlons on a solid
+# rampart, lit windows, and an arched gate. Used on the bare `citadel` home
+# screen; the compact `banner()` is the in-command header. The frame is built
+# programmatically from the wordmark so alignment can never drift.
+_WORDMARK = (
+    "  ____  ___  _____     _     ____   _____  _     ",
+    " / ___||_ _||_   _|   / \\   |  _ \\ | ____|| |    ",
+    "| |     | |   | |    / _ \\  | | | ||  _|  | |    ",
+    "| |___  | |   | |   / ___ \\ | |_| || |___ | |___ ",
+    " \\____||___|  |_|  /_/   \\_\\|____/ |_____||_____|",
+)
+
+
+def _hero_rows() -> tuple[tuple[str, str], ...]:
+    """Assemble the hero as (line, kind) rows; kind drives per-row styling.
+
+    kind ∈ {"wall", "word", "window"} — walls are cyan, the wordmark is bold,
+    and the window row gets a warm glow when color is on.
+    """
+    inner = len(_WORDMARK[0]) + 4  # two columns of courtyard each side
+    width = inner + 2  # plus the flanking walls
+    rows: list[tuple[str, str]] = []
+    merlons = ("▛▜  " * width)[:width].rstrip()
+    rows.append((" " + merlons, "wall"))
+    rows.append((" " + "█" * width, "wall"))
+    rows.append((" █" + " " * inner + "█", "wall"))
+    for line in _WORDMARK:
+        rows.append((" █  " + line + "  █", "word"))
+    rows.append((" █" + " " * inner + "█", "wall"))
+    # Three arched windows, spread evenly across the courtyard.
+    slot = inner // 3
+    lead = (inner - slot * 3) // 2
+    cell = " " * ((slot - 3) // 2)
+    window = cell + "▟▀▙" + " " * (slot - len(cell) - 3)
+    rows.append((" █" + (" " * lead + window * 3).ljust(inner) + "█", "window"))
+    # The gate: an arched lintel over open doors, carved from the base wall.
+    flank = (width - 5) // 2
+    rows.append((" " + "█" * flank + "▛▀▀▀▜" + "█" * (width - 5 - flank), "wall"))
+    rows.append((" " + "█" * flank + "▌   ▐" + "█" * (width - 5 - flank), "wall"))
+    return tuple(rows)
+
+
+_HERO_ROWS = _hero_rows()
+# Widest hero line — the home screen falls back to the compact banner when the
+# terminal is narrower than this.
+HERO_WIDTH = max(len(line) for line, _ in _HERO_ROWS)
 
 _ANSI = {
     "reset": "\033[0m",
@@ -100,11 +132,16 @@ def mark(ok: bool, *, enable: bool = True) -> str:
 
 
 def banner_large(*, color: bool = True) -> str:
-    """The big hero: a figlet CITADEL in a castle frame (cyan walls, bold letters)."""
+    """The big hero: a figlet CITADEL in a fortress (cyan walls, lit windows)."""
     out: list[str] = []
-    for index, line in enumerate(_HERO_LINES):
-        styles = ("bold", "cyan") if index in _HERO_WORDMARK_ROWS else ("cyan",)
-        out.append(paint(line, *styles, enable=color))
+    for line, kind in _HERO_ROWS:
+        if kind == "word":
+            out.append(paint(line, "bold", "cyan", enable=color))
+        elif kind == "window" and color:
+            # Lit windows: a warm glow between the cyan walls.
+            out.append(paint(line[:2], "cyan") + paint(line[2:-1], "yellow") + paint(line[-1], "cyan"))
+        else:
+            out.append(paint(line, "cyan", enable=color))
     return "\n".join(out)
 
 

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -26,10 +26,9 @@ _LABELS: dict[int, tuple[str, tuple[str, ...]]] = {
     2: ("the organization vault", ("dim",)),
 }
 
-# Large hero — a figlet "CITADEL" inside a walled fortress: merlons on a solid
-# rampart, lit windows, and an arched gate. Used on the bare `citadel` home
-# screen; the compact `banner()` is the in-command header. The frame is built
-# programmatically from the wordmark so alignment can never drift.
+# Large hero — just the figlet "CITADEL" wordmark in brand colors. Shown on
+# the bare `citadel` home screen; the compact castle `banner()` stays the
+# in-command header (it is "the mark", see brand.md).
 _WORDMARK = (
     "  ____  ___  _____     _     ____   _____  _     ",
     " / ___||_ _||_   _|   / \\   |  _ \\ | ____|| |    ",
@@ -37,41 +36,36 @@ _WORDMARK = (
     "| |___  | |   | |   / ___ \\ | |_| || |___ | |___ ",
     " \\____||___|  |_|  /_/   \\_\\|____/ |_____||_____|",
 )
+_HERO_INDENT = "  "
+# Brand anchors (see brand.md): Masumi magenta #FA008C (the web brand) fading
+# into the terminal's cyan — one gradient tying both brand surfaces together.
+_BRAND_MAGENTA = (250, 0, 140)
+_BRAND_CYAN = (34, 211, 238)
 
-
-def _hero_rows() -> tuple[tuple[str, str], ...]:
-    """Assemble the hero as (line, kind) rows; kind drives per-row styling.
-
-    kind ∈ {"wall", "word", "window"} — walls are cyan, the wordmark is bold,
-    and the window row gets a warm glow when color is on.
-    """
-    inner = len(_WORDMARK[0]) + 4  # two columns of courtyard each side
-    width = inner + 2  # plus the flanking walls
-    rows: list[tuple[str, str]] = []
-    merlons = ("▛▜  " * width)[:width].rstrip()
-    rows.append((" " + merlons, "wall"))
-    rows.append((" " + "█" * width, "wall"))
-    rows.append((" █" + " " * inner + "█", "wall"))
-    for line in _WORDMARK:
-        rows.append((" █  " + line + "  █", "word"))
-    rows.append((" █" + " " * inner + "█", "wall"))
-    # Three arched windows, spread evenly across the courtyard.
-    slot = inner // 3
-    lead = (inner - slot * 3) // 2
-    cell = " " * ((slot - 3) // 2)
-    window = cell + "▟▀▙" + " " * (slot - len(cell) - 3)
-    rows.append((" █" + (" " * lead + window * 3).ljust(inner) + "█", "window"))
-    # The gate: an arched lintel over open doors, carved from the base wall.
-    flank = (width - 5) // 2
-    rows.append((" " + "█" * flank + "▛▀▀▀▜" + "█" * (width - 5 - flank), "wall"))
-    rows.append((" " + "█" * flank + "▌   ▐" + "█" * (width - 5 - flank), "wall"))
-    return tuple(rows)
-
-
-_HERO_ROWS = _hero_rows()
 # Widest hero line — the home screen falls back to the compact banner when the
 # terminal is narrower than this.
-HERO_WIDTH = max(len(line) for line, _ in _HERO_ROWS)
+HERO_WIDTH = len(_HERO_INDENT) + max(len(line) for line in _WORDMARK)
+
+
+def supports_truecolor() -> bool:
+    """24-bit color support, per the de-facto COLORTERM convention."""
+    return os.getenv("COLORTERM", "").lower() in ("truecolor", "24bit")
+
+
+def _lerp_rgb(start: tuple[int, int, int], end: tuple[int, int, int], t: float) -> tuple[int, int, int]:
+    return tuple(round(s + (e - s) * t) for s, e in zip(start, end))
+
+
+def _gradient_line(line: str, *, width: int) -> str:
+    """Paint one wordmark row with the brand gradient, column by column."""
+    out: list[str] = [_ANSI["bold"]]
+    for column, char in enumerate(line):
+        if char != " ":
+            r, g, b = _lerp_rgb(_BRAND_MAGENTA, _BRAND_CYAN, column / max(width - 1, 1))
+            out.append(f"\033[38;2;{r};{g};{b}m")
+        out.append(char)
+    out.append(_ANSI["reset"])
+    return "".join(out)
 
 _ANSI = {
     "reset": "\033[0m",
@@ -132,16 +126,15 @@ def mark(ok: bool, *, enable: bool = True) -> str:
 
 
 def banner_large(*, color: bool = True) -> str:
-    """The big hero: a figlet CITADEL in a fortress (cyan walls, lit windows)."""
+    """The big hero: the CITADEL wordmark in brand colors — a magenta→cyan
+    gradient on truecolor terminals, bold cyan elsewhere, plain when piped."""
+    width = max(len(line) for line in _WORDMARK)
     out: list[str] = []
-    for line, kind in _HERO_ROWS:
-        if kind == "word":
-            out.append(paint(line, "bold", "cyan", enable=color))
-        elif kind == "window" and color:
-            # Lit windows: a warm glow between the cyan walls.
-            out.append(paint(line[:2], "cyan") + paint(line[2:-1], "yellow") + paint(line[-1], "cyan"))
+    for line in _WORDMARK:
+        if color and supports_truecolor():
+            out.append(_HERO_INDENT + _gradient_line(line, width=width))
         else:
-            out.append(paint(line, "cyan", enable=color))
+            out.append(_HERO_INDENT + paint(line, "bold", "cyan", enable=color))
     return "\n".join(out)
 
 

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -10,9 +10,11 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import threading
 import urllib.error
+import urllib.parse
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
@@ -46,8 +48,9 @@ from kb.onboard import (
     mask_token,
     merge_claude_settings,
     merge_mcp_config,
+    read_token_from_rc,
 )
-from kb.banner import SKIP, banner, banner_large, mark, paint, supports_color
+from kb.banner import HERO_WIDTH, SKIP, banner, banner_large, mark, paint, supports_color
 from kb.access_client import (
     AccessClientError,
     create_seat,
@@ -412,18 +415,37 @@ def _parse_root_arg(raw: str) -> tuple[str, tuple[str, ...]]:
     return path, tags
 
 
-def _wizard_roots(config: CaptureConfig) -> CaptureConfig:
-    print(
-        "\nAdd Approved Capture Roots — folders auto-captured to your Node.\n"
-        "Leave the path empty to finish."
-    )
+def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> CaptureConfig:
+    # Offer the dir the user is already in as a press-Enter default (once) —
+    # nobody should have to copy-paste the path they just ran `citadel` from.
+    default = normalize_path(default_root) if default_root else None
+    if default and any(root.path == default for root in config.roots):
+        default = None  # already approved — nothing to offer
+    print("\nAdd Approved Capture Roots — folders auto-captured to your Node.")
     while True:
-        raw = input("  Root path: ").strip()
+        if default:
+            raw = input(f"  Root path [{default}]: ").strip() or default
+        else:
+            raw = input("  Root path (empty to finish): ").strip()
+        default = None  # offered once; from here Enter finishes
         if not raw:
             break
         normalized = normalize_path(raw)
         if not Path(normalized).exists():
-            print(f"  ! {normalized} does not exist yet (added anyway)")
+            # A leading-slash typo for a home dir ("/masumi" for ~/masumi) is the
+            # common miss — offer the home-relative match instead of silently
+            # recording a root that will never capture anything.
+            guess = Path.home() / raw.lstrip("/") if raw.startswith("/") else None
+            if guess is not None and guess.exists():
+                answer = input(
+                    f"  ! {normalized} does not exist — did you mean {guess}? [Y/n]: "
+                ).strip().lower()
+                if answer in ("", "y", "yes"):
+                    normalized = normalize_path(str(guess))
+                else:
+                    print(f"  ! keeping {normalized} (does not exist yet)")
+            else:
+                print(f"  ! {normalized} does not exist yet (added anyway)")
         print(
             f"  Tags — presets: {', '.join(PRESET_ROOT_TAGS)}; "
             f"'personal' never promotes. Default: {DEFAULT_ROOT_TAG}."
@@ -474,7 +496,7 @@ async def _setup(args: argparse.Namespace) -> int:
             path, tags = _parse_root_arg(raw)
             config = config.with_root(path, tags or (DEFAULT_ROOT_TAG,))
     elif interactive:
-        config = _wizard_roots(config)
+        config = _wizard_roots(config, default_root=str(Path.cwd()))
 
     written = save_capture_config(
         config, path=config_path, updated_at=datetime.now(timezone.utc).isoformat()
@@ -804,6 +826,55 @@ async def _token_revoke(args: argparse.Namespace) -> int:
     return 0 if result.get("ok") else 1
 
 
+async def _token_set(args: argparse.Namespace) -> int:
+    """Set/rotate the seat token this machine uses — verify it, then write the rc.
+
+    The teammate-facing counterpart to the admin mint commands: paste a new
+    token (e.g. after `citadel seat token <slug>`) without re-running the whole
+    onboard flow. A token the Node rejects is NOT written (--skip-verify
+    overrides), so rotation can't silently break a working setup.
+    """
+    color = supports_color()
+    node_url = node_base_url(getattr(args, "node_url", None))
+    rc_path = Path(args.shell_rc).expanduser() if args.shell_rc else detect_shell_rc()
+
+    token = (args.token or "").strip()
+    if not token:
+        if not sys.stdin.isatty():
+            print("citadel token set: pass the token as an argument (no TTY to prompt on).", file=sys.stderr)
+            return 2
+        token = _prompt_hidden("Paste the new seat token (ctdl_…): ")
+    if not token:
+        print("citadel token set: no token given.", file=sys.stderr)
+        return 1
+
+    if not getattr(args, "skip_verify", False):
+        from kb.status import check_auth
+
+        with _Spinner("Verifying the token against your Node…"):
+            auth = await asyncio.to_thread(check_auth, node_url, token)
+        if not auth.ok:
+            print(
+                f"  {mark(False, enable=color)} token not verified ({auth.detail}) — nothing written.",
+                file=sys.stderr,
+            )
+            print(paint("  (pass --skip-verify to write it anyway)", "dim", enable=color), file=sys.stderr)
+            return 1
+        print()
+        print(_render_identity(auth, node_url, color))
+        print()
+
+    previous = read_token_from_rc(rc_path)
+    status = ensure_token_in_rc(rc_path, token)
+    detail = status + (f" · replaced {mask_token(previous)}" if previous and previous != token else "")
+    print(f"  {mark(True, enable=color)} token {mask_token(token)} → {rc_path}  {paint(detail, 'dim', enable=color)}")
+    if (os.environ.get(TOKEN_ENV) or "").strip() != token:
+        print(
+            paint(f"  ! this shell still has the old value — run `source {rc_path}` or open a new shell.", "yellow", enable=color)
+        )
+    return 0
+
+
 def _indent(text: str, prefix: str = "    ") -> str:
     return "\n".join(prefix + line for line in text.splitlines())
 
@@ -1116,14 +1187,8 @@ def _print_banner_animated(text: str, color: bool) -> None:
         time.sleep(0.035)
 
 
-def _render_onboard_identity(auth: Any, node_url: str, color: bool) -> str:
-    """Who this token belongs to — seat, role, access — shown on onboard."""
-    if not getattr(auth, "ok", False):
-        detail = getattr(auth, "detail", "could not verify")
-        return (
-            f"  {mark(False, enable=color)} "
-            + paint(f"token not verified ({detail}) — saved anyway; run `citadel status` to recheck.", "yellow", enable=color)
-        )
+def _render_identity(auth: Any, node_url: str, color: bool) -> str:
+    """Who a verified token belongs to — seat, role, access (onboard/token set)."""
     ident = getattr(auth, "data", None) or {}
     seat = ident.get("seat_slug") or ident.get("actor") or "—"
     caps = ident.get("capabilities") or {}
@@ -1141,17 +1206,46 @@ def _render_onboard_identity(auth: Any, node_url: str, color: bool) -> str:
     ])
 
 
-async def _onboard(args: argparse.Namespace) -> int:
-    repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
-    as_json = getattr(args, "json", False)
-    interactive = sys.stdin.isatty() and not args.non_interactive and not as_json
-    color = supports_color() and not as_json
-    node_url = (getattr(args, "node_url", None) or DEFAULT_NODE_URL).rstrip("/")
+def _prompt_hidden(prompt: str) -> str:
+    """getpass wrapper: the pasted secret is never echoed; Ctrl-D → ""."""
+    try:
+        return getpass.getpass(prompt).strip()
+    except EOFError:
+        print()
+        return ""
 
-    if interactive:
-        _print_banner_animated(banner(color=color), color)
 
-    token = (args.token or os.environ.get(TOKEN_ENV) or "").strip()
+async def _resolve_onboard_token(
+    args: argparse.Namespace, rc_path: Path, node_url: str, *, interactive: bool, color: bool
+) -> tuple[str, Any]:
+    """Pick the token to onboard with, then verify it. Returns (token, auth).
+
+    Interactive flow: an already-configured token (env or shell rc) is shown
+    masked with a keep-or-replace choice; a token the Node rejects offers an
+    immediate re-paste instead of burying the failure at the end of the run.
+    Non-interactive: --token or env only, no verification (scripts/CI stay
+    offline) — auth comes back None.
+    """
+    token = (args.token or "").strip()
+    if not token:
+        env_token = (os.environ.get(TOKEN_ENV) or "").strip()
+        existing, source = env_token, "this shell's env"
+        if not existing and interactive:
+            existing, source = read_token_from_rc(rc_path), str(rc_path)
+        if existing and interactive:
+            print(
+                f"\nAccess token already configured: "
+                f"{paint(mask_token(existing), 'bold', enable=color)}  "
+                f"{paint(f'(from {source})', 'dim', enable=color)}"
+            )
+            answer = input("  Keep it? [Y/n — n to paste a new one]: ").strip().lower()
+            token = existing
+            if answer in ("n", "no"):
+                token = _prompt_hidden("  Paste the new seat token (ctdl_…): ") or existing
+                if token == existing:
+                    print(paint("  (nothing pasted — keeping the existing token)", "dim", enable=color))
+        else:
+            token = existing
     if not token and interactive:
         # Guide the new user to the token instead of dead-ending on an error.
         print(
@@ -1159,11 +1253,57 @@ async def _onboard(args: argparse.Namespace) -> int:
             f"{paint(node_url, 'cyan', enable=color)}\n"
             "  (log in with the admin key → Create Seat → copy the ctdl_… token)\n"
         )
-        try:
-            # getpass: the pasted secret is not echoed to the screen/scrollback.
-            token = getpass.getpass("Paste your Citadel seat token (ctdl_…): ").strip()
-        except (EOFError, KeyboardInterrupt):
+        token = _prompt_hidden("Paste your Citadel seat token (ctdl_…): ")
+    if not token:
+        return "", None
+
+    # Verify the token + show its identity (seat / role / access) up front, so a
+    # rejected token is fixable now — not discovered after every other prompt.
+    auth = None
+    if interactive:
+        from kb.status import check_auth
+
+        while True:
+            with _Spinner("Verifying your token…"):
+                auth = await asyncio.to_thread(check_auth, node_url, token)
             print()
+            if auth.ok:
+                print(_render_identity(auth, node_url, color))
+                break
+            detail = str(getattr(auth, "detail", "")) or "could not verify"
+            if not any(code in detail for code in ("401", "403")):
+                # Node unreachable / network error — a new token won't help.
+                print(
+                    f"  {paint('!', 'yellow', enable=color)} "
+                    + paint(f"could not verify the token ({detail}) — continuing; run `citadel status` later.", "yellow", enable=color)
+                )
+                break
+            print(f"  {mark(False, enable=color)} the Node rejected this token ({detail})")
+            answer = input("  Paste a different token? [y/N]: ").strip().lower()
+            if answer not in ("y", "yes"):
+                print(paint("  (keeping it anyway — fix it later with `citadel token set`)", "dim", enable=color))
+                break
+            new_token = _prompt_hidden("  Paste the new seat token (ctdl_…): ")
+            if not new_token:
+                break
+            token = new_token
+    return token, auth
+
+
+async def _onboard(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).expanduser() if args.repo else git_root_or_cwd()
+    as_json = getattr(args, "json", False)
+    interactive = sys.stdin.isatty() and not args.non_interactive and not as_json
+    color = supports_color() and not as_json
+    node_url = (getattr(args, "node_url", None) or DEFAULT_NODE_URL).rstrip("/")
+    rc_path = Path(args.shell_rc).expanduser() if args.shell_rc else detect_shell_rc()
+
+    if interactive:
+        _print_banner_animated(banner(color=color), color)
+
+    token, _auth = await _resolve_onboard_token(
+        args, rc_path, node_url, interactive=interactive, color=color
+    )
     if not token:
         print(
             "citadel onboard: no token — pass --token or set CITADEL_MCP_ACCESS_TOKEN.",
@@ -1171,16 +1311,6 @@ async def _onboard(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # Verify the token + resolve its identity (seat / role / access) to show the
-    # user who they're onboarding as. Interactive-only: keeps scripts/CI offline.
-    auth = None
-    if interactive:
-        from kb.status import check_auth
-
-        with _Spinner("Verifying your token…"):
-            auth = await asyncio.to_thread(check_auth, node_url, token)
-
-    rc_path = Path(args.shell_rc).expanduser() if args.shell_rc else detect_shell_rc()
     steps: list[tuple[str, str]] = []
     try:
         steps.append((f"token → {rc_path}", ensure_token_in_rc(rc_path, token)))
@@ -1237,18 +1367,18 @@ async def _onboard(args: argparse.Namespace) -> int:
             "  (local cognify also needs: pipx install 'citadel-archive[server]')"
         )
 
-    # Always seed the repo toplevel as a capture root (unless --no-capture) so the
-    # pre-push hook is not a guaranteed no-op out of the box (#43/#35). The wizard
-    # only runs interactively, but a default root is persisted either way.
+    # Capture roots (unless --no-capture): the wizard offers the repo toplevel as
+    # a press-Enter default; whatever happens, an empty config is seeded with the
+    # repo toplevel so the pre-push hook is not a guaranteed no-op (#43/#35).
     if not args.no_capture:
         cfg_path = capture_config_path()
         cfg = load_capture_config(cfg_path)
-        if not cfg.roots:
-            cfg = cfg.with_root(str(repo), (DEFAULT_ROOT_TAG,))  # 'personal' never promotes
         if interactive:
             answer = input("\nSet up Approved Capture Roots now? [Y/n]: ").strip().lower()
             if answer in ("", "y", "yes"):
-                cfg = _wizard_roots(cfg)
+                cfg = _wizard_roots(cfg, default_root=str(repo))
+        if not cfg.roots:
+            cfg = cfg.with_root(str(repo), (DEFAULT_ROOT_TAG,))  # 'personal' never promotes
         save_capture_config(
             cfg, path=cfg_path, updated_at=datetime.now(timezone.utc).isoformat()
         )
@@ -1271,9 +1401,6 @@ async def _onboard(args: argparse.Namespace) -> int:
 
     if not interactive:
         print(banner(color=color))
-    if auth is not None:
-        print()
-        print(_render_onboard_identity(auth, node_url, color))
     print(f"\nCitadel onboarding for {repo}  (token {mask_token(token)}):")
     for label, status in steps:
         text, ok, skipped = _humanize_status(status)
@@ -1289,11 +1416,86 @@ async def _onboard(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cli_version() -> str:
+    try:
+        return _pkg_version("citadel-archive")
+    except PackageNotFoundError:
+        from kb import __version__
+
+        return __version__
+
+
+def _install_channel() -> tuple[str, str]:
+    """How this CLI was installed: ("editable", src) | ("pipx", bin) | ("other", "").
+
+    Drives `citadel update`: editable/source checkouts must never be clobbered
+    by an upgrade, pipx installs know their own upgrade command, anything else
+    gets printed instructions.
+    """
+    try:
+        from importlib.metadata import distribution
+
+        direct = distribution("citadel-archive").read_text("direct_url.json")
+        if direct:
+            info = json.loads(direct)
+            if info.get("dir_info", {}).get("editable"):
+                return "editable", str(info.get("url") or "")
+    except (PackageNotFoundError, ValueError, OSError):
+        pass
+    pipx = shutil.which("pipx")
+    if pipx and "pipx" in Path(sys.prefix).parts:
+        return "pipx", pipx
+    return "other", ""
+
+
+async def _update(args: argparse.Namespace) -> int:
+    """Update citadel in place — the answer to `pipx install` saying
+    "already seems to be installed"; no --force incantations needed."""
+    color = supports_color()
+    channel, detail = _install_channel()
+    if channel == "editable":
+        src = urllib.parse.unquote(detail.removeprefix("file://")) or "the source checkout"
+        print(f"You're running from source (editable install) — update with `git pull` in {src}.")
+        return 0
+    if channel != "pipx":
+        print(
+            "citadel update: this install isn't managed by pipx. Upgrade it with:\n"
+            "  pipx:  pipx install citadel-archive\n"
+            f"  pip:   {sys.executable} -m pip install --upgrade citadel-archive"
+        )
+        return 0
+    current = _cli_version()
+    try:
+        with _Spinner("Checking PyPI for the latest release…"):
+            proc = await asyncio.to_thread(
+                subprocess.run,
+                # --no-cache-dir: never "upgrade" onto a stale cached wheel.
+                [detail, "upgrade", "--pip-args=--no-cache-dir", "citadel-archive"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"citadel update: pipx upgrade failed: {exc}", file=sys.stderr)
+        return 1
+    out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+    if proc.returncode != 0:
+        print(f"citadel update: pipx upgrade failed:\n{out}", file=sys.stderr)
+        return 1
+    if "already at latest" in out:
+        print(f"  {mark(True, enable=color)} already up to date — citadel {current}")
+    else:
+        upgraded = next((line for line in out.splitlines() if "upgraded" in line.lower()), out)
+        print(f"  {mark(True, enable=color)} {upgraded.strip()}")
+    return 0
+
+
 _HOME_MENU = (
     ("Get started", (
         ("onboard", "one-command setup — token · hooks · MCP · capture roots"),
         ("status", "connection · identity · local setup (--json for agents)"),
         ("doctor", "diagnose setup problems · --fix to repair"),
+        ("update", "update citadel to the latest release"),
     )),
     ("Capture", (
         ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
@@ -1307,7 +1509,7 @@ _HOME_MENU = (
     ("Connect & admin", (
         ("mcp", "add Citadel MCP to Claude · Cursor · Codex · …"),
         ("seat", "create · list seats and mint tokens (admin)"),
-        ("token", "create · revoke standalone tokens (admin)"),
+        ("token", "set this machine's seat token · admin create/revoke"),
     )),
 )
 
@@ -1339,9 +1541,15 @@ def _already_onboarded() -> bool:
 
 def _print_home() -> None:
     color = supports_color()
-    print(banner_large(color=color))
-    print()
-    print("  " + paint("the organization vault", "dim", enable=color))
+    cols = shutil.get_terminal_size((80, 24)).columns
+    if cols >= HERO_WIDTH + 2:
+        print(banner_large(color=color))
+        print()
+        print("  " + paint("the organization vault", "dim", enable=color))
+    else:
+        # Narrow terminal: the compact castle (wordmark + tagline inline)
+        # instead of a wrapped, mangled hero.
+        print(banner(color=color))
     if _already_onboarded():
         state = mark(True, enable=color) + " " + paint("set up", "green", enable=color)
     else:
@@ -1352,7 +1560,7 @@ def _print_home() -> None:
             + paint(" — run ", "dim", enable=color)
             + paint("citadel onboard", "cyan", enable=color)
         )
-    print("  " + state)
+    print("  " + state + paint(f"  ·  v{_cli_version()}", "dim", enable=color))
     print()
     # Pad command names to the widest, so descriptions form a clean column.
     pad = max(len(name) for _, rows in _HOME_MENU for name, _ in rows) + 2
@@ -1455,11 +1663,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog="Run `citadel` with no command for the guided home screen, "
         "or `citadel <command> --help` for any command.",
     )
-    try:
-        _version = _pkg_version("citadel-archive")
-    except PackageNotFoundError:
-        from kb import __version__ as _version
-    parser.add_argument("--version", action="version", version=f"citadel {_version}")
+    parser.add_argument("--version", action="version", version=f"citadel {_cli_version()}")
     parser.add_argument(
         "--no-onboard",
         action="store_true",
@@ -1490,6 +1694,13 @@ def build_parser() -> argparse.ArgumentParser:
     doctor.add_argument("--repo", help="Repo to check (default: git toplevel or cwd)")
     doctor.add_argument("--config", help="Override capture config path")
     doctor.set_defaults(handler=_doctor)
+
+    update = subcommands.add_parser(
+        "update",
+        aliases=["upgrade"],
+        help="Update citadel to the latest release (pipx-aware)",
+    )
+    update.set_defaults(handler=_update)
 
     onboard = subcommands.add_parser(
         "onboard",
@@ -1641,9 +1852,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     token = subcommands.add_parser(
         "token",
-        help="Manage standalone tokens (admin — reads CITADEL_ADMIN_KEY)",
+        help="Set this machine's seat token, or manage standalone tokens (admin)",
     )
     token_sub = token.add_subparsers(dest="token_command", required=True)
+
+    token_set = token_sub.add_parser(
+        "set",
+        help="Set/rotate the seat token this machine uses (verifies, then writes your shell rc)",
+    )
+    token_set.add_argument("token", nargs="?", help="Seat token (omit to paste it hidden)")
+    token_set.add_argument("--shell-rc", help="Shell rc file for the token export")
+    token_set.add_argument("--node-url", help="Override Node URL")
+    token_set.add_argument(
+        "--skip-verify", action="store_true", help="Write without checking the token against the Node"
+    )
+    token_set.set_defaults(handler=_token_set)
 
     token_create = token_sub.add_parser(
         "create", help="Issue a standalone (service-account) token, printed once"

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -152,6 +152,15 @@ def _needs_server(
     return wrapper
 
 
+def _prompt(text: str) -> str:
+    """input() that treats Ctrl-D (EOF) as an empty answer, not a traceback."""
+    try:
+        return input(text)
+    except EOFError:
+        print()
+        return ""
+
+
 def _stale_env_hint(status_code: int) -> str | None:
     """The fix-it line for an auth-rejected command run from a stale shell.
 
@@ -165,6 +174,11 @@ def _stale_env_hint(status_code: int) -> str | None:
     rc_path = detect_shell_rc()
     rc_token = read_token_from_rc(rc_path)
     env_token = (os.environ.get(TOKEN_ENV) or "").strip()
+    if "$" in rc_token:
+        # Variable indirection (export TOKEN="$OTHER") — we can't evaluate it,
+        # so a textual mismatch proves nothing; stay quiet rather than send
+        # the user on a `source` loop that can never fix a real 401.
+        return None
     if rc_token and rc_token != env_token:
         return (
             f"this shell's {TOKEN_ENV} is out of date with {rc_path} — "
@@ -444,19 +458,32 @@ def _parse_root_arg(raw: str) -> tuple[str, tuple[str, ...]]:
     return path, tags
 
 
+def _ask_root_tags() -> tuple[str, ...]:
+    print(
+        f"  Tags — presets: {', '.join(PRESET_ROOT_TAGS)}; "
+        f"'personal' never promotes. Default: {DEFAULT_ROOT_TAG}."
+    )
+    tags_raw = _prompt("  Tags (comma-separated): ").strip()
+    return tuple(tags_raw.split(",")) if tags_raw else (DEFAULT_ROOT_TAG,)
+
+
 def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> CaptureConfig:
-    # Offer the dir the user is already in as a press-Enter default (once) —
-    # nobody should have to copy-paste the path they just ran `citadel` from.
+    print("\nAdd Approved Capture Roots — folders auto-captured to your Node.")
+    # The dir the user ran `citadel` from is offered as an explicit yes/no —
+    # Enter accepts, `n` declines. A separate question (not a prefilled path
+    # prompt) so declining is always possible and "empty to finish" below
+    # keeps meaning finish.
     default = normalize_path(default_root) if default_root else None
     if default and any(root.path == default for root in config.roots):
         default = None  # already approved — nothing to offer
-    print("\nAdd Approved Capture Roots — folders auto-captured to your Node.")
+    if default:
+        answer = _prompt(f"  Add {default} (this folder)? [Y/n]: ").strip().lower()
+        if answer in ("", "y", "yes"):
+            tags = _ask_root_tags()
+            config = config.with_root(default, tags)
+            print(f"  + {default}  [{', '.join(normalize_tags(tags))}]")
     while True:
-        if default:
-            raw = input(f"  Root path [{default}]: ").strip() or default
-        else:
-            raw = input("  Root path (empty to finish): ").strip()
-        default = None  # offered once; from here Enter finishes
+        raw = _prompt("  Root path (empty to finish): ").strip()
         if not raw:
             break
         normalized = normalize_path(raw)
@@ -466,7 +493,7 @@ def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> Cap
             # recording a root that will never capture anything.
             guess = Path.home() / raw.lstrip("/") if raw.startswith("/") else None
             if guess is not None and guess.exists():
-                answer = input(
+                answer = _prompt(
                     f"  ! {normalized} does not exist — did you mean {guess}? [Y/n]: "
                 ).strip().lower()
                 if answer in ("", "y", "yes"):
@@ -475,12 +502,7 @@ def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> Cap
                     print(f"  ! keeping {normalized} (does not exist yet)")
             else:
                 print(f"  ! {normalized} does not exist yet (added anyway)")
-        print(
-            f"  Tags — presets: {', '.join(PRESET_ROOT_TAGS)}; "
-            f"'personal' never promotes. Default: {DEFAULT_ROOT_TAG}."
-        )
-        tags_raw = input("  Tags (comma-separated): ").strip()
-        tags = tuple(tags_raw.split(",")) if tags_raw else (DEFAULT_ROOT_TAG,)
+        tags = _ask_root_tags()
         config = config.with_root(normalized, tags)
         print(f"  + {normalized}  [{', '.join(normalize_tags(tags))}]")
     return config
@@ -581,6 +603,7 @@ async def _capture(args: argparse.Namespace) -> int:
     as_json = getattr(args, "json", False)
     results: list[dict[str, Any]] = []
     failures = 0
+    auth_fail_code = 0
     for root, payload in payloads:
         try:
             response = post_capture(config.node_url, token, payload)
@@ -590,17 +613,19 @@ async def _capture(args: argparse.Namespace) -> int:
                 print(f"OK  {root.path} ({status})")
         except urllib.error.HTTPError as exc:
             failures += 1
+            auth_fail_code = auth_fail_code or exc.code
             detail = exc.read().decode(errors="replace")[:200]
             results.append({"root": root.path, "ok": False, "error": f"HTTP {exc.code} {detail}"})
             if not as_json:
                 print(f"FAIL {root.path}: HTTP {exc.code} {detail}", file=sys.stderr)
-                _print_auth_hint("capture", exc.code)
         except (urllib.error.URLError, OSError, ValueError) as exc:
             # Node unreachable / DNS / timeout / non-HTTPS URL — isolate per root.
             failures += 1
             results.append({"root": root.path, "ok": False, "error": str(exc)})
             if not as_json:
                 print(f"FAIL {root.path}: {exc}", file=sys.stderr)
+    if not as_json and auth_fail_code:
+        _print_auth_hint("capture", auth_fail_code)  # once, not per failing root
     if as_json:
         _print_json({"ok": failures == 0, "results": results})
     # Human mode already printed a per-root OK/FAIL line during the loop.
@@ -1265,28 +1290,42 @@ def _prompt_hidden(prompt: str) -> str:
 
 async def _resolve_onboard_token(
     args: argparse.Namespace, rc_path: Path, node_url: str, *, interactive: bool, color: bool
-) -> tuple[str, Any]:
-    """Pick the token to onboard with, then verify it. Returns (token, auth).
+) -> str:
+    """Pick the token to onboard with, then verify it. Returns "" when absent.
 
-    Interactive flow: an already-configured token (env or shell rc) is shown
-    masked with a keep-or-replace choice; a token the Node rejects offers an
-    immediate re-paste instead of burying the failure at the end of the run.
+    Interactive flow: an already-configured token (shell rc first — it's the
+    durable value every new shell exports — then env) is shown masked with a
+    keep-or-replace choice; a token the Node rejects offers an immediate
+    re-paste instead of burying the failure at the end of the run.
     Non-interactive: --token or env only, no verification (scripts/CI stay
-    offline) — auth comes back None.
+    offline).
     """
     token = (args.token or "").strip()
     if not token:
         env_token = (os.environ.get(TOKEN_ENV) or "").strip()
-        existing, source = env_token, "this shell's env"
-        if not existing and interactive:
-            existing, source = read_token_from_rc(rc_path), str(rc_path)
+        # rc wins over env: a stale shell's env must not silently revert a
+        # rotation that `citadel token set` already wrote to the rc.
+        rc_token = read_token_from_rc(rc_path) if interactive else ""
+        if rc_token:
+            existing, source = rc_token, str(rc_path)
+        else:
+            existing, source = env_token, "this shell's env"
         if existing and interactive:
             print(
                 f"\nAccess token already configured: "
                 f"{paint(mask_token(existing), 'bold', enable=color)}  "
                 f"{paint(f'(from {source})', 'dim', enable=color)}"
             )
-            answer = input("  Keep it? [Y/n — n to paste a new one]: ").strip().lower()
+            if env_token and rc_token and env_token != rc_token:
+                print(
+                    paint(
+                        f"  (this shell's env exports a different token {mask_token(env_token)} — "
+                        f"`source {rc_path}` after onboarding aligns it)",
+                        "dim",
+                        enable=color,
+                    )
+                )
+            answer = _prompt("  Keep it? [Y/n — n to paste a new one]: ").strip().lower()
             token = existing
             if answer in ("n", "no"):
                 token = _prompt_hidden("  Paste the new seat token (ctdl_…): ") or existing
@@ -1303,7 +1342,7 @@ async def _resolve_onboard_token(
         )
         token = _prompt_hidden("Paste your Citadel seat token (ctdl_…): ")
     if not token:
-        return "", None
+        return ""
 
     # Verify the token + show its identity (seat / role / access) up front, so a
     # rejected token is fixable now — not discovered after every other prompt.
@@ -1327,7 +1366,7 @@ async def _resolve_onboard_token(
                 )
                 break
             print(f"  {mark(False, enable=color)} the Node rejected this token ({detail})")
-            answer = input("  Paste a different token? [y/N]: ").strip().lower()
+            answer = _prompt("  Paste a different token? [y/N]: ").strip().lower()
             if answer not in ("y", "yes"):
                 print(paint("  (keeping it anyway — fix it later with `citadel token set`)", "dim", enable=color))
                 break
@@ -1335,7 +1374,7 @@ async def _resolve_onboard_token(
             if not new_token:
                 break
             token = new_token
-    return token, auth
+    return token
 
 
 async def _onboard(args: argparse.Namespace) -> int:
@@ -1349,7 +1388,7 @@ async def _onboard(args: argparse.Namespace) -> int:
     if interactive:
         _print_banner_animated(banner(color=color), color)
 
-    token, _auth = await _resolve_onboard_token(
+    token = await _resolve_onboard_token(
         args, rc_path, node_url, interactive=interactive, color=color
     )
     if not token:
@@ -1392,13 +1431,9 @@ async def _onboard(args: argparse.Namespace) -> int:
     # and proactive-ingest work out of the box (#35). Interactive-only; written
     # to the shell rc next to the seat token.
     if interactive:
-        try:
-            llm_key = getpass.getpass(
-                "Optional: paste an OpenRouter API key for local cognify "
-                "(enter to skip): "
-            ).strip()
-        except (EOFError, KeyboardInterrupt):
-            llm_key = ""
+        llm_key = _prompt_hidden(
+            "Optional: paste an OpenRouter API key for local cognify (enter to skip): "
+        )
         if llm_key:
             steps.append(
                 (
@@ -1415,14 +1450,15 @@ async def _onboard(args: argparse.Namespace) -> int:
             "  (local cognify also needs: pipx install 'citadel-archive[server]')"
         )
 
-    # Capture roots (unless --no-capture): the wizard offers the repo toplevel as
-    # a press-Enter default; whatever happens, an empty config is seeded with the
-    # repo toplevel so the pre-push hook is not a guaranteed no-op (#43/#35).
+    # Capture roots (unless --no-capture): the wizard asks about the repo
+    # toplevel explicitly (declinable); if the config still ends up empty, it
+    # is seeded with the repo toplevel so the pre-push hook is not a
+    # guaranteed no-op out of the box (#43/#35).
     if not args.no_capture:
         cfg_path = capture_config_path()
         cfg = load_capture_config(cfg_path)
         if interactive:
-            answer = input("\nSet up Approved Capture Roots now? [Y/n]: ").strip().lower()
+            answer = _prompt("\nSet up Approved Capture Roots now? [Y/n]: ").strip().lower()
             if answer in ("", "y", "yes"):
                 cfg = _wizard_roots(cfg, default_root=str(repo))
         if not cfg.roots:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -152,6 +152,33 @@ def _needs_server(
     return wrapper
 
 
+def _stale_env_hint(status_code: int) -> str | None:
+    """The fix-it line for an auth-rejected command run from a stale shell.
+
+    After `citadel onboard`/`token set` rotate the token in the shell rc, the
+    *current* shell still exports the old value — and env is what commands
+    send. When the Node rejects it (401/403) and the rc disagrees with env,
+    the fix is `source <rc>`, so say exactly that instead of a bare 401.
+    """
+    if status_code not in (401, 403):
+        return None
+    rc_path = detect_shell_rc()
+    rc_token = read_token_from_rc(rc_path)
+    env_token = (os.environ.get(TOKEN_ENV) or "").strip()
+    if rc_token and rc_token != env_token:
+        return (
+            f"this shell's {TOKEN_ENV} is out of date with {rc_path} — "
+            f"run `source {rc_path}` (or open a new shell) and retry."
+        )
+    return None
+
+
+def _print_auth_hint(command: str, status_code: int) -> None:
+    hint = _stale_env_hint(status_code)
+    if hint:
+        print(f"citadel {command}: hint: {hint}", file=sys.stderr)
+
+
 def _result_exit(value: Any) -> int:
     """Exit 1 when a result payload carries ``ok: False``; else 0.
 
@@ -190,6 +217,7 @@ async def _ingest(args: argparse.Namespace) -> int:
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:200] if exc.fp else exc.reason
         print(f"citadel ingest: HTTP {exc.code} {detail}", file=sys.stderr)
+        _print_auth_hint("ingest", exc.code)
         return 1
     except TimeoutError:
         print(
@@ -296,6 +324,7 @@ async def _search(args: argparse.Namespace) -> int:
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:200] if exc.fp else exc.reason
         print(f"citadel search: HTTP {exc.code} {detail}", file=sys.stderr)
+        _print_auth_hint("search", exc.code)
         return 1
     except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
         print(f"citadel search: {exc}", file=sys.stderr)
@@ -565,6 +594,7 @@ async def _capture(args: argparse.Namespace) -> int:
             results.append({"root": root.path, "ok": False, "error": f"HTTP {exc.code} {detail}"})
             if not as_json:
                 print(f"FAIL {root.path}: HTTP {exc.code} {detail}", file=sys.stderr)
+                _print_auth_hint("capture", exc.code)
         except (urllib.error.URLError, OSError, ValueError) as exc:
             # Node unreachable / DNS / timeout / non-HTTPS URL — isolate per root.
             failures += 1
@@ -880,37 +910,55 @@ def _indent(text: str, prefix: str = "    ") -> str:
 
 
 def _wire_detected_tools(node_url: str, *, color: bool) -> None:
-    """Interactive: offer to add Citadel's MCP server to each detected tool.
+    """Interactive: one checkbox list of detected tools, then wire the selection.
 
-    Write-tier tools (token stays in the rc via an env reference) are merged on
-    confirmation; snippet-tier tools print a paste-in block on request; Pi gets
-    a note. Used only on an interactive `citadel onboard`.
+    Write-tier tools (token stays in the rc via an env reference) are merged;
+    snippet-tier tools print a paste-in block; Pi gets a note. Preselection
+    mirrors the old per-tool defaults: write-tier on, snippet-tier off. Used
+    only on an interactive `citadel onboard`.
     """
     from kb import tool_detect
+    from kb.prompt import checkbox_select
 
     detected = tool_detect.detect()
     if not detected:
         return
-    print("\n" + paint("Coding tools", "bold", enable=color))
-    for name in detected:
+    selectable = [name for name in detected if tool_detect.SPECS[name].mode != "note"]
+    notes = [name for name in detected if tool_detect.SPECS[name].mode == "note"]
+
+    chosen: list[str] = []
+    if selectable:
+        labels = [
+            tool_detect.SPECS[name].label
+            + (paint("  (paste-in snippet)", "dim", enable=color) if tool_detect.SPECS[name].mode == "snippet" else "")
+            for name in selectable
+        ]
+        preselected = {i for i, name in enumerate(selectable) if tool_detect.SPECS[name].mode == "write"}
+        print()
+        picked = checkbox_select(
+            paint("Coding tools", "bold", enable=color)
+            + paint(" — add Citadel MCP to:", "dim", enable=color),
+            labels,
+            preselected,
+        )
+        chosen = [selectable[i] for i in sorted(picked)] if picked else []
+
+    results: list[tuple[str, Any]] = []
+    if chosen:
+        with _Spinner(f"Wiring {len(chosen)} tool(s)…"):
+            results = [(name, tool_detect.apply(name, node_url=node_url)) for name in chosen]
+    for name, result in results:
         spec = tool_detect.SPECS[name]
         if spec.mode == "write":
-            answer = input(f"  Add Citadel MCP to {spec.label}? [Y/n]: ").strip().lower()
-            if answer not in ("", "y", "yes"):
-                continue
-            result = tool_detect.apply(name, node_url=node_url)
             sigil = mark(result.action != "error", enable=color)
             print(f"  {sigil} {spec.label}  {paint(f'{result.action} · {result.detail}', 'dim', enable=color)}")
-        elif spec.mode == "snippet":
-            answer = input(f"  Show paste-in MCP snippet for {spec.label}? [y/N]: ").strip().lower()
-            if answer not in ("y", "yes"):
-                continue
-            result = tool_detect.apply(name, node_url=node_url)
-            print(paint(f"    → {spec.config_hint}", "dim", enable=color))
+        else:  # snippet
+            print(f"  {paint(spec.label, 'bold', enable=color)} — paste into {paint(spec.config_hint, 'dim', enable=color)}:")
             print(_indent(result.snippet or ""))
-        else:  # note (e.g. Pi)
-            result = tool_detect.apply(name, node_url=node_url)
-            print(f"  {paint('•', 'dim', enable=color)} {spec.label}: {paint(result.detail, 'dim', enable=color)}")
+    for name in notes:
+        result = tool_detect.apply(name, node_url=node_url)
+        spec = tool_detect.SPECS[name]
+        print(f"  {paint('•', 'dim', enable=color)} {spec.label}: {paint(result.detail, 'dim', enable=color)}")
 
 
 async def _mcp_add(args: argparse.Namespace) -> int:

--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -192,6 +192,31 @@ def ensure_token_in_rc(rc_path: Path, token: str) -> str:
     )
 
 
+def read_token_from_rc(rc_path: Path) -> str:
+    """Best-effort recovery of the exported token value from the shell rc.
+
+    Inverse of ensure_token_in_rc for the line shapes we write (single-quoted)
+    plus plain unquoted/double-quoted exports a user may have added by hand.
+    Lets `citadel onboard` say "already configured — keep or replace?" even in
+    a fresh shell where the env var is not exported yet. Returns "" when absent.
+    """
+    try:
+        lines = rc_path.read_text().splitlines()
+    except OSError:
+        return ""
+    for raw in lines:
+        stripped = raw.strip()
+        for prefix in (f"export {TOKEN_ENV}=", f"{TOKEN_ENV}="):
+            if stripped.startswith(prefix):
+                value = stripped[len(prefix):].strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+                    inner = value[1:-1]
+                    # Undo POSIX single-quote escaping (see _sh_single_quote).
+                    return inner.replace("'\"'\"'", "'") if value[0] == "'" else inner
+                return value.split(" #", 1)[0].strip()
+    return ""
+
+
 def merge_mcp_config(path: Path, base_url: str = DEFAULT_NODE_URL) -> str:
     """Merge the citadel MCP server into .mcp.json, preserving other servers."""
     data = _load_json_object(path)

--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import stat
 import subprocess
 import sys
@@ -168,14 +169,19 @@ def ensure_env_in_rc(rc_path: Path, var_name: str, value: str, *, comment: str) 
     value = value.strip()
     export_line = f"export {var_name}={_sh_single_quote(value)}"
     lines = rc_path.read_text().splitlines() if rc_path.exists() else []
+    # Rewrite the LAST matching line — that's the one a real shell honors, so
+    # a rotation can never be shadowed by a duplicate export further down.
+    match_index = None
     for index, raw in enumerate(lines):
         stripped = raw.strip()
         if stripped.startswith(f"export {var_name}=") or stripped.startswith(f"{var_name}="):
-            if stripped == export_line:
-                return "present"
-            lines[index] = export_line
-            rc_path.write_text("\n".join(lines) + "\n")
-            return "updated"
+            match_index = index
+    if match_index is not None:
+        if lines[match_index].strip() == export_line:
+            return "present"
+        lines[match_index] = export_line
+        rc_path.write_text("\n".join(lines) + "\n")
+        return "updated"
     rc_path.parent.mkdir(parents=True, exist_ok=True)
     with rc_path.open("a", encoding="utf-8") as handle:
         handle.write(f"\n# {comment}\n{export_line}\n")
@@ -196,7 +202,8 @@ def read_token_from_rc(rc_path: Path) -> str:
     """Best-effort recovery of the exported token value from the shell rc.
 
     Inverse of ensure_token_in_rc for the line shapes we write (single-quoted)
-    plus plain unquoted/double-quoted exports a user may have added by hand.
+    plus hand-added exports: shlex handles quoting and trailing comments, and
+    the LAST matching line wins — the same line a real shell would honor.
     Lets `citadel onboard` say "already configured — keep or replace?" even in
     a fresh shell where the env var is not exported yet. Returns "" when absent.
     """
@@ -204,17 +211,18 @@ def read_token_from_rc(rc_path: Path) -> str:
         lines = rc_path.read_text().splitlines()
     except OSError:
         return ""
+    token = ""
     for raw in lines:
         stripped = raw.strip()
         for prefix in (f"export {TOKEN_ENV}=", f"{TOKEN_ENV}="):
             if stripped.startswith(prefix):
                 value = stripped[len(prefix):].strip()
-                if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
-                    inner = value[1:-1]
-                    # Undo POSIX single-quote escaping (see _sh_single_quote).
-                    return inner.replace("'\"'\"'", "'") if value[0] == "'" else inner
-                return value.split(" #", 1)[0].strip()
-    return ""
+                try:
+                    parts = shlex.split(value, comments=True)
+                except ValueError:  # unbalanced quotes — treat as unreadable
+                    parts = []
+                token = parts[0] if parts else ""
+    return token
 
 
 def merge_mcp_config(path: Path, base_url: str = DEFAULT_NODE_URL) -> str:

--- a/kb/prompt.py
+++ b/kb/prompt.py
@@ -10,26 +10,57 @@ everywhere the wizard runs.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 
 from kb.banner import OK, paint, supports_color
 
-_HELP = "↑/↓ move · space toggle · a all · n none · enter apply · q skip"
+_HELP = "↑/↓ move · space toggle · a all · n none · enter apply · q/esc skip"
+_ESC = "esc"  # sentinel for a bare Escape keypress
 
 
-def _read_key(stream) -> str:
-    """One keypress, decoding the 3-byte arrow-key escape sequences."""
-    ch = stream.read(1)
-    if ch == "\x1b" and stream.read(1) == "[":
-        return "\x1b[" + stream.read(1)
-    return ch
+def _read_key(fd: int) -> str:
+    """One keypress, read straight from the fd (os.read — Python's buffered
+    stdin would hide bytes from select). Decodes CSI escape sequences fully
+    (arrows, Delete, PgUp …) so no stray bytes leak into the next read, and
+    detects a *bare* Esc via a short select() poll instead of blocking on a
+    byte that never comes."""
+    import select
+
+    def _one(timeout: float | None = None) -> str:
+        if timeout is not None and not select.select([fd], [], [], timeout)[0]:
+            return ""
+        return os.read(fd, 1).decode(errors="replace")
+
+    ch = _one()
+    if ch != "\x1b":
+        return ch
+    nxt = _one(timeout=0.05)
+    if not nxt:
+        return _ESC
+    if nxt != "[":
+        return _ESC  # Alt-chord or unknown escape — treat as cancel intent
+    seq = ""
+    while True:
+        part = _one(timeout=0.05)
+        seq += part
+        # A CSI sequence ends at its final byte (0x40–0x7E: letters, ~, …).
+        if not part or "\x40" <= part <= "\x7e":
+            return "\x1b[" + seq
 
 
-def _render_rows(options: list[str], checked: set[int], cursor: int, *, color: bool) -> list[str]:
+def _clip(text: str, budget: int) -> str:
+    return text if len(text) <= budget else text[: max(budget - 1, 0)] + "…"
+
+
+def _render_rows(options: list[str], checked: set[int], cursor: int, *, color: bool, width: int) -> list[str]:
     rows = []
     for index, label in enumerate(options):
         box = paint(f"[{OK}]", "green", enable=color) if index in checked else "[ ]"
         pointer = paint("❯", "bold", "cyan", enable=color) if index == cursor else " "
+        # Clip the RAW label so a row can never wrap — a wrapped row would
+        # desync the cursor-up repaint and garble the whole block.
+        label = _clip(label, width - 8)
         text = paint(label, "bold", enable=color) if index == cursor else label
         rows.append(f"  {pointer} {box} {text}")
     return rows
@@ -44,13 +75,14 @@ def _select_raw(header: str, options: list[str], checked: set[int]) -> set[int] 
     cursor = 0
     out = sys.stdout
     drawn = 0
+    width = shutil.get_terminal_size((80, 24)).columns
 
     def render() -> None:
         nonlocal drawn
         if drawn:
             out.write(f"\033[{drawn}A")  # jump back to the top of our block
-        rows = [header, *_render_rows(options, checked, cursor, color=color),
-                "  " + paint(_HELP, "dim", enable=color)]
+        rows = [header, *_render_rows(options, checked, cursor, color=color, width=width),
+                "  " + paint(_clip(_HELP, width - 4), "dim", enable=color)]
         for row in rows:
             out.write("\033[2K" + row + "\n")
         drawn = len(rows)
@@ -65,7 +97,7 @@ def _select_raw(header: str, options: list[str], checked: set[int]) -> set[int] 
         tty.setcbreak(fd)
         while True:
             render()
-            key = _read_key(sys.stdin)
+            key = _read_key(fd)
             if key in ("\x1b[A", "k"):
                 cursor = (cursor - 1) % len(options)
             elif key in ("\x1b[B", "j"):
@@ -78,7 +110,7 @@ def _select_raw(header: str, options: list[str], checked: set[int]) -> set[int] 
                 checked = set()
             elif key in ("\r", "\n"):
                 return checked
-            elif key in ("q", "Q"):
+            elif key in ("q", "Q", _ESC) or not key:
                 return None
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, saved)
@@ -94,7 +126,11 @@ def _select_lines(header: str, options: list[str], checked: set[int]) -> set[int
         for index, label in enumerate(options, 1):
             box = paint(f"[{OK}]", "green", enable=color) if index - 1 in checked else "[ ]"
             print(f"    {box} {index}. {label}")
-        raw = input("  Toggle by number (e.g. 1 3), a all, n none, q skip — Enter to apply: ").strip().lower()
+        try:
+            raw = input("  Toggle by number (e.g. 1 3), a all, n none, q skip — Enter to apply: ").strip().lower()
+        except EOFError:
+            print()
+            return checked
         if not raw:
             return checked
         if raw in ("q", "quit"):
@@ -127,6 +163,10 @@ def checkbox_select(header: str, options: list[str], checked: set[int]) -> set[i
     if raw_capable:
         try:
             return _select_raw(header, options, set(checked))
-        except (ImportError, OSError, ValueError):
-            pass  # no termios / odd tty — fall through to the line prompt
+        except KeyboardInterrupt:
+            raise  # Ctrl-C keeps its meaning: abort cleanly (exit 130)
+        except Exception:
+            # No termios (Windows), termios.error from odd ptys/IDE terminals,
+            # bad ioctls — a cosmetic UI must degrade, never crash onboarding.
+            pass
     return _select_lines(header, options, set(checked))

--- a/kb/prompt.py
+++ b/kb/prompt.py
@@ -1,0 +1,132 @@
+"""Interactive terminal prompts — stdlib only.
+
+`checkbox_select` is an arrow-key multi-select (↑/↓ move, space toggle, enter
+apply) used by `citadel onboard` for the coding-tools step. On terminals where
+raw mode isn't available (no termios — e.g. Windows — or stdin/stdout not a
+real TTY) it degrades to a numeric toggle prompt, so the same call works
+everywhere the wizard runs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from kb.banner import OK, paint, supports_color
+
+_HELP = "↑/↓ move · space toggle · a all · n none · enter apply · q skip"
+
+
+def _read_key(stream) -> str:
+    """One keypress, decoding the 3-byte arrow-key escape sequences."""
+    ch = stream.read(1)
+    if ch == "\x1b" and stream.read(1) == "[":
+        return "\x1b[" + stream.read(1)
+    return ch
+
+
+def _render_rows(options: list[str], checked: set[int], cursor: int, *, color: bool) -> list[str]:
+    rows = []
+    for index, label in enumerate(options):
+        box = paint(f"[{OK}]", "green", enable=color) if index in checked else "[ ]"
+        pointer = paint("❯", "bold", "cyan", enable=color) if index == cursor else " "
+        text = paint(label, "bold", enable=color) if index == cursor else label
+        rows.append(f"  {pointer} {box} {text}")
+    return rows
+
+
+def _select_raw(header: str, options: list[str], checked: set[int]) -> set[int] | None:
+    """Arrow-key checkbox UI. Repaints in place; cursor hidden while active."""
+    import termios
+    import tty
+
+    color = supports_color()
+    cursor = 0
+    out = sys.stdout
+    drawn = 0
+
+    def render() -> None:
+        nonlocal drawn
+        if drawn:
+            out.write(f"\033[{drawn}A")  # jump back to the top of our block
+        rows = [header, *_render_rows(options, checked, cursor, color=color),
+                "  " + paint(_HELP, "dim", enable=color)]
+        for row in rows:
+            out.write("\033[2K" + row + "\n")
+        drawn = len(rows)
+        out.flush()
+
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    out.write("\033[?25l")
+    try:
+        # cbreak (not raw): keypresses arrive unbuffered but Ctrl-C still
+        # signals, so the global KeyboardInterrupt → exit 130 path holds.
+        tty.setcbreak(fd)
+        while True:
+            render()
+            key = _read_key(sys.stdin)
+            if key in ("\x1b[A", "k"):
+                cursor = (cursor - 1) % len(options)
+            elif key in ("\x1b[B", "j"):
+                cursor = (cursor + 1) % len(options)
+            elif key == " ":
+                checked.symmetric_difference_update({cursor})
+            elif key in ("a", "A"):
+                checked = set(range(len(options)))
+            elif key in ("n", "N"):
+                checked = set()
+            elif key in ("\r", "\n"):
+                return checked
+            elif key in ("q", "Q"):
+                return None
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+        out.write("\033[?25h")
+        out.flush()
+
+
+def _select_lines(header: str, options: list[str], checked: set[int]) -> set[int] | None:
+    """Line-based fallback: toggle by number, Enter applies, q skips."""
+    color = supports_color()
+    print(header)
+    while True:
+        for index, label in enumerate(options, 1):
+            box = paint(f"[{OK}]", "green", enable=color) if index - 1 in checked else "[ ]"
+            print(f"    {box} {index}. {label}")
+        raw = input("  Toggle by number (e.g. 1 3), a all, n none, q skip — Enter to apply: ").strip().lower()
+        if not raw:
+            return checked
+        if raw in ("q", "quit"):
+            return None
+        if raw == "a":
+            checked = set(range(len(options)))
+            continue
+        if raw == "n":
+            checked = set()
+            continue
+        for part in raw.replace(",", " ").split():
+            if part.isdigit() and 1 <= int(part) <= len(options):
+                checked.symmetric_difference_update({int(part) - 1})
+
+
+def checkbox_select(header: str, options: list[str], checked: set[int]) -> set[int] | None:
+    """Multi-select over `options`; returns chosen indexes, or None on skip.
+
+    `checked` marks the preselected rows. Uses the arrow-key UI on a capable
+    TTY, the numeric fallback everywhere else.
+    """
+    if not options:
+        return set()
+    checked = {i for i in checked if 0 <= i < len(options)}
+    raw_capable = (
+        os.getenv("TERM", "") != "dumb"
+        and sys.stdin.isatty()
+        and sys.stdout.isatty()
+    )
+    if raw_capable:
+        try:
+            return _select_raw(header, options, set(checked))
+        except (ImportError, OSError, ValueError):
+            pass  # no termios / odd tty — fall through to the line prompt
+    return _select_lines(header, options, set(checked))

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -5,18 +5,20 @@ import io
 from kb.banner import banner, banner_large, paint, supports_color
 
 
-def test_banner_large_has_castle_and_figlet() -> None:
+def test_banner_large_is_the_brand_wordmark(monkeypatch) -> None:
     plain = banner_large(color=False)
-    assert "▛▜" in plain          # crenellations
-    assert "▛▀▀▀▜" in plain       # the arched gate lintel
-    assert "▌   ▐" in plain       # the open gate
     assert "____" in plain        # figlet CITADEL
-    assert "\033[" not in plain
-    lengths = {len(line) for line in plain.splitlines()}
-    assert max(lengths) - min(lengths) <= 1  # walls stay aligned (merlon row is rstripped)
-    colored = banner_large(color=True)
-    assert "\033[1m" in colored and "\033[36m" in colored  # bold figlet + cyan walls
-    assert "\033[33m" in colored  # lit (yellow) windows
+    assert "\033[" not in plain   # plain when piped
+    assert len(plain.splitlines()) == 5  # just the wordmark, nothing else
+
+    monkeypatch.delenv("COLORTERM", raising=False)
+    basic = banner_large(color=True)
+    assert "\033[1m" in basic and "\033[36m" in basic  # bold cyan fallback
+
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    gradient = banner_large(color=True)
+    assert "\033[38;2;250;0;140m" in gradient  # starts at brand magenta #FA008C
+    assert "\033[38;2;34;211;238m" in gradient  # ends at brand cyan
 
 
 def test_banner_plain_has_wordmark_and_no_ansi() -> None:

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -8,11 +8,15 @@ from kb.banner import banner, banner_large, paint, supports_color
 def test_banner_large_has_castle_and_figlet() -> None:
     plain = banner_large(color=False)
     assert "▛▜" in plain          # crenellations
-    assert "▕══" in plain         # castle frame
+    assert "▛▀▀▀▜" in plain       # the arched gate lintel
+    assert "▌   ▐" in plain       # the open gate
     assert "____" in plain        # figlet CITADEL
     assert "\033[" not in plain
+    lengths = {len(line) for line in plain.splitlines()}
+    assert max(lengths) - min(lengths) <= 1  # walls stay aligned (merlon row is rstripped)
     colored = banner_large(color=True)
     assert "\033[1m" in colored and "\033[36m" in colored  # bold figlet + cyan walls
+    assert "\033[33m" in colored  # lit (yellow) windows
 
 
 def test_banner_plain_has_wordmark_and_no_ansi() -> None:

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -12,8 +12,13 @@ def test_banner_large_is_the_brand_wordmark(monkeypatch) -> None:
     assert len(plain.splitlines()) == 5  # just the wordmark, nothing else
 
     monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.setenv("TERM", "xterm")
     basic = banner_large(color=True)
     assert "\033[1m" in basic and "\033[36m" in basic  # bold cyan fallback
+
+    monkeypatch.setenv("TERM", "xterm-256color")
+    approx = banner_large(color=True)
+    assert "\033[38;5;" in approx  # 256-color gradient approximation
 
     monkeypatch.setenv("COLORTERM", "truecolor")
     gradient = banner_large(color=True)

--- a/tests/test_capture_config.py
+++ b/tests/test_capture_config.py
@@ -122,6 +122,7 @@ def test_setup_interactive_wizard(tmp_path: Path, monkeypatch) -> None:
     answers = iter(
         [
             "https://wizard-node.example",  # Node URL prompt
+            "n",                             # decline the offered cwd default
             str(repo),                       # first root path
             "org-work, notes",               # tags
             "",                              # empty path -> finish

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -331,6 +331,12 @@ def test_stale_env_hint_points_at_shell_rc(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_fresh_1234567890")
     assert _stale_env_hint(401) is None  # env matches rc → different problem
 
+    # Variable indirection can't be evaluated — a textual mismatch proves
+    # nothing, so no misleading `source` advice.
+    rc.write_text('export CITADEL_MCP_ACCESS_TOKEN="$WORK_CITADEL_TOKEN"\n')
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_whatever_890")
+    assert _stale_env_hint(401) is None
+
 
 # ---- capture-roots wizard -----------------------------------------------------
 
@@ -360,6 +366,37 @@ def test_wizard_enter_accepts_default_root(tmp_path: Path, monkeypatch) -> None:
     config = _wizard_roots(CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path))
     assert [root.path for root in config.roots] == [str(tmp_path)]
     assert "personal" in config.roots[0].tags
+
+
+def test_wizard_default_root_is_declinable(tmp_path: Path, monkeypatch) -> None:
+    # 'n' to the offered folder, Enter to finish — ending with NO roots must be
+    # possible (an un-declinable default would auto-approve $HOME for capture).
+    from kb.capture_config import CaptureConfig
+
+    answers = iter(["n", ""])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    config = _wizard_roots(CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path))
+    assert config.roots == ()
+
+
+def test_read_key_handles_bare_escape_and_csi_tails() -> None:
+    # Esc alone must not hang or swallow the next key; multi-byte CSI keys
+    # (Delete = ESC [ 3 ~) must be consumed whole.
+    import os as _os
+
+    from kb.prompt import _ESC, _read_key
+
+    r, w = _os.pipe()
+    try:
+        _os.write(w, b"\x1b")  # bare Esc (nothing follows within the poll)
+        assert _read_key(r) == _ESC
+        _os.write(w, b"\x1b[A\x1b[3~q")  # Up, Delete, then 'q'
+        assert _read_key(r) == "\x1b[A"
+        assert _read_key(r) == "\x1b[3~"  # fully consumed, no stray '~'
+        assert _read_key(r) == "q"
+    finally:
+        _os.close(r)
+        _os.close(w)
 
 
 def test_wizard_default_suppressed_when_already_approved(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -261,6 +261,77 @@ def test_update_unmanaged_install_prints_instructions(monkeypatch, capsys) -> No
     assert "pip install --upgrade citadel-archive" in capsys.readouterr().out
 
 
+# ---- coding-tools checkbox + stale-token hint ----------------------------------
+
+
+def test_checkbox_line_fallback_toggles_and_applies(monkeypatch) -> None:
+    from kb.prompt import _select_lines
+
+    answers = iter(["1 3", ""])  # toggle #1 off and #3 on, then apply
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    picked = _select_lines("pick:", ["cursor", "codex", "zed"], {0, 1})
+    assert picked == {1, 2}
+
+
+def test_checkbox_line_fallback_q_skips(monkeypatch) -> None:
+    from kb.prompt import _select_lines
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "q")
+    assert _select_lines("pick:", ["cursor"], {0}) is None
+
+
+def test_wire_detected_tools_applies_only_selection(monkeypatch, capsys) -> None:
+    from kb.cli import _wire_detected_tools
+    from kb.tool_detect import ToolResult
+
+    applied: list[str] = []
+    monkeypatch.setattr("kb.tool_detect.detect", lambda: ["cursor", "codex", "zed", "pi"])
+    monkeypatch.setattr(
+        "kb.tool_detect.apply",
+        lambda name, node_url: applied.append(name)
+        or ToolResult(name, "note" if name == "pi" else "wrote", "ok", snippet="{}"),
+    )
+    # The checkbox returns cursor + zed; codex (preselected) was deselected.
+    monkeypatch.setattr("kb.prompt.checkbox_select", lambda header, options, checked: {0, 2})
+
+    _wire_detected_tools("https://node.example", color=False)
+    out = capsys.readouterr().out
+    assert applied == ["cursor", "zed", "pi"]  # pi is the always-shown note
+    assert "Cursor" in out and "wrote" in out
+    assert "paste into" in out  # zed snippet printed
+
+
+def test_wire_detected_tools_skip_selects_nothing(monkeypatch, capsys) -> None:
+    from kb.cli import _wire_detected_tools
+    from kb.tool_detect import ToolResult
+
+    applied: list[str] = []
+    monkeypatch.setattr("kb.tool_detect.detect", lambda: ["cursor", "codex"])
+    monkeypatch.setattr(
+        "kb.tool_detect.apply",
+        lambda name, node_url: applied.append(name) or ToolResult(name, "wrote", "ok"),
+    )
+    monkeypatch.setattr("kb.prompt.checkbox_select", lambda *a: None)  # user pressed q
+    _wire_detected_tools("https://node.example", color=False)
+    assert applied == []
+
+
+def test_stale_env_hint_points_at_shell_rc(tmp_path: Path, monkeypatch) -> None:
+    from kb.cli import _stale_env_hint
+    from kb.onboard import ensure_token_in_rc
+
+    rc = tmp_path / ".zshrc"
+    ensure_token_in_rc(rc, "ctdl_fresh_1234567890")
+    monkeypatch.setattr("kb.cli.detect_shell_rc", lambda: rc)
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_stale_1234567890")
+
+    hint = _stale_env_hint(401)
+    assert hint and "source" in hint and str(rc) in hint
+    assert _stale_env_hint(500) is None  # only auth failures
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_fresh_1234567890")
+    assert _stale_env_hint(401) is None  # env matches rc → different problem
+
+
 # ---- capture-roots wizard -----------------------------------------------------
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -4,8 +4,11 @@ import argparse
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
-from kb.cli import _doctor, _ingest, _search
+import pytest
+
+from kb.cli import _doctor, _ingest, _search, _token_set, _update, _wizard_roots
 from kb.status import Check, StatusReport
 
 
@@ -147,3 +150,153 @@ def test_ingest_cognifies_by_default(monkeypatch, capsys) -> None:
     assert rc == 0
     assert seen["cognify"] is True
     assert json.loads(capsys.readouterr().out)["cognified"] is True
+
+
+# ---- citadel token set --------------------------------------------------------
+
+
+def _token_set_args(tmp_path: Path, **kw) -> argparse.Namespace:
+    base = dict(
+        token="ctdl_rotated_4567890",
+        shell_rc=str(tmp_path / ".zshrc"),
+        node_url="https://node.example",
+        skip_verify=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_token_set_verifies_then_writes_rc(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "kb.status.check_auth",
+        lambda *a, **k: Check("auth", True, "valid", data={"seat_slug": "sarthi", "role": "writer"}),
+    )
+    rc = asyncio.run(_token_set(_token_set_args(tmp_path)))
+    assert rc == 0
+    assert "ctdl_rotated_4567890" in (tmp_path / ".zshrc").read_text()
+    assert "…7890" in capsys.readouterr().out
+
+
+def test_token_set_rejected_token_writes_nothing(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "kb.status.check_auth", lambda *a, **k: Check("auth", False, "HTTP Error 401: Unauthorized")
+    )
+    rc = asyncio.run(_token_set(_token_set_args(tmp_path)))
+    assert rc == 1
+    assert not (tmp_path / ".zshrc").exists()  # a bad token must not clobber a working one
+    assert "nothing written" in capsys.readouterr().err
+
+
+def test_token_set_skip_verify_writes_offline(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "kb.status.check_auth", lambda *a, **k: pytest.fail("verified despite --skip-verify")
+    )
+    rc = asyncio.run(_token_set(_token_set_args(tmp_path, skip_verify=True)))
+    assert rc == 0
+    assert "ctdl_rotated_4567890" in (tmp_path / ".zshrc").read_text()
+
+
+def test_token_set_no_token_no_tty_exits_two(tmp_path: Path, capsys) -> None:
+    rc = asyncio.run(_token_set(_token_set_args(tmp_path, token=None)))
+    assert rc == 2
+    assert "no TTY" in capsys.readouterr().err
+
+
+# ---- citadel update -----------------------------------------------------------
+
+
+def test_update_editable_install_is_left_alone(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli._install_channel", lambda: ("editable", "file:///src/citadel"))
+    monkeypatch.setattr("kb.cli.subprocess.run", lambda *a, **k: pytest.fail("must not shell out"))
+    rc = asyncio.run(_update(argparse.Namespace()))
+    assert rc == 0
+    assert "git pull" in capsys.readouterr().out
+
+
+def test_update_pipx_already_latest(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli._install_channel", lambda: ("pipx", "/usr/bin/pipx"))
+    monkeypatch.setattr(
+        "kb.cli.subprocess.run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout="citadel-archive is already at latest version 0.2.1 (location: …)",
+            stderr="",
+        ),
+    )
+    rc = asyncio.run(_update(argparse.Namespace()))
+    assert rc == 0
+    assert "already up to date" in capsys.readouterr().out
+
+
+def test_update_pipx_upgraded(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli._install_channel", lambda: ("pipx", "/usr/bin/pipx"))
+    monkeypatch.setattr(
+        "kb.cli.subprocess.run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0,
+            stdout="upgraded package citadel-archive from 0.2.1 to 0.3.0 (location: …)",
+            stderr="",
+        ),
+    )
+    rc = asyncio.run(_update(argparse.Namespace()))
+    assert rc == 0
+    assert "upgraded package citadel-archive" in capsys.readouterr().out
+
+
+def test_update_pipx_failure_exits_one(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli._install_channel", lambda: ("pipx", "/usr/bin/pipx"))
+    monkeypatch.setattr(
+        "kb.cli.subprocess.run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+    )
+    rc = asyncio.run(_update(argparse.Namespace()))
+    assert rc == 1
+    assert "boom" in capsys.readouterr().err
+
+
+def test_update_unmanaged_install_prints_instructions(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli._install_channel", lambda: ("other", ""))
+    rc = asyncio.run(_update(argparse.Namespace()))
+    assert rc == 0
+    assert "pip install --upgrade citadel-archive" in capsys.readouterr().out
+
+
+# ---- capture-roots wizard -----------------------------------------------------
+
+
+def test_wizard_offers_home_relative_guess_for_missing_root(tmp_path: Path, monkeypatch, capsys) -> None:
+    # "/masumi" for ~/masumi is the common typo — the wizard should offer the
+    # home-relative dir that actually exists instead of recording a dead root.
+    from kb.capture_config import CaptureConfig
+
+    (tmp_path / "masumi").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    answers = iter(["/masumi", "", "", ""])  # path → accept guess → default tags → finish
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    config = _wizard_roots(CaptureConfig(node_url="https://node.example"))
+    assert [root.path for root in config.roots] == [str(tmp_path / "masumi")]
+
+
+def test_wizard_enter_accepts_default_root(tmp_path: Path, monkeypatch) -> None:
+    # The dir the user ran `citadel` from is offered as a press-Enter default —
+    # no copy-pasting the path you're already standing in.
+    from kb.capture_config import CaptureConfig
+
+    answers = iter(["", "", ""])  # accept default → default tags → finish
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    config = _wizard_roots(CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path))
+    assert [root.path for root in config.roots] == [str(tmp_path)]
+    assert "personal" in config.roots[0].tags
+
+
+def test_wizard_default_suppressed_when_already_approved(tmp_path: Path, monkeypatch) -> None:
+    from kb.capture_config import CaptureConfig
+
+    existing = CaptureConfig(node_url="https://node.example").with_root(str(tmp_path), ("personal",))
+    answers = iter([""])  # no default on offer → Enter just finishes
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    config = _wizard_roots(existing, default_root=str(tmp_path))
+    assert len(config.roots) == 1  # not duplicated

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -42,7 +42,7 @@ def test_bare_citadel_shows_home_screen(monkeypatch, capsys) -> None:
     assert exc.value.code == 0
     out = capsys.readouterr().out
     assert "the organization vault" in out         # hero tagline
-    assert "▛▜" in out                              # castle hero art
+    assert "____" in out                            # CITADEL wordmark hero
     assert "onboard" in out and "status" in out     # curated command menu
     assert "Get started" in out                     # grouped menu
 

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -257,6 +257,40 @@ def test_read_token_from_rc_handles_manual_lines(tmp_path: Path) -> None:
     assert read_token_from_rc(tmp_path / "missing") == ""
 
 
+def test_read_token_from_rc_quoted_value_with_trailing_comment(tmp_path: Path) -> None:
+    # A hand-edited line with a comment must not leak the quote chars into the
+    # token (Bearer 'ctdl_…' would 401 a perfectly valid setup).
+    rc = tmp_path / ".zshrc"
+    rc.write_text(f"export {TOKEN_ENV}='ctdl_abc123'  # citadel seat\n")
+    assert read_token_from_rc(rc) == "ctdl_abc123"
+
+
+def test_read_token_from_rc_last_export_wins_like_the_shell(tmp_path: Path) -> None:
+    rc = tmp_path / ".zshrc"
+    rc.write_text(
+        f"export {TOKEN_ENV}='ctdl_first_1234567890'\n"
+        f"export {TOKEN_ENV}=ctdl_last_0987654321\n"
+    )
+    assert read_token_from_rc(rc) == "ctdl_last_0987654321"
+
+
+def test_ensure_env_in_rc_rewrites_last_duplicate(tmp_path: Path) -> None:
+    # The shell honors the LAST export; rotation must rewrite that one, or the
+    # new token is silently shadowed by the trailing duplicate.
+    from kb.onboard import ensure_env_in_rc
+
+    rc = tmp_path / ".zshrc"
+    rc.write_text(
+        f"export {TOKEN_ENV}='ctdl_old_a'\n"
+        f"export {TOKEN_ENV}='ctdl_old_b'\n"
+    )
+    assert ensure_env_in_rc(rc, TOKEN_ENV, "ctdl_new_c", comment="x") == "updated"
+    lines = rc.read_text().splitlines()
+    assert lines[0] == f"export {TOKEN_ENV}='ctdl_old_a'"  # untouched (shadowed anyway)
+    assert lines[1] == f"export {TOKEN_ENV}='ctdl_new_c'"  # the shell-effective line
+    assert read_token_from_rc(rc) == "ctdl_new_c"  # reader agrees with the shell
+
+
 def _interactive_onboard_args(tmp_path: Path) -> argparse.Namespace:
     repo = _make_repo(tmp_path)
     return argparse.Namespace(
@@ -314,6 +348,28 @@ def test_onboard_keep_answer_reuses_env_token(tmp_path: Path, monkeypatch, capsy
     assert "ctdl_env_1234567890" in Path(args.shell_rc).read_text()
     out = capsys.readouterr().out
     assert "authenticated" in out  # identity panel shown up front
+
+
+def test_onboard_rc_token_wins_over_stale_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    # A rotation written to the rc must not be silently reverted by onboarding
+    # from an old shell whose env still exports the superseded token.
+    monkeypatch.setenv(TOKEN_ENV, "ctdl_stale_env_67890")
+    args = _interactive_onboard_args(tmp_path)
+    rc_file = Path(args.shell_rc)
+    ensure_token_in_rc(rc_file, "ctdl_rotated_rc_4321")
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    answers = iter([""])  # keep
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    pastes = iter([""])  # skip OpenRouter key
+    monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
+    monkeypatch.setattr("kb.status.check_auth", lambda *a, **k: _auth_ok())
+
+    assert asyncio.run(_onboard(args)) == 0
+    out = capsys.readouterr().out
+    assert "…4321" in out  # the rc (rotated) token is the one offered
+    body = rc_file.read_text()
+    assert "ctdl_rotated_rc_4321" in body and "ctdl_stale_env_67890" not in body
 
 
 def test_onboard_rejected_token_offers_immediate_replacement(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -18,7 +18,9 @@ from kb.onboard import (
     mcp_server_block,
     merge_claude_settings,
     merge_mcp_config,
+    read_token_from_rc,
 )
+from kb.status import Check
 
 
 def test_detect_shell_rc(monkeypatch, tmp_path: Path) -> None:
@@ -237,3 +239,102 @@ def test_onboard_no_token_non_interactive_exits_one(tmp_path: Path, monkeypatch,
     rc = asyncio.run(_onboard(args))
     assert rc == 1
     assert "no token" in capsys.readouterr().err
+
+
+def test_read_token_from_rc_roundtrips_nasty_token(tmp_path: Path) -> None:
+    rc = tmp_path / ".zshrc"
+    nasty = "ctdl_a'b$(whoami)`id`"
+    ensure_token_in_rc(rc, nasty)
+    assert read_token_from_rc(rc) == nasty  # exact inverse of the writer
+
+
+def test_read_token_from_rc_handles_manual_lines(tmp_path: Path) -> None:
+    rc = tmp_path / ".zshrc"
+    rc.write_text(f"{TOKEN_ENV}=ctdl_plain_no_quotes\n")
+    assert read_token_from_rc(rc) == "ctdl_plain_no_quotes"
+    rc.write_text(f'export {TOKEN_ENV}="ctdl_double_quoted"\n')
+    assert read_token_from_rc(rc) == "ctdl_double_quoted"
+    assert read_token_from_rc(tmp_path / "missing") == ""
+
+
+def _interactive_onboard_args(tmp_path: Path) -> argparse.Namespace:
+    repo = _make_repo(tmp_path)
+    return argparse.Namespace(
+        token=None,
+        repo=str(repo),
+        shell_rc=str(tmp_path / ".zshrc"),
+        no_mcp=True,
+        no_capture=True,
+        no_tools=True,
+        non_interactive=False,
+    )
+
+
+def _auth_ok() -> Check:
+    return Check(
+        "auth", ok=True, detail="valid",
+        data={"seat_slug": "sarthi", "role": "writer", "capabilities": {"read": True, "write": True}},
+    )
+
+
+def test_onboard_offers_keep_or_replace_for_configured_token(tmp_path: Path, monkeypatch, capsys) -> None:
+    # Token already wired in the rc (fresh shell: env unset) → onboard must show
+    # it masked and let the user swap in a new one instead of silently reusing it.
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    args = _interactive_onboard_args(tmp_path)
+    rc_file = Path(args.shell_rc)
+    ensure_token_in_rc(rc_file, "ctdl_old_1234567890")
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    answers = iter(["n"])  # replace, don't keep
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    pastes = iter(["ctdl_new_abcdef12345", ""])  # new token, then skip OpenRouter key
+    monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
+    monkeypatch.setattr("kb.status.check_auth", lambda *a, **k: _auth_ok())
+
+    assert asyncio.run(_onboard(args)) == 0
+    out = capsys.readouterr().out
+    assert "…7890" in out  # the existing token shown masked
+    body = rc_file.read_text()
+    assert "ctdl_new_abcdef12345" in body and "ctdl_old_1234567890" not in body
+
+
+def test_onboard_keep_answer_reuses_env_token(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv(TOKEN_ENV, "ctdl_env_1234567890")
+    args = _interactive_onboard_args(tmp_path)
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    answers = iter([""])  # enter → keep
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    pastes = iter([""])  # skip OpenRouter key
+    monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
+    monkeypatch.setattr("kb.status.check_auth", lambda *a, **k: _auth_ok())
+
+    assert asyncio.run(_onboard(args)) == 0
+    assert "ctdl_env_1234567890" in Path(args.shell_rc).read_text()
+    out = capsys.readouterr().out
+    assert "authenticated" in out  # identity panel shown up front
+
+
+def test_onboard_rejected_token_offers_immediate_replacement(tmp_path: Path, monkeypatch, capsys) -> None:
+    # A 401 must surface before the other prompts, with an inline re-paste —
+    # not "saved anyway" at the very end of the run.
+    monkeypatch.setenv(TOKEN_ENV, "ctdl_stale_234567890")
+    args = _interactive_onboard_args(tmp_path)
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    answers = iter(["", "y"])  # keep existing → then agree to re-paste after the 401
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    pastes = iter(["ctdl_fresh_bcdef12345", ""])  # replacement token, skip OpenRouter key
+    monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
+    verdicts = iter([
+        Check("auth", ok=False, detail="HTTP Error 401: Unauthorized"),
+        _auth_ok(),
+    ])
+    monkeypatch.setattr("kb.status.check_auth", lambda *a, **k: next(verdicts))
+
+    assert asyncio.run(_onboard(args)) == 0
+    out = capsys.readouterr().out
+    assert "rejected" in out and "401" in out
+    body = Path(args.shell_rc).read_text()
+    assert "ctdl_fresh_bcdef12345" in body and "ctdl_stale_234567890" not in body


### PR DESCRIPTION
## What

Two batches of CLI UX work, all stdlib-only, driven by live onboarding feedback:

### Token lifecycle
- **onboard keep-or-replace**: an already-configured token (env, or parsed from the shell rc via new `kb.onboard.read_token_from_rc` — works in a fresh shell) is shown masked with a keep/replace prompt instead of being silently reused.
- **Verify first**: the token is checked against the Node *before* any other prompts; the identity panel (seat/role/access) prints up front. A 401/403 offers an immediate hidden re-paste loop instead of \"saved anyway\" at the end.
- **`citadel token set [TOKEN]`**: rotate the seat token without re-running onboard. Verifies first — a rejected token writes nothing (`--skip-verify` overrides); rewrites the rc export in place and reminds you to `source` it.
- **Stale-shell hint**: `ingest`/`search`/`capture` hitting 401/403 while the rc token differs from env now print the actual fix (`source ~/.zshrc`).

### Onboard flow
- **Checkbox tool selection** (`kb/prompt.py`): the coding-tools step is one arrow-key multi-select (↑/↓ · space · a/n · enter · q; cbreak so Ctrl-C still exits 130) with a numeric-toggle fallback when raw mode isn't available. Selection is applied under the spinner. Write-tier tools preselected, snippet-tier off — same defaults as the old per-tool Y/n.
- **Capture-roots wizard**: the dir you ran `citadel` from (repo toplevel on onboard, cwd on setup) is a press-Enter default; a missing root like `/masumi` offers the home-relative `~/masumi` that exists.

### Self-update + brand
- **`citadel update`** (alias `upgrade`): pipx installs run `pipx upgrade --pip-args=--no-cache-dir`; editable/source checkouts are told to `git pull`; anything else gets printed instructions. Fixes the `pipx install` → \"already seems to be installed\" dead end.
- **Brand hero**: bare `citadel` shows just the CITADEL wordmark in brand colors — Masumi magenta `#FA008C` → cyan truecolor gradient (`COLORTERM`), bold-cyan fallback. The compact castle stays as the in-command mark and gains an arched gate. Home screen shows the version and falls back to the compact banner on narrow terminals.

## Testing

- Suite: **630 pass** (25 new: rc token parsing roundtrip, interactive keep/replace + 401 re-paste via monkeypatched prompts, token-set verify/reject/skip, update channels, checkbox fallback toggle, wire-tools selection, stale-env hint, wizard defaults, banner/brand assertions).
- Live against prod Node: `citadel token set ctdl_bogus…` → 401 → nothing written, exit 1; `citadel update` on the editable install → \"git pull\" path; onboarding re-run end-to-end by @sarthib7 (6/6 steps wired).

CLI-only change: no server routes touched; Railway deploy of this merge is a no-op for the API surface.