### PR TITLE
test: restore app.state after every test (#120)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 
@@ -14,3 +16,30 @@ def _isolate_claude_home(tmp_path_factory, monkeypatch):
     home = tmp_path_factory.mktemp("citadel_home")
     monkeypatch.setenv("CITADEL_HOME", str(home))
     yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_state():
+    """Restore kb.server.app.state after every test that assigns to it (#120).
+
+    The route dependencies in kb/server.py resolve their collaborators off the
+    module-level ``app`` singleton, so tests swap in fakes by assigning to
+    app.state and the assignment outlives the test. Snapshot and restore instead
+    of asking 249 assignment sites to clean up after themselves.
+
+    kb.server is looked up through sys.modules rather than imported at module
+    scope because conftest loads for the whole session and kb.server pulls in
+    cognee; test modules are imported at collection, so kb.server is already
+    there whenever a test actually touches it. The snapshot is shallow: this
+    fixes attribute leakage, not in-place mutation of a stored object.
+    """
+    server = sys.modules.get("kb.server")
+    snapshot = dict(server.app.state._state) if server is not None else None
+    yield
+    server = sys.modules.get("kb.server")
+    if server is None:
+        return
+    state = server.app.state._state
+    state.clear()
+    if snapshot:
+        state.update(snapshot)

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -1,0 +1,23 @@
+"""Pin the autouse fixtures in conftest.py, which nothing else covers.
+
+The app.state fixture (#120) is invisible when it works: the suite passes
+identically whether it restores state or does nothing at all. These two tests
+run in order and the second one fails if the fixture stops restoring, which is
+the only way a regression here would ever surface.
+"""
+
+from __future__ import annotations
+
+import kb.server
+
+_SENTINEL = "_conftest_leak_probe"
+
+
+def test_app_state_assignment_inside_a_test() -> None:
+    assert not hasattr(kb.server.app.state, _SENTINEL)
+    setattr(kb.server.app.state, _SENTINEL, object())
+    assert hasattr(kb.server.app.state, _SENTINEL)
+
+
+def test_app_state_assignment_did_not_leak_into_the_next_test() -> None:
+    assert not hasattr(kb.server.app.state, _SENTINEL)


### PR DESCRIPTION
Closes #120.

## The problem

Route dependencies in `kb/server.py` resolve their collaborators off the module-level `app` singleton, so a test that swaps in a fake by assigning to `app.state` leaks that fake into every test that runs afterwards. Twelve sites in `tests/test_server.py` hand-roll a `knowledge_mesh = None` cleanup; the other 249 assignments do not clean up at all.

## The change

An autouse fixture in `tests/conftest.py` snapshots `app.state` before each test and restores it after. `kb.server` is looked up through `sys.modules` rather than imported at conftest scope, because conftest loads for the whole session and `kb.server` pulls in cognee; test modules are imported at collection, so it is already there whenever a test actually touches it.

The alternative the issue raises, converting the twelve `get_*` dependencies into injectable `Depends()` seams, would touch every route signature and all 249 assignment sites.

## Why the second commit exists

The fixture is invisible when it works. The suite passed identically before it existed, so a green run proves nothing about it. `tests/test_conftest_fixtures.py` adds two ordered tests: the first assigns a sentinel to `app.state`, the second asserts it is gone.

Verified by deleting the restore half of the fixture and confirming the second test goes red, then restoring it.

## Known limit

The snapshot is shallow. This fixes attribute leakage, not in-place mutation of a stored object — records added to a shared `AccessStore` still carry over. Worth knowing before anyone treats it as full isolation.

## Test results

`951 passed, 3 failed, 1 skipped`. The 3 failures are pre-existing on `main` and unrelated: two are `ModuleNotFoundError: No module named 'cognee'` (not installed in this environment) and one is `test_importing_cli_pulls_no_server_modules` reporting a leaked `google` module. Ruff clean on both touched files.