### PR TITLE
fix(mcp): return JSON responses so tools/list stops hanging ~91s (#100)

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -619,6 +619,12 @@ def create_mcp_server(
             "user asks to add durable context. Use admin tools only after explicit approval."
         ),
         stateless_http=stateless_http,
+        # Answer each request with an immediate application/json body instead of
+        # an SSE stream. The hosted proxy buffered the streamed response and held
+        # the stream open, so a trivial tools/list took ~91s and clients reported
+        # "connected · tools fetch failed". Our tools return plain dict payloads
+        # (nothing streams), so JSON responses lose nothing. (#100)
+        json_response=True,
         streamable_http_path="/",
         transport_security=_transport_security(),
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,6 +77,61 @@ def run_tool(server: Any, name: str, *args: Any, **kwargs: Any) -> Any:
     return result
 
 
+def test_streamable_http_uses_json_response_not_sse() -> None:
+    """tools/list must return an immediate application/json body, not an SSE stream.
+
+    The hosted proxy buffered the SSE stream and held it open ~91s, so a trivial
+    tools/list hung and clients reported "connected · tools fetch failed" (#100).
+    json_response mode answers each request with a plain JSON body instead.
+    """
+    import httpx
+
+    server = create_mcp_server(FakeHttpClient(), stateless_http=True)
+    assert server.settings.json_response is True
+
+    app = server.streamable_http_app()
+
+    async def _roundtrip() -> tuple[str, int]:
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                headers = {
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                }
+                init = await client.post(
+                    "/",
+                    headers=headers,
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "t", "version": "1"},
+                        },
+                    },
+                )
+                sid = init.headers.get("mcp-session-id")
+                if sid:
+                    headers = {**headers, "mcp-session-id": sid}
+                await client.post(
+                    "/", headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+                )
+                resp = await client.post(
+                    "/",
+                    headers=headers,
+                    json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+                )
+                return resp.headers.get("content-type", ""), resp.text.count('"name"')
+
+    content_type, tool_names = asyncio.run(_roundtrip())
+    assert content_type.startswith("application/json")
+    assert "text/event-stream" not in content_type
+    assert tool_names == len(TOOL_POLICIES)
+
+
 def test_registered_tools_include_safety_annotations() -> None:
     server = create_mcp_server(FakeHttpClient())
 


### PR DESCRIPTION
## Problem

The hosted MCP shows **"connected · tools fetch failed"** — clients register **zero** `citadel_*` tools. Root cause: `tools/list` hangs ~91s.

## Diagnosis (measured)

- `initialize` returns in **0.2s**; `tools/list` takes **90.6s** with a fully compliant handshake on an **idle** node.
- Reading the SSE body line-by-line: silent from 0→91s, then a `ping` + the whole result flushed at once on stream close.
- Locally every code path is fast — `list_tools()` 0.00s / 22 tools, in-process session resolve 0.2s — so the block is in the **SSE transport**, not the handler.

The transport answered over an SSE stream (`stateless_http=True` but `json_response` defaulted to `False`), which the Railway proxy buffers and holds open before closing.

## Fix

`json_response=True` — each request returns an immediate `application/json` body, so there is no stream for the proxy to buffer. Our tools all return plain dict payloads (nothing streams), so JSON responses lose nothing.

Verified locally (httpx ASGITransport) that the transport flips content-type `text/event-stream` → `application/json` and still returns all 22 tools; added a regression test asserting it.

## Note

The 91s is Railway-proxy behaviour, not reproducible in the local ASGI harness, so **final confirmation is post-deploy**: after merge, `initialize` + `tools/list` should both return quickly and clients should list the citadel tools.

This is a minimal, isolated hotfix off `main` (7 lines + a test) — separate from the larger `feat/agent-search-hardening` branch.

Closes #100.