### PR TITLE
fix(promotion): a seat whose every search fails is a failure, not empty

### DIFF
--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -202,6 +202,15 @@ def _coerce_classification(parsed: Any) -> Classification | None:
     )
 
 
+class PromotionEnumerationError(RuntimeError):
+    """Every seed query for a seat failed, so its content could not be read.
+
+    Distinct from "this seat has nothing to promote": that is an empty list and
+    a legitimate result. This means the search path itself is broken, and the
+    caller must not record the seat as successfully processed.
+    """
+
+
 class PromotionEngine:
     """Selective seat-to-Central promotion (ADR-0005 step 2)."""
 
@@ -222,9 +231,12 @@ class PromotionEngine:
         cap = max(1, max_items)
         seen: set[str] = set()
         candidates: list[PromotionCandidate] = []
+        attempted = 0
+        errors: list[str] = []
         for query in DEFAULT_SEED_QUERIES:
             if len(candidates) >= cap:
                 break
+            attempted += 1
             try:
                 results = await self.citadel.search(
                     query, dataset=seat_dataset, top_k=cap
@@ -235,6 +247,7 @@ class PromotionEngine:
                     seat_dataset,
                     exc.__class__.__name__,
                 )
+                errors.append(exc.__class__.__name__)
                 continue
             for result in results:
                 parsed = _candidate_from_result(result)
@@ -247,6 +260,16 @@ class PromotionEngine:
                 candidates.append(parsed)
                 if len(candidates) >= cap:
                     break
+        if attempted and len(errors) == attempted:
+            # Every search we actually ran failed, so an empty candidate list
+            # here means "could not look", not "nothing to promote". Returning []
+            # made the caller count the seat as a clean zero: production logged
+            # "seats=11 promoted=0 failures=0" while all 22 searches were dying
+            # on the Kuzu lock and on DatasetNotFoundError.
+            raise PromotionEnumerationError(
+                f"all {attempted} seed queries failed for {seat_dataset}: "
+                f"{', '.join(sorted(set(errors)))}"
+            )
         return candidates[:cap]
 
     def classify(self, text: str) -> Classification | None:

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -357,3 +357,66 @@ async def test_rejected_candidate_is_not_requeued(
     assert second["queued"] == 0
     assert second["proposals"][0]["reason"] == "previously_rejected"
     assert learning.central_writes == []
+
+
+class _ExplodingCitadel:
+    """Fails a chosen number of leading seed searches, succeeds on the rest."""
+
+    def __init__(self, config: CitadelConfig, *, fail_first: int, exc: Exception) -> None:
+        self.config = config
+        self._fail_first = fail_first
+        self._exc = exc
+        self.calls = 0
+
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.calls += 1
+        if self.calls <= self._fail_first:
+            raise self._exc
+        return [{"text": _org_note()}]
+
+
+def _exploding_engine(tmp_path: Path, *, fail_first: int, exc: Exception) -> PromotionEngine:
+    config = _config()
+    return PromotionEngine(
+        _ExplodingCitadel(config, fail_first=fail_first, exc=exc),
+        FakeLearning(),
+        AccessStore(str(tmp_path / "access.json")),
+        config,
+    )
+
+
+async def test_enumerate_raises_when_every_seed_query_fails(tmp_path: Path) -> None:
+    """A seat whose searches all die is a failure, not an empty seat.
+
+    Production logged "seats=11 promoted=0 failures=0" for days while all 22
+    searches were failing on the Kuzu lock and DatasetNotFoundError, because
+    enumerate swallowed each one and returned [].
+    """
+    total = len(promotion.DEFAULT_SEED_QUERIES)
+    engine = _exploding_engine(tmp_path, fail_first=total, exc=RuntimeError("kuzu locked"))
+
+    with pytest.raises(promotion.PromotionEnumerationError) as caught:
+        await engine.enumerate(SEAT, 20)
+
+    assert "RuntimeError" in str(caught.value)
+    assert SEAT in str(caught.value)
+
+
+async def test_enumerate_stays_best_effort_when_one_query_fails(tmp_path: Path) -> None:
+    """One flaky query must not fail the seat — only a total wipeout does."""
+    if len(promotion.DEFAULT_SEED_QUERIES) < 2:  # pragma: no cover - guards the fixture
+        pytest.skip("needs at least two seed queries")
+    engine = _exploding_engine(tmp_path, fail_first=1, exc=RuntimeError("kuzu locked"))
+
+    candidates = await engine.enumerate(SEAT, 20)
+
+    assert candidates, "a surviving query's results must still be returned"
+
+
+async def test_enumerate_returns_empty_without_raising_when_searches_succeed(
+    tmp_path: Path,
+) -> None:
+    """A genuinely empty seat stays an empty list, not an error."""
+    engine, _, _ = _engine(tmp_path, [])
+
+    assert await engine.enumerate(SEAT, 20) == []


### PR DESCRIPTION
Found while root-causing #88. Not previously filed as an issue; the production logs below are the evidence.

## What production logs, every cycle

```
promotion.enumerate search failed for seat:albina:  RuntimeError
promotion.enumerate search failed for seat:andreas: DatasetNotFoundError
promotion.enumerate search failed for seat:faizan:  DatasetNotFoundError
... 22 lines, 11 seats x 2 seed queries, every hour ...
Promotion stage finished: seats=11 promoted=0 failures=0 dry_run=False
Evolve stage promotion: ok
```

Every seat fails every query, and the stage reports `failures=0` and `ok`. Promotion has been doing nothing while reporting success.

## Why the count was zero

`failures` in `scripts/run_railway.py:250-262` only increments when `engine.run()` raises. But `PromotionEngine.enumerate` caught each seed-query exception, logged a warning, and returned `[]`. An empty list from a broken search is indistinguishable from an empty list from a seat with nothing to promote, so `engine.run` returned normally with zero candidates and the failure was gone.

## The change

`enumerate` now raises `PromotionEnumerationError` when **every query it actually ran** failed.

Deliberately not "any query failed":
- one flaky query out of two keeps the existing best-effort behaviour
- a genuinely empty seat still returns `[]`
- the early `break` at the candidate cap is accounted for, so queries that never ran do not count toward the total

## Callers

Both already handle a raise, and both get more honest as a result:

- `scripts/run_railway.py:253` counts the seat as a failure. With every seat failing, `failures == len(seats)`, so the stage returns 1, and with #89 (PR #137) the pass exits nonzero and the cycle is finally visible.
- `kb/server.py:4678` has a catch-all `except Exception` that records an audit event and returns 500. Today that endpoint returns `200 {"promoted": 0}` while everything failed.

## Note on the two error types

The 22 failures are **two separate bugs**, and this PR only makes them visible:

| Error | Seats | Cause |
|---|---|---|
| `RuntimeError` | albina, jami, patrick, peter, sarthi | the Kuzu lock, #88 |
| `DatasetNotFoundError` | andreas, faizan, francis, isaac, phil, sandro | seat-less tokens, no dataset |

Fixing #88 fixes 5 seats. The other 6 need their own fix and are not covered here.

## Tests

Three added, and the first was verified to fail when the raise is removed:

- `test_enumerate_raises_when_every_seed_query_fails`
- `test_enumerate_stays_best_effort_when_one_query_fails`
- `test_enumerate_returns_empty_without_raising_when_searches_succeed`

`957 passed, 1 skipped` with the project venv. Ruff clean.