### PR TITLE
docs: record UAT findings as merged + verified in production

### DIFF
--- a/docs/uat-2026-07-23-findings.md
+++ b/docs/uat-2026-07-23-findings.md
@@ -9,6 +9,25 @@ verified locally; every claim below is grounded in code or a command that was ru
 Findings are tracked as GitHub issues #100–#106. Fixes landed on
 `feat/agent-search-hardening`.
 
+## Deployment status
+
+All fixes are **merged to `main` and live in production**, verified end-to-end on
+the hosted node:
+
+- MCP hotfixes: **#107** (`json_response`) + **#108** (in-process role
+  resolution) — `tools/list` **~91s → 0.2s**, `application/json`, 13 role-filtered
+  tools for a writer seat.
+- Client troubleshooting doc: **#110**.
+- The full change set (agent search, attested trust model, security + CLI/UAT
+  fixes): **#109**, merged as `d2fa9a0`.
+- Post-deploy verification: `/healthz` 200, auth 200 (writer/sarthi), `tools/list`
+  0.2s, a warm `/search` returned hits carrying the new envelope fields
+  (`content_hint`, `trust_tier: unattested`) — confirming ADR-0012 is live.
+
+Still open by design: **#104** (provenance at ingest — needs a cognee spike),
+**#105** (event-loop starvation — search recall is ~8s warm; fix needs
+cognee/staging validation), **#106** (cross-dataset ordering — a UX decision).
+
 ## Resolution status
 
 | # | Finding | Severity | Status |


### PR DESCRIPTION
Adds a **Deployment status** section to `docs/uat-2026-07-23-findings.md` recording that the whole cycle is merged to `main` and verified live:

- MCP: #107 + #108 → `tools/list` ~91s → **0.2s**
- Full change set: #109 (`d2fa9a0`); troubleshooting doc: #110
- Post-deploy prod check: `/healthz` 200, auth 200, `tools/list` 0.2s, warm `/search` returning hits with the new `content_hint` / `trust_tier: unattested` envelope (ADR-0012 live)
- #104/#105/#106 noted as open by design

Docs-only.