### PR TITLE
feat(dashboard): Masumi magenta accent + light mode

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -423,7 +423,8 @@ LOGIN_HTML = """<!doctype html>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Citadel</title>
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="/static/styles.css?v=pixel-bastion-4" />
+    <link rel="stylesheet" href="/static/styles.css?v=masumi-accent-1" />
+    <script src="/static/theme.js"></script>
   </head>
   <body>
     <main class="login-shell">

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Citadel Archive</title>
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="/static/styles.css?v=pixel-bastion-4" />
+    <link rel="stylesheet" href="/static/styles.css?v=masumi-accent-1" />
+    <script src="/static/theme.js"></script>
   </head>
   <body>
     <div class="app-frame">
@@ -123,6 +124,9 @@
           <div class="sidebar-actions">
             <button id="refreshButton" class="secondary-button compact-button" type="button">
               Refresh
+            </button>
+            <button id="themeToggle" class="secondary-button compact-button" type="button" aria-label="Toggle light or dark theme">
+              ☾ Dark
             </button>
             <button id="logoutButton" class="secondary-button compact-button" type="button">
               Log out

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -38,14 +38,16 @@
   --muted: #a3b3ab;
   --quiet: #7d8b82;
 
-  /* Accent — Masumi brand magenta (#FA008C) */
-  --primary: #fa008c;
-  --primary-strong: #ff5cb0;
-  --primary-deep: #cc0073;
-  --primary-soft: rgba(250, 0, 140, 0.16);
-  --primary-border: rgba(250, 0, 140, 0.45);
+  /* Accent — Masumi Iris Flower magenta (#FF51FF). Bright hue for accents;
+     solid button fills use the deeper magenta so white text stays legible. */
+  --primary: #ff51ff;
+  --primary-strong: #ff86f2;
+  --primary-deep: #c010a0;
+  --primary-hover: #d81ab0;
+  --primary-soft: rgba(255, 81, 255, 0.16);
+  --primary-border: rgba(255, 81, 255, 0.45);
   --primary-text: #ffffff;
-  --focus: #ff5cb0;
+  --focus: #ff51ff;
 
   /* Semantic status — emerald success, cyan info (Citadel CLI heritage), Masumi red */
   --danger: #fa140a;
@@ -62,6 +64,59 @@
   --speed: 140ms;
   --font: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+/* Light theme — Masumi light-first neutral ramp. Token-level only: surfaces,
+   borders and text flip; the #FF51FF accent stays, with active text/links
+   dropping to the readable deep magenta. Applied when the OS prefers light and
+   the user hasn't forced dark, or when explicitly toggled to light. */
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #ffffff;
+  --chrome: #fafafa;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-hover: #f5f5f5;
+  --field: #ffffff;
+  --border: rgba(10, 10, 10, 0.10);
+  --border-strong: rgba(10, 10, 10, 0.18);
+  --border-quiet: rgba(10, 10, 10, 0.06);
+  --text: #0a0a0a;
+  --muted: rgba(10, 10, 10, 0.56);
+  --quiet: rgba(10, 10, 10, 0.42);
+  --primary-strong: #c010a0;
+  --primary-soft: rgba(255, 81, 255, 0.12);
+  --primary-border: rgba(255, 81, 255, 0.5);
+  --primary-hover: #a00a86;
+  --danger: #dc2626;
+  --warning: #b45309;
+  --success: #16a34a;
+  --info: #0891b2;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    color-scheme: light;
+    --bg: #ffffff;
+    --chrome: #fafafa;
+    --surface: #ffffff;
+    --surface-raised: #ffffff;
+    --surface-hover: #f5f5f5;
+    --field: #ffffff;
+    --border: rgba(10, 10, 10, 0.10);
+    --border-strong: rgba(10, 10, 10, 0.18);
+    --border-quiet: rgba(10, 10, 10, 0.06);
+    --text: #0a0a0a;
+    --muted: rgba(10, 10, 10, 0.56);
+    --quiet: rgba(10, 10, 10, 0.42);
+    --primary-strong: #c010a0;
+    --primary-soft: rgba(255, 81, 255, 0.12);
+    --primary-border: rgba(255, 81, 255, 0.5);
+    --primary-hover: #a00a86;
+    --danger: #dc2626;
+    --warning: #b45309;
+    --success: #16a34a;
+    --info: #0891b2;
+  }
 }
 
 * {
@@ -311,8 +366,8 @@ pre {
   flex: 0 0 auto;
   padding: 3px 7px;
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.07);
-  color: rgba(255, 255, 255, 0.55);
+  background: var(--surface-hover);
+  color: var(--muted);
   font-family: var(--mono);
   font-size: 10px;
   font-weight: 600;
@@ -1930,7 +1985,7 @@ pre {
 
 label,
 legend {
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--muted);
   font-size: 11.5px;
   font-weight: 500;
 }
@@ -2079,13 +2134,13 @@ textarea[aria-invalid="true"] {
 
 .primary-button {
   width: 100%;
-  background: var(--primary);
+  background: var(--primary-deep);
   color: var(--primary-text);
   font-weight: 650;
 }
 
 .primary-button:hover {
-  background: var(--primary-deep);
+  background: var(--primary-hover);
 }
 
 .primary-button:disabled,

--- a/kb/static/theme.js
+++ b/kb/static/theme.js
@@ -1,0 +1,43 @@
+/* Citadel dashboard theme toggle. Loaded as an external script (CSP
+   script-src 'self'). Applies any saved preference to <html> as early as
+   possible, then wires an optional #themeToggle button. Default (no saved
+   pref, OS not light) stays dark; OS light without an override shows light. */
+(function () {
+  "use strict";
+  var root = document.documentElement;
+
+  try {
+    var saved = localStorage.getItem("citadel-theme");
+    if (saved === "light" || saved === "dark") root.setAttribute("data-theme", saved);
+  } catch (e) { /* storage blocked — fall back to prefers-color-scheme */ }
+
+  function current() {
+    var attr = root.getAttribute("data-theme");
+    if (attr) return attr;
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches
+      ? "light"
+      : "dark";
+  }
+
+  function label(btn) {
+    if (btn) btn.textContent = current() === "light" ? "☀ Light" : "☾ Dark";
+  }
+
+  function wire() {
+    var btn = document.getElementById("themeToggle");
+    if (!btn) return;
+    label(btn);
+    btn.addEventListener("click", function () {
+      var next = current() === "light" ? "dark" : "light";
+      root.setAttribute("data-theme", next);
+      try { localStorage.setItem("citadel-theme", next); } catch (e) { /* ignore */ }
+      label(btn);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wire);
+  } else {
+    wire();
+  }
+})();


### PR DESCRIPTION
## What

Aligns the **dashboard** to the Masumi accent and adds a **light mode** — scope per request: **accent + light mode only, no component restructure.**

- **Accent → Masumi Iris magenta `#FF51FF`** (was `#fa008c`). To keep white button text legible, solid primary fills route through the deeper magenta `#c010a0` (`--primary-deep`), with `#ff51ff` reserved as the accent hue (soft backgrounds, borders, active text, focus).
- **Light mode** — a Masumi light-first neutral ramp (`#fff`/`#fafafa` surfaces, `#0a0a0a` ink, `#e5e5e5` borders) applied via `prefers-color-scheme: light` **and** a `data-theme` toggle.
- **Theme toggle** — `theme.js` applies a saved preference early and wires a `☀ Light / ☾ Dark` button in the sidebar; also loaded on `/login` so the choice persists.
- **Two hardcoded-color fixes** so light mode is usable: the form `label`/`legend` and the `.brand-chip` now use tokens (they were white-based and vanished on light).
- Bumped the styles cache-buster to `masumi-accent-1`.

## Verified

Login page, fresh server — light + dark both correct: dark text on white, "Seat token" label + "ARCHIVE" chip visible, deep-magenta button with legible white text; dark mode unchanged in structure with the new magenta.

## Known follow-ups (out of this scope)

Light mode is **token-level**. A handful of surfaces still hardcode colors and won't fully adapt yet:
- the CSS **pixel-mark** grid colors (`#fa008c`/`#d6239c`) — still the old pink in the sidebar mark;
- ~9 `rgba(255,255,255,…)` spots (some overlays/borders);
- the full authenticated dashboard (graph chrome, analytics, panels) wasn't visually reviewed in light locally — worth a pass on the Railway preview or after login.

These are the "full component restyle" scope, intentionally deferred. Not deployed — review here before merge.