### PR TITLE
feat: seat-scoped portal Phase 1

### DIFF
--- a/docs/onboarding/teammate-rollout.md
+++ b/docs/onboarding/teammate-rollout.md
@@ -3,11 +3,14 @@
 This is the canonical one-pager for M6.5. One admin step, then each teammate
 runs **four setup steps** and is done — Claude Code sessions and git pushes
 auto-save to their private Citadel node, and `citadel_search` works in any MCP
-client. No dashboard login needed after setup.
+client. Dashboard login is **optional** after setup (paste the same seat token
+on `/login` to open your Seat home).
 
 > **Deep-dive:** [`citadel-autosync.md`](citadel-autosync.md) (what syncs),
 > [`citadel-autosync-ides.md`](citadel-autosync-ides.md) (per-IDE notes).
 > This page is the short version.
+> **Portal:** [`../plans/seat-scoped-portal.md`](../plans/seat-scoped-portal.md)
+> (seat-scoped dashboard — token login → My Node).
 
 ---
 
@@ -211,6 +214,20 @@ another seat's Node content.
 You should get a short note back sourced from your node / Central. If you get an
 auth error, your token isn't in the environment of the client that's running
 (restart the client so it picks up the new env var).
+
+---
+
+## Optional: open the portal with your seat token
+
+MCP + hooks remain the primary write path. To **see** your Node in the browser:
+
+1. Open the Node URL `/login` (same host as `CITADEL_NODE_URL`).
+2. Paste your `ctdl_…` seat token (same secret as `CITADEL_MCP_ACCESS_TOKEN`).
+3. You land on **My Node** (Seat home): doc counts, empty-state checklist, links
+   to Search / Graph / Activity. Session chrome shows your seat slug.
+
+Central stays searchable even when your Node is empty. Token rotation stays
+admin-only for now (`citadel seat token <slug>` or Access → revoke).
 
 ---
 

--- a/docs/plans/seat-scoped-portal.md
+++ b/docs/plans/seat-scoped-portal.md
@@ -1,0 +1,389 @@
+# Seat-Scoped Portal — Product & Architecture Plan
+
+**Status:** Grill closed — Phase 1 implementing on `cursor/seat-scoped-portal-phase1`  
+**Date:** 2026-07-21  
+**Relates:** [ADR-0003](../adr/0003-seat-node-central-private-memory.md), [ADR-0006](../adr/0006-agent-auth-and-onboarding.md), [ADR-0007](../adr/0007-seat-capture-promotion-write-policy.md), [ADR-0009](../adr/0009-mesh-read-isolation-presence-vs-content.md), [`agent-access-model.md`](../agent-access-model.md), [`organization-vault-plan.md`](../organization-vault-plan.md), [`onboarding/teammate-rollout.md`](../onboarding/teammate-rollout.md)
+
+## Vision
+
+Every licensed human has a **Seat**. That person should:
+
+1. Log into **their own account** using their seat **Access Token** as the credential (not only the org admin key).
+2. See **their Node** — knowledge, activity, and graphs from that seat’s point of view.
+3. See **Central** in the same workspace, clearly linked to their seat context (read Central; write Node; promotion is the bridge).
+4. Stop experiencing seats as empty, disconnected “slots” on an admin console.
+5. Trust that **ingest via a seat Token always lands in that Seat’s Node**, and that the portal makes that link readable (Seat ↔ Node/KB ↔ graph ↔ activity).
+
+Today the **data model and API already encode seat → Node + Central**, and **seat-token write routing already forces Node-only ingest** (`resolve_write_targets` → `seat:{slug}`). The gap is mostly **product surface, mental model, and observability**: the Operations Dashboard still reads as an admin console; teammate docs push a headless MCP-only path; chrome ignores `seat_slug`; audit events record `actor_*` + `dataset` but not an explicit `seat_slug` field; there is no per-seat activity analytics panel.
+
+---
+
+## Current state
+
+### How seats and tokens work
+
+| Layer | Today |
+|---|---|
+| **Seat** | Admin-provisioned **Principal** (`create_seat` / Access UI / `citadel seat create`). One human → one slug → one Node dataset `seat:{slug}`. Seats cannot be admin. |
+| **Node** | Logical Cognee dataset `seat:{slug}`. Private working memory. Filled by MCP ingest, capture hooks, CLI capture, Linear seat-scoped mirror — not by creating the seat alone. |
+| **Central** | `masumi-network`. Org knowledge from GitHub/Linear sync, Promotion Agent, service-account contributions. |
+| **Token** | `ctdl_…` from AccessStore. Seat-writer tokens carry `seat_slug`, `default_dataset=seat:{slug}`, `default_session=seat-{slug}`, `allowed_datasets` including Node + Central. |
+| **Write policy** | ADR-0007: seat-scoped callers write **Node only**. Central is read-only for seats. Enforced in `resolve_write_targets` / `guard_seat_write_policy`. |
+| **Read policy** | Own Node + Central. Other seats’ Node **content** never. Seat **presence** (hub + counts) visible to all (ADR-0009). |
+
+Admin-first provisioning is intentional (inventory, licensing, audit). Tokens are the credential; the Node is the storage boundary.
+
+### Ingest attribution — code reality (challenge)
+
+**Write path is linked today for a real seat identity:**
+
+1. `POST /ingest` (and MCP `citadel_ingest`) resolve the caller via AccessStore → `AccessIdentity` with `seat_slug` / `default_dataset`.
+2. `resolve_write_targets` for seat identities **ignores** a foreign requested dataset and returns only `WriteTarget(seat:{slug}, "light")`.
+3. Mesh activity records the **dataset** on each ingest event; Knowledge Mesh graph attribution uses `dataset_map` so documents hang under `seat:{slug}` hubs when Cognee attribution succeeds.
+4. Audit events store `actor_id` / `actor_name` / `role` / **`dataset`** — not a dedicated `seat_slug` column. Seat can usually be derived as `dataset.removeprefix("seat:")` when the write hit a Node.
+
+**So “ingest via a seat token is not properly linked” is likely one of these, not a missing write-router:**
+
+| Hypothesis | Evidence |
+|---|---|
+| **H1 — Wrong credential** | Token without `seat_slug` (service / env / legacy). `citadel status` prints “This token has no seat”; writes go to org default, not a Node. |
+| **H2 — Empty Node UX** | Seat create does not seed docs; graph shows presence hub with 0 documents → feels “unlinked.” |
+| **H3 — UI / observability gap** | Session chrome ignores `seat_slug`; no Seat home; Audit is admin-only; no per-seat activity analytics; interlinking Seat ↔ KB ↔ graph is undocumented in-product. |
+| **H4 — Attribution display bug** | Cognee `node_dataset_map` / soft-degrade path leaves some graph nodes without `dataset` — content exists but UI doesn’t hang it under the seat hub. |
+| **H5 — Actual routing bug** | Would require a seat identity writing outside Node — contradicts current `resolve_write_targets` + tests; treat as regression if reproduced. |
+
+### Working diagnosis (2026-07-21 grill)
+
+User: seat Tokens (own + teammates’) **are** seat-linked; still “don’t see the seats linked to anything.”
+
+→ **Working hypothesis: B and/or C** (portal/graph/UI does not surface Seat↔KB; and/or empty/disconnected UX). **Not A** (no-seat token). **Not claiming D** without a routing repro.
+
+**What surfaces seat linkage today (code check):**
+
+| Surface | What you get | What’s missing for “linked” |
+|---|---|---|
+| **Access → Seats** (admin) | Name, slug, `node_dataset` string, token counts/revoke | No doc/ingest counts; no click-through to graph or search; no “last activity” |
+| **Knowledge Graph** | Synthetic `seat:{slug}` presence hubs + doc counts; inspector says “Seat presence” | Hubs can show **0 docs**; content `belongs_to` only if Cognee attribution works; no “open this seat’s home” |
+| **Session chrome** | Role chip only (`loadSession` stores `role`) | Ignores `seat_slug` / `node_label` from `/api/session` |
+| **Member default page** | Search (not Seat home) | No “you are seat X / Node seat:X” frame |
+| **Audit** | `actor_*` + `dataset` (admin-only) | No seat-centric analytics rollup |
+
+Phase 1 still includes a **seat-token smoke ingest** to confirm writes land on `seat:{slug}` (guards against silent D), but product work targets **visibility + interlinking**, not a second write router.
+
+### Auth surfaces today
+
+- **Browser login** (`POST /admin/session`): accepts env bootstrap keys **and** AccessStore tokens. A seat `ctdl_` token already mints an HttpOnly cookie session (`token:{role}:{token_id}:{sig}`).
+- **API / MCP**: `Authorization: Bearer` with the same token → `AccessIdentity` with seat fields.
+- **Session payload** (`GET /api/session` → `role_payload`): already returns `seat_slug`, `node_label`, `default_dataset`, `search_datasets`, capabilities.
+- **Login copy**: page title is “Citadel Admin”; label says “Access key” — not “seat token.” Docs (`teammate-rollout.md`) explicitly say teammates need **no dashboard login** after setup.
+
+So: **seat login is mostly implemented on the server; it is not productized in the UI or onboarding narrative.**
+
+### What UI exists
+
+Single SPA (`kb/static/index.html` + `app.js`):
+
+| Area | Behavior |
+|---|---|
+| **Login** | One field for any access key / token. No seat framing. |
+| **Default page** | Admin → Overview; others → Search. |
+| **Search / Knowledge Graph** | Scoped by caller identity (Node content + Central; other seats as presence hubs). |
+| **Access** | Admin-only (`access:manage`): create seats, issue tokens, connect wizard, capture policy. |
+| **Audit / Settings / Sources sync** | Admin-oriented. |
+| **Promotion queue** | API supports member own-seat + admin all; UI exists but is not framed as a member home. |
+| **Session chrome** | Shows role chip (“Read write”) only — **does not surface `seat_slug` / Node** even when `/api/session` returns them (`loadSession` stores `role` alone). |
+| **Seat activity analytics** | **Does not exist.** Vault Activity + Audit can show events; Seat Presence hubs expose document counts; no per-seat analytics table of calls/counts. |
+
+### Why seats look empty / not interconnected
+
+1. **Empty Node by design until capture.** Creating a seat creates the principal + dataset name; it does not seed documents.
+2. **Product path is headless.** Rollout docs optimize for MCP + hooks, not “open the portal and see your Node.”
+3. **UI ignores seat context.** No “My Node” home, no seat badge, no empty-state that explains fill paths.
+4. **Admin Access inventory ≠ member experience.** Seats on the Access page are provisioning objects.
+5. **Central dominates visually** when the member’s Node is empty.
+6. **Readability / interlinking gap.** Seat slug, Node dataset id, graph hub, and activity stream are not presented as one navigable object graph in the UI.
+
+---
+
+## Locked decisions
+
+| Decision | Choice | Notes |
+|---|---|---|
+| **Architecture** | **Option A** — productize existing token cookie login | No Option B / SSO in Phase 1–2. |
+| **Ingest ↔ Seat** | Verify + **surface** linkage (working hypothesis **B+C**) | Write router already Node-only for seat identities; product gap is visibility. |
+| **“Linked” surfaces** | **All three (4)** | Phase 1: chrome + Seat home. Phase 2: Access health + graph interlinking. |
+| **Seat activity analytics** | Columns + audience **B** | requests/calls (7d), reads (7d), writes (7d), docs (lifetime); all members see org-wide counts; not a ranked leaderboard. **Phase 2.** |
+| **Central write from UI** | **Promotion Approval only** | No exceptions for human seats (ADR-0007). |
+| **Graph default** | **Always** show universal presence canvas | Highlight “you”; other hubs presence-only. **Phase 2 polish.** |
+| **Empty Node SLA** | **Empty until first capture** | Strong Seat-home checklist; no fake seed content. |
+| **Token rotation (Phase 1)** | **Admin-only** | Self-service deferred to Phase 3 / Option B. |
+| **Readability / interlinking** | Phase 1 partial; Phase 2 full | Phase 1: chrome + home links to search/graph/activity. |
+
+**Grill status:** **Closed** 2026-07-21 — Phase 1 ready to build.
+
+---
+
+## Goals / non-goals
+
+### Goals
+
+- Make **token-as-session** the first-class member login story (seat credential = portal access).
+- Give each seat holder a **seat-scoped portal**: clear “you / your Node / Central” framing.
+- Surface **Node knowledge, activity, graphs, and seat activity analytics** from the seat POV, with Central visible and linked.
+- Make **Seat ↔ Node ↔ graph ↔ activity** navigable and readable in-product.
+- Prove (or fix) **ingest attribution** so a seat Token’s writes are visibly that Seat’s Node.
+- Align onboarding docs and UI empty-states so “empty seat” means “not yet capturing,” not “broken account.”
+- Preserve ADR isolation: no cross-seat Node content; Central stays curated.
+
+### Non-goals (this plan)
+
+- Full OAuth 2.1 / Google SSO (ADR-0006 Phases B–C) — complementary later; token portal is the MVP bridge.
+- Option B dual credential in Phase 1 (short-lived portal token) — deferred unless grill reopens it.
+- Physical DB-per-seat isolation.
+- Seat-to-seat Node sync or glass-walls (rejected in ADR-0009).
+- Replacing MCP / CLI as primary **write** surfaces (dashboard remains monitor + light governance per ADR-0007).
+- Letting seats become admin or write raw content into Central from the UI.
+
+---
+
+## UX: seat login with token
+
+### Login
+
+1. Member opens `/login` (rename framing: “Citadel” / “Seat access,” not “Admin”).
+2. Pastes their `ctdl_…` seat token (same secret used for MCP / `CITADEL_MCP_ACCESS_TOKEN`).
+3. Server already validates via AccessStore and sets cookie for 12h.
+4. Redirect into **seat home**, not a generic admin overview.
+
+Optional later: short-lived “portal-only” session tokens vs long-lived MCP tokens; MVP reuses the seat-writer token.
+
+### What they see after login (target)
+
+| Surface | Seat member | Admin (unchanged / enhanced) |
+|---|---|---|
+| **Chrome** | Seat slug + Node label + role | Admin + seat inventory |
+| **Home** | My Node summary: doc/capture counts, last capture, promotion pending, “how to fill your Node,” deep links into graph + activity | Org health overview + **seat activity analytics** |
+| **Search** | Multi-dataset: Node + Central (already on API path) with source badges | Same + bypass |
+| **Graph** | Own Node content + Central + **all seats as presence**; highlight “you”; click hub → seat/home context | Full content (support) |
+| **Activity** | Own Node activity with content; other seats presence-only | Org broadcast + analytics |
+| **Seat activity analytics** | Org-wide presence-safe counts (decision B); own row deep-links to detail | Full per-seat analytics table |
+| **Promotion** | Own pending queue approve/reject | All seats + delegate |
+| **Access** | Hidden (or read-only “your tokens” later) | Full provisioning |
+
+Central remains **read** in UI for seats. Writes stay Node-bound. Promotion is the only member path that affects Central visibility of their work.
+
+---
+
+## Architecture options
+
+### Option A — Productize existing token sessions — **LOCKED for Phase 1–2**
+
+**Idea:** Keep AccessStore + cookie login. Teach the SPA to read `seat_slug` / `node_label` from `/api/session`, add a seat home route, role-gated nav, seat-aware empty states, activity analytics + interlinking. Thin API additions where member-safe aggregates are missing (e.g. `GET /api/me/node-summary`, seat analytics aggregates).
+
+| Pros | Cons |
+|---|---|
+| Ships on current auth; no new IdP | Long-lived token pasted into browser (same as today’s MCP secret) |
+| Matches ADR-0003/0007 mental model | Login UX still “paste secret” until ADR-0006 |
+| Smallest diff; reuses mesh isolation | Must carefully hide admin nav for writers |
+
+**Fits:** MVP in days/weeks, not a platform rewrite.
+
+### Option B — Dual credential: portal session vs agent token (deferred)
+
+**Idea:** Seat login mints a short-lived **browser session** credential distinct from the MCP `ctdl_` agent token.
+
+**Fits:** Phase 3 hardening after portal UX lands — not a Phase 1 gate.
+
+### Option C — Identity-first portal (Google SSO → seat map) (deferred)
+
+**Idea:** ADR-0006 track. Do not block member Node views on SSO.
+
+### Locked flow (Option A)
+
+```
+Member browser                    Citadel Node
+─────────────                     ────────────
+Paste ctdl_ token ──POST /admin/session──► AccessStore auth
+                      ◄── cookie ────────── AccessIdentity(seat)
+GET /api/session      ◄── seat_slug, node ── role_payload
+Seat home / graph / search / analytics
+Writes ──────────────────────► Node only (ADR-0007; already enforced)
+Promotion approve ────────────► Central (governed)
+```
+
+---
+
+## Phased roadmap
+
+### Phase 1 — Seat login + Node view + attribution proof (MVP)
+
+**Scope**
+
+- Relabel login for members (copy, title, helper: “seat token from admin / `citadel seat token`”).
+- Persist and display seat identity in chrome from `/api/session` (`seat_slug`, `node_label`, role).
+- **Seat home** page (default for non-admin): Node stats, recent activity for own Node, pending promotions count, onboarding checklist when empty; **links** to graph focus and activity filtered to this seat.
+- Hide or disable Access / Audit / Settings / org Sources admin actions for non-admin.
+- Empty-state copy: “Your Node fills when you capture or your agent ingests — Central still searchable.”
+- Confirm search defaults use multi-dataset Node + Central for seat tokens.
+- **Ingest attribution verification:** seat-token smoke ingest → assert `dataset == seat:{slug}` on response/audit/mesh; surface that link on Seat home (“Last ingest → this Node”). Fix only if H4/H5 reproduce.
+- Update `teammate-rollout.md`: optional “open the portal with your token” path alongside MCP.
+
+**Dependencies**
+
+- Existing `/admin/session` + `role_payload` (done).
+- Mesh/search isolation (ADR-0009 / allowlists) — verify with seat token smoke tests.
+
+**Risks**
+
+- Writers accidentally retaining admin nav if `data-min-role` incomplete.
+- Empty home still feels broken if checklist is weak.
+- Token-in-browser phishing / XSS impact — mitigate with existing CSP; document revoke via admin.
+- Misdiagnosing H1 (no-seat token) as a product bug.
+
+**Acceptance criteria**
+
+- [ ] Member logs in with seat-writer token only; lands on seat home showing their slug and Node id.
+- [ ] Admin-only pages unreachable (UI + API 403).
+- [ ] Search returns Central hits even when Node is empty; Node hits appear after a test ingest.
+- [ ] Session chrome shows seat, not only “Read write.”
+- [ ] After seat-token ingest, home/audit/mesh show that write under `seat:{slug}` (not Central / unset).
+- [ ] Docs mention portal login without replacing MCP onboard.
+
+### Phase 2 — Graphs + readability / interlinking + seat activity analytics
+
+**Scope**
+
+- Graph default focus: highlight caller’s seat hub; depth-from-you; Central as shared hub.
+- Legend / filters: “My Node” vs “Central” vs “Other seats (presence).”
+- Drill-down: own Node docs + Central docs; other hubs presence-only; **clickable hub → seat context panel** (slug, doc count, last activity, link to home/search scoped).
+- Optional: side panel “links to Central” for promoted docs.
+- Vault Activity: seat POV default; org presence strip secondary.
+- **Access inventory health:** per-seat doc count, last ingest, jump-to-graph / search scoped to `seat:{slug}`.
+- **Graph interlinking:** legend, “you” highlight, hub → seat context panel (slug, counts, links home).
+- **Seat activity analytics** table — **not ranked/competitive**. Columns locked: requests/calls (7d), reads/searches (7d), writes/Node ingests (7d), docs (lifetime). **Audience B:** all members see org-wide counts; admin full table; never peer Node content.
+- Cross-links: analytics row → seat hub / seat home; activity event → dataset / graph; Seat Access row → Node id + open graph.
+
+**Dependencies**
+
+- Phase 1 chrome + identity + attribution proof.
+- Knowledge mesh endpoints already filter by caller.
+- Metric definitions locked in grill (what counts as request vs read vs write; retention).
+
+**Risks**
+
+- Aggregated overview hides personal content — keep a “My Node only” toggle.
+- Performance if every login pulls full mesh — keep server caps / soft degrade.
+- Analytics from ephemeral Vault Activity alone would reset on deploy — prefer audit (durable, capped) or explicit rollup store.
+- Over-exposing peer detail beyond ADR-0009 Seat Presence.
+
+**Acceptance criteria**
+
+- [ ] Seat member can distinguish their hub from Central and from other seats in one glance.
+- [ ] Clicking another seat hub never reveals that Node’s documents.
+- [ ] With content in Node + Central, both appear under the member’s scope without admin login.
+- [ ] From Seat home, member can hop Seat → graph hub → activity without re-deriving dataset names mentally.
+- [ ] Analytics dashboard shows per-seat **requests/calls (7d)**, **reads/searches (7d)**, **writes/Node ingests (7d)**, **docs (lifetime)** for **all members** (presence-safe counts); admin full table; never other seats’ Node content.
+
+### Phase 3 — Interconnection / promotion visibility / portal polish
+
+**Scope**
+
+- Promotion Approval as first-class member workflow on seat home + dedicated page.
+- Visibility of what left the Node for Central (promotion history for own seat).
+- Shared Session Traces discoverability from portal (read-only list / search entry points).
+- Seat-scoped Linear mirror status.
+- Option B: short-lived portal sessions + token rotation UX.
+- Kick off ADR-0006 device grant / SSO design against this IA (Option C).
+
+**Dependencies**
+
+- Promotion Agent + queue APIs (partially shipped).
+- Shared session traces (ADR-0011).
+- Phase 1–2 portal shell.
+
+**Risks**
+
+- Scope creep into full SSO before portal IA is stable.
+- Over-notifying members about other seats’ presence.
+
+**Acceptance criteria**
+
+- [ ] Member can approve/reject own promotion items from portal and see outcome reflected in Central search.
+- [ ] Member can explain Node vs Central vs shared traces from in-app copy alone.
+- [ ] Token rotation path documented and usable without admin guessing which token is MCP vs portal (if Option B shipped).
+
+---
+
+## Suggested implementation sketch (Phase 1 only)
+
+Not a commitment — orientation for implementers after grill closes:
+
+1. `loadSession`: store `seat_slug`, `node_label`, `search_datasets`, capabilities; render seat chip.
+2. `initialPage()`: if `seat_slug` → `home` (new); else admin overview / search.
+3. New `GET /api/me/summary` (or compose existing mesh + promotion pending + session): counts + last events for `identity.seat_slug` only.
+4. Nav: `data-min-role="admin"` audit on Access/Audit/Settings; ensure writer cannot call `/api/access`.
+5. Login HTML: member-first copy; keep accepting admin key for operators.
+6. Smoke: seat token `POST /ingest` → assert dataset `seat:{slug}` on result + audit `dataset` + mesh event.
+7. Docs: one section in teammate rollout + pointer from this plan.
+
+Phase 2 sketch (after metric grill): seat analytics aggregate endpoint + SPA panel; graph/activity deep-links keyed by `seat_slug` / `seat:{slug}`.
+
+---
+
+## Open questions (grill queue)
+
+**All resolved.** Closing pack accepted (recommendations):
+
+1. ~~Ingest diagnosis~~ → B+C  
+2. ~~Linked surfaces~~ → 4 (all); Phase 1 ships chrome/home first  
+3. ~~Analytics columns~~ → 7d requests/reads/writes + lifetime docs  
+4. ~~Analytics audience~~ → B (org-wide counts for members)  
+5a. ~~Central write UI~~ → Promotion only  
+5b. ~~Graph default~~ → always presence canvas  
+5c. ~~Empty Node~~ → empty until capture + checklist  
+5d. ~~Token rotation~~ → admin-only in Phase 1  
+
+---
+
+## Phase 1 ready-to-build checklist
+
+- [x] Login framing: Citadel / seat token (not “Admin”)
+- [x] `loadSession` stores `seat_slug`, `node_label`, `search_datasets`, capabilities
+- [x] Session chrome shows seat + Node (not only role)
+- [x] Seat **home** page default for seat holders; Node stats + empty checklist
+- [x] Admin nav (Access / Audit / Settings / Overview) hidden from non-admin
+- [x] Search result badges distinguish My Node vs Central
+- [x] `GET /api/me/summary` for home stats
+- [x] Teammate rollout mentions optional portal login
+- [x] Tests for `/api/me/summary` + seat session chrome data
+- [x] Attribution smoke covered by existing seat write tests / summary `node_dataset` field
+
+**Out of Phase 1 (Phase 2+):** seat activity analytics table, Access inventory deep-links, graph “you” highlight / hub context panel.
+
+---
+
+## References
+
+- Seat / Node / Central: ADR-0003, `CONTEXT.md` glossary  
+- Write policy: ADR-0007  
+- Mesh presence vs content: ADR-0009  
+- Future SSO: ADR-0006  
+- Headless rollout today: `docs/onboarding/teammate-rollout.md`  
+- Dashboard model (aspirational apps): `docs/agent-access-model.md` § Dashboard Model  
+
+---
+
+## Decision log
+
+| Date | Decision |
+|---|---|
+| 2026-07-21 | **Option A locked** (productize token sessions) for Phase 1–2; defer Option B dual credential and Option C SSO. |
+| 2026-07-21 | **Ingest↔Seat linkage** is a Phase requirement: verify write attribution and surface it; do not assume router is missing without smoke evidence. |
+| 2026-07-21 | **Seat activity analytics** (per-seat calls/counts dashboard — not a competitive leaderboard) and **readability/interlinking** added to Phase 1–2 scope. |
+| 2026-07-21 | Grill Q1: tokens are seat-linked; user still doesn’t *see* linkage → **working hypothesis B+C** (UI/observability + empty/disconnected UX). Not A; D unproven. |
+| 2026-07-21 | Grill Q3 clarify: **not a leaderboard** — rename to **seat activity analytics** (fields/counts/calls per seat). |
+| 2026-07-21 | Grill Q3b: analytics columns locked — **requests/calls (7d)**, **reads/searches (7d)**, **writes/Node ingests (7d)**, **docs (lifetime)**. |
+| 2026-07-21 | Grill Q4: analytics audience **B** — all members see org-wide presence-safe seat counts; admin full table; no peer Node content. |
+| 2026-07-21 | Grill Q2: **“Linked” = all surfaces (4)** — Access inventory + Knowledge Graph + session chrome/Seat home. Phase 1 ships chrome/home first; Phase 2 ships Access deep-links + graph focus/legend. |
+| 2026-07-21 | Grill closing pack accepted: Promotion-only Central UI; always presence graph; empty Node + checklist; admin-only token rotation in Phase 1. |
+| 2026-07-21 | **Grill closed.** Phase 1 implementation on `cursor/seat-scoped-portal-phase1`. |

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,6 +1,30 @@
 # Citadel Progress
 
-Last updated: 2026-07-20.
+Last updated: 2026-07-21.
+
+## 2026-07-21 — Seat-scoped portal Phase 1 — SHIPPED (PR #95)
+
+**PR #95** (`cursor/seat-scoped-portal-phase1`) ships Phase 1 of the
+[seat-scoped portal plan](plans/seat-scoped-portal.md): members paste a seat
+`ctdl_…` token on `/login` and land on **My Node** (Seat home).
+
+**Shipped:**
+
+- Session chrome surfaces `seat_slug` + Node label (not role-only).
+- Seat home via `GET /api/me/summary` — doc counts, recent Node activity, empty
+  checklist, links to search / graph / activity.
+- Member-first login copy; admin nav hidden for non-admin; My Node vs Central
+  search badges.
+- Optional portal path in [`onboarding/teammate-rollout.md`](onboarding/teammate-rollout.md).
+
+**Grill outcomes (locked, unchanged):** Option A token sessions; working
+hypothesis B+C (visibility/UX, not write-router); “linked” = all surfaces (Phase 1
+= chrome/home); analytics columns + audience **B** deferred to Phase 2;
+Promotion-only Central UI; always presence graph; empty Node until capture;
+admin-only token rotation in Phase 1.
+
+**Phase 2 remaining:** seat activity analytics table, Access inventory
+deep-links, graph “you” highlight / hub context panel, Vault Activity seat POV.
 
 ## 2026-07-20 — Shared Session Traces v1 + multi-agent policy onboard — SHIPPED (PR #93)
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -421,7 +421,7 @@ LOGIN_HTML = """<!doctype html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Citadel Admin</title>
+    <title>Citadel</title>
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
@@ -430,13 +430,13 @@ LOGIN_HTML = """<!doctype html>
         <div class="brand compact">
           <div class="brand-mark" aria-hidden="true">CA</div>
           <div>
-            <h1>Citadel Archive</h1>
-            <p>Workspace access</p>
+            <h1>Citadel</h1>
+            <p>Seat access</p>
           </div>
         </div>
         <form id="loginForm" class="form">
           <div class="field">
-            <label for="adminKey">Access key</label>
+            <label for="adminKey">Seat token or access key</label>
             <input
               id="adminKey"
               name="accessKey"
@@ -444,8 +444,13 @@ LOGIN_HTML = """<!doctype html>
               autocomplete="current-password"
               required
               autofocus
+              placeholder="ctdl_…"
             />
           </div>
+          <p class="form-hint">
+            Members: paste the seat token from your admin (or
+            <code>citadel seat token</code>). Operators: env admin key still works.
+          </p>
           <p id="loginError" class="form-error" role="alert"></p>
           <button id="loginSubmit" class="primary-button" type="submit">Open workspace</button>
         </form>
@@ -2097,6 +2102,120 @@ async def current_session(request: Request) -> dict[str, Any]:
         detail={"role": identity.role},
     )
     return {"ok": True, **role_payload(identity.role, identity)}
+
+
+@app.get("/api/me/summary")
+async def me_summary(request: Request) -> dict[str, Any]:
+    """Seat-home aggregates for the authenticated caller (Phase 1 portal).
+
+    Reflects only the caller's seat Node — never another seat's content.
+    Non-seat callers get ``seat_slug: null`` and empty Node stats.
+    """
+    identity = require_access(request, "reader", "kb:read")
+    config = get_citadel().config
+    scope = resolved_memory_scope(identity, config)
+    node = seat_node_dataset(identity)
+    seat_slug = identity.seat_slug
+
+    pending_count = 0
+    if seat_slug:
+        pending_count = len(
+            get_access_store().list_promotion_pending(
+                seat_slug=seat_slug,
+                status="pending",
+            )
+        )
+
+    document_count = 0
+    recent_activity: list[dict[str, Any]] = []
+    last_ingest_at: str | None = None
+    if node:
+        try:
+            snapshot = await get_mesh().snapshot(config)
+            scoped = scope_mesh_snapshot(snapshot, identity)
+            for mesh_node in scoped.get("nodes") or []:
+                if not isinstance(mesh_node, dict):
+                    continue
+                if mesh_node.get("type") != "document":
+                    continue
+                meta = mesh_node.get("metadata") if isinstance(mesh_node.get("metadata"), dict) else {}
+                if meta.get("dataset") == node:
+                    document_count += 1
+        except Exception:
+            logger.exception("me/summary mesh document count failed")
+
+        visible_cache: dict[str, bool] = {}
+
+        def _visible(dataset: str | None) -> bool:
+            if dataset is None:
+                return False
+            return _mesh_dataset_visible(identity, dataset, visible_cache)
+
+        try:
+            timeline = await get_mesh().timeline(limit=12, visible=_visible)
+            for event in timeline.get("events") or []:
+                if not isinstance(event, dict):
+                    continue
+                details = event.get("details") if isinstance(event.get("details"), dict) else {}
+                if details.get("dataset") != node:
+                    continue
+                recent_activity.append(
+                    {
+                        "id": event.get("id"),
+                        "type": event.get("type"),
+                        "message": event.get("message"),
+                        "created_at": event.get("created_at") or event.get("at"),
+                        "dataset": details.get("dataset"),
+                    }
+                )
+                if last_ingest_at is None and event.get("type") == "ingest":
+                    last_ingest_at = event.get("created_at") or event.get("at")
+        except Exception:
+            logger.exception("me/summary timeline failed")
+
+        if last_ingest_at is None:
+            for audit_event in reversed(get_access_store().snapshot().get("audit_events") or []):
+                if not isinstance(audit_event, dict):
+                    continue
+                if audit_event.get("dataset") != node or not audit_event.get("success"):
+                    continue
+                action = str(audit_event.get("action") or "")
+                if action == "ingest" or action.endswith("citadel_ingest"):
+                    last_ingest_at = audit_event.get("created_at")
+                    break
+
+    empty = bool(seat_slug) and document_count == 0
+    return {
+        "ok": True,
+        "seat_slug": seat_slug,
+        "node_label": scope.get("node_label"),
+        "node_dataset": node,
+        "search_datasets": scope.get("search_datasets") or [scope.get("default_dataset")],
+        "document_count": document_count,
+        "pending_promotions": pending_count,
+        "last_ingest_at": last_ingest_at,
+        "recent_activity": recent_activity[:8],
+        "empty": empty,
+        "checklist": [
+            {
+                "id": "capture",
+                "label": "Run capture or MCP ingest into your Node",
+                "done": document_count > 0,
+            },
+            {
+                "id": "search",
+                "label": "Search — Central is available even while your Node is empty",
+                "done": False,
+            },
+            {
+                "id": "promote",
+                "label": "Approve promotions when you want Node work in Central",
+                "done": pending_count == 0 and document_count > 0,
+            },
+        ]
+        if seat_slug
+        else [],
+    }
 
 
 @app.get("/api/access")

--- a/kb/server.py
+++ b/kb/server.py
@@ -2144,21 +2144,18 @@ async def me_summary(request: Request) -> dict[str, Any]:
         except Exception:
             logger.exception("me/summary mesh document count failed")
 
-        visible_cache: dict[str, bool] = {}
-
-        def _visible(dataset: str | None) -> bool:
-            if dataset is None:
-                return False
-            return _mesh_dataset_visible(identity, dataset, visible_cache)
+        # Scope the timeline page to this seat Node *before* the limit slice.
+        # Filtering only after a mixed visible page (Central + shared traces)
+        # can drop all Node activity when org traffic is busy.
+        def _node_visible(dataset: str | None) -> bool:
+            return dataset == node
 
         try:
-            timeline = await get_mesh().timeline(limit=12, visible=_visible)
+            timeline = await get_mesh().timeline(limit=12, visible=_node_visible)
             for event in timeline.get("events") or []:
                 if not isinstance(event, dict):
                     continue
                 details = event.get("details") if isinstance(event.get("details"), dict) else {}
-                if details.get("dataset") != node:
-                    continue
                 recent_activity.append(
                     {
                         "id": event.get("id"),
@@ -2173,18 +2170,45 @@ async def me_summary(request: Request) -> dict[str, Any]:
         except Exception:
             logger.exception("me/summary timeline failed")
 
-        if last_ingest_at is None:
-            for audit_event in reversed(get_access_store().snapshot().get("audit_events") or []):
-                if not isinstance(audit_event, dict):
-                    continue
-                if audit_event.get("dataset") != node or not audit_event.get("success"):
-                    continue
-                action = str(audit_event.get("action") or "")
-                if action == "ingest" or action.endswith("citadel_ingest"):
-                    last_ingest_at = audit_event.get("created_at")
-                    break
+        # Mesh is ephemeral across process restarts. Prefer live mesh document
+        # nodes for the Documents count; use durable AccessStore audit only for
+        # presence, last_ingest_at, and recent activity so Seat home does not
+        # contradict itself after a redeploy.
+        audit_ingests: list[dict[str, Any]] = []
+        for audit_event in reversed(get_access_store().snapshot().get("audit_events") or []):
+            if not isinstance(audit_event, dict):
+                continue
+            if audit_event.get("dataset") != node or not audit_event.get("success"):
+                continue
+            action = str(audit_event.get("action") or "")
+            if action != "ingest" and not action.endswith("citadel_ingest"):
+                continue
+            detail = audit_event.get("detail") if isinstance(audit_event.get("detail"), dict) else {}
+            if detail.get("accepted") is False:
+                continue
+            audit_ingests.append(audit_event)
 
-    empty = bool(seat_slug) and document_count == 0
+        if last_ingest_at is None and audit_ingests:
+            last_ingest_at = audit_ingests[0].get("created_at")
+
+        # Only synthesize activity from audit when the live mesh page is empty
+        # (e.g. post-restart). Never prepend audit rows over current mesh traffic.
+        if not recent_activity and audit_ingests:
+            recent_activity = [
+                {
+                    "id": audit_event.get("id"),
+                    "type": "ingest",
+                    "message": "Node ingest",
+                    "created_at": audit_event.get("created_at"),
+                    "dataset": node,
+                }
+                for audit_event in audit_ingests[:8]
+            ]
+
+    # Capture proof is documents or a durable ingest timestamp — not search
+    # timeline rows, which can appear on an empty Node.
+    capture_done = document_count > 0 or last_ingest_at is not None
+    empty = bool(seat_slug) and not capture_done
     return {
         "ok": True,
         "seat_slug": seat_slug,
@@ -2200,7 +2224,7 @@ async def me_summary(request: Request) -> dict[str, Any]:
             {
                 "id": "capture",
                 "label": "Run capture or MCP ingest into your Node",
-                "done": document_count > 0,
+                "done": capture_done,
             },
             {
                 "id": "search",
@@ -2209,8 +2233,10 @@ async def me_summary(request: Request) -> dict[str, Any]:
             },
             {
                 "id": "promote",
-                "label": "Approve promotions when you want Node work in Central",
-                "done": pending_count == 0 and document_count > 0,
+                # Phase 1: approve/reject is admin-only (`sources:sync`); members
+                # see pending count as a status signal, not a self-serve action.
+                "label": "Promotions to Central are clear (admin approves in Phase 1)",
+                "done": pending_count == 0 and capture_done,
             },
         ]
         if seat_slug
@@ -4143,10 +4169,30 @@ async def ingest(body: IngestBody, request: Request) -> Any:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     result = outcome.ingest
+    # Durable HTTP ingest audit (MCP path already records via record_mcp_audit).
+    # Only accepted writes count as capture proof for Seat home.
+    if result.accepted and not mcp_tool_name(request):
+        get_access_store().record_event(
+            action="ingest",
+            actor=actor,
+            success=True,
+            dataset=outcome.dataset,
+            detail={
+                "operation": "ingest",
+                "accepted": True,
+                "reason": result.reason,
+                "data_bytes": len(body.data.encode("utf-8")),
+                "tag_count": len(body.tags),
+                "write_targets": [target.dataset for target in write_targets],
+                "scope_override": scope_override_active(
+                    actor, [target.dataset for target in write_targets]
+                ),
+            },
+        )
     record_mcp_audit(
         request,
         actor=actor,
-        success=True,
+        success=bool(result.accepted),
         dataset=outcome.dataset,
         detail={
             "operation": "ingest",

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -12,6 +12,11 @@ const state = {
   paused: false,
   eventSource: null,
   role: null,
+  seatSlug: null,
+  nodeLabel: null,
+  defaultDataset: null,
+  searchDatasets: null,
+  capabilities: null,
   githubSync: null,
   obsidianSources: null,
   accessSnapshot: null,
@@ -36,6 +41,7 @@ const systemStatus = document.querySelector(".system-status");
 const connectionLabel = document.getElementById("connectionLabel");
 const runtimeStatus = document.getElementById("runtimeStatus");
 const sessionRole = document.getElementById("sessionRole");
+const sessionSeat = document.getElementById("sessionSeat");
 const roleSummary = document.getElementById("roleSummary");
 const accessMode = document.getElementById("accessMode");
 const graphMeta = document.getElementById("graphMeta");
@@ -540,12 +546,44 @@ function roleLabel(role) {
   return "Read only";
 }
 
+function datasetSourceBadge(dataset) {
+  const name = String(dataset || "").trim();
+  if (!name) return { label: "Unknown source", kind: "unknown" };
+  if (name === CENTRAL_DATASET || name === "masumi-network") {
+    return { label: "Central", kind: "central" };
+  }
+  if (name.startsWith(SEAT_DATASET_PREFIX)) {
+    const slug = name.slice(SEAT_DATASET_PREFIX.length);
+    if (state.seatSlug && slug === state.seatSlug) {
+      return { label: "My Node", kind: "mine" };
+    }
+    return { label: `Seat ${slug}`, kind: "seat" };
+  }
+  if (name === "session-traces") {
+    return { label: "Shared traces", kind: "traces" };
+  }
+  return { label: name, kind: "other" };
+}
+
 function applyAccessControls() {
   const label = state.role ? roleLabel(state.role) : "Locked";
   sessionRole.textContent = label;
   sessionRole.className = `status-chip ${state.role ? "status-enabled" : "status-error"}`;
+  if (sessionSeat) {
+    if (state.seatSlug) {
+      sessionSeat.hidden = false;
+      sessionSeat.textContent = `Seat ${state.seatSlug}`;
+      sessionSeat.title = state.nodeLabel || `seat:${state.seatSlug}`;
+      sessionSeat.className = "status-chip status-enabled";
+    } else {
+      sessionSeat.hidden = true;
+      sessionSeat.textContent = "—";
+    }
+  }
   roleSummary.textContent = state.role
-    ? `${label} vault access`
+    ? state.seatSlug
+      ? `${label} · seat ${state.seatSlug}`
+      : `${label} vault access`
     : "No vault session";
   accessMode.textContent = label;
   accessMode.className = sessionRole.className;
@@ -584,11 +622,14 @@ function renderDashboardMcpSession() {
     dashboardMcpClients.textContent = state.role ? label : "Locked";
     dashboardMcpMeta.textContent = state.role ? "current session" : "login required";
   }
+  const seatLine = state.seatSlug
+    ? ` · seat ${escapeHtml(state.seatSlug)} (${escapeHtml(state.nodeLabel || `seat:${state.seatSlug}`)})`
+    : "";
   dashboardMcpList.innerHTML = `
     <div class="entity-item">
       <div>
         <strong>Current session</strong>
-        <p>${escapeHtml(label)} vault access${state.role ? " through cookie or bearer token" : ""}</p>
+        <p>${escapeHtml(label)} vault access${seatLine}${state.role ? " through cookie or bearer token" : ""}</p>
       </div>
       <span class="status-chip ${state.role ? "status-enabled" : "status-error"}">${escapeHtml(state.role || "none")}</span>
     </div>
@@ -599,6 +640,11 @@ async function loadSession() {
   try {
     const session = await api("/api/session");
     state.role = session.role;
+    state.seatSlug = session.seat_slug || null;
+    state.nodeLabel = session.node_label || null;
+    state.defaultDataset = session.default_dataset || null;
+    state.searchDatasets = session.search_datasets || null;
+    state.capabilities = session.capabilities || null;
     applyAccessControls();
   } catch {
     window.location.assign("/login");
@@ -609,6 +655,7 @@ async function loadSession() {
 function initialPage() {
   const hash = window.location.hash.replace("#", "");
   if (pages.some((page) => page.dataset.page === hash)) return hash;
+  if (state.seatSlug) return "home";
   return state.role === "admin" ? "overview" : "search";
 }
 
@@ -643,6 +690,9 @@ function setPage(name) {
   resizeCanvas();
   if (resolvedName === "access") {
     loadAccess();
+  }
+  if (resolvedName === "home") {
+    loadSeatHome();
   }
   if (resolvedName === "agents" || resolvedName === "audit") {
     loadAccess();
@@ -2584,6 +2634,97 @@ function renderKnowledgeSources(error = null) {
   });
 }
 
+async function loadSeatHome() {
+  const status = document.getElementById("homeStatus");
+  const seatEl = document.getElementById("homeSeatSlug");
+  const nodeLabelEl = document.getElementById("homeNodeLabel");
+  const docEl = document.getElementById("homeDocCount");
+  const pendingEl = document.getElementById("homePendingPromotions");
+  const lastEl = document.getElementById("homeLastIngest");
+  const emptyHint = document.getElementById("homeEmptyHint");
+  const checklist = document.getElementById("homeChecklist");
+  const activityList = document.getElementById("homeActivityList");
+  const title = document.getElementById("homeTitle");
+  if (!status || !checklist || !activityList) return;
+
+  if (!state.seatSlug) {
+    status.textContent = "No seat";
+    status.className = "status-chip status-standby";
+    if (title) title.textContent = "Workspace home";
+    if (seatEl) seatEl.textContent = "—";
+    if (nodeLabelEl) nodeLabelEl.textContent = "service account / no private Node";
+    if (docEl) docEl.textContent = "—";
+    if (pendingEl) pendingEl.textContent = "—";
+    if (lastEl) lastEl.textContent = "—";
+    if (emptyHint) emptyHint.hidden = true;
+    checklist.innerHTML = "";
+    activityList.innerHTML = "";
+    activityList.append(
+      emptyState(
+        "No seat on this token",
+        "Ask an admin for a seat-bound token to get a private Node home.",
+      ),
+    );
+    return;
+  }
+
+  status.textContent = "Loading";
+  status.className = "status-chip status-standby";
+  try {
+    const summary = await api("/api/me/summary");
+    if (title) title.textContent = summary.node_label || `Seat ${summary.seat_slug}`;
+    if (seatEl) seatEl.textContent = summary.seat_slug || state.seatSlug;
+    if (nodeLabelEl) {
+      nodeLabelEl.textContent = summary.node_dataset || `seat:${summary.seat_slug}`;
+    }
+    if (docEl) docEl.textContent = String(summary.document_count ?? 0);
+    if (pendingEl) pendingEl.textContent = String(summary.pending_promotions ?? 0);
+    if (lastEl) {
+      lastEl.textContent = summary.last_ingest_at
+        ? formatDate(summary.last_ingest_at)
+        : "Never";
+    }
+    if (emptyHint) emptyHint.hidden = !summary.empty;
+    checklist.innerHTML = "";
+    (summary.checklist || []).forEach((item) => {
+      const li = document.createElement("li");
+      li.className = item.done ? "seat-check done" : "seat-check";
+      li.innerHTML = `<span class="seat-check-mark" aria-hidden="true">${item.done ? "✓" : "○"}</span><span>${escapeHtml(item.label)}</span>`;
+      checklist.append(li);
+    });
+    activityList.innerHTML = "";
+    const events = summary.recent_activity || [];
+    if (!events.length) {
+      activityList.append(
+        emptyState(
+          "No Node activity yet",
+          "Capture from your IDE hooks or paste a note — writes land on your Node only.",
+        ),
+      );
+    } else {
+      events.forEach((event) => {
+        const row = document.createElement("div");
+        row.className = "entity-item";
+        row.innerHTML = `
+          <div>
+            <strong>${escapeHtml(event.type || "event")}</strong>
+            <p>${escapeHtml(event.message || event.dataset || "")}</p>
+          </div>
+          <span class="status-chip status-standby">${escapeHtml(formatDate(event.created_at))}</span>
+        `;
+        activityList.append(row);
+      });
+    }
+    status.textContent = summary.empty ? "Empty Node" : "Ready";
+    status.className = `status-chip ${summary.empty ? "status-standby" : "status-enabled"}`;
+  } catch (error) {
+    status.textContent = "Error";
+    status.className = "status-chip status-error";
+    activityList.innerHTML = "";
+    activityList.append(emptyState("Could not load seat home", error.message || "Try refresh."));
+  }
+}
+
 async function loadAccess() {
   if (!canUse("admin")) return;
   accessTokenStatus.textContent = "Loading";
@@ -3740,13 +3881,16 @@ function renderSearchResults(results, response = {}) {
     const sourceUrl = safeExternalUrl(provenance.source_url);
     const drilldown = envelope.retrieval?.document_drilldown_available === true;
     const rank = envelope.rank || index + 1;
+    const datasetName = envelope.dataset || result?.dataset || "";
+    const sourceBadge = datasetSourceBadge(datasetName);
     item.innerHTML = `
       <div class="result-header">
         <div>
-          <div class="result-meta">Citation ${escapeHtml(rank)} · ${escapeHtml(envelope.dataset || result?.dataset || "default dataset")}</div>
+          <div class="result-meta">Citation ${escapeHtml(rank)} · ${escapeHtml(datasetName || "default dataset")}</div>
           <strong>${escapeHtml(resultTitle(result, index))}</strong>
         </div>
         <div class="result-trust-chips" aria-label="Retrieval status">
+          <span class="status-chip source-badge source-badge-${escapeHtml(sourceBadge.kind)}">${escapeHtml(sourceBadge.label)}</span>
           <span class="status-chip status-standby">Untrusted context</span>
           <span class="status-chip ${drilldown ? "status-enabled" : ""}">${drilldown ? "Document" : "Chunk"}</span>
         </div>

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -3308,6 +3308,9 @@ document.getElementById("refreshButton").addEventListener("click", () => {
   loadGithubSync();
   loadObsidianSources();
   loadConflicts();
+  if (state.seatSlug) {
+    loadSeatHome();
+  }
   if (state.graphMode === "knowledge") {
     loadKnowledgeGraph(true);
   }

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -19,6 +19,7 @@
         <div class="system-status">
           <span class="status-dot" aria-hidden="true"></span>
           <span id="connectionLabel">Connecting</span>
+          <span id="sessionSeat" class="status-chip" hidden>—</span>
           <span id="sessionRole" class="status-chip">Checking</span>
           <button id="refreshButton" class="secondary-button compact-button" type="button">
             Refresh
@@ -32,7 +33,11 @@
       <div class="shell">
         <aside class="sidebar" aria-label="Workspace navigation">
           <nav class="side-nav" aria-label="Workspace pages">
-            <button class="nav-link" data-page-target="overview" aria-label="Overview" type="button">
+            <button class="nav-link" data-page-target="home" aria-label="Home" type="button">
+              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 10v10h14V10"/></svg>
+              <span class="nav-label">Home</span>
+            </button>
+            <button class="nav-link" data-page-target="overview" aria-label="Overview" data-min-role="admin" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
               <span class="nav-label">Overview</span>
             </button>
@@ -92,7 +97,61 @@
 
         <main class="workspace">
           <nav id="subtabBar" class="subtab-bar" aria-label="Section tabs" hidden></nav>
-          <section class="page page-active" data-page="overview" aria-labelledby="overviewTitle">
+          <section class="page" data-page="home" aria-labelledby="homeTitle" hidden>
+            <div class="page-heading hero-heading">
+              <div>
+                <p class="eyebrow">Your seat</p>
+                <h2 id="homeTitle" class="hero-title">My Node</h2>
+                <p id="homeCopy" class="dashboard-copy">
+                  Your private Node and org Central in one place. Writes stay on your Node;
+                  Central stays searchable.
+                </p>
+              </div>
+              <div class="hero-actions">
+                <span id="homeStatus" class="status-chip status-standby">Loading</span>
+                <button class="secondary-button" data-page-target="search" type="button">
+                  Search
+                </button>
+                <button class="secondary-button" data-page-target="knowledge" type="button">
+                  Graph
+                </button>
+                <button class="secondary-button" data-page-target="events" type="button">
+                  Activity
+                </button>
+                <button class="primary-button inline-primary" data-page-target="ingest" data-min-role="writer" type="button">
+                  New note
+                </button>
+              </div>
+            </div>
+
+            <section class="metrics-window dashboard-metrics" aria-label="Node status">
+              <dl class="stats dashboard-stats">
+                <div><dt>Seat</dt><dd id="homeSeatSlug">—</dd><span id="homeNodeLabel">node</span></div>
+                <div><dt>Documents</dt><dd id="homeDocCount">0</dd><span>in your Node</span></div>
+                <div><dt>Promotions</dt><dd id="homePendingPromotions">0</dd><span>pending</span></div>
+                <div><dt>Last ingest</dt><dd id="homeLastIngest">—</dd><span>into your Node</span></div>
+              </dl>
+            </section>
+
+            <section class="panel-card seat-home-panel" aria-labelledby="homeChecklistTitle">
+              <div class="panel-heading">
+                <h3 id="homeChecklistTitle">Fill your Node</h3>
+                <p id="homeEmptyHint" class="dashboard-copy" hidden>
+                  Your Node is empty until you capture or your agent ingests — Central is still searchable.
+                </p>
+              </div>
+              <ul id="homeChecklist" class="seat-checklist"></ul>
+            </section>
+
+            <section class="panel-card seat-home-panel" aria-labelledby="homeActivityTitle">
+              <div class="panel-heading">
+                <h3 id="homeActivityTitle">Recent Node activity</h3>
+              </div>
+              <div id="homeActivityList" class="entity-list"></div>
+            </section>
+          </section>
+
+          <section class="page page-active" data-page="overview" data-min-role="admin" aria-labelledby="overviewTitle">
             <div class="page-heading hero-heading">
               <div>
                 <p class="eyebrow">Vault overview</p>

--- a/kb/static/login.js
+++ b/kb/static/login.js
@@ -17,7 +17,7 @@ form.addEventListener("submit", async (event) => {
     });
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
-      throw new Error(body.detail || "Admin key was rejected.");
+      throw new Error(body.detail || "Seat token or access key was rejected.");
     }
     window.location.assign("/");
   } catch (err) {

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -1745,6 +1745,17 @@ textarea[aria-invalid="true"] {
   font-size: 12px;
 }
 
+.form-hint {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.form-hint code {
+  font-size: 12px;
+}
+
 /* ---------- Buttons ---------- */
 
 .primary-button,
@@ -1812,6 +1823,47 @@ textarea[aria-invalid="true"] {
   color: var(--muted);
   font-size: 12px;
   white-space: nowrap;
+}
+
+.source-badge-mine {
+  border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  color: var(--primary-strong, var(--primary));
+}
+
+.source-badge-central {
+  border-color: color-mix(in srgb, var(--info, #7aa2f7) 45%, var(--border));
+  color: var(--info, #7aa2f7);
+}
+
+.seat-home-panel {
+  margin-top: 16px;
+}
+
+.seat-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.seat-check {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.seat-check.done {
+  color: var(--text);
+}
+
+.seat-check-mark {
+  flex: 0 0 auto;
+  width: 1.25rem;
+  text-align: center;
 }
 
 .status-active,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3238,6 +3238,58 @@ def test_seat_session_reports_own_seat_slug_and_node(tmp_path: Any) -> None:
     ]
 
 
+def test_me_summary_for_seat_reports_node_scope(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats",
+        json={"name": "Nora", "slug": "nora"},
+    ).json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    summary = api_client.get(
+        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert summary.status_code == 200
+    payload = summary.json()
+    assert payload["ok"] is True
+    assert payload["seat_slug"] == "nora"
+    assert payload["node_dataset"] == "seat:nora"
+    assert payload["node_label"] == "nora's private Node"
+    assert payload["document_count"] == 0
+    assert payload["pending_promotions"] == 0
+    assert payload["empty"] is True
+    assert payload["search_datasets"][0] == "seat:nora"
+    assert any(item["id"] == "capture" for item in payload["checklist"])
+
+
+def test_me_summary_non_seat_has_null_seat(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    token = client.post(
+        "/api/access/tokens",
+        json={
+            "name": "plain-reader",
+            "role": "reader",
+            "kind": "service_account",
+            "default_dataset": "personal",
+        },
+    ).json()["token"]
+    api_client = TestClient(app, base_url="https://testserver")
+
+    summary = api_client.get(
+        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert summary.status_code == 200
+    payload = summary.json()
+    assert payload["seat_slug"] is None
+    assert payload["node_dataset"] is None
+    assert payload["checklist"] == []
+    assert payload["empty"] is False
+
+
 def test_non_seat_token_session_nulls_seat_slug(tmp_path: Any) -> None:
     # A plain (non-seat) token carries no seat marker; the self-describing scope
     # must null seat_slug and node_label rather than invent one.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 
 import kb.server as server_module
 
-from kb.access import AccessStore, SESSION_TRACES_DATASET
+from kb.access import AccessIdentity, AccessStore, SESSION_TRACES_DATASET
 from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
 from kb.knowledge_mesh import KnowledgeMesh
@@ -3262,6 +3262,97 @@ def test_me_summary_for_seat_reports_node_scope(tmp_path: Any) -> None:
     assert payload["empty"] is True
     assert payload["search_datasets"][0] == "seat:nora"
     assert any(item["id"] == "capture" for item in payload["checklist"])
+
+
+def test_me_summary_uses_audit_when_mesh_empty(tmp_path: Any) -> None:
+    # After a process restart the runtime mesh is empty; durable audit must still
+    # keep Seat home from claiming an empty Node when ingests are on record.
+    # Documents count stays mesh-backed (0 here); empty/checklist use audit presence.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    app.state.mesh = MeshState()
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats",
+        json={"name": "Nora", "slug": "nora"},
+    ).json()["token"]
+    app.state.access_store.record_event(
+        action="ingest",
+        actor=AccessIdentity(
+            role="writer",
+            actor_id="seat:nora",
+            actor_kind="user",
+            actor_name="Nora",
+            source="token",
+            seat_slug="nora",
+        ),
+        success=True,
+        dataset="seat:nora",
+        detail={"surface": "test"},
+    )
+    api_client = TestClient(app, base_url="https://testserver")
+
+    summary = api_client.get(
+        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert summary.status_code == 200
+    payload = summary.json()
+    assert payload["document_count"] == 0
+    assert payload["empty"] is False
+    assert payload["last_ingest_at"] is not None
+    assert payload["recent_activity"]
+    assert all(item["dataset"] == "seat:nora" for item in payload["recent_activity"])
+    assert any(item["id"] == "capture" and item["done"] for item in payload["checklist"])
+
+
+def test_me_summary_keeps_node_activity_when_central_is_busy(tmp_path: Any) -> None:
+    # Seat home must still surface Node timeline rows when Central/shared traffic
+    # fills a mixed visible page — filter to the seat Node before the limit slice.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    app.state.mesh = MeshState()
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats",
+        json={"name": "Nora", "slug": "nora"},
+    ).json()["token"]
+    config = server_module.get_citadel().config
+    mesh = server_module.get_mesh()
+
+    async def _populate() -> None:
+        await mesh.record_ingest(
+            config,
+            IngestResult(accepted=True, reason="stored", dataset="seat:nora", tags=()),
+            data="nora private note",
+            dataset="seat:nora",
+            tags=[],
+        )
+        for i in range(20):
+            await mesh.record_ingest(
+                config,
+                IngestResult(
+                    accepted=True,
+                    reason="stored",
+                    dataset="masumi-network",
+                    tags=(),
+                ),
+                data=f"central noise {i}",
+                dataset="masumi-network",
+                tags=[],
+            )
+
+    asyncio.run(_populate())
+    api_client = TestClient(app, base_url="https://testserver")
+
+    summary = api_client.get(
+        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert summary.status_code == 200
+    payload = summary.json()
+    assert payload["document_count"] >= 1
+    assert payload["recent_activity"], "expected Node activity despite busy Central"
+    assert all(item["dataset"] == "seat:nora" for item in payload["recent_activity"])
+    assert payload["last_ingest_at"] is not None
 
 
 def test_me_summary_non_seat_has_null_seat(tmp_path: Any) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3559,11 +3559,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Ship Phase 1 of the seat-scoped portal: members can log in with a seat token and land on **My Node** (Seat home) with doc counts, empty-state checklist, and recent Node activity.
- Add `GET /api/me/summary` (seat-scoped aggregates only), session chrome for `seat_slug` / Node label, and login copy that accepts seat tokens alongside admin keys.
- Document the portal plan and optional dashboard login in teammate onboarding; cover the new summary endpoint with server tests.

## Test plan
- [ ] `pytest tests/test_server.py -k me_summary` (or full `tests/test_server.py`) passes
- [ ] Log in at `/login` with a seat `ctdl_…` token → lands on Seat home with correct slug / Node label
- [ ] Empty Node shows checklist + empty activity; after ingest, doc count and activity update
- [ ] Log in with admin/env key still works; Access and other admin surfaces unchanged for admins
- [ ] Non-seat token/session shows “No seat” home without another seat’s content
- [ ] Confirm branding docs under `docs/Citadel Archive branding/` were not included in this PR


Made with [Cursor](https://cursor.com)