### PR TITLE
fix(ci): install the server extra so pytest can collect

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
       - name: Install dependencies
-        run: uv sync --dev
+        # --all-extras pulls in the `server` optional-dependency group
+        # (fastapi, mcp, cognee, …); the test suite imports kb.server and the
+        # MCP module, so a base-only sync fails collection with ModuleNotFound.
+        run: uv sync --all-extras --dev
       - name: Lint
         run: uv run ruff check .
       - name: Run tests


### PR DESCRIPTION
Second CI fix. After the lint gate was cleared (#79), the `Run tests` step failed with `ModuleNotFoundError: No module named 'fastapi'` / `'mcp'` — the workflow's `uv sync --dev` installs the dev group (pytest/ruff) but **not** the `server` optional-dependency extra (`fastapi`, `mcp`, `cognee`, …). `tests/test_server.py`, `test_mcp_server.py`, and `test_skills.py` import `kb.server` / the MCP module, so collection aborts in CI while the full suite passes locally (where the venv has the extra).

Fix: `uv sync --all-extras --dev`. No code change.