### PR TITLE
release: v0.2.3 — faster/clearer status, lower-friction onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-07-07
+
 ### Added
 
 - **Seat-bound `citadel token create`** — `--seat <slug>` mints a token bound
@@ -18,12 +20,39 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Changed
 
+- **`citadel status` is faster** — the network checks (node, auth, search,
+  data plane, recent activity, mesh) run concurrently, so wall time is the
+  slowest check instead of the sum of all of them.
+- **`citadel status` is clearer** — the verdict line always prints last;
+  latencies form an aligned dim column (`4.9s` above a second, yellow when
+  slow); the identity line shows where the token writes (`writes: seat:X` /
+  `shared org dataset`); **Local setup names the repo it checked**, so a ✗
+  from the wrong directory reads as "wrong directory" rather than "broken
+  setup" (`citadel doctor` names it too); the knowledge mesh is one compact
+  line; network errors are humanized ("cannot resolve host" instead of the
+  urllib errno dump); a failing search renders as a yellow `!` (it never
+  gates health) instead of a red ✗ contradicting a green verdict; the
+  stale-shell 401 hint (`source ~/.zshrc`) now prints on status like it does
+  on ingest/search; the banner is skipped when output is piped.
+- **`citadel onboard` has less friction** — the token keep-or-replace prompt
+  is a plain `Keep it? [Y/n]`; the capture-roots wizard drops the redundant
+  "set up now?" gate (its first question was already declinable) and asks for
+  tags as a one-line `Tags [personal]:` with the presets explained once up
+  front; the local-cognify pipx hint only prints when an OpenRouter key was
+  actually entered; the step summary reads `N step(s) wired, M skipped`.
 - **`citadel token create --dataset <value>`** — a value that names a seat (or
   uses the `seat:` prefix) is now rejected with a redirect to `--seat`, since a
   bare `default_dataset` pointing at seat-private memory would only mint a
   token the Node 403s. Explicitly empty `--seat ""`/`--dataset ""` (the unset
   shell-variable footgun) are usage errors (exit 2) instead of silently
   minting a standalone token.
+
+### Fixed
+
+- **Onboarding no longer ends green with a dead token** — keeping a token the
+  Node rejected (401/403) marks the token step with a yellow `!` and closes
+  with a warning pointing at `citadel token set`, instead of an all-green
+  "configured" summary whose very next suggestion would fail.
 
 ## [0.2.2] — 2026-07-02
 

--- a/kb/__init__.py
+++ b/kb/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 # hatchling dynamic versioning, and server discovery / the CLI fall back to it
 # when the package is not dist-installed (the Railway node runs from source, so
 # importlib.metadata.version raises there). Keeps server + CLI from drifting.
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 if TYPE_CHECKING:
     from kb.config import CitadelConfig

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -50,7 +50,17 @@ from kb.onboard import (
     merge_mcp_config,
     read_token_from_rc,
 )
-from kb.banner import HERO_WIDTH, SKIP, banner, banner_large, mark, paint, supports_color, tagline
+from kb.banner import (
+    HERO_WIDTH,
+    SKIP,
+    WARN,
+    banner,
+    banner_large,
+    mark,
+    paint,
+    supports_color,
+    tagline,
+)
 from kb.access_client import (
     AccessClientError,
     create_seat,
@@ -67,7 +77,7 @@ from kb.promotion_client import (
     reject_pending,
     run_promotion,
 )
-from kb.status import fetch_mesh, gather_status, render_text
+from kb.status import fetch_mesh, gather_status, render_text, render_verdict
 
 
 def _print_json(value: Any) -> None:
@@ -459,16 +469,15 @@ def _parse_root_arg(raw: str) -> tuple[str, tuple[str, ...]]:
 
 
 def _ask_root_tags() -> tuple[str, ...]:
-    print(
-        f"  Tags — presets: {', '.join(PRESET_ROOT_TAGS)}; "
-        f"'personal' never promotes. Default: {DEFAULT_ROOT_TAG}."
-    )
-    tags_raw = _prompt("  Tags (comma-separated): ").strip()
+    tags_raw = _prompt(f"  Tags [{DEFAULT_ROOT_TAG}]: ").strip()
     return tuple(tags_raw.split(",")) if tags_raw else (DEFAULT_ROOT_TAG,)
 
 
 def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> CaptureConfig:
-    print("\nAdd Approved Capture Roots — folders auto-captured to your Node.")
+    print("\nApproved Capture Roots — folders auto-captured to your Node.")
+    # Tag semantics explained once up front, so the per-root Tags prompt can
+    # stay a one-liner with a press-Enter default.
+    print(f"  Tag presets: {', '.join(PRESET_ROOT_TAGS)} — 'personal' never promotes.")
     # The dir the user ran `citadel` from is offered as an explicit yes/no —
     # Enter accepts, `n` declines. A separate question (not a prefilled path
     # prompt) so declining is always possible and "empty to finish" below
@@ -1170,23 +1179,38 @@ async def _status(args: argparse.Namespace) -> int:
         )
 
     if args.json:
-        report = await _gather()
+        report, mesh = await asyncio.gather(
+            _gather(), asyncio.to_thread(fetch_mesh, node_url, token)
+        )
         payload = report.to_dict()
-        payload["mesh"] = await asyncio.to_thread(fetch_mesh, node_url, token)
+        payload["mesh"] = mesh
         _print_json(payload)
     else:
         # The search check can take ~15s cold — spin so it doesn't look hung.
         with _Spinner("Checking Citadel…"):
-            report = await _gather()
-            mesh = await asyncio.to_thread(fetch_mesh, node_url, token)
+            report, mesh = await asyncio.gather(
+                _gather(), asyncio.to_thread(fetch_mesh, node_url, token)
+            )
         use_color = supports_color()
-        print(banner(color=use_color))
-        print()
-        print(render_text(report, color=use_color))
+        if sys.stdout.isatty():
+            # Piped output is for parsing/paging — skip the castle art.
+            print(banner(color=use_color))
+            print()
+        # Verdict last — the bottom line belongs at the bottom, not buried
+        # above the mesh block.
+        print(render_text(report, color=use_color, verdict=False))
         mesh_block = _render_mesh(mesh, use_color)
         if mesh_block:
             print()
             print(mesh_block)
+        print()
+        print(render_verdict(report, color=use_color))
+        auth = next((c for c in report.checks if c.name == "auth"), None)
+        if auth is not None and not auth.ok:
+            code = 401 if "401" in auth.detail else 403 if "403" in auth.detail else 0
+            hint = _stale_env_hint(code) if code else None
+            if hint:
+                print(paint(f"  hint: {hint}", "yellow", enable=use_color))
     return 0 if report.healthy else 1
 
 
@@ -1200,15 +1224,20 @@ def _render_mesh(mesh: dict[str, Any], color: bool) -> str:
         value = stats.get(key)
         return value if isinstance(value, int) else 0
 
-    lines = [
-        paint("Knowledge mesh", "bold", enable=color),
-        f"  documents {paint(str(num('documents')), 'bold', enable=color)}   "
-        f"nodes {num('nodes')}   edges {num('edges')}   searches {num('searches')}",
+    parts = [
+        f"{paint(str(num('documents')), 'bold', enable=color)} documents",
+        f"{num('nodes')} nodes",
+        f"{num('edges')} edges",
+        f"{num('searches')} searches",
     ]
     last = stats.get("last_indexed_at")
     if last:
-        lines.append(paint(f"  last indexed {str(last)[:19]}", "dim", enable=color))
-    return "\n".join(lines)
+        parts.append(paint(f"last indexed {str(last)[:16].replace('T', ' ')}", "dim", enable=color))
+    return (
+        paint("Knowledge mesh", "bold", enable=color)
+        + "\n  "
+        + " · ".join(parts)
+    )
 
 
 def _mcp_node_url(path: Path) -> str | None:
@@ -1332,8 +1361,12 @@ async def _doctor(args: argparse.Namespace) -> int:
         })
         return rc
 
-    print(banner(color=color))
-    print()
+    if sys.stdout.isatty():
+        print(banner(color=color))
+        print()
+    # Several checks are repo-relative — name the repo so a miss from the
+    # wrong directory reads as "wrong directory", not "broken setup".
+    print(paint(f"repo: {repo}", "dim", enable=color))
     if not issues:
         print(paint("✓ No problems found.", "green", enable=color))
         return 0
@@ -1409,8 +1442,12 @@ def _prompt_hidden(prompt: str) -> str:
 
 async def _resolve_onboard_token(
     args: argparse.Namespace, rc_path: Path, node_url: str, *, interactive: bool, color: bool
-) -> str:
-    """Pick the token to onboard with, then verify it. Returns "" when absent.
+) -> tuple[str, bool]:
+    """Pick the token to onboard with, then verify it.
+
+    Returns ``(token, rejected)`` — ``token`` is "" when absent; ``rejected``
+    is True when the Node answered 401/403 and the user chose to keep the
+    token anyway, so the summary can warn instead of ending green.
 
     Interactive flow: an already-configured token (shell rc first — it's the
     durable value every new shell exports — then env) is shown masked with a
@@ -1444,7 +1481,7 @@ async def _resolve_onboard_token(
                         enable=color,
                     )
                 )
-            answer = _prompt("  Keep it? [Y/n — n to paste a new one]: ").strip().lower()
+            answer = _prompt("  Keep it? [Y/n]: ").strip().lower()
             token = existing
             if answer in ("n", "no"):
                 token = _prompt_hidden("  Paste the new seat token (ctdl_…): ") or existing
@@ -1461,7 +1498,7 @@ async def _resolve_onboard_token(
         )
         token = _prompt_hidden("Paste your Citadel seat token (ctdl_…): ")
     if not token:
-        return ""
+        return "", False
 
     # Verify the token + show its identity (seat / role / access) up front, so a
     # rejected token is fixable now — not discovered after every other prompt.
@@ -1493,7 +1530,12 @@ async def _resolve_onboard_token(
             if not new_token:
                 break
             token = new_token
-    return token
+    rejected = (
+        auth is not None
+        and not auth.ok
+        and any(code in str(getattr(auth, "detail", "")) for code in ("401", "403"))
+    )
+    return token, rejected
 
 
 async def _onboard(args: argparse.Namespace) -> int:
@@ -1507,7 +1549,7 @@ async def _onboard(args: argparse.Namespace) -> int:
     if interactive:
         _print_banner_animated(banner(color=color), color)
 
-    token = await _resolve_onboard_token(
+    token, token_rejected = await _resolve_onboard_token(
         args, rc_path, node_url, interactive=interactive, color=color
     )
     if not token:
@@ -1551,7 +1593,7 @@ async def _onboard(args: argparse.Namespace) -> int:
     # to the shell rc next to the seat token.
     if interactive:
         llm_key = _prompt_hidden(
-            "Optional: paste an OpenRouter API key for local cognify (enter to skip): "
+            "\nOpenRouter API key for local cognify — Enter to skip: "
         )
         if llm_key:
             steps.append(
@@ -1565,9 +1607,10 @@ async def _onboard(args: argparse.Namespace) -> int:
                     ),
                 )
             )
-        print(
-            "  (local cognify also needs: pipx install 'citadel-archive[server]')"
-        )
+            # Only relevant once a key exists — noise for everyone who skipped.
+            print(
+                "  (local cognify also needs: pipx install 'citadel-archive[server]')"
+            )
 
     # Capture roots (unless --no-capture): the wizard asks about the repo
     # toplevel explicitly (declinable); if the config still ends up empty, it
@@ -1577,9 +1620,10 @@ async def _onboard(args: argparse.Namespace) -> int:
         cfg_path = capture_config_path()
         cfg = load_capture_config(cfg_path)
         if interactive:
-            answer = _prompt("\nSet up Approved Capture Roots now? [Y/n]: ").strip().lower()
-            if answer in ("", "y", "yes"):
-                cfg = _wizard_roots(cfg, default_root=str(repo))
+            # Straight into the wizard — its first question is already a
+            # declinable Y/n, so a separate "set up now?" gate was one prompt
+            # of pure friction.
+            cfg = _wizard_roots(cfg, default_root=str(repo))
         if not cfg.roots:
             cfg = cfg.with_root(str(repo), (DEFAULT_ROOT_TAG,))  # 'personal' never promotes
         save_capture_config(
@@ -1608,10 +1652,27 @@ async def _onboard(args: argparse.Namespace) -> int:
     for label, status in steps:
         text, ok, skipped = _humanize_status(status)
         sigil = paint(SKIP, "yellow", enable=color) if skipped else mark(ok, enable=color)
+        if token_rejected and label.startswith("token → "):
+            # The Node said 401/403 up front — the summary must not end green.
+            sigil = paint(WARN, "yellow", enable=color)
+            text += " — Node rejected this token"
         print(f"  {sigil} {label}  {paint(text, 'dim', enable=color)}")
     done = sum(1 for _, status in steps if not status.startswith("skipped"))
+    skipped_count = len(steps) - done
+    summary = f"Citadel configured — {done} step(s) wired"
+    if skipped_count:
+        summary += f", {skipped_count} skipped"
     print()
-    print(paint(f"Citadel configured — {done}/{len(steps)} steps wired.", "green", enable=color))
+    print(paint(summary + ".", "green", enable=color))
+    if token_rejected:
+        print(
+            paint(
+                f"{WARN} The Node rejected this token — searches will fail until you set "
+                "a valid one with `citadel token set`.",
+                "yellow",
+                enable=color,
+            )
+        )
     print(
         f"\nNext: restart your shell (or `source {rc_path}`), then in your agent ask:\n"
         '  "use citadel_search to find what we decided about the vault"'

--- a/kb/status.py
+++ b/kb/status.py
@@ -18,6 +18,7 @@ import shutil
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -63,6 +64,22 @@ def _request(
     return json.loads(body) if body else {}
 
 
+def _humanize_net_error(exc: Exception) -> str:
+    """Human words for the common network failures — raw urllib reasons read
+    like C errno dumps ('nodename nor servname provided, or not known')."""
+    text = str(exc)
+    lowered = text.lower()
+    if isinstance(exc, urllib.error.HTTPError):
+        return text
+    if "nodename nor servname" in lowered or "name or service not known" in lowered or "getaddrinfo" in lowered:
+        return "cannot resolve host"
+    if "connection refused" in lowered:
+        return "connection refused"
+    if isinstance(exc, TimeoutError) or "timed out" in lowered:
+        return "timed out"
+    return text
+
+
 @dataclass
 class Check:
     name: str
@@ -79,6 +96,7 @@ class StatusReport:
     identity: dict[str, Any]
     checks: list[Check]
     recent: list[dict[str, Any]]
+    repo: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -87,6 +105,7 @@ class StatusReport:
             "identity": self.identity,
             "checks": [asdict(c) for c in self.checks],
             "recent": self.recent,
+            "repo": self.repo,
         }
 
 
@@ -103,7 +122,7 @@ def check_node_health(base_url: str, *, timeout: float = _TIMEOUT) -> Check:
     try:
         data = _request("GET", f"{base_url.rstrip('/')}/healthz", timeout=timeout)
     except Exception as exc:
-        return Check("node", ok=False, detail=str(exc))
+        return Check("node", ok=False, detail=_humanize_net_error(exc))
     latency = int((time.monotonic() - started) * 1000)
     ok = bool(data.get("ok"))
     return Check("node", ok=ok, detail="healthy" if ok else "unhealthy", latency_ms=latency)
@@ -118,7 +137,7 @@ def check_auth(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -
             "GET", f"{base_url.rstrip('/')}/api/session", token=token, timeout=timeout
         )
     except Exception as exc:
-        return Check("auth", ok=False, detail=str(exc))
+        return Check("auth", ok=False, detail=_humanize_net_error(exc))
     latency = int((time.monotonic() - started) * 1000)
     identity = {
         "seat_slug": data.get("seat_slug"),
@@ -145,11 +164,11 @@ def check_search(base_url: str, token: str | None, *, timeout: float = _SEARCH_T
     except TimeoutError:
         return Check(
             "search", ok=False,
-            detail=f"timed out (>{int(timeout)}s, node warming up)",
+            detail=f"timed out after {int(timeout)}s — node warming up",
             data={"timed_out": True},
         )
     except Exception as exc:
-        return Check("search", ok=False, detail=str(exc))
+        return Check("search", ok=False, detail=_humanize_net_error(exc))
     latency = int((time.monotonic() - started) * 1000)
     results = data.get("results")
     if results is None:
@@ -342,17 +361,27 @@ def gather_status(
     base_url = base_url.rstrip("/")
     repo = repo or Path.cwd()
 
-    node = check_node_health(base_url, timeout=timeout)
-    auth = check_auth(base_url, token, timeout=timeout)
-    checks = [node, auth]
-    if with_search:
-        checks.append(check_search(base_url, token))  # uses its own longer timeout
-    corpus = check_corpus(base_url, token, timeout=timeout)
-    if corpus is not None:
-        checks.append(corpus)
+    # The network checks are independent, so they run concurrently — wall time
+    # is the slowest check (search, when cold), not the sum of all of them.
+    # Each check still captures its own failure, so a thread never raises.
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        node_f = pool.submit(check_node_health, base_url, timeout=timeout)
+        auth_f = pool.submit(check_auth, base_url, token, timeout=timeout)
+        search_f = pool.submit(check_search, base_url, token) if with_search else None
+        corpus_f = pool.submit(check_corpus, base_url, token, timeout=timeout)
+        recent_f = (
+            pool.submit(fetch_recent, base_url, token, timeout=timeout) if with_recent else None
+        )
+        node = node_f.result()
+        auth = auth_f.result()
+        checks = [node, auth]
+        if search_f is not None:
+            checks.append(search_f.result())  # uses its own longer timeout
+        corpus = corpus_f.result()
+        if corpus is not None:
+            checks.append(corpus)
+        recent = recent_f.result() if recent_f is not None else []
     checks.extend(check_local_setup(repo, config_path))
-
-    recent = fetch_recent(base_url, token, timeout=timeout) if with_recent else []
     # A RED corpus gate (sources tracked but graph empty, or the canary failed)
     # makes the whole report unhealthy — no more green over a broken data plane (#27).
     corpus_ok = corpus.ok if corpus is not None else True
@@ -362,6 +391,7 @@ def gather_status(
         identity=auth.data,
         checks=checks,
         recent=recent,
+        repo=str(repo),
     )
 
 
@@ -381,48 +411,97 @@ _CHECK_LABELS = {
 }
 
 
-def render_text(report: StatusReport, *, color: bool = False) -> str:
-    from kb.banner import mark, paint
+def _fmt_latency(latency_ms: int | None) -> str:
+    """Humanized latency: '143ms' below a second, '5.8s' above."""
+    if latency_ms is None:
+        return ""
+    if latency_ms >= 1000:
+        return f"{latency_ms / 1000:.1f}s"
+    return f"{latency_ms}ms"
+
+
+# A check slower than this gets its latency called out instead of dimmed.
+_SLOW_MS = 3000
+
+
+def render_text(report: StatusReport, *, color: bool = False, verdict: bool = True) -> str:
+    from kb.banner import WARN, mark, paint
 
     ident = report.identity
     seat = ident.get("seat_slug") or ident.get("actor") or "—"
     role = ident.get("role") or "—"
+    identity_line = f"seat: {paint(str(seat), 'bold', enable=color)}   role: {role}"
+    # Where this token writes — the onboard identity panel's "writes" fact,
+    # surfaced here too so status answers it without a second command.
+    if ident.get("capabilities", {}).get("write"):
+        writes = f"seat:{ident['seat_slug']}" if ident.get("seat_slug") else "shared org dataset"
+        identity_line += f"   writes: {writes}"
     lines = [
-        f"seat: {paint(str(seat), 'bold', enable=color)}   role: {role}",
+        identity_line,
         paint(f"node: {report.node_url}", "dim", enable=color),
         "",
     ]
 
     cols = shutil.get_terminal_size((80, 24)).columns
 
-    def _row(check: Check) -> str:
+    def _row(check: Check, detail_width: int) -> str:
         label = _CHECK_LABELS.get(check.name, check.name)
-        latency = f"  ({check.latency_ms}ms)" if check.latency_ms is not None else ""
+        latency = _fmt_latency(check.latency_ms)
         detail = check.detail
-        budget = cols - 21 - len(latency)  # 2 indent + glyph + space + 16 label + space
+        budget = cols - 22 - len(latency)  # 2 indent + glyph + space + 16 label + space + gap
         if budget > 8 and len(detail) > budget:
             detail = detail[: budget - 1] + "…"
-        return f"  {mark(check.ok, enable=color)} {label:<16} {detail}{latency}"
+        if latency:
+            slow = (check.latency_ms or 0) >= _SLOW_MS
+            pad = " " * max(detail_width - len(detail) + 2, 2)
+            latency = pad + paint(latency, "yellow" if slow else "dim", enable=color)
+        sigil = mark(check.ok, enable=color)
+        if not check.ok and check.name == "search":
+            # Search never gates health — a red ✗ next to a green verdict reads
+            # as a contradiction, so the non-gating failure warns instead.
+            sigil = paint(WARN, "yellow", enable=color)
+        return f"  {sigil} {label:<16} {detail}{latency}"
 
     conn = [c for c in report.checks if c.name in _CONNECTIVITY]
     local = [c for c in report.checks if c.name not in _CONNECTIVITY]
+
+    def _section(title: str, checks: list[Check], note: str = "") -> list[str]:
+        # Latencies form one aligned (and dimmed) column per section, so the
+        # details read as a block instead of a ragged mix of text and numbers.
+        width = min(max((len(c.detail) for c in checks), default=0), max(cols - 30, 8))
+        header = paint(title, "bold", enable=color) + (paint(note, "dim", enable=color) if note else "")
+        return [header, *(_row(c, width) for c in checks)]
+
     if conn:
-        lines.append(paint("Connectivity", "bold", enable=color))
-        lines.extend(_row(c) for c in conn)
+        lines.extend(_section("Connectivity", conn))
         lines.append("")
     if local:
-        lines.append(paint("Local setup", "bold", enable=color))
-        lines.extend(_row(c) for c in local)
+        # Local checks are repo-relative — name the repo, so a ✗ from the wrong
+        # directory reads as "wrong directory", not "broken setup".
+        note = f"  — {report.repo}" if report.repo else ""
+        lines.extend(_section("Local setup", local, note))
 
     if report.recent:
         lines.append("")
-        lines.append("Recent activity")
+        lines.append(paint("Recent activity", "bold", enable=color))
         for item in report.recent[:5]:
             when = item.get("created_at") or item.get("timestamp") or ""
             label = item.get("title") or item.get("action") or item.get("detail") or "—"
-            lines.append(f"  · {str(when)[:19]}  {label}")
+            lines.append(f"  · {paint(str(when)[:19], 'dim', enable=color)}  {label}")
 
-    lines.append("")
+    if verdict:
+        lines.append("")
+        lines.append(render_verdict(report, color=color))
+    return "\n".join(lines)
+
+
+def render_verdict(report: StatusReport, *, color: bool = False) -> str:
+    """The one-line (plus hints) bottom-line summary — always the last thing printed."""
+    from kb.banner import paint
+
+    lines: list[str] = []
+    conn = [c for c in report.checks if c.name in _CONNECTIVITY]
+    local = [c for c in report.checks if c.name not in _CONNECTIVITY]
     conn_fail = [c for c in conn if not c.ok]
     local_fail = [c for c in local if not c.ok]
     # A cold-node Search TIMEOUT is non-gating noise; a hard Search error is not.
@@ -446,10 +525,10 @@ def render_text(report: StatusReport, *, color: bool = False) -> str:
             )
             lines.append(paint("  Run `citadel doctor --fix` to repair.", "dim", enable=color))
         if search_warming:
-            lines.append(paint("  Search: node warming up (non-gating).", "dim", enable=color))
+            lines.append(paint("  Search is still warming up — retry in a minute.", "dim", enable=color))
         elif search_degraded:
             detail = next((c.detail for c in search_fail), "")
-            lines.append(paint(f"  Search degraded — {detail} (non-gating).", "yellow", enable=color))
+            lines.append(paint(f"  Search degraded — {detail}. Not blocking.", "yellow", enable=color))
     else:
         node_auth_fail = [c for c in conn_fail if c.name in ("node", "auth")]
         corpus_fail = next((c for c in conn if c.name == "corpus" and not c.ok), None)

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -394,3 +394,25 @@ def test_onboard_rejected_token_offers_immediate_replacement(tmp_path: Path, mon
     assert "rejected" in out and "401" in out
     body = Path(args.shell_rc).read_text()
     assert "ctdl_fresh_bcdef12345" in body and "ctdl_stale_234567890" not in body
+
+
+def test_onboard_kept_rejected_token_warns_in_summary(tmp_path: Path, monkeypatch, capsys) -> None:
+    # Keeping a 401'd token must not end on an all-green summary (probe finding:
+    # a new user walked away from a dead token thinking setup succeeded).
+    monkeypatch.setenv(TOKEN_ENV, "ctdl_stale_234567890")
+    args = _interactive_onboard_args(tmp_path)
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    answers = iter(["", ""])  # keep existing → decline the re-paste offer
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+    pastes = iter([""])  # skip OpenRouter key
+    monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
+    monkeypatch.setattr(
+        "kb.status.check_auth",
+        lambda *a, **k: Check("auth", ok=False, detail="HTTP Error 401: Unauthorized"),
+    )
+
+    assert asyncio.run(_onboard(args)) == 0
+    out = capsys.readouterr().out
+    assert "Node rejected this token" in out  # on the token step line + closing warning
+    assert "citadel token set" in out

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -202,6 +202,47 @@ def test_render_text_smoke() -> None:
     assert "✓" in out
 
 
+def test_render_text_names_the_checked_repo() -> None:
+    # Local checks are repo-relative — a ✗ from the wrong directory must read
+    # as "wrong directory", not "broken setup", so the repo is always named.
+    report = StatusReport(
+        node_url="https://node.example",
+        healthy=True,
+        identity={},
+        checks=[Check("mcp", ok=False, detail="not configured")],
+        recent=[],
+        repo="/some/checked/repo",
+    )
+    assert "/some/checked/repo" in render_text(report)
+
+
+def test_render_text_search_failure_warns_not_fails() -> None:
+    # Search never gates health — its failure renders as a yellow ! warning,
+    # not the same red ✗ as a fatal check, so glyphs can't contradict the
+    # green "Connected" verdict.
+    report = StatusReport(
+        node_url="https://node.example",
+        healthy=True,
+        identity={},
+        checks=[
+            Check("node", ok=True, detail="healthy"),
+            Check("search", ok=False, detail="timed out after 15s — node warming up", data={"timed_out": True}),
+        ],
+        recent=[],
+    )
+    out = render_text(report)
+    search_row = next(line for line in out.splitlines() if "Search" in line)
+    assert "!" in search_row
+    assert "✗" not in search_row
+
+
+def test_humanize_net_error_translates_dns_noise() -> None:
+    # Raw urllib reasons read like C errno dumps — humans get words.
+    exc = OSError("<urlopen error [Errno 8] nodename nor servname provided, or not known>")
+    assert status_mod._humanize_net_error(exc) == "cannot resolve host"
+    assert status_mod._humanize_net_error(OSError("[Errno 61] Connection refused")) == "connection refused"
+
+
 def test_status_command_json_and_exit(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         status_mod._OPENER,


### PR DESCRIPTION
Cuts CLI UX fixes from the 2026-07-07 session plus the already-merged seat-bound token create into v0.2.3.

## status
- Network checks run concurrently — wall time = slowest check (search), not the sum.
- Verdict line always last; aligned dim latency column (seconds format, yellow when slow); identity line shows the token's write scope; Local setup (and doctor) name the checked repo; mesh as one line; banner skipped when piped; humanized network errors; non-gating search failures warn (!) instead of contradicting a green verdict; stale-shell 401 hint now on status too.

## onboard
- `Keep it? [Y/n]` without the bracket essay (dev feedback); roots wizard drops the redundant "set up now?" gate; one-line `Tags [personal]:` prompt; OpenRouter pipx hint only when a key was entered.
- **Fix:** keeping a Node-rejected token no longer ends on an all-green summary — the token step warns and the run closes with a `citadel token set` pointer.

## tests
652 pass (4 new regression tests: repo naming, search warn glyph, net-error humanization, rejected-token summary).

Full details in `CHANGELOG.md` § 0.2.3.