### PR TITLE
fix(ci): remove pre-existing unused imports so ruff CI passes

### DIFF
--- a/tests/test_promotion_refs.py
+++ b/tests/test_promotion_refs.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 from kb.promotion_refs import (
-    ReferenceAssessment,
     assess_org_reference,
     extract_repo_hints,
     load_tracked_org_repos,


### PR DESCRIPTION
The `ruff check .` step added in the new CI workflow failed on its first run against two **pre-existing** F401 violations in `tests/test_promotion_refs.py` (unused `pytest` and `ReferenceAssessment` imports, introduced in a9aecbc on 2026-06-28, before any CI existed). Because Lint runs before pytest, the whole job failed and tests were skipped — the tests themselves pass.

`ruff check --fix` removes the two imports; `ruff check .` is now clean repo-wide and the file's 7 tests still pass. Test-only change, no runtime effect.