### PR TITLE
fix(mcp): resolve tools/list role in-process (the real ~91s fix) (#100)

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -36,6 +36,36 @@ TRUTHY = frozenset({"1", "true", "yes", "on"})
 AUDIT_VIEWS = frozenset({"all", "mcp", "access", "failures"})
 PUBLIC_HOST_RE = re.compile(r"^(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?$")
 
+# tools/list resolves the caller's role in-process; if that ever fails it uses a
+# bounded threaded HTTP fallback so the handler never blocks the event loop.
+_TOOLS_LIST_SESSION_HTTP_TIMEOUT = 2.0
+_TOOLS_LIST_SESSION_WAIT = 2.5
+
+
+def _session_from_token_inprocess(token: str) -> dict[str, Any] | None:
+    """Resolve role/seat for tools/list WITHOUT a nested HTTP self-call.
+
+    A synchronous ``GET /api/session`` from inside the tools/list handler runs on
+    the same event loop that must serve it, so it self-deadlocks and — after the
+    HTTP client's 3 retries — takes ~90s, which is why clients report
+    "connected · tools fetch failed" with zero tools. ``access_key_identity``
+    reads the access store in-process, so it returns in milliseconds. Fails open
+    (returns ``None``) so a lookup error never blanks the tool list.
+    """
+    try:
+        from kb.server import access_key_identity
+    except Exception:
+        return None
+    try:
+        pair = access_key_identity(token)
+    except Exception as exc:  # noqa: BLE001 - fail open
+        logger.warning("tools/list access_key_identity failed: %s", exc)
+        return None
+    if not pair:
+        return None
+    identity, _ = pair
+    return {"ok": True, "role": identity.role, "seat_slug": identity.seat_slug}
+
 
 class CitadelMcpError(RuntimeError):
     pass
@@ -1173,12 +1203,14 @@ def create_mcp_server(
     async def _role_filtered_list_tools() -> list[Any]:
         """Hide tools the caller cannot use from tools/list (#33).
 
-        Resolves the caller's role + seat via /api/session and drops tools whose
-        required role exceeds the caller (so a writer/reader never sees the 6
-        admin tools) and citadel_contribute for seat holders (Central is
-        read-only from seat MCP). Server-side 403s remain the real enforcement;
-        this only stops 403 trial-and-error and fails OPEN on any resolution
-        error so a transient session lookup never blanks the tool list.
+        Resolves the caller's role + seat IN-PROCESS (preferred) or via a short
+        threaded HTTP fallback — never with a sync self-call on the event loop.
+        A nested blocking ``GET /api/session`` self-deadlocks the hosted
+        streamable-HTTP transport: it runs on the same loop that must serve it,
+        so after the HTTP client's retries tools/list takes ~90s and clients
+        register zero tools. Server-side 403s remain the real enforcement; this
+        only stops 403 trial-and-error and fails OPEN on any resolution error so
+        a transient lookup never blanks the tool list. (#100)
         """
         all_tools = await mcp.list_tools()
         try:
@@ -1188,13 +1220,22 @@ def create_mcp_server(
         token = _bearer_from_context(ctx)
         if not token:
             return all_tools  # stdio / unauthenticated handshake — call-time authz still applies
-        try:
-            session = CitadelHttpClient(
-                base_url=_self_base_url(), access_token=token
-            ).get("/api/session")
-        except Exception as exc:  # noqa: BLE001 - fail open for availability
-            logger.warning("tools/list role filter could not resolve session: %s", exc)
-            return all_tools
+        session = _session_from_token_inprocess(token)
+        if session is None:
+            try:
+                session = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        lambda: CitadelHttpClient(
+                            base_url=_self_base_url(),
+                            access_token=token,
+                            timeout=_TOOLS_LIST_SESSION_HTTP_TIMEOUT,
+                        ).get("/api/session")
+                    ),
+                    timeout=_TOOLS_LIST_SESSION_WAIT,
+                )
+            except Exception as exc:  # noqa: BLE001 - fail open for availability
+                logger.warning("tools/list role filter could not resolve session: %s", exc)
+                return all_tools
         return _filter_tools_for_session(all_tools, session)
 
     return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,6 +77,41 @@ def run_tool(server: Any, name: str, *args: Any, **kwargs: Any) -> Any:
     return result
 
 
+def test_tools_list_session_resolved_in_process_not_via_self_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tools/list must resolve the caller's role in-process, never by a sync
+    GET /api/session self-call.
+
+    The self-call runs on the same event loop that must serve it, so after the
+    HTTP client's 3 retries (30s each) tools/list took ~90s and clients
+    registered zero tools (#100). access_key_identity reads the access store
+    in-process and returns in milliseconds.
+    """
+    from types import SimpleNamespace
+
+    import kb.server as server_mod
+
+    monkeypatch.setattr(
+        server_mod,
+        "access_key_identity",
+        lambda token: (SimpleNamespace(role="reader", seat_slug="sarthi"), "cookie"),
+    )
+
+    session = mcp_server._session_from_token_inprocess("ctdl_x")
+    assert session == {"ok": True, "role": "reader", "seat_slug": "sarthi"}
+
+    # Fails open (no tool list blanking) when the store lookup errors or misses.
+    def boom(token: str) -> Any:
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setattr(server_mod, "access_key_identity", boom)
+    assert mcp_server._session_from_token_inprocess("ctdl_x") is None
+
+    monkeypatch.setattr(server_mod, "access_key_identity", lambda token: None)
+    assert mcp_server._session_from_token_inprocess("ctdl_x") is None
+
+
 def test_streamable_http_uses_json_response_not_sse() -> None:
     """tools/list must return an immediate application/json body, not an SSE stream.
 


### PR DESCRIPTION
## The real root cause

The earlier `json_response=True` fix (PR #107, deployed) changed the transport but `tools/list` was still ~91s. Prod logs after that deploy showed why:

```
Processing request of type ListToolsRequest
GET /api/session failed with TimeoutError; retrying (attempt 1/3)
GET /api/session failed with TimeoutError; retrying (attempt 2/3)
```

The tools/list **role filter** ran a **synchronous** `CitadelHttpClient(...).get("/api/session")` directly on the event loop. That self-call has to be served by the same loop it is blocking, so it times out (30s client default) and the HTTP client retries 3×: ~30s × 3 ≈ 90s. This also explains why the SSE body looked "buffered" for 91s — the handler was blocked the whole time, not just the proxy.

## Fix

Resolve the caller's role **in-process** via `access_key_identity` (reads the access store, no loop, ~0.2s), with a **bounded off-loop** `wait_for(to_thread(...), 2.5s)` HTTP fallback so the handler can never block on the self-deadlock again. Fails open (returns all tools) on any resolution error — server-side 403s remain the real enforcement.

Verified locally: `_session_from_token_inprocess` returns in 0.2s with no network; `list_tools()` returns all 22 tools; added a regression test asserting in-process resolution + fail-open. 32 MCP tests pass.

Stacks on top of #107 (both are needed: json_response for the transport, this for the handler). Minimal, isolated off `main`.

Closes #100.