### PR TITLE
fix(mesh): readable Knowledge Mesh — labels, collapse, concept-map

### DIFF
--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -44,15 +44,46 @@ _FRONTMATTER_SCAN_LINES = 30
 # makes a useful label.
 _PUNCT_ONLY_RE = re.compile(r"^[\W_]+$")
 
+# Cognee's summariser opens nearly every TextSummary with boilerplate —
+# "This chunk is about …", "This document describes …", "This input is a …" —
+# so every derived label reads identically. Strip that lead-in so the real
+# subject shows. The subject noun is restricted to a known set so ordinary
+# names ("This is the auth service") are never touched.
+_SUMMARY_LEAD_RE = re.compile(
+    r"^(?:the|this|these|it|here)\s+"
+    r"(?:chunk|input|document|text|section|note|page|passage|content|summary|"
+    r"entry|file|record|snippet|paragraph|excerpt|data|list|log)s?\s+"
+    r"(?:is|are|describes?|discusses|contains?|covers?|provides?|details?|"
+    r"explains?|outlines?|summari[sz]es?|represents?|lists?|shows?|appears?|"
+    r"captures?|documents?|reflects?)\s+"
+    r"(?:to\s+be\s+|that\s+|how\s+|about\s+|a\s+|an\s+|the\s+|of\s+)*",
+    re.IGNORECASE,
+)
 
-def _first_line_label(text: str, max_len: int) -> str:
+
+def _strip_summary_lead(line: str) -> str:
+    """Drop a cognee summariser lead-in; recapitalise the surviving subject.
+
+    Returns ``""`` when only punctuation survives (e.g. "This chunk is about
+    ."), so callers fall through to the next label source.
+    """
+    cleaned = _SUMMARY_LEAD_RE.sub("", line, count=1).strip()
+    if not cleaned or _PUNCT_ONLY_RE.match(cleaned):
+        return ""
+    if cleaned == line:
+        return line
+    return cleaned[0].upper() + cleaned[1:]
+
+
+def _first_line_label(text: str, max_len: int, *, clean=None) -> str:
     """First non-empty line, whitespace-collapsed, ellipsis-truncated when cut.
 
     Text opening with a ``---`` fence skips the whole YAML frontmatter block —
     up to and including the closing ``---``/``...`` fence within the first
     ``_FRONTMATTER_SCAN_LINES`` lines; when no closing fence is found only the
     opening fence line is skipped. Lines that are only dashes/punctuation are
-    never returned as labels.
+    never returned as labels. ``clean`` optionally rewrites the surviving line
+    (applied BEFORE truncation so the subject is not cut off by a lead-in).
     """
     lines = text.splitlines()
     start = 0
@@ -66,6 +97,10 @@ def _first_line_label(text: str, max_len: int) -> str:
         collapsed = " ".join(line.split())
         if not collapsed or _PUNCT_ONLY_RE.match(collapsed):
             continue
+        if clean is not None:
+            collapsed = clean(collapsed)
+            if not collapsed:
+                continue
         if len(collapsed) <= max_len:
             return collapsed
         return collapsed[: max_len - 1] + "…"
@@ -81,15 +116,18 @@ def _node_label(node_id: str, properties: dict[str, Any]) -> str:
         value = properties.get(key)
         if isinstance(value, str) and value.strip():
             if key == "text":
-                # Chunk nodes: raw chunk bodies are paragraphs, not names —
-                # keep the first non-empty line, tightly capped. Bodies with
-                # no labelable line (e.g. only dashes) fall through to the
-                # next key.
-                label = _first_line_label(value, _CHUNK_LABEL_MAX)
+                # Chunk/summary nodes: raw bodies are paragraphs, not names —
+                # keep the first non-empty line, tightly capped, with the
+                # summariser lead-in stripped. Bodies with no labelable line
+                # (e.g. only dashes) fall through to the next key.
+                label = _first_line_label(value, _CHUNK_LABEL_MAX, clean=_strip_summary_lead)
                 if label:
                     return label
                 continue
-            return " ".join(value.split())[:120]
+            # name/label/title may still carry a summariser sentence — strip it
+            # too, but keep the original when nothing boilerplate matched.
+            collapsed = " ".join(value.split())
+            return (_strip_summary_lead(collapsed) or collapsed)[:120]
     return str(node_id)[:120]
 
 
@@ -139,7 +177,7 @@ def _derive_fallback_label(
         for key in ("text", "name", "label"):
             value = properties.get(key)
             if isinstance(value, str) and value.strip():
-                label = _first_line_label(value, _DOC_LABEL_MAX)
+                label = _first_line_label(value, _DOC_LABEL_MAX, clean=_strip_summary_lead)
                 if label:
                     return label
 
@@ -425,7 +463,7 @@ def build_graph_payload(
                     best = (key, text)
             if best is None:
                 continue
-            label = _first_line_label(best[1], _DOC_LABEL_MAX)
+            label = _first_line_label(best[1], _DOC_LABEL_MAX, clean=_strip_summary_lead)
             if not label:
                 continue
             node = internal_nodes[doc_id]

--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -101,6 +101,64 @@ def _node_type(properties: dict[str, Any]) -> str:
     return "node"
 
 
+def _raw_props_by_id(raw_nodes: list[Any]) -> dict[str, dict[str, Any]]:
+    """Index ``{node_id: properties}`` for neighbour/own-property label lookups."""
+    index: dict[str, dict[str, Any]] = {}
+    for raw in raw_nodes:
+        try:
+            node_id, properties = str(raw[0]), raw[1]
+        except (TypeError, IndexError, KeyError):
+            continue
+        if isinstance(properties, dict):
+            index[node_id] = properties
+    return index
+
+
+def _basename_label(location: str) -> str:
+    """Source-file basename from a ``raw_data_location`` path (``/`` or ``\\``)."""
+    return location.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1].strip()
+
+
+def _derive_fallback_label(
+    node_id: str,
+    raw_props: dict[str, dict[str, Any]],
+    nodeset_of: dict[str, str],
+    summary_of: dict[str, str],
+) -> str:
+    """Best-available label for an internal node the chunk pass could not name.
+
+    Tried in descending descriptiveness: (1) the first line of a neighbouring
+    TextSummary, (2) the source-file basename from ``raw_data_location`` (skipped
+    when it is itself a cognee-internal ``text_<md5>.txt`` name), (3) the name of
+    the NodeSet the node belongs to (coarse but real). Returns ``""`` when no
+    source yields a usable label, leaving the internal name in place.
+    """
+    summary_id = summary_of.get(node_id)
+    if summary_id:
+        properties = raw_props.get(summary_id, {})
+        for key in ("text", "name", "label"):
+            value = properties.get(key)
+            if isinstance(value, str) and value.strip():
+                label = _first_line_label(value, _DOC_LABEL_MAX)
+                if label:
+                    return label
+
+    location = raw_props.get(node_id, {}).get("raw_data_location")
+    if isinstance(location, str) and location.strip():
+        base = _basename_label(location)
+        stem = base.rsplit(".", 1)[0] if "." in base else base
+        if base and not _is_internal_label(node_id, stem):
+            return base[:_DOC_LABEL_MAX]
+
+    nodeset_id = nodeset_of.get(node_id)
+    if nodeset_id:
+        label = _node_label(nodeset_id, raw_props.get(nodeset_id, {}))
+        if label and not _is_internal_label(nodeset_id, label):
+            return label[:_DOC_LABEL_MAX]
+
+    return ""
+
+
 def _raw_id(raw: Any) -> str | None:
     try:
         return str(raw[0])
@@ -233,6 +291,7 @@ def build_graph_payload(
     limit: int = DEFAULT_MAX_NODES,
     dataset_map: dict[str, list[str]] | None = None,
     presence: list[dict[str, Any]] | None = None,
+    collapse_orphan_documents: bool = False,
 ) -> dict[str, Any]:
     """Shape raw Cognee graph tuples into the ``{nodes, edges}`` contract.
 
@@ -295,6 +354,11 @@ def build_graph_payload(
         node_by_id[node_key] = node
         if len(nodes) >= limit:
             break
+
+    # Captured before collapse can shrink ``nodes`` so ``truncated`` keeps its
+    # meaning ("more raw nodes exist than were shaped"), not "collapse removed
+    # some".
+    kept_count = len(nodes)
 
     # Kept nodes still wearing a cognee-internal label (``text_<md5>`` or the
     # bare node id) get a human label derived from their chunk text below.
@@ -368,6 +432,83 @@ def build_graph_payload(
             node["internal_name"] = node["label"]
             node["label"] = label
 
+    # Internal-labeled nodes the chunk pass still could not name.
+    still_internal: dict[str, dict[str, Any]] = {
+        node_id: node
+        for node_id, node in internal_nodes.items()
+        if _is_internal_label(node_id, node["label"])
+    }
+    raw_props: dict[str, dict[str, Any]] | None = None
+
+    if collapse_orphan_documents and still_internal:
+        # Fold unnamed "orphan" documents — internal-labeled TextDocuments the
+        # chunk pass could not name whose only real membership is a NodeSet
+        # (legacy session-cache imports) — into that NodeSet node, which then
+        # carries a ``collapsed`` count. Keeps the canvas readable: one hub per
+        # set instead of a cloud of ``text_<md5>`` dots. Removed ids leave
+        # ``kept_ids`` so their edges drop in the edge pass below. Opt-in;
+        # default off keeps the exact prior node set. Runs AFTER caller-scoped
+        # visibility filtering (KnowledgeMesh.graph), so it is display-only and
+        # never widens what a scoped caller can see.
+        nodeset_ids = {
+            node["id"]
+            for node in nodes
+            if "nodeset" in str(node.get("type", "")).lower()
+        }
+        collapse_into: dict[str, str] = {}
+        if nodeset_ids:
+            for raw in raw_edges:
+                try:
+                    source, target, relationship = str(raw[0]), str(raw[1]), str(raw[2])
+                except (TypeError, IndexError, KeyError):
+                    continue
+                if relationship != "belongs_to_set":
+                    continue
+                for doc_id, set_id in ((source, target), (target, source)):
+                    if (
+                        doc_id in still_internal
+                        and set_id in nodeset_ids
+                        and "document" in str(node_by_id[doc_id].get("type", "")).lower()
+                    ):
+                        collapse_into.setdefault(doc_id, set_id)
+        for doc_id, set_id in collapse_into.items():
+            hub = node_by_id.get(set_id)
+            if hub is None:
+                continue
+            hub["collapsed"] = int(hub.get("collapsed", 0)) + 1
+            node_by_id.pop(doc_id, None)
+            kept_ids.discard(doc_id)
+            still_internal.pop(doc_id, None)
+        if collapse_into:
+            nodes = [node for node in nodes if node["id"] in kept_ids]
+
+    if still_internal:
+        # Fallback labels for the survivors: neighbouring TextSummary, source
+        # basename, or NodeSet name (see ``_derive_fallback_label``). One edge
+        # sweep resolves each survivor's TextSummary and NodeSet neighbours.
+        if raw_props is None:
+            raw_props = _raw_props_by_id(raw_nodes)
+        nodeset_of: dict[str, str] = {}
+        summary_of: dict[str, str] = {}
+        for raw in raw_edges:
+            try:
+                source, target, relationship = str(raw[0]), str(raw[1]), str(raw[2])
+            except (TypeError, IndexError, KeyError):
+                continue
+            for node_id, other_id in ((source, target), (target, source)):
+                if node_id not in still_internal:
+                    continue
+                other_type = _node_type(raw_props.get(other_id, {})).lower()
+                if relationship == "belongs_to_set" and "nodeset" in other_type:
+                    nodeset_of.setdefault(node_id, other_id)
+                elif "summary" in other_type:
+                    summary_of.setdefault(node_id, other_id)
+        for node_id, node in still_internal.items():
+            label = _derive_fallback_label(node_id, raw_props, nodeset_of, summary_of)
+            if label:
+                node["internal_name"] = node["label"]
+                node["label"] = label
+
     edges: list[dict[str, Any]] = []
     for raw in raw_edges:
         try:
@@ -384,8 +525,9 @@ def build_graph_payload(
             }
         )
 
-    # Raw-count semantics captured before synthetic hubs are appended.
-    truncated = len(raw_nodes) > len(nodes)
+    # Raw-count semantics captured before synthetic hubs are appended;
+    # ``kept_count`` is the pre-collapse shaped count.
+    truncated = len(raw_nodes) > kept_count
 
     if dataset_map or presence:
         # Synthesize one hub node per dataset attached to at least one KEPT
@@ -497,6 +639,7 @@ class KnowledgeMesh:
         limit: int = DEFAULT_MAX_NODES,
         dataset_visible: Callable[[str], bool] | None = None,
         presence: list[dict[str, Any]] | None = None,
+        collapse_orphans: bool = False,
     ) -> dict[str, Any]:
         """Shaped graph payload; ``dataset_visible`` scopes CONTENT per caller.
 
@@ -596,6 +739,7 @@ class KnowledgeMesh:
                 limit=limit,
                 dataset_map=dataset_map,
                 presence=presence,
+                collapse_orphan_documents=collapse_orphans,
             )
         )
         if dataset_visible is not None:

--- a/kb/server.py
+++ b/kb/server.py
@@ -2415,6 +2415,7 @@ async def mesh_graph(request: Request, limit: int | None = None) -> Any:
                 else lambda name: dataset_visible_to(identity, name)
             ),
             presence=mesh_presence_hubs(),
+            collapse_orphans=True,
         )
     return jsonable_encoder({**graph, "limit": effective_limit})
 

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -388,11 +388,18 @@ function aggregateKnowledgeMesh(nodes, links) {
     const kind = nodeKind(node);
     return kind === "document" || kind === "chunk";
   };
+  // Cognee TextSummary nodes are per-chunk summaries ("This chunk is about …"),
+  // not concepts — drop them from the concept map so labels aren't all boilerplate.
+  const isSummary = (node) => rawType(node).includes("summary");
   const keep = new Set();
   for (const node of nodes) {
     if (node.type === "dataset" || isConcept(node)) {
       keep.add(node.id);
-    } else if (!isDocLike(node) && (degree.get(node.id) || 0) >= AGG_MIN_ENTITY_DEGREE) {
+    } else if (
+      !isDocLike(node) &&
+      !isSummary(node) &&
+      (degree.get(node.id) || 0) >= AGG_MIN_ENTITY_DEGREE
+    ) {
       keep.add(node.id);
     }
   }

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -366,6 +366,62 @@ function rebuildNeighborLinks(nodes, links) {
   return byId;
 }
 
+// Overview default for Knowledge Mesh: fold the raw document/chunk cloud into
+// per-hub counts so the graph reads as a concept map — dataset/seat hubs, the
+// entity TYPES (EntityType/NodeSet), and the well-connected entities that tie
+// them together — instead of a 200-node hairball. Documents attributed to a
+// dataset become a "· N docs" count on that hub; sparsely-linked entities and
+// the document/chunk nodes themselves drop out. Degree is measured on the full
+// link set before anything is removed.
+const AGG_MIN_ENTITY_DEGREE = 6;
+
+function aggregateKnowledgeMesh(nodes, links) {
+  const degree = new Map();
+  for (const link of links) {
+    degree.set(link.source, (degree.get(link.source) || 0) + 1);
+    degree.set(link.target, (degree.get(link.target) || 0) + 1);
+  }
+  const rawType = (node) => String(node.type || "").toLowerCase();
+  const isConcept = (node) =>
+    rawType(node).includes("entitytype") || rawType(node).includes("nodeset");
+  const isDocLike = (node) => {
+    const kind = nodeKind(node);
+    return kind === "document" || kind === "chunk";
+  };
+  const keep = new Set();
+  for (const node of nodes) {
+    if (node.type === "dataset" || isConcept(node)) {
+      keep.add(node.id);
+    } else if (!isDocLike(node) && (degree.get(node.id) || 0) >= AGG_MIN_ENTITY_DEGREE) {
+      keep.add(node.id);
+    }
+  }
+  // Fold each dropped, document-like node into its dataset hub's count.
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const folded = new Map();
+  for (const link of links) {
+    if ((link.relationship || link.label) !== "belongs_to") continue;
+    const a = byId.get(link.source);
+    const b = byId.get(link.target);
+    const hub = a && a.type === "dataset" ? a : b && b.type === "dataset" ? b : null;
+    const other = hub === a ? b : a;
+    if (hub && other && !keep.has(other.id) && isDocLike(other)) {
+      folded.set(hub.id, (folded.get(hub.id) || 0) + 1);
+    }
+  }
+  const keptNodes = nodes
+    .filter((node) => keep.has(node.id))
+    .map((node) => {
+      const count = folded.get(node.id);
+      if (!count) return node;
+      return { ...node, docCount: count, label: `${node.label} · ${count} docs` };
+    });
+  const keptLinks = links.filter(
+    (link) => keep.has(link.source) && keep.has(link.target),
+  );
+  return { nodes: keptNodes, links: keptLinks };
+}
+
 // Map the active {nodes,edges} into force-graph graphData and precompute
 // node.neighbors + node.links once for fast hover highlighting.
 function buildForceGraphData() {
@@ -397,6 +453,11 @@ function buildForceGraphData() {
       label: edge.label || edge.relationship,
       relationship: edge.relationship || edge.label,
     });
+  }
+  // Knowledge Mesh overview aggregates to a readable concept map by default;
+  // the raw graph (state.realGraph) stays untouched for inspection/search.
+  if (state.graphMode === "knowledge" && state.graphAggregate !== false) {
+    ({ nodes, links } = aggregateKnowledgeMesh(nodes, links));
   }
   // resolveCentralId's highest-degree fallback reads node.neighbors, which is
   // only populated by rebuildNeighborLinks — so resolve AFTER the first pass,
@@ -1410,12 +1471,25 @@ function initializeGraph() {
     .cooldownTicks(120)
     .onNodeHover(handleNodeHover)
     .onNodeClick(handleNodeClick)
-    .onBackgroundClick(() => selectNode(null));
+    .onBackgroundClick(() => selectNode(null))
+    // Re-frame once the simulation settles, not on a fixed timer: the layout is
+    // still collapsing at 400ms, so an early one-shot zoomToFit left the graph a
+    // tiny blob in an empty canvas. needsFit is re-armed on every data load.
+    .onEngineStop(() => {
+      if (graph.instance && graph.needsFit) {
+        graph.needsFit = false;
+        graph.instance.zoomToFit(500, 60);
+      }
+    });
 
-  // Stronger centre pull keeps the pinned Central hub framed and the cloud tight.
+  // Spread the cloud so structure is legible instead of a dense ball: stronger
+  // charge repulsion plus a real link distance (defaults clump ~200 nodes onto
+  // the pinned Central hub).
   if (typeof graph.instance.d3Force === "function") {
     const charge = graph.instance.d3Force("charge");
-    if (charge && typeof charge.strength === "function") charge.strength(-120);
+    if (charge && typeof charge.strength === "function") charge.strength(-300);
+    const link = graph.instance.d3Force("link");
+    if (link && typeof link.distance === "function") link.distance(58);
   }
 }
 
@@ -1449,8 +1523,18 @@ function linkWidth(link) {
 // nodes appear only past the zoom threshold so the default view stays clean.
 function drawNodeLabel(node, ctx, globalScale) {
   const isCentral = node.id === graph.centralId;
-  if (!isCentral && globalScale < LABEL_ZOOM_THRESHOLD) return;
-  if (graph.highlightNodes.size && !graph.highlightNodes.has(node.id) && !isCentral) return;
+  // Hubs and entity-type concepts carry the map, so they stay labelled at any
+  // zoom; individual entities only appear once the user zooms past the
+  // threshold, keeping the default framing readable.
+  const rawType = String(node.type || "").toLowerCase();
+  const isKeyNode =
+    isCentral ||
+    nodeKind(node) === "dataset" ||
+    nodeKind(node) === "seat" ||
+    rawType.includes("entitytype") ||
+    rawType.includes("nodeset");
+  if (!isKeyNode && globalScale < LABEL_ZOOM_THRESHOLD) return;
+  if (graph.highlightNodes.size && !graph.highlightNodes.has(node.id) && !isKeyNode) return;
   const label = truncate(String(node.label || node.id), isCentral ? 28 : 22);
   const fontSize = (isCentral ? 13 : 11) / globalScale;
   ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
@@ -1491,9 +1575,12 @@ function renderGraph() {
 
   graph.instance.graphData({ nodes: data.nodes, links: data.links });
   graph.instance.centerAt(0, 0);
+  // Arm a settle-fit for this data set (handled by onEngineStop); keep a single
+  // coarse early fit on first paint as a fallback if the engine never stops.
+  graph.needsFit = true;
   if (!graph.viewInitialized) {
     graph.viewInitialized = true;
-    window.setTimeout(() => graph.instance && graph.instance.zoomToFit(600, 40), 400);
+    window.setTimeout(() => graph.instance && graph.instance.zoomToFit(600, 60), 400);
   }
 }
 
@@ -1966,7 +2053,10 @@ function meshGraphRetryDelay(index) {
 async function fetchMeshGraphWithBackoff() {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      return await api("/api/mesh/graph");
+      // Pull the fuller graph (server caps at 1000): the overview aggregates it
+      // down to a concept map, and the raw 200-node slice leaves too few entity
+      // types/hubs once documents are folded away.
+      return await api("/api/mesh/graph?limit=1000");
     } catch (error) {
       const retriable =
         error && error.status === 429 && attempt < MESH_GRAPH_RETRY_BASES_MS.length;

--- a/tests/test_knowledge_mesh.py
+++ b/tests/test_knowledge_mesh.py
@@ -740,3 +740,147 @@ def test_dashes_only_chunk_text_leaves_internal_document_label_unchanged() -> No
     doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
     assert doc["label"] == INTERNAL_DOC_NAME
     assert "internal_name" not in doc
+
+
+# --- fallback labels when no is_part_of chunk names an internal node ----------
+
+SECOND_INTERNAL_DOC_NAME = "text_" + "b" * 32
+
+
+def test_internal_document_labeled_by_summary_neighbor() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("sum-1", {"text": "Weekly release notes\nrest", "type": "TextSummary"}),
+    ]
+    payload = build_graph_payload(nodes, [("sum-1", "doc-1", "made_from", {})], limit=10)
+
+    doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
+    assert doc["label"] == "Weekly release notes"
+    assert doc["internal_name"] == INTERNAL_DOC_NAME
+
+
+def test_internal_document_labeled_by_raw_data_location_basename() -> None:
+    payload = build_graph_payload(
+        [
+            (
+                "doc-1",
+                {
+                    "name": INTERNAL_DOC_NAME,
+                    "type": "TextDocument",
+                    "raw_data_location": "/data/store/README.md",
+                },
+            )
+        ],
+        [],
+        limit=10,
+    )
+
+    doc = payload["nodes"][0]
+    assert doc["label"] == "README.md"
+    assert doc["internal_name"] == INTERNAL_DOC_NAME
+
+
+def test_internal_raw_data_location_name_is_not_used_as_label() -> None:
+    # A cognee-generated text_<md5>.txt path is no better than the internal name.
+    payload = build_graph_payload(
+        [
+            (
+                "doc-1",
+                {
+                    "name": INTERNAL_DOC_NAME,
+                    "type": "TextDocument",
+                    "raw_data_location": f"/data/store/{INTERNAL_DOC_NAME}.txt",
+                },
+            )
+        ],
+        [],
+        limit=10,
+    )
+
+    doc = payload["nodes"][0]
+    assert doc["label"] == INTERNAL_DOC_NAME
+    assert "internal_name" not in doc
+
+
+def test_internal_document_labeled_by_nodeset_membership() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
+    ]
+    payload = build_graph_payload(
+        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10
+    )
+
+    doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
+    assert doc["label"] == "user_sessions_from_cache"
+    assert doc["internal_name"] == INTERNAL_DOC_NAME
+
+
+def test_summary_fallback_wins_over_nodeset_fallback() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("sum-1", {"text": "Concrete summary line", "type": "TextSummary"}),
+        ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
+    ]
+    edges = [
+        ("sum-1", "doc-1", "made_from", {}),
+        ("doc-1", "set-1", "belongs_to_set", {}),
+    ]
+    payload = build_graph_payload(nodes, edges, limit=10)
+
+    doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
+    assert doc["label"] == "Concrete summary line"
+
+
+# --- collapse orphan documents into their NodeSet hub (opt-in) ----------------
+
+
+def test_collapse_orphans_folds_internal_documents_into_nodeset() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("doc-2", {"name": SECOND_INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
+    ]
+    edges = [
+        ("doc-1", "set-1", "belongs_to_set", {}),
+        ("doc-2", "set-1", "belongs_to_set", {}),
+    ]
+    payload = build_graph_payload(
+        nodes, edges, limit=10, collapse_orphan_documents=True
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"set-1"}
+    hub = payload["nodes"][0]
+    assert hub["collapsed"] == 2
+    # Collapsed documents take their edges with them.
+    assert payload["edges"] == []
+
+
+def test_orphans_are_not_collapsed_without_opt_in() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
+    ]
+    payload = build_graph_payload(
+        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"doc-1", "set-1"}
+    set_node = next(node for node in payload["nodes"] if node["id"] == "set-1")
+    assert "collapsed" not in set_node
+
+
+def test_named_document_is_never_collapsed() -> None:
+    nodes = [
+        ("doc-1", {"name": "Design Doc", "type": "TextDocument"}),
+        ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
+    ]
+    payload = build_graph_payload(
+        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10,
+        collapse_orphan_documents=True,
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"doc-1", "set-1"}

--- a/tests/test_knowledge_mesh.py
+++ b/tests/test_knowledge_mesh.py
@@ -872,6 +872,38 @@ def test_orphans_are_not_collapsed_without_opt_in() -> None:
     assert "collapsed" not in set_node
 
 
+def test_summary_boilerplate_lead_in_is_stripped_from_labels() -> None:
+    nodes = [
+        ("sum-1", {"text": "This chunk is about a repository of question-answer pairs", "type": "TextSummary"}),
+        ("sum-2", {"name": "This document describes the release checklist", "type": "TextSummary"}),
+        ("sum-3", {"text": "This input is a list of 40 empty questions", "type": "TextSummary"}),
+    ]
+    payload = build_graph_payload(nodes, [], limit=10)
+    labels = {node["id"]: node["label"] for node in payload["nodes"]}
+    assert labels["sum-1"] == "Repository of question-answer pairs"
+    assert labels["sum-2"] == "Release checklist"
+    assert labels["sum-3"] == "List of 40 empty questions"
+
+
+def test_ordinary_name_is_not_mistaken_for_summary_boilerplate() -> None:
+    # "This is the auth service" has no summary noun after the pronoun, so it
+    # must survive untouched.
+    payload = build_graph_payload(
+        [("n-1", {"name": "This is the auth service", "type": "Entity"})], [], limit=10
+    )
+    assert payload["nodes"][0]["label"] == "This is the auth service"
+
+
+def test_internal_document_summary_fallback_strips_boilerplate() -> None:
+    nodes = [
+        ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
+        ("sum-1", {"text": "This chunk is about the promotion pipeline", "type": "TextSummary"}),
+    ]
+    payload = build_graph_payload(nodes, [("sum-1", "doc-1", "made_from", {})], limit=10)
+    doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
+    assert doc["label"] == "Promotion pipeline"
+
+
 def test_named_document_is_never_collapsed() -> None:
     nodes = [
         ("doc-1", {"name": "Design Doc", "type": "TextDocument"}),


### PR DESCRIPTION
Makes the overview Knowledge Mesh understandable instead of an unlabeled hairball. Verified against live prod data via a local static+API proxy; **not deployed**.

## Commits
- **Backend labels + collapse** — fallback label chain (TextSummary → `raw_data_location` basename → NodeSet name) for cognee-internal `text_<md5>` nodes; opt-in collapse of orphan session-cache docs into their NodeSet hub with a count. Isolation path (ADR-0009) untouched — both run after caller-scoped filtering.
- **Aggregated concept map (frontend)** — the overview folds the raw doc/chunk cloud into per-hub counts and shows the concept skeleton (dataset/seat hubs + EntityType + connective entities); fit-on-settle, spread forces, hub labels always on.
- **Boilerplate strip** — cognee opens most summaries with "This chunk is about…"; strip the lead-in from labels and drop TextSummary nodes from the concept map.

## Tests
49/49 `test_knowledge_mesh.py` + server graph tests pass; ruff clean; console clean in-browser.