### PR TITLE
feat(cli): citadel activity + capture receipts (DX-5/DX-6)

### DIFF
--- a/kb/cli.py
+++ b/kb/cli.py
@@ -77,7 +77,7 @@ from kb.promotion_client import (
     reject_pending,
     run_promotion,
 )
-from kb.status import fetch_mesh, gather_status, render_text, render_verdict
+from kb.status import fetch_events, fetch_mesh, gather_status, render_text, render_verdict
 
 
 def _print_json(value: Any) -> None:
@@ -1240,6 +1240,97 @@ def _render_mesh(mesh: dict[str, Any], color: bool) -> str:
     )
 
 
+def _render_event(event: dict[str, Any], color: bool) -> str:
+    """One Vault Activity line: `HH:MM  <type>  <message>  (dataset)`."""
+    created = str(event.get("created_at") or "")
+    stamp = created[11:16] if len(created) >= 16 else created[:5]
+    etype = str(event.get("type") or "event")
+    message = str(event.get("message") or "").strip()
+    details = event.get("details") if isinstance(event.get("details"), dict) else {}
+    timeline = event.get("timeline") if isinstance(event.get("timeline"), dict) else {}
+    dataset = details.get("dataset") or timeline.get("dataset") or ""
+    line = (
+        paint(f"{stamp:>5}", "dim", enable=color)
+        + "  "
+        + paint(f"{etype:<12}", "bold", enable=color)
+        + " "
+        + message
+    )
+    if dataset:
+        line += paint(f"  ({dataset})", "dim", enable=color)
+    return line
+
+
+def _activity_local(limit: int) -> int:
+    """Print the tail of the local capture-receipt log (offline, no server)."""
+    from kb.hooks.receipt import activity_log_path
+
+    path = activity_log_path()
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        print("No local capture receipts yet — capture something (git push / session close) first.")
+        return 0
+    lines = [line for line in text.splitlines() if line.strip()]
+    for line in lines[-limit:]:
+        print(line)
+    if not lines:
+        print("No local capture receipts yet.")
+    return 0
+
+
+async def _activity(args: argparse.Namespace) -> int:
+    """Show the caller's own Node Vault Activity — recent, or live-tailed (--watch).
+
+    Own-Node events carry content; the server scopes the feed per caller
+    (ADR-0009), so this never shows another seat's Node content.
+    """
+    limit = max(1, min(int(args.limit or 20), 160))
+    if args.local:
+        return _activity_local(limit)
+
+    config_path = Path(args.config).expanduser() if args.config else capture_config_path()
+    try:
+        node_url = args.node_url or load_capture_config(config_path).node_url
+    except ValueError:
+        node_url = args.node_url or DEFAULT_NODE_URL
+    token = capture_token() or None
+    use_color = supports_color()
+
+    data = await asyncio.to_thread(fetch_events, node_url, token, limit=limit, event_type=args.type)
+    if args.json and not args.watch:
+        _print_json(data)
+        return 0
+
+    events = list(reversed(data.get("events") or []))  # oldest -> newest reads like a growing feed
+    for event in events:
+        print(_render_event(event, use_color))
+    last_id = data.get("latest_event_id")
+    if last_id is None:
+        last_id = events[-1]["id"] if events else 0
+
+    if not args.watch:
+        if not events:
+            print(paint("No recent activity.", "dim", enable=use_color))
+            if not token:
+                print(paint("  (no token configured — run `citadel onboard`)", "yellow", enable=use_color))
+        return 0
+
+    print(paint("— watching your Node (Ctrl-C to stop) —", "dim", enable=use_color))
+    while True:
+        await asyncio.sleep(3)
+        data = await asyncio.to_thread(
+            fetch_events, node_url, token, after_id=last_id, limit=160, event_type=args.type
+        )
+        fresh = list(reversed(data.get("events") or []))
+        for event in fresh:
+            print(_render_event(event, use_color))
+        if fresh:
+            last_id = fresh[-1]["id"]
+        elif data.get("latest_event_id") is not None:
+            last_id = max(last_id, data["latest_event_id"])
+
+
 def _mcp_node_url(path: Path) -> str | None:
     """The Node base URL wired into .mcp.json (citadel server), sans /mcp/ suffix."""
     try:
@@ -1947,6 +2038,23 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--no-search", action="store_true", help="Skip the search smoke check")
     status.add_argument("--no-recent", action="store_true", help="Skip recent-activity fetch")
     status.set_defaults(handler=_status)
+
+    activity = subcommands.add_parser(
+        "activity",
+        help="Show your Node's vault activity — captures, syncs, promotions, searches",
+    )
+    activity.add_argument("--watch", action="store_true", help="Live-tail new activity (Ctrl-C to stop)")
+    activity.add_argument(
+        "--local",
+        action="store_true",
+        help="Show local capture receipts from ~/.citadel/activity.log (offline, no server)",
+    )
+    activity.add_argument("--limit", type=int, default=20, help="How many recent events to show (default 20)")
+    activity.add_argument("--type", help="Filter by event type (ingest, search, promotion, github_sync, …)")
+    activity.add_argument("--json", action="store_true", help="Machine-readable output")
+    activity.add_argument("--node-url", help="Override Node URL (default: from config)")
+    activity.add_argument("--config", help="Override capture config path")
+    activity.set_defaults(handler=_activity)
 
     doctor = subcommands.add_parser(
         "doctor",

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -77,7 +77,14 @@ from kb.promotion_client import (
     reject_pending,
     run_promotion,
 )
-from kb.status import fetch_events, fetch_mesh, gather_status, render_text, render_verdict
+from kb.status import (
+    fetch_events,
+    fetch_mesh,
+    fetch_presence,
+    gather_status,
+    render_text,
+    render_verdict,
+)
 
 
 def _print_json(value: Any) -> None:
@@ -1279,11 +1286,48 @@ def _activity_local(limit: int) -> int:
     return 0
 
 
+def _render_presence(board: dict[str, Any], color: bool) -> str:
+    """The team-presence board: one row per seat, `seat:<slug>  <n> docs`.
+
+    Renders only Seat Presence (slug + contribution count) — no Node content.
+    """
+    seats = [s for s in (board.get("seats") or []) if isinstance(s, dict)]
+    if not seats:
+        return paint("No seats visible.", "dim", enable=color)
+    # Central and higher-contribution seats first; slug is the only identity.
+    seats.sort(key=lambda s: (-(s.get("documents") or 0), str(s.get("seat") or "")))
+    width = max((len(str(s.get("seat") or "")) for s in seats), default=0)
+    rows = [paint("Team presence", "bold", enable=color)]
+    for seat in seats:
+        slug = str(seat.get("seat") or "")
+        docs = seat.get("documents")
+        count = f"{docs} docs" if isinstance(docs, int) else "—"
+        rows.append(f"  {slug.ljust(width)}  {paint(count, 'dim', enable=color)}")
+    return "\n".join(rows)
+
+
+async def _activity_global(node_url: str, token: str | None, color: bool, watch: bool) -> int:
+    """Live team-presence broadcast — Seat Presence only (ADR-0009), no content."""
+    board = await asyncio.to_thread(fetch_presence, node_url, token)
+    print(_render_presence(board, color))
+    if not token and not (board.get("seats")):
+        print(paint("  (no token configured — run `citadel onboard`)", "yellow", enable=color))
+    if not watch:
+        return 0
+    print(paint("— watching team presence (Ctrl-C to stop) —", "dim", enable=color))
+    while True:
+        await asyncio.sleep(10)  # gentle: /api/mesh/graph is TTL-cached + latency-watched
+        board = await asyncio.to_thread(fetch_presence, node_url, token)
+        print()
+        print(_render_presence(board, color))
+
+
 async def _activity(args: argparse.Namespace) -> int:
     """Show the caller's own Node Vault Activity — recent, or live-tailed (--watch).
 
     Own-Node events carry content; the server scopes the feed per caller
-    (ADR-0009), so this never shows another seat's Node content.
+    (ADR-0009), so this never shows another seat's Node content. ``--global``
+    switches to the org Seat Presence board (counts only, no content).
     """
     limit = max(1, min(int(args.limit or 20), 160))
     if args.local:
@@ -1296,6 +1340,9 @@ async def _activity(args: argparse.Namespace) -> int:
         node_url = args.node_url or DEFAULT_NODE_URL
     token = capture_token() or None
     use_color = supports_color()
+
+    if getattr(args, "global_broadcast", False):
+        return await _activity_global(node_url, token, use_color, args.watch)
 
     data = await asyncio.to_thread(fetch_events, node_url, token, limit=limit, event_type=args.type)
     if args.json and not args.watch:
@@ -2044,6 +2091,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show your Node's vault activity — captures, syncs, promotions, searches",
     )
     activity.add_argument("--watch", action="store_true", help="Live-tail new activity (Ctrl-C to stop)")
+    activity.add_argument(
+        "--global",
+        dest="global_broadcast",
+        action="store_true",
+        help="Live team presence — every seat's contribution count (Seat Presence only, no content)",
+    )
     activity.add_argument(
         "--local",
         action="store_true",

--- a/kb/hooks/receipt.py
+++ b/kb/hooks/receipt.py
@@ -1,0 +1,85 @@
+"""Local capture receipts for the fail-silent sync hooks (DX-5).
+
+The git-push and SessionEnd hooks capture silently by design. That leaves a dev
+with no signal that anything happened — the "black box after onboard" problem.
+A receipt makes the invisible visible WITHOUT weakening the hook contract:
+
+- **Stdlib-only + best-effort.** Every function swallows its own errors, so a
+  receipt can never break a hook (hooks always exit 0, never block a git push
+  or session close).
+- **Never surfaces the token.** Receipts carry only counts/summaries.
+- One line per capture is appended to ``~/.citadel/activity.log`` (0600, honoring
+  ``$CITADEL_HOME`` / ``$CITADEL_CAPTURE_CONFIG_PATH``) so ``citadel activity
+  --local`` can show it offline; the line is also printed to stderr when
+  ``CITADEL_HOOK_VERBOSE`` is truthy.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Keep the log bounded — it is a rolling receipt trail, not an audit store.
+_MAX_BYTES = 128 * 1024
+_KEEP_LINES = 200
+
+
+def _base_dir() -> Path:
+    """The local Citadel dir — mirrors ``kb.capture_config.capture_config_path``'s
+    resolution so receipts land next to ``capture.json``."""
+    override = os.getenv("CITADEL_CAPTURE_CONFIG_PATH")
+    if override:
+        return Path(override).expanduser().parent
+    home = os.getenv("CITADEL_HOME")
+    return Path(home).expanduser() if home else Path.home() / ".citadel"
+
+
+def activity_log_path() -> Path:
+    return _base_dir() / "activity.log"
+
+
+def _verbose() -> bool:
+    return (os.getenv("CITADEL_HOOK_VERBOSE") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _roll(path: Path) -> None:
+    """Trim the log to the last ``_KEEP_LINES`` once it grows past ``_MAX_BYTES``."""
+    try:
+        if path.stat().st_size <= _MAX_BYTES:
+            return
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-_KEEP_LINES:]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def write_receipt(kind: str, summary: str) -> None:
+    """Append a one-line capture receipt; echo to stderr when verbose. Never raises.
+
+    ``kind`` is a short tag (``push`` / ``session``); ``summary`` is human text
+    like ``captured commit a1b2c3d → your Node``. Contains no token.
+    """
+    line = f"{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}  {kind}  {summary}"
+    try:
+        path = activity_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError:
+            pass
+        _roll(path)
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        pass  # a receipt must never break the hook
+    if _verbose():
+        try:
+            sys.stderr.write(f"citadel: {summary}\n")
+        except Exception:
+            pass

--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -374,6 +374,11 @@ def _sync_one(
         if tag not in tags:
             tags.append(tag)
     post_ingest(_base_url(), token, note, tags)
+    # DX-5 receipt: make the silent capture visible. write_receipt never raises,
+    # and any import/call failure is caught by run()'s fail-silent except.
+    from kb.hooks.receipt import write_receipt
+
+    write_receipt("push", f"captured commit {sha[:7]} on {branch} → your Node")
 
 
 def run(stdin: Any, remote_name: str = "") -> int:

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -351,6 +351,11 @@ def run(stream_in: Any) -> int:
         tags = build_tags(cwd if isinstance(cwd, str) else "")
 
         post_ingest(_base_url(), token, note, tags)
+        # DX-5 receipt: make the silent session capture visible (never raises,
+        # never surfaces the token; any failure is caught below).
+        from kb.hooks.receipt import write_receipt
+
+        write_receipt("session", "session captured → your Node")
     except Exception:
         # Fail-silent: never block session close, never surface the token.
         return 0

--- a/kb/status.py
+++ b/kb/status.py
@@ -309,6 +309,39 @@ def fetch_events(
     return data if isinstance(data, dict) else {}
 
 
+def fetch_presence(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -> dict[str, Any]:
+    """Best-effort org **Seat Presence** board (ADR-0009): every seat's slug and
+    contribution count, org-visible by design.
+
+    Reads ONLY the ``dataset``-type presence hubs from ``/api/mesh/graph`` — seat
+    slug + ``presence.documents`` — and ignores every content node, so this can
+    never surface another seat's **Node** content. ``limit=1`` keeps content
+    shaping minimal; presence hubs are appended regardless of the cap. ``{}`` on
+    any error / missing token.
+    """
+    if not token:
+        return {}
+    try:
+        data = _request(
+            "GET", f"{base_url.rstrip('/')}/api/mesh/graph?limit=1", token=token, timeout=timeout
+        )
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    seats: list[dict[str, Any]] = []
+    for node in data.get("nodes") or []:
+        if not isinstance(node, dict) or node.get("type") != "dataset":
+            continue
+        label = str(node.get("label") or node.get("dataset") or "").strip()
+        if not label:
+            continue
+        presence = node.get("presence") if isinstance(node.get("presence"), dict) else {}
+        docs = presence.get("documents")
+        seats.append({"seat": label, "documents": docs if isinstance(docs, int) else None})
+    return {"seats": seats}
+
+
 def check_local_setup(repo: Path, config_path: Path | None = None) -> list[Check]:
     checks: list[Check] = []
     checks.append(

--- a/kb/status.py
+++ b/kb/status.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
@@ -275,6 +276,34 @@ def fetch_mesh(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -
         return {}
     try:
         data = _request("GET", f"{base_url.rstrip('/')}/api/mesh", token=token, timeout=timeout)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def fetch_events(
+    base_url: str,
+    token: str | None,
+    *,
+    after_id: int | None = None,
+    limit: int = 20,
+    event_type: str | None = None,
+    timeout: float = _TIMEOUT,
+) -> dict[str, Any]:
+    """Best-effort GET /api/knowledge/events (the caller-scoped Vault Activity
+    timeline). Returns ``{}`` on any error / missing token. ``after_id`` resumes
+    after the last seen event id (for --watch polling)."""
+    if not token:
+        return {}
+    query = f"limit={max(1, min(int(limit), 160))}"
+    if after_id is not None:
+        query += f"&after_id={int(after_id)}"
+    if event_type:
+        query += f"&type={urllib.parse.quote(event_type)}"
+    try:
+        data = _request(
+            "GET", f"{base_url.rstrip('/')}/api/knowledge/events?{query}", token=token, timeout=timeout
+        )
     except Exception:
         return {}
     return data if isinstance(data, dict) else {}

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kb.hooks import receipt
+
+
+def _iso_home(monkeypatch, path: Path) -> None:
+    monkeypatch.delenv("CITADEL_CAPTURE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("CITADEL_HOME", str(path))
+
+
+def test_activity_log_path_honors_citadel_home(monkeypatch, tmp_path: Path) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    assert receipt.activity_log_path() == tmp_path / "activity.log"
+
+
+def test_activity_log_path_from_capture_config_override(monkeypatch, tmp_path: Path) -> None:
+    cfg = tmp_path / "sub" / "capture.json"
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(cfg))
+    assert receipt.activity_log_path() == cfg.parent / "activity.log"
+
+
+def test_write_receipt_appends_lines_with_private_perms(monkeypatch, tmp_path: Path) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    receipt.write_receipt("push", "captured commit abc1234 → your Node")
+    receipt.write_receipt("session", "session captured → your Node")
+
+    log = tmp_path / "activity.log"
+    lines = log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert "push" in lines[0] and "abc1234" in lines[0]
+    assert "session" in lines[1]
+    # Receipts are private (mirrors capture.json 0600).
+    assert (log.stat().st_mode & 0o777) == 0o600
+
+
+def test_write_receipt_never_surfaces_a_token(monkeypatch, tmp_path: Path) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    # write_receipt only ever writes what it is handed — assert the summary is
+    # verbatim and nothing token-shaped is invented.
+    receipt.write_receipt("push", "captured commit deadbee → your Node")
+    body = (tmp_path / "activity.log").read_text(encoding="utf-8")
+    assert "ctdl_" not in body
+    assert "Bearer" not in body
+
+
+def test_write_receipt_never_raises_on_unwritable_path(monkeypatch, tmp_path: Path) -> None:
+    # Parent of the log dir is a file, so mkdir fails — must be swallowed.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x")
+    monkeypatch.delenv("CITADEL_CAPTURE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("CITADEL_HOME", str(blocker / "nested"))
+    receipt.write_receipt("push", "should not crash")  # no exception = pass
+
+
+def test_write_receipt_verbose_echoes_to_stderr(monkeypatch, tmp_path, capsys) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("CITADEL_HOOK_VERBOSE", "1")
+    receipt.write_receipt("push", "captured X → your Node")
+    err = capsys.readouterr().err
+    assert "citadel: captured X → your Node" in err
+
+
+def test_write_receipt_quiet_by_default(monkeypatch, tmp_path, capsys) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("CITADEL_HOOK_VERBOSE", raising=False)
+    receipt.write_receipt("push", "captured Y → your Node")
+    assert capsys.readouterr().err == ""
+
+
+def test_roll_trims_oversized_log(monkeypatch, tmp_path: Path) -> None:
+    _iso_home(monkeypatch, tmp_path)
+    log = tmp_path / "activity.log"
+    log.write_text("old line\n" * 100_000, encoding="utf-8")  # > 128 KB
+    assert log.stat().st_size > receipt._MAX_BYTES
+
+    receipt.write_receipt("push", "fresh line")
+
+    lines = log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) <= receipt._KEEP_LINES + 1
+    assert lines[-1].endswith("fresh line")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -335,3 +335,46 @@ def test_render_event_line() -> None:
     assert "ingest" in line
     assert "Memory indexed" in line
     assert "seat:sarthi" in line
+
+
+# --- Seat Presence broadcast (citadel activity --global / DX-7) --------------
+
+
+def test_fetch_presence_extracts_only_seat_hubs_no_content(monkeypatch) -> None:
+    # A content node MUST be ignored — fetch_presence may only surface Seat
+    # Presence (slug + count), never another seat's Node content (ADR-0009).
+    graph = {
+        "nodes": [
+            {"id": "doc-1", "label": "Alice private doc", "type": "TextDocument"},
+            {"id": "dataset:seat:alice", "label": "seat:alice", "type": "dataset",
+             "presence": {"documents": 5}},
+            {"id": "dataset:masumi-network", "label": "masumi-network", "type": "dataset",
+             "presence": {"documents": 100}},
+        ]
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/api/mesh/graph": graph}))
+    board = status_mod.fetch_presence("https://node.example", "ctdl_tok")
+
+    labels = {s["seat"] for s in board["seats"]}
+    assert labels == {"seat:alice", "masumi-network"}
+    assert not any("private doc" in str(s).lower() for s in board["seats"])
+    alice = next(s for s in board["seats"] if s["seat"] == "seat:alice")
+    assert alice["documents"] == 5
+
+
+def test_fetch_presence_empty_without_token() -> None:
+    assert status_mod.fetch_presence("https://node.example", None) == {}
+
+
+def test_render_presence_board_sorts_by_count() -> None:
+    from kb.cli import _render_presence
+
+    board = {"seats": [
+        {"seat": "seat:sarthi", "documents": 23},
+        {"seat": "masumi-network", "documents": 1022},
+    ]}
+    out = _render_presence(board, color=False)
+    assert "Team presence" in out
+    assert "seat:sarthi" in out
+    assert "23 docs" in out
+    assert out.index("masumi-network") < out.index("seat:sarthi")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -283,3 +283,55 @@ def test_status_command_unhealthy_exits_one(tmp_path: Path, monkeypatch, capsys)
     rc = asyncio.run(_status(args))
     assert rc == 1
     assert "Not connected" in capsys.readouterr().out
+
+
+# --- Vault Activity feed (citadel activity / DX-6) ---------------------------
+
+
+def test_fetch_events_empty_without_token() -> None:
+    assert status_mod.fetch_events("https://node.example", None) == {}
+
+
+def test_fetch_events_builds_scoped_url_and_parses(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
+        captured["url"] = request.full_url
+        return _FakeResp(
+            {"events": [{"id": 7, "type": "ingest", "message": "Memory indexed"}], "latest_event_id": 7}
+        )
+
+    monkeypatch.setattr(status_mod._OPENER, "open", fake_open)
+    data = status_mod.fetch_events(
+        "https://node.example", "ctdl_tok", after_id=3, limit=5, event_type="ingest"
+    )
+    assert "/api/knowledge/events?" in captured["url"]
+    assert "limit=5" in captured["url"]
+    assert "after_id=3" in captured["url"]
+    assert "type=ingest" in captured["url"]
+    assert data["latest_event_id"] == 7
+
+
+def test_fetch_events_swallows_errors(monkeypatch) -> None:
+    def boom(request: Any, timeout: float | None = None) -> _FakeResp:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(status_mod._OPENER, "open", boom)
+    assert status_mod.fetch_events("https://node.example", "ctdl_tok") == {}
+
+
+def test_render_event_line() -> None:
+    from kb.cli import _render_event
+
+    event = {
+        "id": 5,
+        "type": "ingest",
+        "message": "Memory indexed",
+        "details": {"dataset": "seat:sarthi"},
+        "created_at": "2026-07-16T12:13:16Z",
+    }
+    line = _render_event(event, color=False)
+    assert "12:13" in line
+    assert "ingest" in line
+    assert "Memory indexed" in line
+    assert "seat:sarthi" in line


### PR DESCRIPTION
Dev-side visibility — the first DevEx increment from the grill. After `citadel onboard` it was a black box; this surfaces the **Vault Activity** the server already produces and makes the fail-silent hooks legible. No new telemetry.

## DX-5 — capture receipts
The git-push / SessionEnd hooks append a one-line receipt (`captured commit <sha> → your Node`) to `~/.citadel/activity.log` (0600, honors `CITADEL_HOME`) and echo to stderr when `CITADEL_HOOK_VERBOSE` is set. New stdlib-only `kb/hooks/receipt.py`; the write **never raises and never surfaces the token**, preserving the hook contract (non-blocking, always exit 0).

## DX-6 — `citadel activity`
`citadel activity [--watch] [--local] [--type T] [--json] [--limit N]` shows the caller's **own Node** Vault Activity via `/api/knowledge/events` — **server-scoped per ADR-0009, never another seat's content**. `--watch` polls `after_id` on an interval; `--local` tails the offline receipt log. New `status.fetch_events`.

## Verification
Verified live against prod (real ingest/reject events, `--json` timeline) and receipts round-trip locally. **95 tests pass** (8 new receipt tests + fetch_events/render tests); ruff clean.

## Not in this PR
Global team-presence broadcast (DX-7, `citadel activity --global`) — **Seat Presence only, content-stripped** — is the next increment.