### PR TITLE
Agent-onboarding hardening: seat-bound tokens, headless skill, --json error parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`citadel activity` now appears on the home-screen menu** (bare `citadel`),
+  under Knowledge alongside `search` and `ingest`.
+
+### Changed
+
+- **`SKILL.md` reworked for cold-agent onboarding (validated by a fresh-agent
+  audit).** Adds an **Agent Fast Start** runbook (`install → set token →
+  status --json verify → search`) and a **How Citadel Works** 30-second model
+  (datasets = `seat:<slug>` Node vs `masumi-network` Central, caller-scoped
+  search, two-stage write/cognify, activity-vs-mesh, roles). Explicit "never run
+  bare `citadel onboard` in an agent/CI session" warning (use
+  `--non-interactive --token`); the auth-failure contract agents rely on
+  (`auth.ok==false` while `node.ok==true` ⇒ token problem, not install; exit
+  codes); the `activity --local/--global/--watch` flags; and the `search --json`
+  payload shape. All documented commands verified against the shipped CLI.
+- **`SKILL.md` now mandates SEAT-BOUND tokens for teammates.** New admin warning
+  (Team Onboarding) plus a fix to "Connecting a New Agent" step 1, which
+  previously told admins to hand over a *service-account* token — a seat-less
+  token has no default dataset, so the teammate's searches fail with
+  `DatasetNotFoundError` and writes route to the shared org dataset. Documents
+  the mint (`citadel seat token <slug>` / dashboard *Assign to seat*) and the
+  `status --json` signature of a correctly-provisioned token.
+
+### Fixed
+
+- **`--json` error paths are now valid JSON across the read/write CLI.**
+  `citadel onboard` (no-token + hook-install), `citadel search`, `citadel ingest`,
+  and `citadel capture` previously printed a plain-text line on the no-token
+  failure path under `--json`, so an agent piping the output choked. They now
+  emit `{"ok": false, "error": ...}`, matching `status`/`promotion`.
+- **No-token error no longer nudges toward the interactive wizard.** The message
+  led with `run \`citadel onboard\`` (bare = interactive, hangs a headless agent);
+  it now reads `citadel onboard --non-interactive --token ctdl_...`.
+- **`citadel status --json` surfaces the stale-token drift hint** (env vs shell
+  rc) on the JSON surface — as `checks[].data.hint` on the `auth` check and a
+  top-level `hint` — so agents (which parse `--json`) get the same actionable
+  401 diagnostic the human path already printed.
+
 ## [0.3.0] — 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ offers Approved Capture Roots. Get a `ctdl_…` seat token from a vault admin (t
 Access page or `POST /api/access/tokens`). One token per person or agent; rotate
 anything that lands in chat or logs.
 
+> **Admins: mint a seat-bound token, not a bare service account.** On the Access
+> page pick a seat under *Assign to seat* (or run `citadel seat token <slug>`) so
+> the token inherits a `seat:<slug>` default dataset. A seat-less
+> (service-account) token has **no default dataset** — the teammate authenticates
+> fine but every search fails with `DatasetNotFoundError` and writes route to the
+> shared org dataset. A correct token shows `seat_slug` + `default_dataset:
+> seat:<slug>` in `citadel status --json`.
+
 ### Self-host the server
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,61 @@ Vault content and `ctdl_` tokens never belong in the public repo. See
 | Roles | `reader`, `writer`, `admin` |
 | Local stdio MCP (dev only) | `uv run python -m kb.mcp_server` |
 
+## Agent Fast Start
+
+Handed a `ctdl_...` token and told to use Citadel? Four commands, headless, no prompts:
+
+```bash
+citadel --version                             # already installed & >= 0.3.0? skip the install
+pipx install citadel-archive                  # install if missing (or `citadel update` if older)
+export CITADEL_MCP_ACCESS_TOKEN=ctdl_...       # your token, intact — no quotes, no whitespace
+citadel status --json                          # VERIFY — prints identity + role, or the exact failure reason
+citadel search "your question" --json          # use it
+```
+
+**Verify-first is not optional.** `citadel status --json` tells you immediately
+whether the token works — parse `checks[]` where `name == "auth"`:
+
+- `auth.ok == true` → you're in; `auth.data` has your `seat_slug`, `role`, `capabilities`.
+- `auth.ok == false` **while** `node.ok == true` → **token problem, not an install or
+  network problem.** Reinstalling won't help — fix the token or its Node. (Only when
+  your *shell* token is stale vs your rc does a `hint` field — and a top-level `hint`
+  — appear with the exact `source ...` fix; a plain missing/rejected token has no
+  `hint`, just the `auth.detail`.)
+- Every read command exits `1` on 401/no-token and `0` on success — safe to branch on.
+
+**Never run bare `citadel onboard` in an agent/CI session** — it's the interactive
+wizard. To wire hooks / `.mcp.json` / capture non-interactively:
+
+```bash
+citadel onboard --non-interactive --token ctdl_...
+```
+
+## How Citadel Works (30-second model)
+
+- **Datasets are the unit of storage.** Your seat has a private dataset
+  `seat:<slug>` (your **Node**); the org shares `masumi-network` (**Central**). A
+  token reads its **allowed datasets** and writes to its **default dataset**. A
+  token with **no seat has no default dataset** → search returns
+  `DatasetNotFoundError` (this is the #1 onboarding failure — mint seat-bound).
+- **Search** (`citadel search` / `citadel_search`) runs semantic + graph retrieval
+  over the datasets your token can see and returns ranked hits. Consume each hit's
+  `text`, `document_name`, and the `_citadel` provenance envelope (`rank`,
+  `dataset`, `content_sha256`, `retrieval.document_drilldown_available`); the rest
+  are Cognee internals. Content is **caller-scoped** (ADR-0009): you see your seat +
+  Central, never another seat's content.
+- **Writing is two-stage.** `citadel ingest` / `citadel_ingest` *stages* a note
+  (`status: session_stored`) — **not searchable yet**. A separate **cognify** pass
+  builds the embeddings + graph edges that make it findable. The CLI `citadel
+  ingest` cognifies inline by default; MCP ingest stages only, so expect 0 hits for
+  a fresh MCP note until the next admin/cron cognify.
+- **Activity vs Mesh.** `citadel activity` = recent events (captures, syncs,
+  searches — a transient projection). The **Knowledge Mesh** = the durable graph.
+  `citadel activity --global` = team **Seat Presence** (contribution counts only,
+  never another seat's content).
+- **Roles.** `reader` (search/read) · `writer` (+ ingest) · `admin` (+ sync,
+  cognify, token management, audit). A seat-bound token inherits its seat's role.
+
 ## Team Onboarding
 
 For Codex-compatible agents, install the public Citadel skill first:
@@ -54,6 +109,21 @@ hosted connector, vault usage, and data-boundary skills. Then provide a
 per-agent `ctdl_...` token. Do not share one token across multiple users or
 agents, and rotate any token that was pasted into chat or logs.
 
+> **Admins — mint a SEAT-BOUND token for a teammate, never a bare one.** A token
+> minted without a seat is a *service account*: it has **no default dataset**, so
+> the teammate's searches fail with `DatasetNotFoundError` and their writes route
+> to the shared org dataset. This looks like "invalid/mis-provisioned token" but
+> the token authenticates fine — it's just seat-less. Always bind to the seat:
+>
+> ```bash
+> citadel seat list                        # is the seat provisioned?
+> citadel seat create <slug> --role writer # new seat + its bound writer token (printed once)
+> citadel seat token <slug>                # OR: re-mint a token for an existing seat
+> ```
+>
+> A correctly seat-bound token reports `seat_slug: <slug>`,
+> `default_dataset: seat:<slug>`, and the seat's role in `citadel status --json`.
+
 The hosted skill index includes content hashes. Agents that load skills from
 URLs can verify `/skills/*` markdown with the `X-Citadel-Skill-SHA256` or
 `X-Citadel-Skill-Integrity` response headers.
@@ -66,39 +136,44 @@ requirements, tool policy metadata, and public/private boundary rules.
 ### Option A — Headless CLI (Recommended for agents)
 
 The `citadel` CLI is the most dependable agent integration: plain HTTPS against
-the Node from any terminal, CI job, hook, or headless runner — no MCP wiring,
-no tool registration to depend on. Install the standalone client (zero-dep base):
+the Node from any terminal, CI job, hook, or headless runner — no MCP wiring, no
+tool registration to depend on. See **Agent Fast Start** above for the 4-command
+setup. Install the standalone client (zero-dep base):
 
 ```bash
 pipx install citadel-archive
-# upgrade: citadel update   (pipx-aware self-update; skips the stale wheel cache)
+citadel --version   # confirm >= 0.3.0  (older? run `citadel update` — pipx-aware self-update)
 # bootstrap installer: curl -fsSL https://raw.githubusercontent.com/masumi-network/Citadel-Archive/main/install.sh | sh
 ```
 
-Auth: export `CITADEL_MCP_ACCESS_TOKEN` (or run `citadel onboard` once — it
-writes the export to your shell rc). Add `--json` to reads for machine output.
+Common commands (add `--json` to any read for machine output; every read exits
+`1` on auth failure, `0` on success):
 
 ```bash
-citadel search "What did I learn about Railway?" --json --top-k 5
-citadel ingest "A useful note" --tag personal --tag research   # writes to your Node
-citadel status --json          # connection · identity · local setup
-citadel activity --json        # recent Node activity — captures, syncs, promotions, searches
+citadel status --json          # connection · identity · role · latency (add --no-search to skip the smoke search)
+citadel search "..." --json --top-k 5    # search the vault
+citadel activity --json        # recent Vault Activity — captures · syncs · promotions · searches
+citadel activity --local       # offline capture receipts (~/.citadel/activity.log) — no server needed
+citadel activity --global      # team Seat Presence board (contribution counts only, never another seat's content)
+citadel activity --watch       # live-tail new activity
+citadel ingest "note" --tag x  # WRITE — two-stage; NOT searchable until an admin cognify (see "Writing to Citadel")
 citadel promotion list --json  # your pending Promotion Approval queue
-citadel onboard            # token (keep-or-replace, verified up front) + hooks +
-                           # .mcp.json + capture roots + checkbox tool selection
-citadel token set          # rotate this machine's seat token (verify-first)
-citadel update             # self-update the CLI (alias: upgrade)
-citadel doctor --fix       # diagnose / repair local setup
-citadel mcp add claude     # add the Citadel MCP server to a client (`citadel mcp list`)
-citadel seat create        # admin: mint a seat token (needs CITADEL_ADMIN_KEY)
-citadel seat token <slug>  # admin: mint a fresh token for an existing seat
+citadel onboard --non-interactive --token ctdl_...   # wire hooks/.mcp.json/capture, no prompts (the agent path)
+citadel doctor --fix           # diagnose / repair local setup
+citadel mcp add claude         # add the Citadel MCP server to a client (`citadel mcp list`)
+citadel seat create            # admin: mint a seat token (needs CITADEL_ADMIN_KEY)
+citadel seat token <slug>      # admin: re-mint a token for an existing seat
 ```
 
 `citadel search` and `citadel ingest` are HTTP-backed against the Node by
-default (no `[server]` extra); `--local` runs the in-process server stack
-instead. **Agents should shell out to these commands rather than depending on
-MCP tool registration** — the CLI works even when a client's MCP session
-carries no tools.
+default (no `[server]` extra); `--local` runs the in-process server stack instead.
+
+**`search --json` payload:** consume each hit's `text`, `document_name`, and the
+`_citadel` envelope (`rank`, `dataset`, `content_sha256`,
+`retrieval.document_drilldown_available`); the remaining fields are Cognee
+internals — ignore them. **Agents should shell out to these commands rather than
+depending on MCP tool registration** — the CLI works even when a client's MCP
+session carries no tools.
 
 ### Option B — MCP Server (in-session tools)
 
@@ -314,8 +389,13 @@ Load the connector skill and follow it end-to-end:
 
 Summary:
 
-1. **Get a token.** Ask the user for their Citadel service-account token (starts with `ctdl_`). Never ask for seed phrases, private keys, or admin keys.
-2. **Choose the role.** Reader for search-only; writer if the agent should also ingest.
+1. **Get a token.** Ask the user for their Citadel token (starts with `ctdl_`). For a
+   person/teammate this must be a **seat-bound** token (admin mints it with
+   `citadel seat token <slug>`, or the dashboard's *Assign to seat* picker) — a
+   seat-less *service-account* token has **no default dataset** and every search
+   fails with `DatasetNotFoundError`. Never ask for seed phrases, private keys, or admin keys.
+2. **Choose the role.** Reader for search-only; writer if the agent should also ingest
+   (a seat-bound token inherits the seat's role — mint the seat as `writer` if it ingests).
 3. **Write the config.** See `docs/mcp/README.md` or `.mcp.json.example` for Claude Code, Codex, and Cursor templates.
 4. **Set `CITADEL_MCP_MAX_INGEST_BYTES`** to limit ingest payload size (default 200KB).
 5. **Gate write/admin tools.** Configure the client to require approval for `citadel_ingest`, `citadel_contribute`, `citadel_record_feedback`, `citadel_run_learning_agent`, `citadel_run_backup_mirror`, and `citadel_improve`.

--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -29,6 +29,13 @@ citadel seat token jane
 `https://citadel-archive-production.up.railway.app/skills/connect` — does the
 same thing if you'd rather click.)
 
+> ⚠️ **Always bind the token to a seat.** On the Access page choose the seat under
+> *Assign to seat*; do **not** leave it on *No seat — service account*. A seat-less
+> token has no default dataset, so the teammate authenticates fine but every
+> search fails with `DatasetNotFoundError` and writes route to the shared org
+> dataset. Confirm before handing it over: the token should show `seat_slug` and
+> `default_dataset: seat:<slug>` in `citadel status --json`.
+
 Hand the token to the teammate over a private channel. It is a secret — treat
 it like a password.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,6 +1,49 @@
 # Citadel Progress
 
-Last updated: 2026-07-14.
+Last updated: 2026-07-16.
+
+## 2026-07-16 — Agent-onboarding hardening: seat-bound tokens, headless skill, `--json` error parity
+
+Triggered by a real teammate incident: an admin minted a **seat-less
+(service-account) token**, handed it to a teammate's Codex agent, and every
+search failed with `DatasetNotFoundError` — misread by the agent as an "invalid
+token." Root cause was provisioning, not auth: a token with no seat has no
+default dataset. Two cold-agent usability passes (fresh subagent driving the
+headless CLI + auditing the skill) drove the fixes below.
+
+**Diagnosis confirmed against code:** tokens default to `kind="service_account"`
+with no `seat_slug` / `default_dataset`; a seat-less token has no dataset to
+search → `DatasetNotFoundError`, and its writes route to the shared org dataset.
+Fix is to mint **seat-bound** (`citadel seat token <slug>` / dashboard *Assign to
+seat*), which inherits the seat's role + `seat:<slug>` default dataset.
+
+- **`SKILL.md` reworked for cold-agent onboarding (fresh-agent audit: "production
+  ready").** New **Agent Fast Start** runbook (`install → set token →
+  status --json verify → search`) and a **How Citadel Works** 30-second model
+  (datasets/Node/Central, caller-scoped search, two-stage ingest/cognify,
+  activity-vs-mesh, roles). Explicit "never run bare `citadel onboard` in an
+  agent/CI session" warning; the auth-failure contract (`auth.ok==false` while
+  `node.ok==true` ⇒ token problem, not install; exit codes); `activity
+  --local/--global/--watch`; and the `search --json` payload shape.
+- **Seat-bound token mandate.** New admin warning in Team Onboarding + fixed
+  "Connecting a New Agent" step 1, which had told admins to hand over a
+  *service-account* token (the exact footgun). Both name the
+  `DatasetNotFoundError` symptom and the correct mint.
+- **CLI `--json` error parity.** `onboard` (no-token + hook-install), `search`,
+  `ingest`, and `capture` printed a plain-text line on the no-token failure path
+  under `--json`, choking agents that pipe the output. All now emit
+  `{"ok": false, "error": ...}`, matching `status`/`promotion`.
+- **`status --json` surfaces the stale-token drift hint** (`checks[].data.hint` +
+  top-level `hint`) so agents parsing `--json` get the `source <rc>` fix the human
+  path already printed.
+- **No-token message no longer nudges bare `onboard`** — now suggests
+  `citadel onboard --non-interactive --token ctdl_...`.
+- **`citadel activity` added to the bare-`citadel` home menu** (under Knowledge).
+
+Verified: ruff clean; 731 tests pass (3 pre-existing `cognee`-extra failures,
+unrelated). `[Unreleased]` CHANGELOG updated. **Follow-up (ops, not code):** the
+teammate still needs an admin to mint her a seat-bound token and revoke the
+tokens leaked in chat.
 
 ## 2026-07-14 — Dashboard graph, mesh read isolation, /mcp fix — SHIPPED + DEPLOYED
 

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -210,6 +210,28 @@ def _print_auth_hint(command: str, status_code: int) -> None:
         print(f"citadel {command}: hint: {hint}", file=sys.stderr)
 
 
+# Agent-safe wording: lead with the env var, and when we name onboard use the
+# NON-interactive form — a bare `citadel onboard` in an agent/CI session hangs on
+# prompts, so never nudge toward it from a machine-facing error path.
+_NO_TOKEN_MSG = (
+    "no token — set CITADEL_MCP_ACCESS_TOKEN, "
+    "or run `citadel onboard --non-interactive --token ctdl_...`."
+)
+
+
+def _emit_no_token(command: str, *, as_json: bool) -> int:
+    """Uniform no-token error: a JSON object under ``--json``, else plain text.
+
+    Keeps `--json` machine-readable on the failure path (matches `status` /
+    `onboard`) so an agent piping the output never chokes on a plain-text line.
+    """
+    if as_json:
+        _print_json({"ok": False, "error": _NO_TOKEN_MSG})
+    else:
+        print(f"citadel {command}: {_NO_TOKEN_MSG}", file=sys.stderr)
+    return 1
+
+
 def _result_exit(value: Any) -> int:
     """Exit 1 when a result payload carries ``ok: False``; else 0.
 
@@ -230,11 +252,7 @@ async def _ingest(args: argparse.Namespace) -> int:
     base_url = node_base_url(getattr(args, "node_url", None))
     token = capture_token()
     if not token:
-        print(
-            "citadel ingest: no token — set CITADEL_MCP_ACCESS_TOKEN or run `citadel onboard`.",
-            file=sys.stderr,
-        )
-        return 1
+        return _emit_no_token("ingest", as_json=getattr(args, "json", False))
     from kb.status import ingest_node
 
     # Cognify inline (server-side) by default so the note is immediately
@@ -342,11 +360,7 @@ async def _search(args: argparse.Namespace) -> int:
     base_url = node_base_url(getattr(args, "node_url", None))
     token = capture_token()
     if not token:
-        print(
-            "citadel search: no token — set CITADEL_MCP_ACCESS_TOKEN or run `citadel onboard`.",
-            file=sys.stderr,
-        )
-        return 1
+        return _emit_no_token("search", as_json=getattr(args, "json", False))
     from kb.status import search_node
 
     try:
@@ -610,11 +624,7 @@ async def _capture(args: argparse.Namespace) -> int:
 
     token = capture_token()
     if not token:
-        print(
-            "citadel capture: no token — set CITADEL_MCP_ACCESS_TOKEN or run `citadel onboard`.",
-            file=sys.stderr,
-        )
-        return 1
+        return _emit_no_token("capture", as_json=getattr(args, "json", False))
 
     as_json = getattr(args, "json", False)
     results: list[dict[str, Any]] = []
@@ -1191,6 +1201,16 @@ async def _status(args: argparse.Namespace) -> int:
         )
         payload = report.to_dict()
         payload["mesh"] = mesh
+        # Mirror the human path's drift hint onto the JSON surface — agents parse
+        # `--json` and would otherwise miss the most actionable 401 diagnostic.
+        auth_c = next((c for c in payload["checks"] if c.get("name") == "auth"), None)
+        if auth_c is not None and not auth_c.get("ok"):
+            detail = str(auth_c.get("detail", ""))
+            code = 401 if "401" in detail else 403 if "403" in detail else 0
+            hint = _stale_env_hint(code) if code else None
+            if hint:
+                auth_c.setdefault("data", {})["hint"] = hint
+                payload["hint"] = hint
         _print_json(payload)
     else:
         # The search check can take ~15s cold — spin so it doesn't look hung.
@@ -1691,10 +1711,11 @@ async def _onboard(args: argparse.Namespace) -> int:
         args, rc_path, node_url, interactive=interactive, color=color
     )
     if not token:
-        print(
-            "citadel onboard: no token — pass --token or set CITADEL_MCP_ACCESS_TOKEN.",
-            file=sys.stderr,
-        )
+        msg = "no token — pass --token or set CITADEL_MCP_ACCESS_TOKEN."
+        if as_json:
+            _print_json({"ok": False, "error": msg, "token_rejected": token_rejected})
+        else:
+            print(f"citadel onboard: {msg}", file=sys.stderr)
         return 1
 
     steps: list[tuple[str, str]] = []
@@ -1707,7 +1728,10 @@ async def _onboard(args: argparse.Namespace) -> int:
         if not args.no_mcp:
             steps.append(("MCP server (.mcp.json)", merge_mcp_config(repo / ".mcp.json", node_url)))
     except ValueError as exc:
-        print(f"citadel onboard: {exc}", file=sys.stderr)
+        if as_json:
+            _print_json({"ok": False, "error": str(exc)})
+        else:
+            print(f"citadel onboard: {exc}", file=sys.stderr)
         return 1
 
     # A custom --node-url is persisted to the capture config so MCP and capture
@@ -1907,6 +1931,7 @@ _HOME_MENU = (
     ("Knowledge", (
         ("search", "search the Organization Vault"),
         ("ingest", "add a durable note to your Node"),
+        ("activity", "recent vault activity — captures · syncs · searches (--global for the team)"),
     )),
     ("Connect & admin", (
         ("mcp", "add Citadel MCP to Claude · Cursor · Codex · …"),


### PR DESCRIPTION
## Why

A real teammate incident: an admin minted a **seat-less (service-account) token**, handed it to a teammate's Codex agent, and every search failed with `DatasetNotFoundError` — misread by the agent as an "invalid token." Root cause was **provisioning, not auth**: a token with no seat has no default dataset. Two cold-agent passes (a fresh subagent driving the headless CLI, then auditing the rewritten skill — verdict: *"production-ready"*) drove these fixes.

Confirmed against code: tokens default to `kind="service_account"` with no `seat_slug`/`default_dataset`; a seat-less token has no dataset to search → `DatasetNotFoundError`, and its writes route to the shared org dataset.

## Changes

**`fix(cli)` — machine-facing surfaces:**
- `--json` error parity: `onboard` (no-token + hook-install), `search`, `ingest`, `capture` now emit `{"ok": false, "error": ...}` on the no-token path (were plain text → choked agents piping `--json`). Shared `_emit_no_token` helper.
- `status --json` surfaces the stale-token drift hint (`checks[].data.hint` + top-level `hint`).
- No-token message no longer nudges bare `citadel onboard` → suggests `--non-interactive --token`.
- `citadel activity` added to the bare-`citadel` home menu.

**`docs` — onboarding correctness:**
- `SKILL.md`: **Agent Fast Start** runbook + **How Citadel Works** model; Option A rewrite; explicit "never run bare `onboard` in an agent/CI session" warning; auth-failure contract.
- **Seat-bound token mandate** — admin warning in Team Onboarding + fixed "Connecting a New Agent" step 1 (previously told admins to hand over a *service-account* token, the exact footgun).
- `README.md` + `docs/onboarding/teammate-rollout.md`: seat-bound admin callouts naming the `DatasetNotFoundError` symptom and the `status --json` confirm check.
- `docs/progress.md`: 2026-07-16 entry. `CHANGELOG.md`: `[Unreleased]`.

## Verification

- `ruff check` clean
- 731 tests pass (3 pre-existing `cognee`-extra failures on this base env, unrelated — fail on clean `main` too)
- `onboard/search --json` no-token → valid JSON, exit 1, verified by hand
- `status --json` drift hint verified against a simulated drifted token

## Not in this PR (ops, not code)
The teammate still needs an **admin** to mint her a seat-bound token and revoke the tokens leaked in chat — can't be done from a writer-only machine.