### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-16
+
 ### Added
 
+- **Overview Knowledge Mesh reads as a concept map.** The default overview
+  aggregates the raw document/chunk cloud into per-hub counts and renders the
+  concept skeleton (dataset/seat hubs + entity types + well-connected entities);
+  the force layout fits on settle and spreads legibly instead of collapsing into
+  a hairball. Cognee-internal `text_<md5>` document nodes gain a fallback label
+  (nearest summary → source basename → NodeSet name), unnamed orphan
+  session-cache documents collapse into their NodeSet hub with a count, and the
+  summariser's "This chunk is about …" boilerplate is stripped from labels.
+- **`citadel activity` — dev-side visibility into the vault.** A new CLI command
+  shows your Node's **Vault Activity** (captures, syncs, promotions, searches):
+  `--watch` live-tails, `--local` shows offline capture receipts, `--global`
+  shows a team **Seat Presence** board (every seat's contribution count —
+  presence only, never another seat's Node content), `--json` for agents. The
+  fail-silent git-push / SessionEnd hooks now leave a one-line capture receipt in
+  `~/.citadel/activity.log` (and stderr when `CITADEL_HOOK_VERBOSE` is set).
 - **Document drill-down in the Knowledge Mesh.** Clicking a graph node fetches
   and renders its document text in the inspector; textless `TextDocument` nodes
   are assembled from their linked `DocumentChunk` neighbors.

--- a/kb/__init__.py
+++ b/kb/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 # hatchling dynamic versioning, and server discovery / the CLI fall back to it
 # when the package is not dist-installed (the Railway node runs from source, so
 # importlib.metadata.version raises there). Keeps server + CLI from drifting.
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 
 if TYPE_CHECKING:
     from kb.config import CitadelConfig


### PR DESCRIPTION
Cuts **v0.3.0**. Bumps `kb/__init__.py` `__version__` 0.2.3 → 0.3.0 and moves the `[Unreleased]` backlog into a dated 0.3.0 CHANGELOG entry.

## What ships in 0.3.0
- **ADR-0009 mesh read-isolation + dashboard** (the overdue backlog from #76/#77 — BREAKING: `/api/mesh/graph`, `/api/mesh`+`/events`, `/api/documents` are now caller-scoped for non-admin tokens).
- **Overview concept-map graph** (#81) — aggregation, fit-on-settle, orphan collapse, `text_<md5>` fallback labels, "This chunk is about…" boilerplate strip.
- **`citadel activity`** (#83) — dev-side vault visibility (`--watch` / `--local` / `--global` presence board / `--json`) + fail-silent capture receipts.

## Release mechanism
Merging this + pushing tag `v0.3.0` triggers `.github/workflows/publish.yml` → PyPI (trusted publishing, OIDC). **Publishing is irreversible** — the tag push is gated on explicit approval.

No code changes beyond the version bump + CHANGELOG.