### PR TITLE
fix(cli): make status search smoke opt-in with a 3s budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Changed
 
+- **`citadel status` no longer smoke-tests `/search` by default.** The search
+  check never gated `healthy`, but it often dominated wall time (Railway/cognee
+  ~4–20s, or a full 20s timeout). Use `--check-search` when you want it; smoke
+  timeout is 3s (full `citadel search` still uses 20s). `--no-search` remains a
+  no-op alias for existing scripts.
 - **`SKILL.md` reworked for cold-agent onboarding (validated by a fresh-agent
   audit).** Adds an **Agent Fast Start** runbook (`install → set token →
   status --json verify → search`) and a **How Citadel Works** 30-second model

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -1252,7 +1252,10 @@ async def _status(args: argparse.Namespace) -> int:
             token,
             repo=repo,
             config_path=config_path,
-            with_search=not args.no_search,
+            # Search smoke is opt-in: it never gates `healthy` and often costs
+            # multi-second Railway/cognee latency (or the full smoke budget).
+            with_search=bool(getattr(args, "check_search", False))
+            and not bool(getattr(args, "no_search", False)),
             with_recent=not args.no_recent,
         )
 
@@ -1274,7 +1277,7 @@ async def _status(args: argparse.Namespace) -> int:
                 payload["hint"] = hint
         _print_json(payload)
     else:
-        # The search check can take ~20s cold — spin so it doesn't look hung.
+        # --check-search can take a few seconds cold — spin so it doesn't look hung.
         with _Spinner("Checking Citadel…"):
             report, mesh = await asyncio.gather(
                 _gather(), asyncio.to_thread(fetch_mesh, node_url, token)
@@ -2211,7 +2214,16 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--node-url", help="Override Node URL (default: from config)")
     status.add_argument("--repo", help="Repo to check hooks/MCP in (default: git toplevel or cwd)")
     status.add_argument("--config", help="Override capture config path")
-    status.add_argument("--no-search", action="store_true", help="Skip the search smoke check")
+    status.add_argument(
+        "--check-search",
+        action="store_true",
+        help="Also smoke-test /search (opt-in; short timeout; never gates health)",
+    )
+    status.add_argument(
+        "--no-search",
+        action="store_true",
+        help="Skip the search smoke check (default; kept for script compatibility)",
+    )
     status.add_argument("--no-recent", action="store_true", help="Skip recent-activity fetch")
     status.set_defaults(handler=_status)
 

--- a/kb/status.py
+++ b/kb/status.py
@@ -30,7 +30,10 @@ TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
 MCP_SERVER_NAME = "citadel"
 SESSION_HOOK_MARKER = "kb.hooks.sync_session"
 _TIMEOUT = 8.0
-_SEARCH_TIMEOUT = 20.0  # align with server default; cognee cold-start is slow; non-gating
+_SEARCH_TIMEOUT = 20.0  # full vault search (`citadel search`); cognee cold-start is slow
+# Status smoke must not inherit the full search budget — search never gates
+# `healthy`, so a 20s hang was pure wall-time tax on every `citadel status`.
+_SMOKE_SEARCH_TIMEOUT = 3.0
 _INGEST_TIMEOUT = 60.0  # /ingest does real write work (and cold nodes are slow)
 _SMOKE_QUERY = "citadel status connectivity smoke"
 
@@ -150,7 +153,9 @@ def check_auth(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -
     return Check("auth", ok=bool(data.get("ok")), detail="valid", latency_ms=latency, data=identity)
 
 
-def check_search(base_url: str, token: str | None, *, timeout: float = _SEARCH_TIMEOUT) -> Check:
+def check_search(
+    base_url: str, token: str | None, *, timeout: float = _SMOKE_SEARCH_TIMEOUT
+) -> Check:
     if not token:
         return Check("search", ok=False, detail="skipped (no token)")
     started = time.monotonic()
@@ -164,11 +169,21 @@ def check_search(base_url: str, token: str | None, *, timeout: float = _SEARCH_T
         )
     except TimeoutError:
         return Check(
-            "search", ok=False,
-            detail=f"timed out after {int(timeout)}s — node warming up",
+            "search",
+            ok=False,
+            detail=f"timed out after {timeout:g}s — node warming up",
             data={"timed_out": True},
         )
     except Exception as exc:
+        # urllib may wrap a socket timeout as URLError("timed out") — treat like
+        # TimeoutError so the smoke budget reads as warm-up, not a cryptic net error.
+        if "timed out" in str(exc).lower():
+            return Check(
+                "search",
+                ok=False,
+                detail=f"timed out after {timeout:g}s — node warming up",
+                data={"timed_out": True},
+            )
         return Check("search", ok=False, detail=_humanize_net_error(exc))
     latency = int((time.monotonic() - started) * 1000)
     results = data.get("results")
@@ -190,6 +205,7 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
     if not token:
         return None
     url = f"{base_url.rstrip('/')}/readyz"
+    started = time.monotonic()
     try:
         data = _request("GET", url, token=token, timeout=timeout)
     except urllib.error.HTTPError as exc:
@@ -201,13 +217,14 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
             return None
     except Exception:
         return None
+    latency = int((time.monotonic() - started) * 1000)
     corpus = data.get("corpus") or {}
     canary = data.get("canary")
     indexed = corpus.get("indexed_docs")
     tracked = corpus.get("tracked_sources")
     ok = bool(corpus.get("ok", True)) and (canary is None or bool(canary.get("ok", True)))
     detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
-    return Check("corpus", ok=ok, detail=detail, data={"canary": canary})
+    return Check("corpus", ok=ok, detail=detail, latency_ms=latency, data={"canary": canary})
 
 
 def search_node(
@@ -428,7 +445,7 @@ def gather_status(
     *,
     repo: Path | None = None,
     config_path: Path | None = None,
-    with_search: bool = True,
+    with_search: bool = False,
     with_recent: bool = True,
     timeout: float = _TIMEOUT,
 ) -> StatusReport:
@@ -436,7 +453,8 @@ def gather_status(
     repo = repo or Path.cwd()
 
     # The network checks are independent, so they run concurrently — wall time
-    # is the slowest check (search, when cold), not the sum of all of them.
+    # is the slowest check, not the sum of all of them. Search smoke is opt-in
+    # (non-gating) and uses a short budget so status stays snappy by default.
     # Each check still captures its own failure, so a thread never raises.
     with ThreadPoolExecutor(max_workers=5) as pool:
         node_f = pool.submit(check_node_health, base_url, timeout=timeout)
@@ -450,7 +468,7 @@ def gather_status(
         auth = auth_f.result()
         checks = [node, auth]
         if search_f is not None:
-            checks.append(search_f.result())  # uses its own longer timeout
+            checks.append(search_f.result())
         corpus = corpus_f.result()
         if corpus is not None:
             checks.append(corpus)

--- a/skills/citadel-archive/SKILL.md
+++ b/skills/citadel-archive/SKILL.md
@@ -172,7 +172,7 @@ Common commands (add `--json` to any read for machine output; every read exits
 `1` on auth failure, `0` on success):
 
 ```bash
-citadel status --json          # connection · identity · role · latency (add --no-search to skip the smoke search)
+citadel status --json          # connection · identity · role · latency (add --check-search to smoke /search)
 citadel search "..." --json --top-k 5    # search the vault
 citadel activity --json        # recent Vault Activity — captures · syncs · promotions · searches
 citadel activity --local       # offline capture receipts (~/.citadel/activity.log) — no server needed

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -87,6 +87,44 @@ def test_check_local_setup_all_missing(tmp_path: Path, monkeypatch) -> None:
     assert checks["capture_roots"].ok  # "none" is a valid state
 
 
+def test_gather_status_skips_search_by_default(tmp_path: Path, monkeypatch) -> None:
+    seen: list[str] = []
+
+    def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
+        url = request.full_url
+        seen.append(url)
+        if "/healthz" in url:
+            return _FakeResp({"ok": True})
+        if "/api/session" in url:
+            return _FakeResp({"ok": True, "role": "writer", "seat_slug": "s", "actor": {"name": "S"}})
+        if "/readyz" in url:
+            return _FakeResp({"ok": True, "corpus": {"ok": True, "tracked_sources": 1, "indexed_docs": 1}})
+        if "/api/contributions/recent" in url:
+            return _FakeResp({"contributions": []})
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(status_mod._OPENER, "open", fake_open)
+    report = gather_status(
+        "https://node.example", "ctdl_tok", repo=tmp_path, config_path=tmp_path / "c.json"
+    )
+    assert report.healthy
+    assert all("/search" not in u for u in seen)
+    assert all(c.name != "search" for c in report.checks)
+
+
+def test_check_search_uses_short_smoke_timeout(monkeypatch) -> None:
+    captured: dict[str, float | None] = {"timeout": None}
+
+    def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
+        captured["timeout"] = timeout
+        return _FakeResp({"results": [{"id": 1}]})
+
+    monkeypatch.setattr(status_mod._OPENER, "open", fake_open)
+    check = status_mod.check_search("https://node.example", "ctdl_tok")
+    assert check.ok
+    assert captured["timeout"] == status_mod._SMOKE_SEARCH_TIMEOUT
+
+
 def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         status_mod._OPENER,
@@ -107,7 +145,13 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
             }
         ),
     )
-    report = gather_status("https://node.example", "ctdl_tok", repo=tmp_path, config_path=tmp_path / "c.json")
+    report = gather_status(
+        "https://node.example",
+        "ctdl_tok",
+        repo=tmp_path,
+        config_path=tmp_path / "c.json",
+        with_search=True,
+    )
     assert report.healthy
     assert report.identity["seat_slug"] == "sarthi"
     names = {c.name: c.ok for c in report.checks}
@@ -226,7 +270,7 @@ def test_render_text_search_failure_warns_not_fails() -> None:
         identity={},
         checks=[
             Check("node", ok=True, detail="healthy"),
-            Check("search", ok=False, detail="timed out after 20s — node warming up", data={"timed_out": True}),
+            Check("search", ok=False, detail="timed out after 3s — node warming up", data={"timed_out": True}),
         ],
         recent=[],
     )
@@ -285,6 +329,7 @@ def test_status_command_json_and_exit(tmp_path: Path, monkeypatch, capsys) -> No
         node_url="https://node.example",
         repo=str(tmp_path),
         config=str(tmp_path / "c.json"),
+        check_search=False,
         no_search=False,
         no_recent=False,
     )
@@ -307,6 +352,7 @@ def test_status_command_unhealthy_exits_one(tmp_path: Path, monkeypatch, capsys)
         node_url="https://node.example",
         repo=str(tmp_path),
         config=str(tmp_path / "c.json"),
+        check_search=False,
         no_search=True,
         no_recent=True,
     )


### PR DESCRIPTION
## Summary
- Default `citadel status` no longer smoke-tests `/search` (that check never gated `healthy` but often cost ~4–20s on Railway/cognee, or a full 20s timeout).
- Opt in with `--check-search`; smoke budget is **3s** (full `citadel search` still uses 20s). `--no-search` kept as a no-op alias for scripts.
- Tests cover skip-by-default + short smoke timeout; CHANGELOG + skill notes updated.

## Timings
| Path | Before | After |
|------|--------|-------|
| `citadel status` (default) | ~4–20s when search smoke ran (or 20s timeout) | Search skipped; wall time ≈ health/auth/corpus/recent only |
| `citadel status --check-search` | n/a (was always on) | Caps smoke at **3s** |
| `citadel search` | 20s budget | Unchanged (20s) |

## Test plan
- [x] `pytest tests/test_status.py` (28 passed)
- [ ] Manual: `citadel status` returns quickly without a search check
- [ ] Manual: `citadel status --check-search` includes search with ≤3s smoke timeout
- [ ] Manual: `citadel status --no-search` still works (compat no-op)


Made with [Cursor](https://cursor.com)