### PR TITLE
feat: public /info state-of-the-vault page + /api/state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The result is organizational memory that behaves like a company vault: private w
   <img src="docs/brand/readme-dashboard.jpg" alt="Citadel Archive dashboard — Overview analytics, Knowledge Mesh, and vault workflow" width="860" />
 </p>
 
+**📊 [State of the Vault](https://citadel-archive-production.up.railway.app/info)** — a live report of current metrics, shipped releases, and the roadmap, served from the running node.
+
 ## What Citadel does
 
 - **Organization Vault** — Central (`masumi-network`) holds org-wide structured knowledge; each seat has a private **Node** (`seat:{slug}`) for working memory. You read your Node + Central; you never read another seat's Node.

--- a/kb/server.py
+++ b/kb/server.py
@@ -2074,6 +2074,13 @@ async def login() -> HTMLResponse:
     return HTMLResponse(LOGIN_HTML)
 
 
+@app.get("/info", include_in_schema=False)
+async def info_page() -> FileResponse:
+    # Public "State of the Vault" report. Static shell; live tiles hydrate from
+    # /api/state so the numbers stay current without redeploying the page.
+    return FileResponse(STATIC_DIR / "info.html")
+
+
 @app.post("/admin/session")
 async def create_admin_session(body: AdminSessionBody, response: Response) -> dict[str, Any]:
     access_key = body.access_key or body.admin_key
@@ -2579,6 +2586,74 @@ async def revoke_access_token(token_id: str, request: Request) -> dict[str, Any]
 @app.get("/healthz")
 async def healthz() -> dict[str, str | bool]:
     return {"ok": True, "service": "citadel"}
+
+
+@app.get("/api/state")
+async def public_state(request: Request, response: Response) -> dict[str, Any]:
+    """Public, no-secrets snapshot for the /info page — safe aggregates only.
+
+    Never exposes vault content, per-seat data, graph node dumps, internal
+    source URLs, or tokens. A syncer hiccup degrades to empty, never a 500.
+    """
+    from datetime import datetime, timezone
+
+    response.headers.update(PUBLIC_CACHE_HEADERS)
+
+    async def _safe(coro: Any) -> dict[str, Any]:
+        try:
+            return await coro
+        except Exception:  # best-effort: the public page must never 500 on a sync blip
+            return {}
+
+    sources: list[dict[str, Any]] = []
+    gh = await _safe(get_github_syncer().status())
+    if gh:
+        sources.append(
+            {
+                "name": gh.get("org"),
+                "type": "github",
+                "documents": gh.get("tracked_repositories", 0),
+                "status": "tracked" if gh.get("last_checked_at") else "ready",
+                "last_synced_at": gh.get("last_checked_at"),
+            }
+        )
+    rc = await _safe(get_repo_content_syncer().status())
+    if rc:
+        sources.append(
+            {
+                "name": rc.get("org"),
+                "type": "repo_content",
+                "documents": rc.get("tracked_files", 0),
+                "status": "tracked" if rc.get("last_checked_at") else "ready",
+                "last_synced_at": rc.get("last_checked_at"),
+            }
+        )
+    ln = await _safe(get_linear_syncer().status())
+    if ln:
+        sources.append(
+            {
+                "name": "Linear workspace",
+                "type": "linear",
+                "documents": ln.get("issue_count", 0),
+                "status": "tracked" if ln.get("last_synced_at") else "ready",
+                "last_synced_at": ln.get("last_synced_at"),
+            }
+        )
+
+    docs_total = sum(int(s.get("documents") or 0) for s in sources)
+    return {
+        "ok": True,
+        "service": "Citadel Archive",
+        "version": app.version,
+        "healthy": True,
+        "sources": sources,
+        "totals": {
+            "documents": docs_total,
+            "github_repositories": int(gh.get("tracked_repositories", 0) or 0) if gh else 0,
+            "linear_issues": int(ln.get("issue_count", 0) or 0) if ln else 0,
+        },
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 @app.get("/.well-known/citadel.json")

--- a/kb/static/info.css
+++ b/kb/static/info.css
@@ -1,0 +1,241 @@
+/* Citadel — State of the Vault (/info). Served under a strict CSP:
+   no inline <style>/<script>/style="". Chart bar heights are set via CSSOM
+   in info.js (allowed). Fonts are self-hosted (font-src 'self'). */
+
+@font-face {
+  font-family: "Inter";
+  src: url("/static/fonts/Inter.var.woff2") format("woff2");
+  font-weight: 100 900;
+  font-display: swap;
+}
+@font-face {
+  font-family: "JetBrains Mono";
+  src: url("/static/fonts/JetBrainsMono.var.woff2") format("woff2");
+  font-weight: 100 800;
+  font-display: swap;
+}
+
+:root {
+  --ground: #f3f3f8;
+  --surface: #ffffff;
+  --surface-2: #eeedf5;
+  --ink: #2a2636;
+  --ink-2: #5d5872;
+  --ink-3: #928da8;
+  --border: #e8e6f1;
+  --border-2: #ded9ec;
+
+  --magenta: #b13a8c;
+  --magenta-soft: #f7e9f3;
+  --teal: #0e8194;
+  --teal-soft: #e2f1f3;
+
+  --shipped: #0e8194;  --shipped-bg: #e2f1f3;
+  --progress: #96590f; --progress-bg: #f6eddb;
+  --planned: #7150c6;  --planned-bg: #ede8f9;
+  --good: #2f8f5b;     --good-bg: #e4f2ea;
+
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --sans: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --radius: 14px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ground: #16151e; --surface: #1e1c28; --surface-2: #252334;
+    --ink: #edecf5; --ink-2: #b3aec6; --ink-3: #837e9c; --border: #2c2a3c; --border-2: #353249;
+    --magenta: #eb7cc4; --magenta-soft: #2a1826; --teal: #52d2dc; --teal-soft: #142f35;
+    --shipped: #52d2dc; --shipped-bg: #142f35; --progress: #e6ac54; --progress-bg: #2a2213;
+    --planned: #ac91f2; --planned-bg: #201a33; --good: #63c48c; --good-bg: #16281e;
+  }
+}
+:root[data-theme="light"] {
+  --ground: #f3f3f8; --surface: #ffffff; --surface-2: #eeedf5;
+  --ink: #2a2636; --ink-2: #5d5872; --ink-3: #928da8; --border: #e8e6f1; --border-2: #ded9ec;
+  --magenta: #b13a8c; --magenta-soft: #f7e9f3; --teal: #0e8194; --teal-soft: #e2f1f3;
+  --shipped: #0e8194; --shipped-bg: #e2f1f3; --progress: #96590f; --progress-bg: #f6eddb;
+  --planned: #7150c6; --planned-bg: #ede8f9; --good: #2f8f5b; --good-bg: #e4f2ea;
+}
+:root[data-theme="dark"] {
+  --ground: #16151e; --surface: #1e1c28; --surface-2: #252334;
+  --ink: #edecf5; --ink-2: #b3aec6; --ink-3: #837e9c; --border: #2c2a3c; --border-2: #353249;
+  --magenta: #eb7cc4; --magenta-soft: #2a1826; --teal: #52d2dc; --teal-soft: #142f35;
+  --shipped: #52d2dc; --shipped-bg: #142f35; --progress: #e6ac54; --progress-bg: #2a2213;
+  --planned: #ac91f2; --planned-bg: #201a33; --good: #63c48c; --good-bg: #16281e;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } * { transition: none !important; } }
+body {
+  margin: 0; background: var(--ground); color: var(--ink);
+  font-family: var(--sans); font-size: 16.5px; line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 840px; margin: 0 auto; padding: 0 26px 110px; }
+a { color: var(--magenta); text-underline-offset: 2px; }
+::selection { background: var(--magenta-soft); }
+
+/* theme toggle */
+.themebtn {
+  position: fixed; top: 16px; right: 16px; z-index: 10;
+  font-family: var(--mono); font-size: 12px; color: var(--ink-2);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  padding: 6px 11px; cursor: pointer;
+}
+.themebtn:hover { color: var(--magenta); border-color: var(--magenta); }
+.themebtn:focus-visible { outline: 2px solid var(--magenta); outline-offset: 2px; }
+
+/* header */
+header { padding: 58px 0 0; }
+.brandrow { display: flex; align-items: center; gap: 15px; margin-bottom: 32px; }
+.mark { display: grid; grid-template-columns: repeat(7,1fr); grid-template-rows: repeat(7,1fr); width: 40px; height: 40px; gap: 1.5px; flex: 0 0 auto; }
+.mark i { border-radius: 1px; }
+.mark i.on { background: linear-gradient(135deg, var(--magenta), var(--teal)); }
+.wordmark { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: .16em; text-transform: uppercase; line-height: 1.1; }
+.subword { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); letter-spacing: .1em; }
+
+.eyebrow { font-family: var(--mono); font-size: 11px; letter-spacing: .24em; text-transform: uppercase; color: var(--magenta); margin: 0 0 15px; font-weight: 600; }
+h1 { font-size: clamp(29px, 5vw, 43px); line-height: 1.1; margin: 0 0 18px; letter-spacing: -.022em; text-wrap: balance; font-weight: 750; }
+h1 .grad { background: linear-gradient(100deg, var(--magenta), var(--teal)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.meta { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.pill { font-family: var(--mono); font-size: 11.5px; font-weight: 600; padding: 5px 12px; border-radius: 999px; border: 1px solid var(--border-2); color: var(--ink-2); background: var(--surface); }
+.pill.live { color: var(--good); border-color: transparent; background: var(--good-bg); display: inline-flex; align-items: center; gap: 6px; }
+.pill.live .hdot { width: 7px; height: 7px; border-radius: 50%; background: var(--good); }
+.pill.live.down { color: var(--progress); background: var(--progress-bg); }
+.pill.live.down .hdot { background: var(--progress); }
+
+/* TLDR */
+.tldr { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 26px 30px; margin: 34px 0 0; position: relative; overflow: hidden; }
+.tldr::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 4px; background: linear-gradient(var(--magenta), var(--teal)); }
+.tldr .lbl { margin: 0 0 12px; font-size: 11px; font-family: var(--mono); letter-spacing: .2em; text-transform: uppercase; color: var(--magenta); font-weight: 600; }
+.tldr p { margin: 0 0 13px; font-size: 17px; }
+.tldr p:last-child { margin-bottom: 0; color: var(--ink-2); font-size: 15.5px; }
+
+/* jump nav */
+nav.toc { display: flex; flex-wrap: wrap; gap: 8px; margin: 22px 0 0; }
+nav.toc a { font-family: var(--mono); font-size: 12px; text-decoration: none; color: var(--ink-2); background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 6px 11px; transition: border-color .15s, color .15s; }
+nav.toc a:hover { color: var(--magenta); border-color: var(--magenta); }
+
+/* section scaffolding */
+section { padding-top: 62px; }
+.sechead { margin-bottom: 6px; }
+.kicker { font-family: var(--mono); font-size: 11px; letter-spacing: .2em; text-transform: uppercase; color: var(--teal); font-weight: 600; display: block; margin-bottom: 8px; }
+.sechead h2 { font-size: 25px; margin: 0; letter-spacing: -.02em; font-weight: 720; }
+.lede { color: var(--ink-2); max-width: 62ch; margin: 12px 0 28px; font-size: 15.5px; }
+
+/* metrics */
+.metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.metric { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 16px 17px; }
+.metric .n { font-family: var(--mono); font-size: 25px; font-weight: 700; letter-spacing: -.02em; font-variant-numeric: tabular-nums; line-height: 1.1; color: var(--ink); }
+.metric .n small { font-size: 14px; color: var(--ink-3); font-weight: 500; }
+.metric .k { font-size: 12.5px; color: var(--ink-2); margin-top: 6px; line-height: 1.35; }
+.metric.accent .n { color: var(--magenta); }
+.metric.tealn .n { color: var(--teal); }
+.metric .n.pending { color: var(--ink-3); }
+.verified { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); margin-top: 14px; display: flex; align-items: center; gap: 7px; }
+.verified .vdot { width: 6px; height: 6px; border-radius: 50%; background: var(--good); flex: 0 0 auto; }
+
+/* pillars */
+.pillars { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px 22px; }
+.card h3 { margin: 0 0 9px; font-size: 16px; font-weight: 680; display: flex; align-items: center; gap: 10px; }
+.card h3 .dot { width: 9px; height: 9px; border-radius: 3px; background: linear-gradient(135deg, var(--magenta), var(--teal)); flex: 0 0 auto; }
+.card p { margin: 0; color: var(--ink-2); font-size: 14.5px; line-height: 1.6; }
+.card .tag { display: inline-block; margin-top: 13px; font-family: var(--mono); font-size: 10.5px; letter-spacing: .03em; color: var(--teal); background: var(--teal-soft); padding: 3px 9px; border-radius: 6px; }
+
+/* details / go-deeper */
+details { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; margin-top: 14px; overflow: hidden; }
+details[open] { border-color: var(--border-2); }
+summary { list-style: none; cursor: pointer; padding: 16px 20px; display: flex; align-items: center; gap: 11px; font-weight: 600; font-size: 15px; color: var(--ink); }
+summary::-webkit-details-marker { display: none; }
+summary:focus-visible { outline: 2px solid var(--magenta); outline-offset: -2px; border-radius: 12px; }
+summary .chev { font-family: var(--mono); color: var(--magenta); transition: transform .2s ease; flex: 0 0 auto; font-size: 13px; }
+details[open] summary .chev { transform: rotate(90deg); }
+summary .go { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--ink-3); margin-left: auto; font-weight: 600; }
+.dbody { padding: 2px 22px 22px; }
+.dbody p { margin: 0 0 12px; color: var(--ink-2); font-size: 14.5px; }
+.dbody p:last-child { margin-bottom: 0; }
+.dbody h4 { margin: 18px 0 8px; font-size: 13.5px; font-family: var(--mono); letter-spacing: .04em; color: var(--ink); text-transform: uppercase; }
+.dbody ul { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 9px; }
+.dbody li { position: relative; padding-left: 20px; font-size: 14.5px; color: var(--ink-2); line-height: 1.55; }
+.dbody li::before { content: ""; position: absolute; left: 2px; top: 8px; width: 6px; height: 6px; border-radius: 50%; background: var(--teal); }
+.dbody li b { color: var(--ink); font-weight: 640; }
+
+/* architecture diagram */
+.arch { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 26px 26px 22px; margin-bottom: 28px; display: grid; grid-template-columns: 1fr auto 1fr; grid-template-areas: "phead . ohead" "psrc . osrc" "pnode bridge central" "access access access"; column-gap: 18px; row-gap: 12px; align-items: stretch; }
+.lanehead { font-family: var(--mono); font-size: 10.5px; letter-spacing: .16em; text-transform: uppercase; font-weight: 600; }
+.lanehead.p { grid-area: phead; color: var(--magenta); }
+.lanehead.o { grid-area: ohead; color: var(--teal); }
+.srccol { display: flex; flex-direction: column; gap: 6px; }
+.srccol.p { grid-area: psrc; } .srccol.o { grid-area: osrc; }
+.node-chip { font-family: var(--mono); font-size: 11.5px; color: var(--ink-2); background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; padding: 6px 10px; }
+.flowcap { font-family: var(--mono); font-size: 10px; color: var(--ink-3); letter-spacing: .04em; margin-top: 2px; }
+.store { border-radius: 11px; padding: 15px 16px; display: flex; flex-direction: column; gap: 3px; border: 1px solid var(--border-2); }
+.store b { font-size: 15px; } .store span { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.store.node { grid-area: pnode; background: var(--magenta-soft); }
+.store.node b { color: var(--magenta); }
+.store.central { grid-area: central; background: var(--teal-soft); }
+.store.central b { color: var(--teal); }
+.bridge { grid-area: bridge; align-self: center; text-align: center; font-family: var(--mono); font-size: 10px; color: var(--ink-3); line-height: 1.5; max-width: 120px; }
+.bridge .arw { display: block; font-size: 15px; color: var(--magenta); letter-spacing: -1px; }
+.access { grid-area: access; margin-top: 8px; text-align: center; font-size: 13.5px; color: var(--ink-2); background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; }
+.access b { color: var(--ink); }
+
+/* activity chart */
+.chartwrap { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 22px 24px 18px; margin-bottom: 28px; }
+.charthead { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.charthead .t { font-size: 14px; font-weight: 650; }
+.charthead .note { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); }
+.chart { display: flex; align-items: flex-end; gap: 3%; height: 168px; }
+.bar-col { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: flex-end; gap: 6px; height: 100%; min-width: 0; }
+.bar-val { font-family: var(--mono); font-size: 11px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+.bar-col.ship .bar-val { color: var(--magenta); font-weight: 600; }
+.bar { width: 76%; max-width: 30px; min-height: 3px; border-radius: 5px 5px 0 0; background: var(--surface-2); border: 1px solid var(--border-2); transition: filter .15s; }
+.bar-col.ship .bar { background: linear-gradient(var(--magenta), var(--teal)); border: none; }
+.bar-col:hover .bar { filter: brightness(1.06); }
+.bar-lbl { font-family: var(--mono); font-size: 9.5px; color: var(--ink-3); text-align: center; line-height: 1.3; }
+.bar-tag { font-family: var(--mono); font-size: 9px; color: var(--magenta); font-weight: 600; text-align: center; line-height: 1.2; min-height: 11px; }
+
+/* release timeline */
+.rail { position: relative; padding-left: 30px; }
+.rail::before { content: ""; position: absolute; left: 5px; top: 12px; bottom: 12px; width: 2px; background: linear-gradient(var(--magenta), var(--teal)); opacity: .3; }
+.rel { position: relative; margin-bottom: 12px; }
+.rel:last-child { margin-bottom: 0; }
+.rel > details { margin-top: 0; }
+.rel::before { content: ""; position: absolute; left: -30px; top: 19px; width: 12px; height: 12px; border-radius: 50%; background: var(--ground); border: 2.5px solid var(--magenta); z-index: 1; }
+.rel.tip::before { background: linear-gradient(135deg, var(--magenta), var(--teal)); border: none; box-shadow: 0 0 0 4px var(--magenta-soft); }
+.relsum { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.ver { font-family: var(--mono); font-weight: 700; font-size: 15.5px; color: var(--magenta); }
+.date { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); }
+.reltitle { color: var(--ink-2); font-size: 13.5px; flex-basis: 100%; margin-top: 2px; }
+
+/* next */
+.status-legend { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px; }
+.chip { font-family: var(--mono); font-size: 10.5px; font-weight: 600; letter-spacing: .05em; padding: 4px 11px; border-radius: 7px; text-transform: uppercase; white-space: nowrap; }
+.chip.ship { color: var(--shipped); background: var(--shipped-bg); }
+.chip.prog { color: var(--progress); background: var(--progress-bg); }
+.chip.plan { color: var(--planned); background: var(--planned-bg); }
+.next { display: flex; flex-direction: column; gap: 12px; }
+.nrow { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px 22px; display: grid; grid-template-columns: 118px 1fr; gap: 20px; align-items: start; }
+.nrow .left { display: flex; padding-top: 3px; }
+.nrow h3 { margin: 0 0 6px; font-size: 16px; font-weight: 680; }
+.nrow p { margin: 0; color: var(--ink-2); font-size: 14.5px; line-height: 1.6; }
+.nrow p .k { color: var(--ink); font-weight: 640; }
+
+/* footer */
+footer { margin-top: 30px; color: var(--ink-2); font-size: 15px; }
+.cmd { font-family: var(--mono); font-size: 13.5px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; color: var(--ink); margin: 15px 0; overflow-x: auto; white-space: nowrap; }
+.cmd .p { color: var(--magenta); user-select: none; }
+.foot-note { color: var(--ink-3); font-size: 13.5px; margin-top: 16px; }
+code { font-family: var(--mono); font-size: .83em; background: var(--surface-2); padding: 1.5px 6px; border-radius: 5px; color: var(--ink); }
+
+@media (max-width: 760px) { .metrics { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 620px) {
+  .pillars { grid-template-columns: 1fr; }
+  .nrow { grid-template-columns: 1fr; gap: 11px; }
+  body { font-size: 16px; }
+  summary .go { display: none; }
+  .arch { grid-template-columns: 1fr; grid-template-areas: "phead" "psrc" "pnode" "bridge" "ohead" "osrc" "central" "access"; }
+  .bridge { max-width: none; margin: 2px 0; }
+  .bar-val, .bar-tag { font-size: 8.5px; }
+}

--- a/kb/static/info.html
+++ b/kb/static/info.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Citadel — State of the Vault</title>
+  <meta name="description" content="Citadel: shared, governed memory for your team and its AI agents. Current state, shipped releases, and roadmap.">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/static/info.css">
+  <script src="/static/info.js" defer></script>
+</head>
+<body>
+  <button class="themebtn" id="themebtn" type="button" aria-label="Toggle light or dark theme">theme</button>
+  <div class="wrap">
+    <header>
+      <div class="brandrow">
+        <div class="mark" id="mark" aria-hidden="true"></div>
+        <div>
+          <div class="wordmark">Citadel</div>
+          <div class="subword">the organization vault</div>
+        </div>
+      </div>
+      <p class="eyebrow">State of the vault · internal report</p>
+      <h1>Shared, governed memory for the team <span class="grad">and its AI agents</span>.</h1>
+      <div class="meta">
+        <span class="pill live" id="pill-health"><span class="hdot"></span><span id="pill-health-text">Live · v0.4.0</span></span>
+        <span class="pill">Railway + PyPI</span>
+        <span class="pill">Window: v0.2.0 → v0.4.0</span>
+      </div>
+
+      <div class="tldr">
+        <p class="lbl">TL;DR — read this, skim the rest</p>
+        <p>Citadel is a working <b>organization vault</b>: your commits, coding sessions, docs, and Linear issues flow in automatically, and you search your private <b>Node</b> plus org <b>Central</b> from the CLI or any MCP agent. Everything is personal-by-default and read-isolated — no one reads another seat's Node.</p>
+        <p>Across v0.2 → v0.4 we shipped zero-dependency onboarding, autonomous ingestion, Linear sync, read-side isolation, and <b>Shared Session Traces</b> (share a dead end, reference-only, without leaking private memory). Next: a <b>GitHub App</b> for PR context + checks, a <b>Google Chat digest bot</b>, and one <b>central agent hub</b> over all org knowledge. Every section below expands — open the ones you care about.</p>
+      </div>
+
+      <nav class="toc" aria-label="Jump to section">
+        <a href="#state">01 · Current state</a>
+        <a href="#works">02 · How it works</a>
+        <a href="#live">03 · What's live</a>
+        <a href="#releases">04 · Releases</a>
+        <a href="#next">05 · What's next</a>
+        <a href="#start">06 · Get started</a>
+      </nav>
+    </header>
+
+    <section id="state">
+      <div class="sechead"><span class="kicker">01 — Current state</span><h2>Where things stand today</h2></div>
+      <p class="lede">Health and scale. The live tiles below refresh from the running node each time this page loads; the rest are repo facts as of the last report.</p>
+      <div class="metrics">
+        <div class="metric tealn"><div class="n" id="m-version">v0.4.0</div><div class="k">deployed &amp; healthy on Railway</div></div>
+        <div class="metric"><div class="n" id="m-docs">—</div><div class="k" id="m-docs-sub">GitHub org sync</div></div>
+        <div class="metric accent"><div class="n">10</div><div class="k">releases shipped (v0.1.0 → v0.4.0)</div></div>
+        <div class="metric"><div class="n">377</div><div class="k">commits · 166 since v0.2.0</div></div>
+        <div class="metric"><div class="n">807</div><div class="k">tests across 52 files · CI on every push</div></div>
+        <div class="metric"><div class="n">25</div><div class="k">MCP tools for agents</div></div>
+        <div class="metric"><div class="n">10</div><div class="k">architecture decision records</div></div>
+        <div class="metric"><div class="n">~25k</div><div class="k">LOC · 53 modules · zero-dep client</div></div>
+      </div>
+      <p class="verified"><span class="vdot"></span><span id="state-updated">Live tiles pull from <code>/api/state</code>. Repo facts (commits, tests, LOC) are as of the last report — v0.4.0, 2026-07-22.</span></p>
+    </section>
+
+    <section id="works">
+      <div class="sechead"><span class="kicker">02 — The model</span><h2>How Citadel works</h2></div>
+      <p class="lede">Three ideas carry the whole system: a private space per person, a shared org space, and strict rules for what moves between them. Read the summary, or expand for the mechanics.</p>
+      <div class="arch">
+        <div class="lanehead p">Personal</div>
+        <div class="lanehead o">Organization</div>
+        <div class="srccol p">
+          <span class="node-chip">git pre-push</span>
+          <span class="node-chip">SessionEnd hook</span>
+          <span class="node-chip">citadel capture</span>
+          <span class="flowcap">↓ capture, fail-silent</span>
+        </div>
+        <div class="srccol o">
+          <span class="node-chip">GitHub org</span>
+          <span class="node-chip">Linear workspace</span>
+          <span class="node-chip">Repo content</span>
+          <span class="flowcap">↓ evolve, hourly</span>
+        </div>
+        <div class="store node"><b>Your Node</b><span>seat:slug · private</span></div>
+        <div class="bridge"><span class="arw">▸▸</span>Promotion<br>secret-scan · approve</div>
+        <div class="store central"><b>Central</b><span>masumi-network · org</span></div>
+        <div class="access">You &amp; agents read via <b>MCP · CLI · Web</b> — caller-scoped: your Node + Central, never another seat's.</div>
+      </div>
+      <div class="pillars">
+        <div class="card"><h3><span class="dot"></span>Seat · Node · Central</h3><p>Each teammate has a private <b>Node</b> (<code>seat:slug</code>) for working memory. The org shares <b>Central</b> (<code>masumi-network</code>). You read your Node + Central, never another seat's.</p><span class="tag">read-isolation · ADR-0009</span></div>
+        <div class="card"><h3><span class="dot"></span>Tiered ingestion</h3><p>Private Node memory is indexed lightly and fast. Org-bound content goes through the full Learning Process — security review, enrichment, structuring — before it lands in Central.</p><span class="tag">light Node · full Central</span></div>
+        <div class="card"><h3><span class="dot"></span>Governed promotion</h3><p>Seat writes stay on your Node by default. Reaching Central takes org sync, a tagged contribution, or the Promotion Agent — secret-scanned and approved, never a silent mirror of every note.</p><span class="tag">secret-scan · gated · approved</span></div>
+        <div class="card"><h3><span class="dot"></span>Two front doors</h3><p>Agents use a hosted <b>MCP</b> endpoint (URL + token, 25 tools). Humans use a zero-dependency <b>CLI</b> where every command speaks <code>--json</code>, plus a web UI with the live Knowledge Mesh.</p><span class="tag">MCP + CLI + web</span></div>
+      </div>
+      <details>
+        <summary><span class="chev">▸</span> The access &amp; data model in one pass <span class="go">Go deeper</span></summary>
+        <div class="dbody">
+          <p>Citadel is a FastAPI service over a cognee-backed retrieval layer, but the moat is the governance around it — the part cognee will never have.</p>
+          <h4>Read scope</h4>
+          <ul>
+            <li>A caller sees their own <b>Node</b>, <b>Central</b>, and non-seat datasets — resolved by a four-pass cross-dataset visibility algorithm.</li>
+            <li><b>Seat presence is universal</b> (every seat is a hub with a slug + counts), but content is caller-scoped. Foreign-seat drill-down returns <b>404, not 403</b> — no existence oracle.</li>
+            <li>Admin/env tokens bypass for operations; every call is audited.</li>
+          </ul>
+          <h4>Write scope</h4>
+          <ul>
+            <li>All seat-scoped writes land on the owning Node. Untagged writes to Central are rejected (403).</li>
+            <li>Every write path — HTTP, MCP, hooks, feedback — runs the seat write-policy guard and a secret scan.</li>
+          </ul>
+          <h4>Promotion to Central</h4>
+          <ul>
+            <li>The <b>Promotion Agent</b> cross-references GitHub org repos + Central, auto-promotes known work after secret-scan + LLM review, and queues new-project candidates for human approval (dashboard / MCP / <code>citadel promotion</code>).</li>
+          </ul>
+        </div>
+      </details>
+    </section>
+
+    <section id="live">
+      <div class="sechead"><span class="kicker">03 — Shipped &amp; live</span><h2>What you can use right now</h2></div>
+      <p class="lede">The capabilities that are in production today. The three you'll touch most are session sharing, autonomous capture, and Linear sync.</p>
+      <div class="pillars">
+        <div class="card"><h3><span class="dot"></span>Shared Session Context</h3><p>SessionEnd distills how you approached a problem into a private Session Trace. Hit a dead end worth flagging? <code>citadel_share_session</code> shares a redacted, compacted version to a shared dataset.</p><span class="tag">reference-only · never promotes</span></div>
+        <div class="card"><h3><span class="dot"></span>Autonomous ingestion</h3><p>A git pre-push hook and Claude Code SessionEnd hook snapshot work to your Node — fail-silent. An hourly evolve cycle folds GitHub, Linear, and repo content into the graph.</p><span class="tag">hooks + hourly evolve</span></div>
+        <div class="card"><h3><span class="dot"></span>Linear sync</h3><p>The full workspace syncs to Central; issues assigned to you mirror into your Node as a Seat-Scoped Mirror — so an agent answers "what do I need to do?" from your memory.</p><span class="tag">workspace → Central · yours → Node</span></div>
+        <div class="card"><h3><span class="dot"></span>Knowledge Mesh &amp; portal</h3><p>A web UI renders org knowledge as a concept map and a live sync/search/ingest timeline. Portal Phase 1: paste your token, land on <b>My Node</b> — stats, checklist, deep links.</p><span class="tag">Pixel Bastion brand · caller-scoped</span></div>
+      </div>
+      <details>
+        <summary><span class="chev">▸</span> How Shared Session Traces actually work <span class="go">Go deeper</span></summary>
+        <div class="dbody">
+          <p>Shipped in v0.4.0 (ADR-0011). The goal: let the team learn from each other's dead ends without exposing anyone's raw private working memory.</p>
+          <ul>
+            <li><b>Explicit only.</b> SessionEnd always writes a private Node trace (light tier). Sharing is a deliberate call — <code>citadel_share_session</code> or <code>POST /api/share-session</code> — and requires an <b>Approved Capture Root</b> (server-side <code>cwd</code> check).</li>
+            <li><b>Compact Session Context.</b> The client distills + redacts the trace; the server runs an LLM dead-end refinement only when real tool-error pairs exist, then <b>dual-writes</b> to your Node and the shared <code>session-traces</code> dataset.</li>
+            <li><b>Deferred cognify</b> (~5–15 min, coalesced) — sharing doesn't block the tool call, and your private Node memory is never enriched.</li>
+            <li><b>Trust demotion.</b> Default <code>citadel_search</code> includes traces with a <code>reference-only</code> tag. Traces never promote to Central and never feed the daily improve loop.</li>
+          </ul>
+        </div>
+      </details>
+      <details>
+        <summary><span class="chev">▸</span> The autonomous ingestion pipeline <span class="go">Go deeper</span></summary>
+        <div class="dbody">
+          <p>Zero per-session ceremony. Three capture paths feed your Node; one scheduled cycle keeps Central fresh.</p>
+          <h4>Capture (→ your Node)</h4>
+          <ul>
+            <li><b>git pre-push hook</b> — a commit-metadata snapshot on every push from an Approved Capture Root.</li>
+            <li><b>SessionEnd hook</b> — distills a coding session and posts it to your seat. Reuses the one token you already set. HTTPS-only, refuses redirects, fail-silent.</li>
+            <li><b><code>citadel capture</code></b> — summarizes each approved root (git metadata + README, never raw files).</li>
+          </ul>
+          <h4>Evolve (→ Central, hourly)</h4>
+          <ul>
+            <li>GitHub org digest + repo content sync + Linear sync run as staged subprocesses, then cognify runs in-loop on the web service — the single Kuzu writer. Cadence went 6h → 1h in v0.2.1.</li>
+          </ul>
+        </div>
+      </details>
+    </section>
+
+    <section id="releases">
+      <div class="sechead"><span class="kicker">04 — Release history</span><h2>v0.2.0 → v0.4.0</h2></div>
+      <p class="lede">Every tag shipped to PyPI and deployed to Railway. Expand any release for its full notes.</p>
+      <div class="chartwrap">
+        <div class="charthead"><span class="t">Commits per week</span><span class="note">brand-color bars = a release shipped that week</span></div>
+        <div class="chart" id="chart" role="img" aria-label="Commits per week from mid-May to late July 2026, peaking at 91 in the week of June 22."></div>
+      </div>
+      <div class="rail">
+        <div class="rel tip">
+          <details open>
+            <summary><span class="chev">▸</span><span class="relsum"><span class="ver">v0.4.0</span><span class="date">2026-07-22 · latest</span><span class="reltitle">Shared team memory, the seat portal, and a real brand.</span></span></summary>
+            <div class="dbody"><ul>
+              <li><b>Shared Session Traces v1</b> — explicit in-session share via MCP + <code>/api/share-session</code>; Compact Session Context, reference-only in search, deferred cognify. (ADR-0011)</li>
+              <li><b>Multi-agent policy on onboard</b> — the same agent policy installed to AGENTS.md, Cursor, Windsurf, GEMINI.md, and Claude Code.</li>
+              <li><b>Seat portal Phase 1</b> — members log in and land on "My Node" with doc counts, activity, and a checklist.</li>
+              <li><b>Pixel Bastion brand + analytics panels</b> — CLI mark, README banner, favicon, dashboard chrome; CSP-safe charts.</li>
+              <li><b>Security</b> — Obsidian vaults enforce ownership; <code>/api/knowledge/events</code> and <code>/feedback</code> are now caller-scoped; pip-audit CI gate.</li>
+            </ul></div>
+          </details>
+        </div>
+        <div class="rel">
+          <details>
+            <summary><span class="chev">▸</span><span class="relsum"><span class="ver">v0.3.0</span><span class="date">2026-07-16</span><span class="reltitle">Read-side privacy release + graph legibility.</span></span></summary>
+            <div class="dbody"><ul>
+              <li><b>Mesh read isolation (ADR-0009)</b> — graph, activity, and document drill-down are caller-scoped; seat presence stays universal.</li>
+              <li><b>Knowledge Mesh reads as a concept map</b> — per-hub aggregation, human labels, drill-down, kind-filter legend.</li>
+              <li><b><code>citadel activity</code></b> — dev-side view of your vault; <code>--watch</code> and a <code>--global</code> seat-presence board.</li>
+              <li><b>Agent-onboarding hardening</b> — seat-bound token mandate, headless SKILL runbook, <code>--json</code> error parity.</li>
+            </ul></div>
+          </details>
+        </div>
+        <div class="rel">
+          <details>
+            <summary><span class="chev">▸</span><span class="relsum"><span class="ver">v0.2.2 – v0.2.3</span><span class="date">2026-07-02 · 07-07</span><span class="reltitle">Onboarding &amp; token friction, removed.</span></span></summary>
+            <div class="dbody"><ul>
+              <li><b>Seat-bound token minting</b> — <code>token create --seat</code> inherits the seat's role and private dataset; interactive picker replaces the service-account footgun.</li>
+              <li><b><code>citadel token set</code> + <code>citadel update</code></b> — rotate a token or self-update without re-running onboard; stale-shell auth hints tell you the actual fix.</li>
+            </ul></div>
+          </details>
+        </div>
+        <div class="rel">
+          <details>
+            <summary><span class="chev">▸</span><span class="relsum"><span class="ver">v0.2.0 – v0.2.1</span><span class="date">2026-06-29</span><span class="reltitle">Top-to-bottom CLI DX overhaul (PyPI + Railway).</span></span></summary>
+            <div class="dbody"><ul>
+              <li><b>Seat-scoped ingest that works</b> — <code>ingest</code>/<code>search</code> HTTP-backed by default and routed to your seat; inline cognify makes notes searchable immediately.</li>
+              <li><b>First-run onboarding + multi-tool MCP</b> — <code>citadel mcp add</code> wires Cursor, Codex, Gemini, Windsurf; guided first run; <code>citadel doctor</code> repairs setup drift.</li>
+              <li><b>Seat / token commands + faster status</b> — concurrent health checks; the old TUI folded into <code>citadel status</code>.</li>
+              <li><b>Evolve cadence 6h → 1h</b> — GitHub / Linear / repo sync + cognify now run hourly.</li>
+            </ul></div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section id="next">
+      <div class="sechead"><span class="kicker">05 — The road ahead</span><h2>What's next</h2></div>
+      <p class="lede">Honest status: some of this is in active design, some is still a sketch we're pressure-testing. Nothing here is claimed as shipped.</p>
+      <div class="status-legend">
+        <span class="chip prog">In design</span>
+        <span class="chip plan">Brainstorming</span>
+      </div>
+      <div class="next">
+        <div class="nrow"><div class="left"><span class="chip plan">Brainstorming</span></div><div><h3>GitHub App — PR context injection + verifying checks</h3><p>A GitHub App that injects relevant vault context into pull requests and runs <span class="k">verifying checks</span> as a PR status — kept <span class="k">in sync with Linear</span> and other connected apps, so a review sees the same knowledge an agent would. Direction sketched via the modular update-agent architecture; not built yet.</p></div></div>
+        <div class="nrow"><div class="left"><span class="chip prog">In design</span></div><div><h3>One central agent hub</h3><p>A single point of access to <span class="k">all org knowledge and context</span> — an internal update agent plus hosted MCP consolidating GitHub, Citadel search, Linear, and future approved sources behind one contract. Repository boundary and initial contract are drafted.</p></div></div>
+        <div class="nrow"><div class="left"><span class="chip prog">In design</span></div><div><h3>Google Chat digest bot</h3><p>A daily <span class="k">Organization Update Digest</span> to one Google Chat space — what changed, what's open, what merged, plus a cautious source-linked "Agent read." Outbound-only in Phase 1; app-auth and schedule locked in ADR-0002. Silent on quiet days.</p></div></div>
+        <div class="nrow"><div class="left"><span class="chip prog">In design</span></div><div><h3>Structured Knowledge — own the representation</h3><p>Make durable, first-class <span class="k">Structured Knowledge</span> the source of truth Citadel owns, with cognee demoted to a rebuildable index. Plus a retrieval eval harness (<code>citadel bench</code>) and vault lint (<code>citadel lint</code>). This is how we stop being "just a cognee wrapper." (ADR-0010)</p></div></div>
+        <div class="nrow"><div class="left"><span class="chip plan">Brainstorming</span></div><div><h3>Session Traces v1.1 + more surfaces</h3><p>Retraction controls (<code>citadel unshare</code>, ~90-day TTL, admin hard-delete), overlap-ranked <span class="k">prior-work retrieval</span>, and more delivery gateways — Agent Messenger, Slack, email, webhook — off the same update-agent contract.</p></div></div>
+      </div>
+    </section>
+
+    <section id="start">
+      <div class="sechead"><span class="kicker">06 — Join in</span><h2>Get started in one command</h2></div>
+      <p class="lede">Onboarding wires your seat token, autosync hooks, MCP, and agent policy in a single pass. Ask an admin for a <b>seat-bound</b> token first — a seat-less one authenticates but can't search.</p>
+      <div class="cmd"><span class="p">$ </span>pip install citadel-archive &amp;&amp; citadel onboard</div>
+      <footer>
+        <p>Verify anytime with <code>citadel status</code>. Live node: <code>citadel-archive-production.up.railway.app</code></p>
+        <p class="foot-note" id="foot-note">State-of-the-vault report · live tiles from <code>/api/state</code> · window v0.2.0 → v0.4.0.</p>
+      </footer>
+    </section>
+  </div>
+</body>
+</html>

--- a/kb/static/info.js
+++ b/kb/static/info.js
@@ -1,0 +1,121 @@
+/* Citadel — /info page behavior. Loaded as an external script (CSP script-src
+   'self'). No inline handlers. Chart bar heights use CSSOM (allowed under a
+   strict style-src). */
+(function () {
+  "use strict";
+
+  // ---- theme (prefers-color-scheme by default; toggle persists an override) ----
+  var root = document.documentElement;
+  try {
+    var saved = localStorage.getItem("citadel-info-theme");
+    if (saved === "light" || saved === "dark") root.setAttribute("data-theme", saved);
+  } catch (e) { /* storage blocked — fall back to prefers-color-scheme */ }
+
+  function currentTheme() {
+    var attr = root.getAttribute("data-theme");
+    if (attr) return attr;
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  var btn = document.getElementById("themebtn");
+  if (btn) {
+    btn.addEventListener("click", function () {
+      var next = currentTheme() === "dark" ? "light" : "dark";
+      root.setAttribute("data-theme", next);
+      try { localStorage.setItem("citadel-info-theme", next); } catch (e) { /* ignore */ }
+    });
+  }
+
+  // ---- Pixel Bastion mark (7x7 crenellated castle) ----
+  var grid = ["1010101", "1111111", "1111111", "1111111", "1101011", "1101011", "1101011"];
+  var mark = document.getElementById("mark");
+  if (mark) {
+    grid.join("").split("").forEach(function (c) {
+      var cell = document.createElement("i");
+      if (c === "1") cell.className = "on";
+      mark.appendChild(cell);
+    });
+  }
+
+  // ---- commits per week (baked from git log at report time) ----
+  var weeks = [
+    { l: "May 18", v: 9 },
+    { l: "May 25", v: 24 },
+    { l: "Jun 1", v: 30 },
+    { l: "Jun 8", v: 26 },
+    { l: "Jun 15", v: 20 },
+    { l: "Jun 22", v: 91, tag: "v0.1.x" },
+    { l: "Jun 29", v: 78, tag: "v0.2.0–2.2" },
+    { l: "Jul 6", v: 5, tag: "v0.2.3" },
+    { l: "Jul 13", v: 41, tag: "v0.3.0" },
+    { l: "Jul 20", v: 53, tag: "v0.4.0" }
+  ];
+  var chart = document.getElementById("chart");
+  if (chart) {
+    var max = weeks.reduce(function (m, w) { return Math.max(m, w.v); }, 1);
+    weeks.forEach(function (w) {
+      var col = document.createElement("div");
+      col.className = "bar-col" + (w.tag ? " ship" : "");
+      col.title = w.v + " commits · week of " + w.l + (w.tag ? " · " + w.tag : "");
+      var val = document.createElement("div"); val.className = "bar-val"; val.textContent = w.v;
+      var bar = document.createElement("div"); bar.className = "bar";
+      bar.style.height = Math.max(3, Math.round(w.v / max * 104)) + "px";
+      var tag = document.createElement("div"); tag.className = "bar-tag"; tag.textContent = w.tag || "";
+      var lbl = document.createElement("div"); lbl.className = "bar-lbl"; lbl.textContent = w.l;
+      col.appendChild(val); col.appendChild(bar); col.appendChild(tag); col.appendChild(lbl);
+      chart.appendChild(col);
+    });
+  }
+
+  // ---- live tiles from /api/state ----
+  function rel(iso) {
+    if (!iso) return "";
+    var t = Date.parse(iso);
+    if (isNaN(t)) return "";
+    var mins = Math.round((Date.now() - t) / 60000);
+    if (mins < 2) return "just now";
+    if (mins < 60) return mins + " min ago";
+    var hrs = Math.round(mins / 60);
+    if (hrs < 24) return hrs + (hrs === 1 ? " hour ago" : " hours ago");
+    var days = Math.round(hrs / 24);
+    if (days < 8) return days + (days === 1 ? " day ago" : " days ago");
+    return "on " + new Date(t).toISOString().slice(0, 10);
+  }
+  function vlabel(v) {
+    if (!v) return "";
+    return /^[0-9]/.test(v) ? "v" + v : v;
+  }
+  function set(id, text) { var el = document.getElementById(id); if (el) el.textContent = text; }
+
+  fetch("/api/state", { headers: { "Accept": "application/json" } })
+    .then(function (r) { if (!r.ok) throw new Error("state " + r.status); return r.json(); })
+    .then(function (d) {
+      var ver = vlabel(d.version) || "v0.4.0";
+      set("m-version", ver);
+      var healthEl = document.getElementById("pill-health");
+      var healthText = document.getElementById("pill-health-text");
+      if (d.healthy === false) {
+        if (healthEl) healthEl.classList.add("down");
+        if (healthText) healthText.textContent = "Degraded · " + ver;
+      } else if (healthText) {
+        healthText.textContent = "Live · " + ver;
+      }
+
+      var gh = (d.sources || []).filter(function (s) { return s.type === "github"; })[0];
+      var repos = (d.totals && d.totals.github_repositories) || (gh && gh.documents) || 0;
+      var docsEl = document.getElementById("m-docs");
+      if (docsEl) docsEl.innerHTML = repos + " <small>repos</small>";
+      var when = gh && gh.last_synced_at ? rel(gh.last_synced_at) : "";
+      set("m-docs-sub", "GitHub org synced" + (when ? " · " + when : ""));
+
+      var upd = rel(d.updated_at);
+      set("state-updated", "Live tiles updated" + (upd ? " " + upd : "") +
+        " · repo facts (commits, tests, LOC) as of v0.4.0, 2026-07-22.");
+      set("foot-note", "State-of-the-vault report · live tiles from /api/state" +
+        (upd ? " (updated " + upd + ")" : "") + " · window v0.2.0 → v0.4.0.");
+    })
+    .catch(function () {
+      set("m-docs", "—");
+      set("m-docs-sub", "GitHub org sync (live data unavailable)");
+      set("state-updated", "Live data unavailable right now — showing repo facts as of v0.4.0, 2026-07-22.");
+    });
+})();


### PR DESCRIPTION
## What

Adds a public **State of the Vault** report served by the node at **`GET /info`**, backed by a new public **`GET /api/state`** endpoint so the metric tiles stay in sync with the running node.

- **`/info`** (`kb/static/info.html` + `info.css` + `info.js`) — current metrics, shipped releases (v0.2 → v0.4), an architecture diagram, a commit-velocity chart, and the roadmap, with progressive `Go deeper` expanders. Soft, eye-friendly palette; both light/dark themes; self-hosted Inter / JetBrains Mono.
- **`/api/state`** — public JSON, **safe aggregates only**: version, health, per-source doc/repo counts, last-sync, totals. Modeled on the existing `/.well-known/citadel.json` precedent — never exposes vault content, per-seat data, internal source URLs, or tokens. A syncer blip degrades to empty rather than 500.
- **README** — links the report.

## Freshness

Live tiles (version, health, GitHub repo count, last-sync) hydrate client-side from `/api/state` on each load. Narrative, releases, and the commit chart are baked in the page and updated on edit.

## Security / CSP

Public, no auth. Under the node's strict CSP (`script-src 'self'; style-src 'self'`, no `unsafe-inline`): CSS/JS are external files, decorative marks use `::before`, chart bar heights use CSSOM. Security headers apply via the existing middleware.

## Verification

- ruff clean; `node --check info.js` OK.
- Routes registered; `/info` → 200 (HTML, CSP applied), `/api/state` → 200 (valid JSON, `cache-control: public, max-age=300`), degrades to zeros offline.
- `tests/test_server.py` 140 passed, `tests/test_skills.py` 12 passed.
- Live-verified in a browser: JS hydration fills the tiles from `/api/state`; chart + mark render.

## Note

The README link resolves once this merges and Railway auto-deploys.