### PR TITLE
fix(cognify): require a real search hit for the verify canary (#114)

### DIFF
--- a/kb/service.py
+++ b/kb/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 from hashlib import sha256
 import logging
@@ -28,6 +29,12 @@ logger = logging.getLogger(__name__)
 # negatives/zero to 1 and caps absurd values so no caller — present, future, or one that
 # bypasses pydantic — can drive an unbounded recall into the search-backend timeout.
 MAX_SEARCH_TOP_K = 100
+
+# The cognify verify canary re-searches for its marker, because cognify can be
+# settling when the first search runs. Module-level so a test can shrink them
+# instead of sleeping through the real backoff.
+CANARY_SEARCH_ATTEMPTS = 3
+CANARY_SEARCH_BACKOFF_SECONDS = 2.0
 
 
 class Citadel:
@@ -250,10 +257,23 @@ class Citadel:
             marker = f"COGNIFY_TEST_MARKER_{uuid4().hex}"
             await self.ingest(marker, dataset=target_dataset)
             await self.cognee.cognify(datasets=[target_dataset], force=force)
-            matches = await self.search(marker, dataset=target_dataset, top_k=10)
+            # Cognify can still be settling, so re-search a bounded number of
+            # times before calling it a miss (#114). Without this, requiring a
+            # real search hit would flag a slow-but-healthy node as broken.
+            search_hit = False
+            attempts = 0
+            for attempt in range(CANARY_SEARCH_ATTEMPTS):
+                attempts = attempt + 1
+                matches = await self.search(marker, dataset=target_dataset, top_k=10)
+                if _marker_in_results(marker, matches):
+                    search_hit = True
+                    break
+                if attempts < CANARY_SEARCH_ATTEMPTS:
+                    await asyncio.sleep(CANARY_SEARCH_BACKOFF_SECONDS)
             verification = {
                 "marker": marker,
-                "search_hit": _marker_in_results(marker, matches),
+                "search_hit": search_hit,
+                "search_attempts": attempts,
             }
             # Backprop (#15): the canary marker used to persist forever, surfacing in
             # search/linear_search results. Delete its node now so verify leaves no
@@ -266,7 +286,12 @@ class Citadel:
         )
         if verification is not None:
             verification["graph_grew"] = graph_grew
-            verification["ok"] = bool(verification["search_hit"] or graph_grew)
+            # graph_grew is diagnostic detail, NOT a pass condition (#114). Any
+            # concurrent ingest grows the graph, so growth is no evidence that
+            # THIS marker became retrievable. Production showed the cost:
+            # "grew=True canary_ok=True" every hour while two of five ingest
+            # stages were dead on the Kuzu lock and contributing nothing.
+            verification["ok"] = bool(verification["search_hit"])
 
         return {
             # Surface the verify canary verdict at the top level so the CLI exit

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,6 +9,7 @@ from kb.config import CitadelConfig
 from kb.models import FeedbackRequest
 from kb.security_scan import SecretContentError
 from kb.service import MAX_SEARCH_TOP_K, Citadel
+import kb.service as service
 
 
 class FakeCognee:
@@ -232,8 +233,11 @@ async def test_cognify_dataset_verify_ingests_marker_and_confirms_hit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cognify_dataset_verify_failure_propagates_top_level_ok() -> None:
+async def test_cognify_dataset_verify_failure_propagates_top_level_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A failed verify canary must set top-level ok=False (CLI exit code)."""
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
 
     class StuckCognee(FakeCognee):
         async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
@@ -249,7 +253,62 @@ async def test_cognify_dataset_verify_failure_propagates_top_level_ok() -> None:
     result = await kb.cognify_dataset(verify=True)
 
     assert result["verification"]["ok"] is False
+    assert result["verification"]["search_attempts"] == service.CANARY_SEARCH_ATTEMPTS
     assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_cognify_canary_is_not_ok_on_graph_growth_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#114: a growing graph is not evidence the marker became retrievable.
+
+    Production ran "grew=True canary_ok=True" every hour while github_sync and
+    linear_sync were dead on the Kuzu lock. Any concurrent ingest grows the
+    graph, so growth must stay diagnostic detail and never a pass condition.
+    """
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
+
+    class GrowsButUnsearchable(FakeCognee):
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            return []  # never retrievable...
+
+    fake = GrowsButUnsearchable()  # ...but FakeCognee's graph still grows
+    kb = Citadel(CitadelConfig(default_dataset="masumi-network"), cognee=fake)
+
+    result = await kb.cognify_dataset(verify=True)
+
+    assert result["verification"]["graph_grew"] is True
+    assert result["verification"]["search_hit"] is False
+    assert result["verification"]["ok"] is False
+    assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_cognify_canary_accepts_a_late_search_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cognify settles in the background, so a bounded retry must be allowed."""
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
+
+    class SlowCognee(FakeCognee):
+        def __init__(self) -> None:
+            super().__init__()
+            self.recall_calls = 0
+
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.recall_calls += 1
+            # Miss once, then settle — a healthy node that is merely slow.
+            return [] if self.recall_calls < 2 else [{"content": query}]
+
+    fake = SlowCognee()
+    kb = Citadel(CitadelConfig(default_dataset="masumi-network"), cognee=fake)
+
+    result = await kb.cognify_dataset(verify=True)
+
+    assert result["verification"]["search_hit"] is True
+    assert result["verification"]["search_attempts"] == 2
+    assert result["ok"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #114.

## Caught live in production while root-causing #88

```
Evolve scheduler: cognify finished (graph_after={'nodes': 14652, 'edges': 103257} grew=True canary_ok=True)
Evolve scheduler: cognify finished (graph_after={'nodes': 14656, 'edges': 103291} grew=True canary_ok=True)
Evolve scheduler: cognify finished (graph_after={'nodes': 14670, 'edges': 103758} grew=True canary_ok=True)
```

`canary_ok=True` on all three, while `github_sync` and `linear_sync` failed on the Kuzu lock in every one of those cycles and contributed nothing to the graph the canary was "verifying". The graph grew by 18 nodes in three hours, which is what two of five dead ingest stages looks like.

This is the exact false-green the issue predicted.

## The change

`kb/service.py`: `verification["ok"]` now requires `search_hit`. `graph_grew` stays in the payload as diagnostic detail.

Because cognify settles in the background, tightening the condition alone would flag a slow-but-healthy node as broken. So the marker search retries a bounded number of times before counting as a miss, and the payload gains `search_attempts` so an operator can see whether a pass was instant or took the full budget.

`CANARY_SEARCH_ATTEMPTS = 3` and `CANARY_SEARCH_BACKOFF_SECONDS = 2.0` are module constants specifically so tests shrink the backoff to 0 rather than sleeping. Without that, the existing failure test really did sleep about 4 seconds.

## Blast radius

`ok` feeds `/readyz` (503), the `scripts/run_railway.py` exit code, and `citadel doctor`. A node whose cognify genuinely does not make content retrievable will now go red where it previously stayed green. That is the point of the issue, but it is the thing to watch after deploy.

## Tests

Four, and the key one was verified to fail against the old condition (`assert True is False` at `tests/test_service.py:283`):

- `test_cognify_canary_is_not_ok_on_graph_growth_alone` — new, the regression guard
- `test_cognify_canary_accepts_a_late_search_hit` — new, proves the retry works and pins `search_attempts == 2`
- `test_cognify_dataset_verify_failure_propagates_top_level_ok` — now also asserts the full attempt budget was spent
- `test_cognify_dataset_verify_ingests_marker_and_confirms_hit` — unchanged, still green

`956 passed, 1 skipped` with the project venv. Ruff clean.