### PR TITLE
Release v0.2.2 — CLI UX sprint (tagline highlight + version bump + docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ All notable changes to `citadel-archive` are documented here. Format follows
   home-relative dir that does (`~/masumi`) instead of recording a dead root.
 - **Brand-color hero** — the opening art is now just the CITADEL wordmark in
   brand colors: a Masumi-magenta → cyan gradient on truecolor terminals, bold
-  cyan elsewhere. The compact castle banner (the mark) stays as the in-command
+  cyan elsewhere, and the "the organization vault" tagline highlighted in
+  brand magenta. The compact castle banner (the mark) stays as the in-command
   header and gains an arched gate; the home screen falls back to it on narrow
   terminals and shows the installed version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.2] — 2026-07-02
 
 ### Added
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -177,8 +177,7 @@ Install the standalone client (zero-dep base) — no clone, no `uv`:
 
 ```bash
 pipx install citadel-archive
-# upgrade: pipx install --force citadel-archive --pip-args=--no-cache-dir
-#          (plain `pipx upgrade` can land a stale cached build)
+# upgrade: citadel update   (pipx-aware self-update; skips the stale wheel cache)
 # bootstrap installer: curl -fsSL https://raw.githubusercontent.com/masumi-network/Citadel-Archive/main/install.sh | sh
 ```
 
@@ -189,7 +188,10 @@ run the in-process server stack instead (needs the `[server]` extra).
 ```bash
 citadel search "What did I learn about Railway?"        # HTTP-backed by default
 citadel ingest "A useful note" --tag personal --tag research
-citadel onboard            # token + git/Claude hooks + .mcp.json + capture roots
+citadel onboard            # token (keep-or-replace, verified up front) + hooks +
+                           # .mcp.json + capture roots + checkbox tool selection
+citadel token set          # rotate this machine's seat token (verify-first)
+citadel update             # self-update the CLI (alias: upgrade)
 citadel doctor --fix       # diagnose / repair local setup
 citadel mcp add claude     # add the Citadel MCP server to a client (`citadel mcp list`)
 citadel seat create        # admin: mint a seat token (needs CITADEL_ADMIN_KEY)

--- a/kb/__init__.py
+++ b/kb/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 # hatchling dynamic versioning, and server discovery / the CLI fall back to it
 # when the package is not dist-installed (the Railway node runs from source, so
 # importlib.metadata.version raises there). Keeps server + CLI from drifting.
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 if TYPE_CHECKING:
     from kb.config import CitadelConfig

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -132,6 +132,21 @@ def mark(ok: bool, *, enable: bool = True) -> str:
     return paint(glyph(ok), "green" if ok else "red", enable=enable)
 
 
+def tagline(*, color: bool = True) -> str:
+    """The brand tagline under the hero — highlighted in brand magenta on
+    capable terminals (256-color approximation below truecolor), cyan on
+    basic ones, plain when piped."""
+    text = "the organization vault"
+    if not color:
+        return text
+    r, g, b = _BRAND_MAGENTA
+    if supports_truecolor():
+        return f"\033[38;2;{r};{g};{b}m{text}{_ANSI['reset']}"
+    if "256color" in os.getenv("TERM", ""):
+        return f"\033[38;5;{_ansi256(_BRAND_MAGENTA)}m{text}{_ANSI['reset']}"
+    return paint(text, "cyan")
+
+
 def banner_large(*, color: bool = True) -> str:
     """The big hero: the CITADEL wordmark in brand colors — a magenta→cyan
     gradient (24-bit, or the xterm-256 approximation), bold cyan on basic

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -50,7 +50,7 @@ from kb.onboard import (
     merge_mcp_config,
     read_token_from_rc,
 )
-from kb.banner import HERO_WIDTH, SKIP, banner, banner_large, mark, paint, supports_color
+from kb.banner import HERO_WIDTH, SKIP, banner, banner_large, mark, paint, supports_color, tagline
 from kb.access_client import (
     AccessClientError,
     create_seat,
@@ -1629,7 +1629,7 @@ def _print_home() -> None:
     if cols >= HERO_WIDTH + 2:
         print(banner_large(color=color))
         print()
-        print("  " + paint("the organization vault", "dim", enable=color))
+        print("  " + tagline(color=color))
     else:
         # Narrow terminal: the compact castle (wordmark + tagline inline)
         # instead of a wrapped, mangled hero.

--- a/tasks.md
+++ b/tasks.md
@@ -1,5 +1,36 @@
 # Citadel Tasks
 
+## CLI UX sprint (2026-07-02) — SHIPPED as v0.2.2 (PR #72 + tagline follow-up)
+
+Full change list: [`CHANGELOG.md` § 0.2.2](CHANGELOG.md).
+
+- [x] Onboard token flow: keep-or-replace for an existing token (rc wins over a
+      stale env), verification + identity panel up front, 401 re-paste loop
+- [x] `citadel token set` (verify-first rotation) · `citadel update`/`upgrade`
+      (pipx-aware self-update)
+- [x] Checkbox multi-select for onboard coding-tools (`kb/prompt.py`; raw-fd
+      keys, Esc/CSI-safe, width-clipped repaint, numeric fallback)
+- [x] Capture-roots wizard: declinable press-Enter default (repo/cwd),
+      `/masumi`→`~/masumi` did-you-mean, post-wizard seed keeps #43 guarantee
+- [x] Brand hero: CITADEL wordmark in magenta `#FA008C`→cyan gradient
+      (truecolor/256/bold-cyan tiers) + magenta tagline; compact castle stays
+      the in-command mark (arched gate)
+- [x] Stale-shell 401/403 hint on ingest/search/capture (`source ~/.zshrc`)
+- [x] Pre-merge workflow code review: 10 verified findings, all fixed
+      (rc parsing via shlex + last-export-wins, EOF-safe prompts, termios
+      degradation, repaint clipping). Suite 637 pass.
+
+**Todos / carry-over:**
+
+- [ ] sarthi's seat token 403s against prod (predates v0.2.2) — mint fresh
+      (`citadel seat token sarthi` with admin key), then `citadel token set`
+- [ ] Release gates from the read-side sprint: rotate secrets · verify #69 on
+      the node · profile #50
+- [ ] Deferred CLI refactors: global `--json`/`--node-url` parent-parser,
+      did-you-mean for subparser typos
+- [ ] Event-driven sync (GitHub/Linear webhooks → per-event ingest +
+      incremental cognify) to replace polling — user-preferred next project
+
 ## Read-side hardening sprint (issues #25–#53) — ~SHIPPED (16 closed, 4 pending verify)
 
 Plan + full status: [`docs/read-side-hardening-sprint.md`](docs/read-side-hardening-sprint.md)

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 import io
 
-from kb.banner import banner, banner_large, paint, supports_color
+from kb.banner import banner, banner_large, paint, supports_color, tagline
+
+
+def test_tagline_is_brand_highlighted(monkeypatch) -> None:
+    assert tagline(color=False) == "the organization vault"  # plain when piped
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    assert "\033[38;2;250;0;140m" in tagline(color=True)  # brand magenta
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert "\033[38;5;" in tagline(color=True)  # 256-color approximation
+    monkeypatch.setenv("TERM", "xterm")
+    assert "\033[36m" in tagline(color=True)  # cyan fallback
 
 
 def test_banner_large_is_the_brand_wordmark(monkeypatch) -> None:


### PR DESCRIPTION
Rolls up the release of the CLI UX sprint:

- **feat/hero-tagline-highlight** merged in: "the organization vault" under the hero is brand magenta `#FA008C` (truecolor / 256 / cyan tiers), matching the wordmark gradient.
- **Version bump** `0.2.1` → `0.2.2` (`kb.__version__`, single source of truth).
- **CHANGELOG**: Unreleased → `[0.2.2] — 2026-07-02` (token set / update / checkbox onboard / brand hero / wizard defaults / stale-shell hint).
- **SKILL.md**: CLI quick-ref updated (`citadel token set`, `citadel update`, checkbox onboard); upgrade hint now points at the self-updater.
- **tasks.md**: CLI UX sprint progress + carry-over todos (prod token 403, read-side release gates, deferred parser refactors, event-driven sync).

Suite: **637 pass**. After merge: tag `v0.2.2` → PyPI via Trusted Publishing (publish.yml).