### PR TITLE
fix(mcp): hosted /mcp public client targets $PORT, not localhost:8000

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -472,7 +472,7 @@ class CitadelHttpClient:
         timeout: float = 30.0,
     ) -> None:
         self.base_url = _validate_base_url(
-            base_url or os.getenv("CITADEL_HTTP_BASE_URL") or "http://localhost:8000"
+            base_url or os.getenv("CITADEL_HTTP_BASE_URL") or _self_base_url()
         )
         self.access_token = (
             access_token
@@ -625,7 +625,7 @@ def create_mcp_server(
 
     def resolve_public_client() -> CitadelHttpClient:
         base_url = getattr(fallback, "base_url", None) if fallback is not None else None
-        return CitadelHttpClient(base_url=base_url, access_token="")
+        return CitadelHttpClient(base_url=base_url or _self_base_url(), access_token="")
 
     def public_manifest() -> dict[str, Any]:
         if fallback is not None and hasattr(fallback, "get_public"):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -480,6 +480,23 @@ def test_remote_http_base_url_is_rejected_without_escape_hatch(
     assert client.base_url == "http://citadel.example"
 
 
+def test_public_client_targets_self_base_url_not_localhost_8000(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Hosted /mcp has no fallback client, so the public path builds a client with
+    # base_url=None. On Railway the app listens on $PORT, not 8000, so the default
+    # must resolve to the in-process self base URL, never http://localhost:8000.
+    monkeypatch.delenv("CITADEL_HTTP_BASE_URL", raising=False)
+    monkeypatch.delenv("CITADEL_MCP_SELF_BASE_URL", raising=False)
+    monkeypatch.setenv("PORT", "9137")
+
+    client = CitadelHttpClient(base_url=None, access_token="")
+
+    assert client.base_url == mcp_server._self_base_url()
+    assert client.base_url == "http://127.0.0.1:9137"
+    assert client.base_url != "http://localhost:8000"
+
+
 def test_missing_access_token_error_does_not_leak_env_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## The bug

The hosted `/mcp` is unusable: MCP clients register zero tools, and public resource reads (e.g. `citadel://discovery`) fail with `[Errno 111] Connection refused` to `http://localhost:8000`.

Root cause:
- `kb/server.py` mounts `create_mcp_server()` with **no fallback client** (line ~144).
- In `kb/mcp_server.py`, `resolve_public_client()` computed `base_url = None` because there is no fallback, then built `CitadelHttpClient(base_url=None, ...)`.
- `CitadelHttpClient.__init__` defaulted a `None` base URL to the literal `"http://localhost:8000"`.
- On Railway the app listens on `$PORT`, not `8000`, so the in-process self-call was refused.

The **authed** path was already correct — it routes through `_self_base_url()` which returns `http://127.0.0.1:$PORT`. Only the **public** client path was broken.

## The fix

- `resolve_public_client()`: fall back to `_self_base_url()` when there is no fallback `base_url`, so public reads hit the in-process API on the right port.
- `CitadelHttpClient.__init__`: replace the `"http://localhost:8000"` literal with `_self_base_url()` so no code path can silently target port 8000 in a hosted deploy. `_self_base_url()` honors `CITADEL_MCP_SELF_BASE_URL` / `PORT`, so the stdio transport (which may legitimately set `CITADEL_HTTP_BASE_URL`) is unaffected — the explicit env/base_url still take precedence.

Diff is 2 lines of product code plus a regression test.

## The test

`tests/test_mcp_server.py::test_public_client_targets_self_base_url_not_localhost_8000` constructs the no-fallback public client path with `PORT=9137` and no `CITADEL_HTTP_BASE_URL`, and asserts the base URL resolves to `_self_base_url()` (`http://127.0.0.1:9137`), **not** `http://localhost:8000`.

`uv run --no-sync pytest tests/ -q`: **653 passed**, plus 1 pre-existing unrelated failure (`test_client_boundary.py::test_importing_cli_pulls_no_server_modules` leaks `google` — reproduces identically on clean `main`; environmental, caused by the subprocess running under the framework Python's global site-packages). The full `tests/test_mcp_server.py` suite is green (29 passed).

## Remaining known issue (out of scope)

This fixes only the `localhost:8000` self-call. The deeper `/mcp` problem — event-loop starvation that makes `tools/list` time out under load (related to #50, in-loop cognify running on the web's single FastAPI loop) — is **not** addressed here and remains a known issue.