### PR TITLE
docs: document citadel activity (README + rollout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pipx install citadel-archive          # the `citadel` command (zero-dep client)
 
 citadel onboard                       # token + hooks + MCP + capture roots (idempotent)
 citadel status                        # connection · identity · local setup  (--json for agents)
+citadel activity                      # what your Node is doing — captures, syncs, promotions
 ```
 
 > **No Python yet?** The bootstrap installer checks for Python 3.10+, **asks
@@ -115,6 +116,7 @@ decisions live in [`docs/adr/`](docs/adr/).
 citadel onboard                       # one-command setup
 citadel doctor [--fix]                # diagnose (and repair) your local setup
 citadel status [--json]               # health + identity + local setup + knowledge mesh
+citadel activity [--watch] [--global] # your Node's vault activity (--watch live-tails); --global = team presence board (counts only); --local = offline capture receipts
 citadel capture [--dry-run] [--json]  # push summaries of Approved Capture Roots
 citadel search "what did we decide about the vault?"   # HTTP-backed via your seat (--json)
 citadel ingest "A durable note" --tag decision         # → your seat Node, cognified inline

--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -168,6 +168,23 @@ citadel status        # connection + identity + local setup + knowledge mesh (ex
 health, your seat + role, and whether your hooks/MCP/capture roots are wired up.
 Agents run `citadel status --json` to check connectivity programmatically.
 
+### See what Citadel is doing
+
+Capture is silent by default, so once you're onboarded, `citadel activity` shows
+what your Node is actually doing:
+
+```bash
+citadel activity              # recent captures, syncs, promotions, searches on your Node
+citadel activity --watch      # live-tail as it happens
+citadel activity --global     # team presence board — every seat's contribution count
+citadel activity --local      # offline capture receipts (works with no server)
+```
+
+Every `git push` / session close now leaves a one-line receipt in
+`~/.citadel/activity.log` (set `CITADEL_HOOK_VERBOSE=1` to also echo it to your
+terminal). `--global` shows **Seat Presence only** — counts and slugs, never
+another seat's Node content.
+
 You should get a short note back sourced from your node / Central. If you get an
 auth error, your token isn't in the environment of the client that's running
 (restart the client so it picks up the new env var).


### PR DESCRIPTION
Docs-only follow-up to 0.3.0. `citadel activity` shipped in the release but wasn't documented anywhere user-facing.

- **README** — added `citadel activity` to the quick-start and the CLI reference (`--watch` / `--global` / `--local`).
- **docs/onboarding/teammate-rollout.md** — new "See what Citadel is doing" subsection: recent/watch/global/local, the `~/.citadel/activity.log` receipts, and the Seat-Presence-only rule for `--global`.

No code changes.