### PR TITLE
feat(cli): seat-bound token create with picker + seat-dataset validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to `citadel-archive` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Seat-bound `citadel token create`** — `--seat <slug>` mints a token bound
+  to an existing seat (it inherits the seat's role and private dataset;
+  `--role`/`--kind`/`--expires-at` are standalone-only and rejected alongside
+  `--seat`). On a TTY with no `--seat`/`--dataset` and none of the standalone
+  flags, an interactive picker offers the active seats or a standalone
+  service-account token (`0`, empty to cancel). `citadel seat token <slug>`
+  stays as the re-mint shortcut for an existing seat.
+
+### Changed
+
+- **`citadel token create --dataset <value>`** — a value that names a seat (or
+  uses the `seat:` prefix) is now rejected with a redirect to `--seat`, since a
+  bare `default_dataset` pointing at seat-private memory would only mint a
+  token the Node 403s. Explicitly empty `--seat ""`/`--dataset ""` (the unset
+  shell-variable footgun) are usage errors (exit 2) instead of silently
+  minting a standalone token.
+
 ## [0.2.2] — 2026-07-02
 
 ### Added

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -834,15 +834,116 @@ async def _seat_token(args: argparse.Namespace) -> int:
     return 0
 
 
+class _PickerAborted(Exception):
+    """The user cancelled the interactive seat picker (empty answer / EOF)."""
+
+
+def _active_seats(base_url: str) -> list[dict[str, Any]]:
+    result = list_seats(base_url=base_url)
+    return [seat for seat in (result.get("seats") or []) if not seat.get("disabled")]
+
+
+def _pick_seat(seats: list[dict[str, Any]]) -> str | None:
+    """Interactive seat picker for `token create` — a slug, or None for standalone."""
+    color = supports_color()
+    print("Assign this token to a seat (its writes land in that seat's private node):")
+    for index, seat in enumerate(seats, start=1):
+        slug = paint(str(seat.get("seat_slug")), "cyan", enable=color)
+        print(f"  {index}) {slug}  {seat.get('name', '')}  role={seat.get('role')}")
+    print("  0) standalone service-account token (no seat)")
+    while True:
+        answer = _prompt(f"Select [0-{len(seats)}]: ").strip()
+        if not answer:
+            raise _PickerAborted
+        if answer.isdigit() and int(answer) <= len(seats):
+            choice = int(answer)
+            return None if choice == 0 else str(seats[choice - 1].get("seat_slug"))
+        print(f"  enter a number between 0 and {len(seats)} (empty to cancel)")
+
+
+def _print_seat_token_result(result: dict[str, Any]) -> None:
+    color = supports_color()
+    principal = result.get("principal", {})
+    print(
+        paint(
+            f"New token for seat {principal.get('seat_slug')}  (dataset {principal.get('default_dataset')})",
+            "green",
+            enable=color,
+        )
+    )
+    if result.get("token"):
+        _print_minted_token(result["token"], result.get("api_token", {}), color=color)
+
+
 async def _token_create(args: argparse.Namespace) -> int:
     as_json = args.json
+    base_url = node_base_url(args.node_url)
+    seat_slug = args.seat
+    dataset = args.dataset
+
+    if seat_slug and dataset:
+        print("citadel token create: choose --seat or --dataset, not both.", file=sys.stderr)
+        return 2
+    if seat_slug and (args.role or args.kind or args.expires_at):
+        print(
+            "citadel token create: seat tokens inherit the seat's role — "
+            "--role/--kind/--expires-at only apply to standalone tokens.",
+            file=sys.stderr,
+        )
+        return 2
+
     try:
+        # Interactive picker: TTY, human output, and no explicit target given.
+        if not seat_slug and not dataset and not as_json and sys.stdin.isatty() and sys.stdout.isatty():
+            try:
+                seat_slug = _pick_seat(_active_seats(base_url))
+            except _PickerAborted:
+                print("citadel token create: cancelled.", file=sys.stderr)
+                return 1
+
+        if seat_slug:
+            known = {seat.get("seat_slug") for seat in _active_seats(base_url)}
+            if seat_slug not in known:
+                listing = ", ".join(sorted(str(slug) for slug in known)) or "none yet — `citadel seat create`"
+                print(
+                    f"citadel token create: no seat '{seat_slug}'. Seats: {listing}",
+                    file=sys.stderr,
+                )
+                return 1
+            result = issue_seat_token(seat_slug, base_url=base_url, token_name=args.name)
+            if as_json:
+                _print_json(result)
+            else:
+                _print_seat_token_result(result)
+            return 0
+
+        if dataset:
+            # The seat: namespace is private memory — seat tokens must come from
+            # --seat so they carry the seat identity and allowlist, not a bare
+            # default_dataset that the Node will 403.
+            slug = dataset.removeprefix("seat:")
+            known = {seat.get("seat_slug") for seat in _active_seats(base_url)}
+            if dataset.startswith("seat:") or slug in known:
+                if slug in known:
+                    print(
+                        f"citadel token create: '{dataset}' is a seat — mint a seat-bound token: "
+                        f"citadel token create \"{args.name}\" --seat {slug}",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"citadel token create: no seat '{slug}' — create it first: "
+                        f"citadel seat create \"Name\" {slug}",
+                        file=sys.stderr,
+                    )
+                return 1
+
         result = create_token(
-            base_url=node_base_url(args.node_url),
+            base_url=base_url,
             name=args.name,
-            role=args.role,
-            kind=args.kind,
-            default_dataset=args.dataset,
+            role=args.role or "reader",
+            kind=args.kind or "service_account",
+            default_dataset=dataset,
             expires_at=args.expires_at,
         )
     except AccessClientError as exc:
@@ -1927,7 +2028,8 @@ def build_parser() -> argparse.ArgumentParser:
     seat_create.set_defaults(handler=_seat_create)
 
     seat_token = seat_sub.add_parser(
-        "token", help="Mint a fresh token for an EXISTING seat (re-link a lost seat token)"
+        "token",
+        help="Mint a fresh token for an EXISTING seat (alias of `citadel token create --seat <slug>`)",
     )
     seat_token.add_argument("slug", help="Seat slug, e.g. sarthi")
     seat_token.add_argument("--json", action="store_true", help="Machine-readable output")
@@ -1953,18 +2055,24 @@ def build_parser() -> argparse.ArgumentParser:
     token_set.set_defaults(handler=_token_set)
 
     token_create = token_sub.add_parser(
-        "create", help="Issue a standalone (service-account) token, printed once"
+        "create",
+        help="Issue a token, printed once — seat-bound (--seat, or interactive picker) or standalone",
     )
     token_create.add_argument("name", help="Token name/label")
     token_create.add_argument(
-        "--role", default="reader", choices=("reader", "writer", "admin"),
-        help="Token role (default: reader)",
+        "--seat", help="Bind the token to an EXISTING seat by slug (omit for an interactive picker)"
     )
     token_create.add_argument(
-        "--kind", default="service_account", choices=("service_account", "user"),
-        help="Principal kind (default: service_account)",
+        "--role", default=None, choices=("reader", "writer", "admin"),
+        help="Standalone-token role (default: reader; seat tokens inherit the seat's role)",
     )
-    token_create.add_argument("--dataset", help="Default dataset for the token")
+    token_create.add_argument(
+        "--kind", default=None, choices=("service_account", "user"),
+        help="Standalone-token principal kind (default: service_account)",
+    )
+    token_create.add_argument(
+        "--dataset", help="Default dataset for a standalone token (for seats use --seat)"
+    )
     token_create.add_argument("--expires-at", help="ISO 8601 expiry timestamp (optional)")
     token_create.add_argument("--json", action="store_true", help="Machine-readable output")
     token_create.add_argument("--node-url", help="Override Node URL")

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -881,6 +881,14 @@ async def _token_create(args: argparse.Namespace) -> int:
     seat_slug = args.seat
     dataset = args.dataset
 
+    # Explicit-but-blank values (--seat "$SLUG" with the var unset) must not read
+    # as "flag omitted" — that would silently mint a standalone token with exit 0.
+    if seat_slug is not None and not seat_slug.strip():
+        print("citadel token create: --seat needs a seat slug.", file=sys.stderr)
+        return 2
+    if dataset is not None and not dataset.strip():
+        print("citadel token create: --dataset needs a dataset name.", file=sys.stderr)
+        return 2
     if seat_slug and dataset:
         print("citadel token create: choose --seat or --dataset, not both.", file=sys.stderr)
         return 2
@@ -894,7 +902,17 @@ async def _token_create(args: argparse.Namespace) -> int:
 
     try:
         # Interactive picker: TTY, human output, and no explicit target given.
-        if not seat_slug and not dataset and not as_json and sys.stdin.isatty() and sys.stdout.isatty():
+        # --role/--kind/--expires-at signal standalone intent (and minted
+        # immediately before seat binding existed) — never route them into the
+        # picker, where a picked seat would silently drop them.
+        if (
+            not seat_slug
+            and not dataset
+            and not (args.role or args.kind or args.expires_at)
+            and not as_json
+            and sys.stdin.isatty()
+            and sys.stdout.isatty()
+        ):
             try:
                 seat_slug = _pick_seat(_active_seats(base_url))
             except _PickerAborted:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -542,3 +542,44 @@ def test_pick_seat_choices() -> None:
             _pick_seat(SEATS)
     finally:
         builtins.input = original
+
+
+def test_token_create_empty_seat_is_usage_error(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(seat="")))
+    assert rc == 2
+    assert "--seat needs a seat slug" in capsys.readouterr().err
+    assert not calls
+
+
+def test_token_create_blank_dataset_is_usage_error(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(dataset="  ")))
+    assert rc == 2
+    assert "--dataset needs a dataset name" in capsys.readouterr().err
+    assert not calls
+
+
+def test_token_create_standalone_flags_skip_picker_on_tty(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(
+        "kb.cli._pick_seat",
+        lambda seats: pytest.fail("picker must not run when standalone flags are explicit"),
+    )
+    rc = asyncio.run(
+        _token_create(
+            _token_create_args(json=False, role="writer", expires_at="2027-01-01T00:00:00Z")
+        )
+    )
+    assert rc == 0
+    assert calls["standalone"]["role"] == "writer"
+    assert calls["standalone"]["expires_at"] == "2027-01-01T00:00:00Z"
+    assert "seat" not in calls

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -408,3 +408,137 @@ def test_wizard_default_suppressed_when_already_approved(tmp_path: Path, monkeyp
 
     config = _wizard_roots(existing, default_root=str(tmp_path))
     assert len(config.roots) == 1  # not duplicated
+
+
+# ---- citadel token create (seat binding) ---------------------------------------
+
+
+SEATS = [
+    {"seat_slug": "alice", "name": "Alice", "role": "writer", "disabled": False},
+    {"seat_slug": "sarthi", "name": "Sarthi", "role": "writer", "disabled": False},
+]
+
+
+def _token_create_args(**kw):
+    base = dict(
+        name="ci-bot", seat=None, dataset=None, role=None, kind=None,
+        expires_at=None, json=True, node_url="https://node.example",
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _wire_access(monkeypatch, *, seats=None):
+    calls = {}
+
+    def fake_issue_seat_token(slug, **k):
+        calls["seat"] = (slug, k.get("token_name"))
+        return {"ok": True, "token": "ctdl_seat", "principal": {"seat_slug": slug}, "api_token": {}}
+
+    def fake_create_token(**k):
+        calls["standalone"] = k
+        return {"ok": True, "token": "ctdl_standalone", "principal": {"id": "p1"}, "api_token": k}
+
+    monkeypatch.setattr("kb.cli.list_seats", lambda **k: {"seats": seats if seats is not None else SEATS})
+    monkeypatch.setattr("kb.cli.issue_seat_token", fake_issue_seat_token)
+    monkeypatch.setattr("kb.cli.create_token", fake_create_token)
+    return calls
+
+
+def test_token_create_seat_and_dataset_conflict(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(seat="alice", dataset="x")))
+    assert rc == 2
+    assert "not both" in capsys.readouterr().err
+
+
+def test_token_create_seat_rejects_role_flags(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(seat="alice", role="admin")))
+    assert rc == 2
+    assert "inherit" in capsys.readouterr().err
+
+
+def test_token_create_seat_mints_via_seat_endpoint(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(seat="alice")))
+    assert rc == 0
+    assert calls["seat"] == ("alice", "ci-bot")
+    assert "standalone" not in calls
+    assert json.loads(capsys.readouterr().out)["token"] == "ctdl_seat"
+
+
+def test_token_create_unknown_seat_lists_available(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(seat="bob")))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no seat 'bob'" in err and "alice" in err
+    assert not calls
+
+
+def test_token_create_dataset_matching_seat_slug_redirects(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(dataset="sarthi")))
+    assert rc == 1
+    assert "--seat sarthi" in capsys.readouterr().err
+    assert not calls
+
+
+def test_token_create_seat_prefixed_unknown_dataset_fails(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(dataset="seat:ghost")))
+    assert rc == 1
+    assert "no seat 'ghost'" in capsys.readouterr().err
+    assert not calls
+
+
+def test_token_create_plain_dataset_stays_standalone(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(dataset="masumi-network")))
+    assert rc == 0
+    assert calls["standalone"]["default_dataset"] == "masumi-network"
+    assert calls["standalone"]["role"] == "reader"  # default fills in
+    assert json.loads(capsys.readouterr().out)["token"] == "ctdl_standalone"
+
+
+def test_token_create_no_target_non_tty_skips_picker(monkeypatch, capsys) -> None:
+    from kb.cli import _token_create
+
+    calls = _wire_access(monkeypatch)
+    rc = asyncio.run(_token_create(_token_create_args(json=False)))
+    assert rc == 0
+    assert "standalone" in calls and "seat" not in calls
+
+
+def test_pick_seat_choices() -> None:
+    from kb.cli import _PickerAborted, _pick_seat
+
+    answers = iter(["7", "2"])  # out-of-range re-prompts, then a valid pick
+    import builtins
+
+    original = builtins.input
+    builtins.input = lambda prompt="": next(answers)
+    try:
+        assert _pick_seat(SEATS) == "sarthi"
+        builtins.input = lambda prompt="": "0"
+        assert _pick_seat(SEATS) is None
+        builtins.input = lambda prompt="": ""
+        with pytest.raises(_PickerAborted):
+            _pick_seat(SEATS)
+    finally:
+        builtins.input = original

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,6 @@ wheels = [
 
 [[package]]
 name = "citadel-archive"
-version = "0.1.3"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -767,16 +766,12 @@ server = [
     { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-tui = [
-    { name = "textual" },
-]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
-    { name = "textual" },
 ]
 
 [package.metadata]
@@ -788,17 +783,15 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'server'", specifier = ">=2.10.5,<3.0.0" },
     { name = "python-dotenv", marker = "extra == 'server'", specifier = ">=1.0.1,<2.0.0" },
     { name = "requests", marker = "extra == 'server'", specifier = ">=2.32.0,<3.0.0" },
-    { name = "textual", marker = "extra == 'tui'", specifier = ">=0.50" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.34.0,<1.0.0" },
 ]
-provides-extras = ["server", "tui"]
+provides-extras = ["server"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=7.4.0,<9" },
     { name = "pytest-asyncio", specifier = ">=0.21.1,<2" },
     { name = "ruff", specifier = ">=0.9.2,<1" },
-    { name = "textual", specifier = ">=0.50" },
 ]
 
 [[package]]
@@ -2018,18 +2011,6 @@ wheels = [
 ]
 
 [[package]]
-name = "linkify-it-py"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "uc-micro-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
-]
-
-[[package]]
 name = "litellm"
 version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2161,11 +2142,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
-[package.optional-dependencies]
-linkify = [
-    { name = "linkify-it-py" },
-]
-
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -2274,18 +2250,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
-]
-
-[[package]]
-name = "mdit-py-plugins"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -4465,23 +4429,6 @@ wheels = [
 ]
 
 [[package]]
-name = "textual"
-version = "8.2.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py", extra = ["linkify"] },
-    { name = "mdit-py-plugins" },
-    { name = "platformdirs" },
-    { name = "pygments" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
-]
-
-[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4690,15 +4637,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "uc-micro-py"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`citadel token create` can now mint **seat-bound** tokens, closing the gap where the only paths to a seat token were `seat create` / `seat token`:

- `--seat <slug>` mints via `POST /api/access/seats/<slug>/tokens`; the token inherits the seat's role and private dataset. `--role`/`--kind`/`--expires-at` are standalone-only and rejected alongside `--seat` (exit 2).
- On a TTY with no target and no standalone flags, an interactive picker lists the active seats plus a `0) standalone service-account token` option (empty answer cancels).
- `--dataset` values that name a seat (bare slug or `seat:` prefix) are rejected with a redirect to `--seat` — a bare `default_dataset` pointing at seat-private memory would only mint a token the Node 403s.
- `citadel seat token <slug>` stays as the re-mint shortcut; its help now points at the equivalent `token create --seat`.

## Hardening (adversarially verified review, 4 confirmed findings fixed)

- Explicit-but-blank `--seat ""`/`--dataset ""` (unset shell var) exit 2 instead of silently minting a standalone reader token with exit 0.
- Explicit `--role`/`--kind`/`--expires-at` skip the picker and mint standalone immediately (pre-branch behavior); previously a picked seat silently dropped the requested role/expiry.
- CHANGELOG `[Unreleased]` entry added.
- `uv.lock` refreshed after the earlier `tui`/textual extra removal.

## Tests

Suite: **649 pass** (12 new on this branch). Lint clean. Empty-flag guard live-verified (`--seat ""` exits 2 before any network call).
