### PR TITLE
docs(mcp): troubleshoot "connected but fails / reconnect does nothing"

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -556,6 +556,37 @@ Citadel stores only the SHA-256 hash. The raw token is shown once at creation.
 
 ## Troubleshooting
 
+### "Connected" but tools fail, and clicking reconnect does nothing
+
+The most common teammate report — and the server is almost always fine. This is a
+client **launch-environment** issue.
+
+`.mcp.json` authenticates with `Bearer ${CITADEL_MCP_ACCESS_TOKEN}`, and the MCP
+client expands that placeholder **once, from the environment it was launched in**.
+If that variable was empty or held a stale/revoked token at launch, every request
+carries a bad token (→ 401), so the panel shows failed. Crucially, **`/mcp` →
+reconnect re-reads the config but NOT your shell environment** — it keeps sending
+the same captured token, so it looks like "nothing happens."
+
+A reconnect cannot fix this; you need a fresh process:
+
+1. In a **new terminal**, confirm a valid token is exported:
+   `printf '%s' "$CITADEL_MCP_ACCESS_TOKEN" | tail -c 5` should show your token's
+   last 4 characters. If it's empty, `source ~/.zshrc` (or open a new terminal).
+2. Confirm the token actually works: `citadel status --json` → `auth.ok: true`.
+   (A `401` here means the token is stale/revoked — mint a fresh seat token and
+   update your rc; do not put a literal token in the git-tracked `.mcp.json`.)
+3. **Fully quit** the client — exit the CLI, or Cmd-Q the app; *not* `/mcp`
+   reconnect — and **relaunch it from that terminal** so it recaptures the env.
+
+**macOS:** apps launched from the Dock/Spotlight do **not** inherit `~/.zshrc`, so
+the placeholder resolves to empty. Launch from a terminal, or set the token in the
+GUI login environment: `launchctl setenv CITADEL_MCP_ACCESS_TOKEN <token>`.
+
+`citadel doctor` flags the common case (token in rc but missing from the current
+env). This is distinct from **connected but zero tools** — see
+[Claude Code (local + cloud)](#claude-code-local--cloud) for that.
+
 ### Server won't start
 
 ```bash


### PR DESCRIPTION
## Why

The most common teammate MCP report: `/mcp` shows citadel **failed**, and clicking **reconnect does nothing**. The server and the token are usually both fine — it's a client **launch-environment** issue that isn't documented.

`.mcp.json` authenticates with `Bearer ${CITADEL_MCP_ACCESS_TOKEN}`, which the MCP client expands **once, from the environment it was launched in**. If that variable was empty or held a stale token at launch, every request carries a bad token (→ 401) → "failed". And `/mcp` → reconnect **re-reads the config but not the shell environment**, so it keeps sending the same captured token — hence "nothing happens."

## What

Adds a Troubleshooting subsection (`docs/mcp/README.md`) with the real fix: verify a valid token is exported, confirm with `citadel status --json`, then **fully relaunch** the client (not reconnect) from that terminal. Covers the macOS Dock/Spotlight caveat (GUI apps don't inherit `~/.zshrc`) and keeps the token out of the git-tracked `.mcp.json` (public repo).

Docs-only; no code change. Diagnosed live this cycle: server-side `tools/list` is 0.2s and the configured token returns `200`, but a running client that captured an empty/stale token kept failing until a full relaunch.