### PR TITLE
docs: record the dashboard + mesh-isolation + /mcp release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,30 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Document drill-down in the Knowledge Mesh.** Clicking a graph node fetches
+  and renders its document text in the inspector; textless `TextDocument` nodes
+  are assembled from their linked `DocumentChunk` neighbors.
+- **Seat presence + graph legibility.** Every seat renders as a presence hub;
+  document nodes are labeled from their first line of text (not `text_<hash>`);
+  a color-coded legend filters node kinds (chunks hidden by default); the
+  inspector shows kind, seat, and clickable neighbors; edges carry relationship
+  tooltips. The canvas opens on the **Knowledge Mesh** (the durable graph)
+  rather than the restart-transient **Vault Activity** projection, and the
+  header has a **Log out** button.
+- **Seat-assignment dropdown on token creation.** The dashboard's "Create access
+  token" form gains an *Assign to seat* picker that mints a seat-scoped token
+  (scope derives from the seat); "No seat" keeps the service-account path.
+- **CI.** GitHub Actions runs `pytest` + `ruff` on every PR and push.
+
 ### Changed
 
+- **Agent skills default to the headless CLI.** `SKILL.md` and the vault /
+  proactive-ingest skills now teach CLI-first access (`citadel search --json`,
+  `citadel ingest`) with the hosted MCP as an optional in-session accelerator —
+  and an explicit "if no `citadel_*` tools registered, fall back to the CLI,
+  don't retry MCP" rule.
 - **BREAKING (ADR-0009 mesh read isolation).** `/api/mesh/graph`, the
   `/api/mesh` + `/events` activity projection, and `/api/documents` drill-down
   are now caller-scoped for non-admin tokens: content is limited to the caller's
@@ -34,6 +56,15 @@ All notable changes to `citadel-archive` are documented here. Format follows
 - Dashboard graph now surfaces a degraded/empty banner on fallback instead of
   rendering a broken engine as a healthy empty mesh, labels the server node cap,
   and no longer mis-pins an arbitrary node as the org Central hub.
+- **Hosted `/mcp` public client targets `$PORT`, not `localhost:8000`.** The
+  no-fallback public path (and the `CitadelHttpClient` default) now resolve to
+  `_self_base_url()`, so public MCP resource reads reach the in-process API on
+  Railway instead of a refused `localhost:8000` connection. (The separate
+  event-loop-starvation cause of `tools/list` timeouts under load — issue #50 —
+  is not addressed here.)
+- Search results no longer advertise `document_drilldown_available` for an id
+  that `/api/documents` would 404 for the caller; the hint now reuses the same
+  visibility gate as the drill-down endpoint, per caller.
 
 ## [0.2.3] — 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ evolves only through governed promotion and org sync.
   `citadel_ingest` / `citadel_contribute` to write. Per-call audit.
 - **Governed sharing** — seat writes stay on your Node; Central updates via org
   sync and the Promotion Agent. Secrets blocked on every write path.
-- **Live knowledge graph** — Central + all seat Nodes on one canvas, plus a
-  real-time activity timeline in the web UI.
+- **Knowledge Mesh + Vault Activity** — two canvases in the web UI: the
+  **Knowledge Mesh** (source-linked documents, concepts, and the seats they
+  belong to) and **Vault Activity** (the live sync/search/ingest timeline).
+  Every seat is visible as a presence hub, but content stays caller-scoped —
+  you see Central plus your own Node, never another seat's Node content
+  (ADR-0009). Click any node to read its document.
 - **Zero-dependency client** — `pip install citadel-archive` is pure stdlib; the
   server stack is an opt-in extra.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,6 +1,54 @@
 # Citadel Progress
 
-Last updated: 2026-06-30.
+Last updated: 2026-07-14.
+
+## 2026-07-14 — Dashboard graph, mesh read isolation, /mcp fix — SHIPPED + DEPLOYED
+
+Started as a dashboard papercut ("clicking a node shows metadata but no text")
+and grew into a read-side privacy release once a `/grill-with-docs` pass found
+the graph surfaces were leaking seat Node content org-wide.
+
+**PR #76 (dashboard + isolation) + PR #77 (/mcp fix)** merged to `main` →
+Railway auto-deployed (deployment `f5bdccca`, clean boot, `/healthz` 200,
+`assert_cognee_dataset_api` self-check passed). 707 tests green.
+
+- **ADR-0009 mesh read isolation.** The whole-graph endpoint plus the
+  `/api/mesh` + `/events` activity projection and the `/api/documents`
+  drill-down served every seat's Node content (documents, chunk text, extracted
+  entities, ingest/search event text) to any reader token — a violation of
+  ADR-0003 that `/search` already enforced. Now caller-scoped (own Node +
+  Central; admin bypass), fail-closed on attribution failure, with a
+  404-equals-missing drill-down (no existence oracle) and layered entity
+  visibility (a shared entity can't resurface a hidden document; an `is_a` edge
+  alone never promotes a non-EntityType). **Seat presence stays universal** —
+  every seat is a hub (slug + counts only, never names/emails). New glossary
+  terms **Seat Presence** and **Vault Activity**; `CONTEXT.md` "Graph views"
+  section rewritten.
+- **Graph legibility + drill-down.** Human labels from first-chunk text, a
+  kind-filter legend (chunks hidden by default), a richer inspector with
+  clickable neighbors and document text, edge tooltips, Knowledge-Mesh default
+  view, and a Log out button. Plus a seat-assignment dropdown on token minting.
+- **Production-readiness pass (measured, 5-dimension audit).** Fixed 3 blockers
+  + 12 majors before merge: `get_document` no longer reads the whole 34k-edge
+  graph per click (targeted node read); `/api/mesh/graph` shaping runs off the
+  event loop with a dedicated concurrency cap; the raw graph read and the
+  dataset-attribution map are TTL-cached with single-flight; attribution is one
+  joined query with stale-while-error. The audit also caught the projection
+  leak above.
+- **/mcp base-URL fix (PR #77).** The public MCP client defaulted to
+  `localhost:8000` while Railway listens on `$PORT`, so public resource reads
+  hit a refused connection. Now `_self_base_url()`. The deeper `tools/list`
+  loop-starvation half (#50) is still open.
+- **Skills → headless-CLI-first**, so agents stop retrying MCP when a session
+  registers no tools.
+
+**Verified in prod:** deploy health + clean boot. **Not verifiable in prod this
+session:** isolation and MCP tool registration end-to-end — the local seat
+token is rejected (seat `sarthi` has 0 active tokens; needs a fresh mint). All
+isolation logic was verified live on a seeded localhost demo across
+admin/seat/reader identities. **Follow-ups still open:** the `/mcp` loop
+starvation (#50), three unverifiable UI papercuts (no browser harness this
+session), and the `0.3.0` version cut.
 
 ## 2026-06-30 — Read-side hardening sprint (issues #25–#53) — SHIPPED
 

--- a/tasks.md
+++ b/tasks.md
@@ -1,5 +1,35 @@
 # Citadel Tasks
 
+## Dashboard graph + mesh read isolation + /mcp fix (2026-07-14) — SHIPPED + DEPLOYED
+
+Merged to `main` (PR #76 dashboard/isolation, PR #77 /mcp) → Railway deploy
+`f5bdccca`, clean boot, 707 tests. Full write-up: [`docs/progress.md`](docs/progress.md) ·
+decision record: [`docs/adr/0009-mesh-read-isolation-presence-vs-content.md`](docs/adr/0009-mesh-read-isolation-presence-vs-content.md).
+
+- [x] Node document drill-down (assemble textless `TextDocument` from chunks)
+- [x] Seat presence hubs + dataset attribution in the Knowledge Mesh
+- [x] Graph legibility: human labels, kind-filter legend (chunks off by default),
+      neighbor inspector, edge tooltips, Knowledge-Mesh default view, Log out
+- [x] Seat-assignment dropdown on token creation (seat-scoped mint)
+- [x] **ADR-0009 read isolation**: `/api/mesh/graph`, `/api/mesh`+`/events`
+      projection, `/api/documents` scoped per caller; fail-closed; no 404 oracle;
+      presence stays universal (slug only). `CONTEXT.md` terms + ADR added.
+- [x] Production-readiness audit (measured): 3 blockers + 12 majors fixed
+      (targeted doc read, off-loop shaping + dedicated cap, TTL/single-flight
+      caches, joined attribution query, projection-leak fix)
+- [x] `/mcp` public-client base URL → `$PORT` (PR #77)
+- [x] Skills default to headless CLI; MCP demoted to optional accelerator
+- [x] CI: pytest + ruff on PR/push
+
+**Todos / carry-over:**
+
+- [ ] `/mcp` loop-starvation half (#50 / in-loop cognify): base-URL fixed, but
+      `tools/list` can still time out under load — needs the systemic fix
+- [ ] Three UI papercuts deferred (no browser harness this session): projection-
+      event click → bogus inspector, spinner-after-fetch-failure, meta rebuild perf
+- [ ] Cut `0.3.0` (CHANGELOG `[Unreleased]` carries the BREAKING notes)
+- [ ] Verify isolation + MCP tools end-to-end against prod once a valid token exists
+
 ## CLI UX sprint (2026-07-02) — SHIPPED as v0.2.2 (PR #72 + tagline follow-up)
 
 Full change list: [`CHANGELOG.md` § 0.2.2](CHANGELOG.md).
@@ -22,8 +52,10 @@ Full change list: [`CHANGELOG.md` § 0.2.2](CHANGELOG.md).
 
 **Todos / carry-over:**
 
-- [ ] sarthi's seat token 403s against prod (predates v0.2.2) — mint fresh
-      (`citadel seat token sarthi` with admin key), then `citadel token set`
+- [ ] sarthi's seat token rejected by prod (still open 2026-07-14) — confirmed
+      cause: seat `sarthi` has **0 active tokens** in the prod access store.
+      Mint fresh: `railway run -- citadel seat token sarthi` then
+      `citadel token set <token>` (admin key stays in Railway env)
 - [ ] Release gates from the read-side sprint: rotate secrets · verify #69 on
       the node · profile #50
 - [ ] Deferred CLI refactors: global `--json`/`--node-url` parent-parser,


### PR DESCRIPTION
Documentation-only follow-up to the merged **#76** (dashboard + ADR-0009 read isolation) and **#77** (/mcp base-URL fix), now live in prod.

## Updates
- **CHANGELOG.md** `[Unreleased]`: adds the feature entries that shipped (document drill-down, seat presence + graph legibility, seat-assignment token dropdown, CI), the skills → headless-CLI change, the `/mcp` public-client base-URL fix, and the honest search-drilldown-hint fix. The BREAKING ADR-0009 note was already present.
- **docs/progress.md**: new dated 2026-07-14 section — merged + deployed status (deployment `f5bdccca`, clean boot, 707 tests), what was verified in prod vs. the localhost demo, and the open follow-ups.
- **tasks.md**: marks the sprint SHIPPED with its checklist and carry-over; sharpens the long-standing `sarthi` token todo (confirmed cause: 0 active tokens in the prod access store).
- **README.md**: the graph feature bullet now names **Knowledge Mesh** vs **Vault Activity** and states the presence-vs-content isolation.

No code changes. Safe to merge independently; nothing deploys behavior.