### PR TITLE
fix(security): close three cross-seat authorization gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ All notable changes to `citadel-archive` are documented here. Format follows
   the mint (`citadel seat token <slug>` / dashboard *Assign to seat*) and the
   `status --json` signature of a correctly-provisioned token.
 
+### Security
+
+- **`POST /feedback` now resolves the caller-supplied dataset and session.**
+  The handler passed `body.dataset` and `body.session_id` straight through to
+  the durable write, skipping `resolve_write_dataset` / `resolve_session_id` —
+  the only write-scoped route that did (`/ingest` and `/api/contribute` both
+  gate them). A writer token could therefore write feedback into, and emit mesh
+  events attributed to, a dataset outside its allowlist, including another
+  seat's node. Feedback text is now also byte-capped like `/ingest`
+  (`FeedbackBody.text` carries no `max_length` of its own).
+
 ### Fixed
 
 - **`--json` error paths are now valid JSON across the read/write CLI.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Security
 
+- **`GET /api/knowledge/events` is now caller-scoped (ADR-0009).** The handler
+  called `require_access` and discarded the identity, returning every seat's
+  events — message, dataset, and error operation/reason — to any reader token,
+  while its two sibling projections (`/api/mesh`, `/events`) both scoped. This
+  was visible in plain `citadel activity` output, which printed other seats'
+  ingests under the caller's own token. `Mesh.timeline()` gains an optional
+  `visible` predicate, applied before the limit slice so a caller still gets a
+  full page of their own events; `latest_event_id` stays global so `--watch`
+  resumption cannot loop. Admin/env tokens are unaffected.
 - **`POST /feedback` now resolves the caller-supplied dataset and session.**
   The handler passed `body.dataset` and `body.session_id` straight through to
   the durable write, skipping `resolve_write_dataset` / `resolve_session_id` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Security
 
+- **Obsidian vaults now enforce ownership (ADR-0009).** `owner_actor_id` was
+  recorded at vault registration and read nowhere, so `/api/obsidian/manifest`,
+  `/api/obsidian/sync/pull`, `/api/obsidian/sync/push`,
+  `/api/obsidian/conflicts/{id}/resolve`, and the Obsidian branch of
+  `/api/documents/{id}` were gated only by scope — and both
+  `obsidian:sync:pull` and `kb:read` are in the default reader set. Any token
+  could therefore read another seat's full note bodies and revision history, or
+  push revisions into their vault, given a vault id that `/api/sources`
+  discloses. All five now fail closed with **404, never 403**, matching the
+  cognee drill-down rule so a scoped caller cannot use the status code as an
+  existence oracle. Admin/env callers are unaffected.
 - **`GET /api/knowledge/events` is now caller-scoped (ADR-0009).** The handler
   called `require_access` and discarded the identity, returning every seat's
   events — message, dataset, and error operation/reason — to any reader token,

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha1
@@ -241,8 +242,16 @@ class MeshState:
         limit: int = 50,
         event_type: str | None = None,
         kind: str | None = None,
+        visible: Callable[[Any], bool] | None = None,
     ) -> dict[str, Any]:
-        """Return a bounded, newest-first event timeline for resume/backfill reads."""
+        """Return a bounded, newest-first event timeline for resume/backfill reads.
+
+        ``visible`` scopes events to the caller by ``details.dataset`` (ADR-0009).
+        It runs BEFORE the limit slice so a caller still receives a full page of
+        their own events rather than whatever survives filtering one page of
+        everyone's. ``latest_event_id`` stays global on purpose: --watch resumes
+        from it, and rewinding it to the last visible id would re-poll forever.
+        """
         async with self._lock:
             events = list(self.events)
             if after_id is not None:
@@ -254,6 +263,12 @@ class MeshState:
                     event
                     for event in events
                     if event.get("timeline", {}).get("kind") == kind
+                ]
+            if visible is not None:
+                events = [
+                    event
+                    for event in events
+                    if visible((event.get("details") or {}).get("dataset"))
                 ]
             return {
                 "generated_at": utc_now(),

--- a/kb/obsidian_sync.py
+++ b/kb/obsidian_sync.py
@@ -459,6 +459,30 @@ class ObsidianSyncStore:
             raise KeyError(vault_id)
         return vault
 
+    def vault_owner(self, vault_id: str) -> str | None:
+        """Return the vault's ``owner_actor_id``; raise KeyError if unknown.
+
+        Callers enforce ownership at the HTTP boundary — this only exposes the
+        field, which was recorded at registration and previously read nowhere.
+        """
+        return self._vault(self._load(), vault_id).get("owner_actor_id")
+
+    def document_vault_id(self, document_id: str) -> str | None:
+        """Return the id of the vault a document belongs to (its ``source_id``)."""
+        data = self._load()
+        document = data.get("documents", {}).get(document_id)
+        if not document:
+            raise KeyError(document_id)
+        return document.get("source_id")
+
+    def conflict_vault_id(self, conflict_id: str) -> str | None:
+        """Return the id of the vault a conflict belongs to (its ``source_id``)."""
+        data = self._load()
+        conflict = data.get("conflicts", {}).get(conflict_id)
+        if not conflict:
+            raise KeyError(conflict_id)
+        return conflict.get("source_id")
+
     def _next_sequence(self, data: dict[str, Any]) -> int:
         data["sequence"] = int(data.get("sequence", 0)) + 1
         return data["sequence"]

--- a/kb/server.py
+++ b/kb/server.py
@@ -2806,9 +2806,29 @@ async def register_obsidian_vault(body: ObsidianVaultBody, request: Request) -> 
     return {"ok": True, "vault": jsonable_encoder(vault)}
 
 
+def assert_obsidian_vault_owned(identity: AccessIdentity, vault_id: str) -> None:
+    """Fail closed unless the caller owns the vault (ADR-0009).
+
+    A vault's ``owner_actor_id`` is recorded at registration but was never read,
+    so any token holding the obsidian sync scopes could address another seat's
+    vault by id — and ids are disclosed by /api/sources. Mirrors the cognee
+    drill-down rule at /api/documents: 404, never 403, so a scoped caller cannot
+    use the status code as an existence oracle. Admin/env callers bypass.
+    """
+    if can_bypass_dataset_allowlist(identity):
+        return
+    try:
+        owner = get_obsidian_sync().vault_owner(vault_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Vault not found.") from exc
+    if owner != identity.actor_id:
+        raise HTTPException(status_code=404, detail="Vault not found.")
+
+
 @app.get("/api/obsidian/manifest")
 async def obsidian_manifest(request: Request, vault_id: str, cursor: int | None = None) -> Any:
-    require_access(request, "reader", "obsidian:sync:pull")
+    identity = require_access(request, "reader", "obsidian:sync:pull")
+    assert_obsidian_vault_owned(identity, vault_id)
     try:
         manifest = get_obsidian_sync().manifest(vault_id=vault_id, cursor=cursor)
     except KeyError as exc:
@@ -2819,6 +2839,10 @@ async def obsidian_manifest(request: Request, vault_id: str, cursor: int | None 
 @app.post("/api/obsidian/sync/push")
 async def push_obsidian_sync(body: ObsidianPushBody, request: Request) -> Any:
     actor = require_access(request, "writer", "obsidian:sync:push")
+    # The dataset was already resolved; the vault was not — actor was recorded on
+    # the record but never compared to owner_actor_id, so a writer could push
+    # revisions into another seat's vault.
+    assert_obsidian_vault_owned(actor, body.vault_id)
     citadel = get_citadel()
     mesh_state = get_mesh()
     push_dataset = resolve_write_dataset(actor, body.dataset, citadel.config)
@@ -2968,7 +2992,8 @@ async def push_obsidian_sync(body: ObsidianPushBody, request: Request) -> Any:
 
 @app.get("/api/obsidian/sync/pull")
 async def pull_obsidian_sync(request: Request, vault_id: str, cursor: int | None = None) -> Any:
-    require_access(request, "reader", "obsidian:sync:pull")
+    identity = require_access(request, "reader", "obsidian:sync:pull")
+    assert_obsidian_vault_owned(identity, vault_id)
     try:
         result = get_obsidian_sync().pull(vault_id=vault_id, cursor=cursor)
     except KeyError as exc:
@@ -2983,8 +3008,16 @@ async def resolve_obsidian_conflict(
     request: Request,
 ) -> Any:
     actor = require_access(request, "writer", "obsidian:sync:push")
+    obsidian = get_obsidian_sync()
     try:
-        result = get_obsidian_sync().resolve_conflict(
+        conflict_vault = obsidian.conflict_vault_id(conflict_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Conflict not found.") from exc
+    # actor was passed through for attribution only; resolving a conflict writes
+    # a document body, so it needs the same vault ownership gate as push.
+    assert_obsidian_vault_owned(actor, conflict_vault or "")
+    try:
+        result = obsidian.resolve_conflict(
             conflict_id=conflict_id,
             actor=actor,
             resolution=body.resolution,
@@ -3093,7 +3126,12 @@ async def source_document(document_id: str, request: Request) -> Any:
             raise HTTPException(status_code=404, detail="Document not found.")
         return {"ok": True, "document": jsonable_encoder(github_document)}
     try:
-        document = get_obsidian_sync().document(document_id)
+        obsidian = get_obsidian_sync()
+        document = obsidian.document(document_id)
+        # document() is a flat global lookup returning the full body and every
+        # revision, so it needs the same ownership gate as manifest/pull. The
+        # cognee branch below already 404s foreign documents; this one didn't.
+        assert_obsidian_vault_owned(identity, obsidian.document_vault_id(document_id) or "")
     except KeyError:
         # Not a github/obsidian doc — fall back to resolving a native cognee
         # search-hit id against the graph store (#28).

--- a/kb/server.py
+++ b/kb/server.py
@@ -2335,16 +2335,28 @@ async def knowledge_events(
     event_type: str | None = Query(default=None, alias="type"),
     kind: str | None = None,
 ) -> Any:
-    require_access(request, "reader", "kb:read")
+    identity = require_access(request, "reader", "kb:read")
     if after_id is not None and after_id < 0:
         raise HTTPException(status_code=422, detail="after_id must be zero or greater.")
     if not 1 <= limit <= 160:
         raise HTTPException(status_code=422, detail="Timeline limit must be between 1 and 160.")
+    # ADR-0009: the timeline carries Node content (event messages, dataset names,
+    # and error operations/reasons), so scope it to the caller exactly as the two
+    # sibling projections do — /api/mesh via scope_mesh_snapshot and /events via
+    # _mesh_dataset_visible. This endpoint previously discarded the identity and
+    # returned every seat's events to any reader token.
+    visible_cache: dict[str, bool] = {}
+    visible = (
+        None
+        if can_bypass_dataset_allowlist(identity)
+        else (lambda dataset: _mesh_dataset_visible(identity, dataset, visible_cache))
+    )
     timeline = await get_mesh().timeline(
         after_id=after_id,
         limit=limit,
         event_type=event_type,
         kind=kind,
+        visible=visible,
     )
     return jsonable_encoder({"ok": True, **timeline})
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -4111,17 +4111,27 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
 @app.post("/feedback")
 async def feedback(body: FeedbackBody, request: Request) -> Any:
     actor = require_access(request, "writer", "kb:feedback")
+    # Feedback text lands in durable storage on a cache miss, so it needs the same
+    # byte cap as /ingest — FeedbackBody.text carries no max_length of its own.
+    if body.text:
+        enforce_ingest_size(body.text)
     citadel = get_citadel()
     mesh_state = get_mesh()
-    dataset = body.dataset or citadel.config.default_dataset
+    # Feedback is a durable write on a cache miss, so the caller-supplied dataset
+    # and session MUST go through the same resolvers as /ingest and /api/contribute.
+    # Passing body.dataset through unresolved let any writer token write into (and
+    # emit mesh events attributed to) another seat's node, which
+    # enforce_dataset_allowlist is default-deny for.
+    dataset = resolve_write_dataset(actor, body.dataset, citadel.config)
+    session_id = resolve_session_id(actor, body.session_id)
     try:
         result = await citadel.feedback(
             FeedbackRequest(
                 qa_id=body.qa_id,
                 score=body.score,
                 text=body.text,
-                session_id=body.session_id,
-                dataset=body.dataset,
+                session_id=session_id,
+                dataset=dataset,
             )
         )
     except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -499,6 +499,49 @@ def test_knowledge_events_api_returns_resumable_timeline() -> None:
     assert unauthenticated.status_code == 401
 
 
+def test_knowledge_events_scopes_timeline_to_the_caller(tmp_path: Any) -> None:
+    # ADR-0009: the timeline carries Node content (event messages, dataset names,
+    # error operations). It previously discarded the identity and returned every
+    # seat's events to any reader token — visible in plain `citadel activity`
+    # output, which printed other seats' ingests under the caller's own token.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    created = admin.post(
+        "/api/access/tokens",
+        json={
+            "name": "scoped-reader",
+            "role": "writer",
+            "kind": "service_account",
+            "default_dataset": "personal",
+            "allowed_datasets": ["personal"],
+        },
+    )
+    token = created.json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # An event on a dataset the scoped token cannot see, and one it can.
+    admin.post("/ingest", json={"data": "Another seat's note", "dataset": "masumi-network"})
+    api_client.post("/ingest", json={"data": "My own note"}, headers=headers)
+
+    scoped = api_client.get("/api/knowledge/events?limit=50", headers=headers)
+    unscoped = admin.get("/api/knowledge/events?limit=50")
+
+    assert scoped.status_code == 200
+    scoped_datasets = {
+        (event.get("details") or {}).get("dataset") for event in scoped.json()["events"]
+    }
+    assert "masumi-network" not in scoped_datasets
+    assert "personal" in scoped_datasets
+    # latest_event_id stays global so --watch resumption cannot loop forever.
+    assert scoped.json()["latest_event_id"] == unscoped.json()["latest_event_id"]
+    # An admin/bypass caller still sees everything.
+    unscoped_datasets = {
+        (event.get("details") or {}).get("dataset") for event in unscoped.json()["events"]
+    }
+    assert {"masumi-network", "personal"} <= unscoped_datasets
+
+
 def test_reader_access_can_view_and_search_but_not_mutate() -> None:
     client = authed_client("test-reader")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1280,6 +1280,69 @@ def test_backup_mirror_push_errors_are_audited(tmp_path: Any) -> None:
     assert events[-1]["detail"]["reason"] == "publish_failed"
 
 
+def test_obsidian_vault_is_not_readable_or_writable_by_another_actor(tmp_path: Any) -> None:
+    # owner_actor_id was recorded at registration and read nowhere, so any token
+    # holding the obsidian scopes could address another seat's vault by id — and
+    # ids are disclosed via /api/sources. Reads returned full note bodies and
+    # revision history. 404 (not 403) everywhere: no existence oracle.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
+    admin = authed_client()
+
+    owner_token = admin.post(
+        "/api/access/tokens",
+        json={"name": "vault-owner", "role": "writer", "kind": "service_account"},
+    ).json()["token"]
+    intruder_token = admin.post(
+        "/api/access/tokens",
+        json={"name": "vault-intruder", "role": "writer", "kind": "service_account"},
+    ).json()["token"]
+
+    api = TestClient(app, base_url="https://testserver")
+    owner_headers = {"Authorization": f"Bearer {owner_token}"}
+    intruder_headers = {"Authorization": f"Bearer {intruder_token}"}
+
+    vault_id = api.post(
+        "/api/obsidian/vaults", json={"vault_name": "Private Vault"}, headers=owner_headers
+    ).json()["vault"]["id"]
+    api.post(
+        "/api/obsidian/sync/push",
+        json={
+            "vault_id": vault_id,
+            "documents": [{"path": "Secrets.md", "content": "private body", "base_rev": None}],
+        },
+        headers=owner_headers,
+    )
+
+    owner_manifest = api.get(f"/api/obsidian/manifest?vault_id={vault_id}", headers=owner_headers)
+    document_id = owner_manifest.json()["documents"][0]["id"]
+
+    intruder_manifest = api.get(
+        f"/api/obsidian/manifest?vault_id={vault_id}", headers=intruder_headers
+    )
+    intruder_pull = api.get(
+        f"/api/obsidian/sync/pull?vault_id={vault_id}&cursor=0", headers=intruder_headers
+    )
+    intruder_document = api.get(f"/api/documents/{document_id}", headers=intruder_headers)
+    intruder_push = api.post(
+        "/api/obsidian/sync/push",
+        json={
+            "vault_id": vault_id,
+            "documents": [{"path": "Secrets.md", "content": "overwritten", "base_rev": None}],
+        },
+        headers=intruder_headers,
+    )
+
+    assert owner_manifest.status_code == 200
+    assert intruder_manifest.status_code == 404
+    assert intruder_pull.status_code == 404
+    assert intruder_document.status_code == 404
+    assert intruder_push.status_code == 404
+    # The owner still has full access, and an admin/bypass token is unaffected.
+    assert api.get(f"/api/documents/{document_id}", headers=owner_headers).status_code == 200
+    assert admin.get(f"/api/obsidian/manifest?vault_id={vault_id}").status_code == 200
+
+
 def test_obsidian_vault_sync_registers_pushes_pulls_and_lists_sources(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -780,6 +780,63 @@ def test_token_allowed_datasets_rejects_other_dataset(tmp_path: Any) -> None:
     assert denied.json()["detail"] == "Dataset not allowed: masumi-network."
 
 
+def test_feedback_rejects_dataset_outside_token_allowlist(tmp_path: Any) -> None:
+    # /feedback is a durable write on a cache miss. Before this was resolved, a
+    # writer token could name any dataset — including another seat's node, which
+    # enforce_dataset_allowlist is default-deny for — and have the write and its
+    # mesh event attributed there.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    created = client.post(
+        "/api/access/tokens",
+        json={
+            "name": "scoped-feedback-writer",
+            "role": "writer",
+            "kind": "service_account",
+            "default_dataset": "personal",
+            "allowed_datasets": ["personal"],
+        },
+    )
+    token = created.json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    denied = api_client.post(
+        "/feedback",
+        json={"qa_id": "qa-1", "score": 1, "text": "useful", "dataset": "seat:someone-else"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    allowed = api_client.post(
+        "/feedback",
+        json={"qa_id": "qa-1", "score": 1, "text": "useful"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert denied.status_code == 403
+    assert denied.json()["detail"] == "Dataset not allowed: seat:someone-else."
+    assert allowed.status_code == 200
+
+
+def test_feedback_rejects_oversized_text(tmp_path: Any) -> None:
+    # FeedbackBody.text carries no max_length; the durable-write path needs the
+    # same byte cap as /ingest.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    created = client.post(
+        "/api/access/tokens",
+        json={"name": "feedback-writer", "role": "writer", "kind": "service_account"},
+    )
+    token = created.json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    oversized = api_client.post(
+        "/feedback",
+        json={"qa_id": "qa-1", "score": 1, "text": "x" * (200 * 1024 + 1)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert oversized.status_code == 413
+
+
 def test_tokens_without_memory_fields_use_config_defaults(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     client = authed_client()


### PR DESCRIPTION
Closes three cross-seat authorization gaps found in the 2026-07-19 audit. Each is a
read or write that authenticated but never checked *whose* data it touched — scope
alone was the gate, and the relevant scopes are all in the default reader/writer sets,
so no privilege escalation was needed to reach any of them.

## The three

**`/feedback` — unscoped dataset + session** (`43c30fc`)
Passed `body.dataset` / `body.session_id` straight into the durable write, skipping
`resolve_write_dataset` / `resolve_session_id`. It was the only write-scoped route in
its range that did — `/ingest` and `/api/contribute` both gate the same fields. A
writer token could name another seat's node and have both the write and its mesh event
attributed there. Reachable from MCP too: `citadel_record_feedback` forwards the fields
verbatim. Also byte-caps feedback text, which had no `max_length` and so bypassed the
`/ingest` limit on a cache miss.

**`/api/knowledge/events` — unfiltered timeline** (`d73c849`)
Called `require_access`, discarded the identity, and returned `get_mesh().timeline(...)`
whole — every seat's events, including message text, dataset names, and the failing
operation and reason. Both sibling projections (`/api/mesh`, `/events`) already scope.
The leak showed up in plain `citadel activity` output. `Mesh.timeline()` gains an
optional `visible` predicate applied *before* the limit slice, so a caller gets a full
page of their own events rather than the remnants of one page of everyone's.
`latest_event_id` stays global so `--watch` still resumes correctly.

**Obsidian vault ownership never enforced** (`ab18631`)
`ObsidianVault.owner_actor_id` was set at registration and never read again, leaving
five endpoints gated by scope alone: manifest, sync/pull, sync/push,
conflicts/{id}/resolve, and the Obsidian branch of `/api/documents/{id}`. Reads returned
full note bodies and revision history; push wrote revisions into the target vault. Only
a vault id was needed, which `/api/sources` hands to any `sources:read` caller. All five
now go through `assert_obsidian_vault_owned`.

## Notes

- Ownership failures return **404, not 403**, so a scoped caller can't use the status
  code as an existence oracle — matching the rule the cognee drill-down branch already
  applied ten lines below the Obsidian one.
- Admin/env callers bypass all three checks, as elsewhere.
- Vault lookups go through new `vault_owner` / `document_vault_id` / `conflict_vault_id`
  accessors on the sync store rather than handlers reaching into its state.

## Testing

`127 passed` in `tests/test_server.py`. Each of the three commits adds tests that fail
against the pre-fix handlers (200 where 403/404/413 is now expected).
