### PR TITLE
fix(evolve): run Phase 1 in the web loop instead of a subprocess (#88)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import contextvars
 import logging
 import os
+from collections.abc import Iterator
 from time import monotonic, perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
@@ -65,12 +68,39 @@ def assert_cognee_dataset_api() -> None:
     from cognee.modules.users.methods import get_default_user  # noqa: F401
 
 
-def _suppress_inline_cognify() -> bool:
-    """True when this process must ADD only and never cognify (Kuzu write).
+_SUPPRESS_INLINE_COGNIFY: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "citadel_suppress_inline_cognify", default=False
+)
 
-    Set on the evolve Phase-1 subprocess so it cannot write Kuzu while the web
-    process owns the single writer (#47); the web cognifies in Phase 2.
+
+@contextlib.contextmanager
+def suppress_inline_cognify() -> Iterator[None]:
+    """Make this task tree ADD only, without touching the rest of the process.
+
+    The evolve Phase 1 used to be a subprocess carrying
+    CITADEL_SUPPRESS_INLINE_COGNIFY=true in its env. Now that it runs inside the
+    web process (#88), an env var would be the wrong tool: it is process-wide, so
+    a teammate's ingest arriving during the ~30s pass would silently go add-only
+    too. A context variable is scoped to this task tree, and asyncio propagates
+    it into child tasks and ``asyncio.to_thread`` calls, which is exactly the
+    reach the stages need and no further.
     """
+    token = _SUPPRESS_INLINE_COGNIFY.set(True)
+    try:
+        yield
+    finally:
+        _SUPPRESS_INLINE_COGNIFY.reset(token)
+
+
+def _suppress_inline_cognify() -> bool:
+    """True when this caller must ADD only and never cognify (Kuzu write).
+
+    Set by :func:`suppress_inline_cognify` around the in-loop evolve Phase 1, or
+    process-wide by CITADEL_SUPPRESS_INLINE_COGNIFY for the standalone evolve
+    entrypoint. Either way the web cognifies in Phase 2 as the sole writer (#47).
+    """
+    if _SUPPRESS_INLINE_COGNIFY.get():
+        return True
     return os.getenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "").strip().lower() in {
         "1",
         "true",

--- a/kb/server.py
+++ b/kb/server.py
@@ -246,56 +246,47 @@ async def _evolve_scheduler_loop(interval_seconds: int) -> None:
     first pass waits one full interval so a redeploy never triggers a heavy cycle
     on boot.
     """
-    import sys
+    from kb.cognee_client import suppress_inline_cognify
+    from scripts.run_railway import run_evolve_in_loop
 
     while True:
         await asyncio.sleep(interval_seconds)
         logger.info("Evolve scheduler: starting scheduled pass")
-        # Phase 1 — heavy stages in a subprocess that frees the Kuzu lock on exit.
-        # Hold the in-process writer lock across the subprocess so no web-loop
-        # cognify (an interactive ingest's, /api/cognify/run) writes Kuzu while the
-        # subprocess owns the on-disk lock — that cross-process overlap is the
-        # hourly "Lock is held by PID N" crash (#47). Phase 2 re-acquires it itself.
-        proc = None
+        # Phase 1 — heavy stages, in this loop. Hold the in-process writer lock
+        # across them so no interactive cognify (an ingest's, /api/cognify/run)
+        # writes Kuzu underneath the pass. Phase 2 re-acquires it itself.
         writer_lock = getattr(getattr(get_citadel(), "cognee", None), "writer_lock", None)
         acquired = False
         try:
             if writer_lock is not None:
                 await writer_lock.acquire()
                 acquired = True
-            proc = await asyncio.create_subprocess_exec(
-                sys.executable,
-                "-m",
-                "scripts.run_railway",
-                env={
-                    **os.environ,
-                    "CITADEL_RUN_MODE": "evolve",
-                    "CITADEL_EVOLVE_COGNIFY_ENABLED": "false",
-                    # Add-only in Phase 1: the per-ingest background cognify is a
-                    # Kuzu write, so suppress it here and let the web cognify in
-                    # Phase 2 as the sole writer — no cross-process collision (#47).
-                    "CITADEL_SUPPRESS_INLINE_COGNIFY": "true",
-                },
-            )
-            code = await proc.wait()
+            # Phase 1 runs HERE, in the web's own loop, not in a subprocess (#88).
+            # A second process can never open the graph: cognee holds an exclusive
+            # OS file lock on cognee_graph_kuzu for the lifetime of whichever
+            # process opens it, and that is always this one. github_sync and
+            # linear_sync died on "Could not set lock on file" every hour because
+            # of it. Add-only for the duration so the per-ingest background
+            # cognify does not storm the writer lock; Phase 2 below cognifies once
+            # as the sole writer (#47).
+            with suppress_inline_cognify():
+                code = await run_evolve_in_loop()
             if code == 0:
                 logger.info("Evolve scheduler: stages finished (exit=0)")
             else:
                 # A partial failure is the normal broken case, not an edge one:
-                # the stage names are already in the subprocess's "Evolve
-                # finished: ... failed=..." line, so log at ERROR here to make
-                # the cycle visibly bad rather than an INFO nobody reads (#89).
+                # the stage names are already on the "Evolve finished: ...
+                # failed=..." line, so log at ERROR here to make the cycle
+                # visibly bad rather than an INFO nobody reads (#89).
                 logger.error(
                     "Evolve scheduler: stages finished with failures (exit=%s) — "
                     "see the 'Evolve finished' line above for which stages failed",
                     code,
                 )
         except asyncio.CancelledError:
-            if proc is not None and proc.returncode is None:
-                proc.terminate()
             raise
         except Exception:
-            logger.exception("Evolve scheduler: stages subprocess failed")
+            logger.exception("Evolve scheduler: stages failed")
         finally:
             if acquired:
                 writer_lock.release()

--- a/scripts/run_github_sync.py
+++ b/scripts/run_github_sync.py
@@ -7,6 +7,7 @@ non-zero when the scheduler should mark the run as failed.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -226,7 +227,14 @@ def _print_result(result: dict[str, Any]) -> None:
     print(json.dumps(_public_summary(result), indent=2, default=str))
 
 
-def run() -> int:
+async def arun() -> int:
+    """The body of :func:`run`, awaitable on the caller's own event loop.
+
+    The evolve scheduler runs this inside the web process's loop (#88), where
+    ``run_async`` is unusable: it falls back to ``asyncio.run``, which raises
+    inside a running loop. Blocking HTTP moves to a thread so the web's request
+    loop is not stalled for the duration of the sync.
+    """
     force = _bool(os.getenv("CITADEL_GITHUB_SYNC_FORCE"), default=False)
     dry_run = _bool(os.getenv("CITADEL_GITHUB_SYNC_DRY_RUN"), default=False)
     post_to_chat = _bool(os.getenv("CITADEL_ORG_DIGEST_POST_TO_CHAT"), default=True)
@@ -252,7 +260,8 @@ def run() -> int:
             )
             return 1
         logger.info("Starting scheduled GitHub sync through %s", endpoint)
-        status_code, result = _post_json(
+        status_code, result = await asyncio.to_thread(
+            _post_json,
             endpoint,
             payload=payload,
             access_key=access_key,
@@ -267,16 +276,11 @@ def run() -> int:
             return 1
     else:
         logger.info("Starting scheduled GitHub sync in-process")
-        # run_async, not asyncio.run: in the evolve chain this shares the one stage
-        # loop so cognee's cached engine is not bound to a throwaway loop (#69).
-        # Standalone (no shared loop) it falls back to asyncio.run.
-        result = run_async(
-            _run_local(
-                force=force,
-                dry_run=dry_run,
-                post_to_chat=post_to_chat,
-                include_digest_preview=include_digest_preview,
-            )
+        result = await _run_local(
+            force=force,
+            dry_run=dry_run,
+            post_to_chat=post_to_chat,
+            include_digest_preview=include_digest_preview,
         )
 
     if result.get("ok") is False:
@@ -286,6 +290,16 @@ def run() -> int:
     _log_result(result)
     _print_result(result)
     return 0
+
+
+def run() -> int:
+    """Synchronous entrypoint for the CLI and the standalone cron service.
+
+    run_async, not asyncio.run: in the evolve chain this shares the one stage
+    loop so cognee's cached engine is not bound to a throwaway loop (#69).
+    Standalone (no shared loop) it falls back to asyncio.run.
+    """
+    return run_async(arun())
 
 
 def main() -> None:

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Awaitable
 from typing import Callable
 
 from scripts.stage_loop import run_async, stage_loop
@@ -60,6 +61,12 @@ def _github_sync_stage() -> int:
     return run_github_sync()
 
 
+async def _github_sync_stage_async() -> int:
+    from scripts.run_github_sync import arun
+
+    return await arun()
+
+
 def _skills_refresh_stage() -> int:
     from kb.skills import refresh_skill_catalog
 
@@ -80,17 +87,23 @@ def _self_improve_stage() -> int:
     return run_self_improve()
 
 
+async def _self_improve_stage_async() -> int:
+    from scripts.run_self_improve import arun
+
+    return await arun()
+
+
 def _backup_mirror_stage() -> int:
     from scripts.run_backup_mirror import run as run_backup_mirror
 
     return run_backup_mirror()
 
 
-def _repo_content_sync_stage() -> int:
+async def _repo_content_sync_stage_async() -> int:
     from kb.repo_content_sync import RepoContentSyncer
     from kb.service import Citadel
 
-    result = run_async(RepoContentSyncer(Citadel.from_env()).run())
+    result = await RepoContentSyncer(Citadel.from_env()).run()
     if not result.get("ok"):
         return 1
     if result.get("enabled") is False:
@@ -104,6 +117,10 @@ def _repo_content_sync_stage() -> int:
         result.get("improved"),
     )
     return 0
+
+
+def _repo_content_sync_stage() -> int:
+    return run_async(_repo_content_sync_stage_async())
 
 
 def _cognify_mode(*, verify: bool) -> int:
@@ -212,7 +229,7 @@ def _cognify_stage() -> int:
     return _cognify_mode(verify=False)
 
 
-def _promotion_stage() -> int:
+async def _promotion_stage_async() -> int:
     """Selective seat-node -> Central promotion across every seat (ADR-0005 step 3).
 
     Reuses :class:`kb.promotion.PromotionEngine`, honoring its opt-in
@@ -263,7 +280,7 @@ def _promotion_stage() -> int:
             promoted += result.get("promoted") or 0
         return promoted, failures
 
-    promoted, failures = run_async(_run())
+    promoted, failures = await _run()
     logger.info(
         "Promotion stage finished: seats=%s promoted=%s failures=%s dry_run=%s",
         len(seats),
@@ -275,6 +292,10 @@ def _promotion_stage() -> int:
     if failures and failures == len(seats):
         return 1
     return 0
+
+
+def _promotion_stage() -> int:
+    return run_async(_promotion_stage_async())
 
 
 def pipeline_stages() -> list[tuple[str, bool, Callable[[], int]]]:
@@ -308,7 +329,7 @@ def pipeline_stages() -> list[tuple[str, bool, Callable[[], int]]]:
     ]
 
 
-def _linear_sync_stage() -> int:
+async def _linear_sync_stage_async() -> int:
     """Sync the Linear workspace into Central (+ seat mirrors) for the evolve cron.
 
     No-op (exit 0) when ``CITADEL_LINEAR_API_KEY`` is unset, so the stage is safe
@@ -343,7 +364,11 @@ def _linear_sync_stage() -> int:
         )
         return 0
 
-    return run_async(_run())
+    return await _run()
+
+
+def _linear_sync_stage() -> int:
+    return run_async(_linear_sync_stage_async())
 
 
 def evolve_stages() -> list[tuple[str, bool, Callable[[], int]]]:
@@ -388,6 +413,60 @@ def evolve_stages() -> list[tuple[str, bool, Callable[[], int]]]:
             _cognify_stage,
         ),
     ]
+
+
+def evolve_stages_async() -> list[tuple[str, bool, Callable[[], Awaitable[int]]]]:
+    """The evolve stages as awaitables, for running inside the web loop (#88).
+
+    Mirrors :func:`evolve_stages` name-for-name and toggle-for-toggle;
+    ``test_evolve_stage_lists_stay_in_sync`` pins that. ``cognify`` is absent on
+    purpose: the scheduler runs it itself afterwards as Phase 2, which is what
+    the old subprocess expressed by setting CITADEL_EVOLVE_COGNIFY_ENABLED=false.
+    """
+    return [
+        (
+            "github_sync",
+            _bool(os.getenv("CITADEL_EVOLVE_GITHUB_SYNC_ENABLED"), default=True),
+            _github_sync_stage_async,
+        ),
+        (
+            "repo_content_sync",
+            _bool(os.getenv("CITADEL_EVOLVE_REPO_CONTENT_SYNC_ENABLED"), default=True),
+            _repo_content_sync_stage_async,
+        ),
+        (
+            "self_improve",
+            _bool(os.getenv("CITADEL_EVOLVE_SELF_IMPROVE_ENABLED"), default=True),
+            _self_improve_stage_async,
+        ),
+        (
+            "promotion",
+            _bool(os.getenv("CITADEL_EVOLVE_PROMOTION_ENABLED"), default=True),
+            _promotion_stage_async,
+        ),
+        (
+            "linear_sync",
+            _bool(os.getenv("CITADEL_EVOLVE_LINEAR_SYNC_ENABLED"), default=True),
+            _linear_sync_stage_async,
+        ),
+    ]
+
+
+async def run_evolve_in_loop() -> int:
+    """Run the evolve stages on the caller's loop. The web scheduler's Phase 1.
+
+    Replaces spawning ``python -m scripts.run_railway`` as a subprocess. That
+    subprocess could never succeed for any cognee-touching stage: the web
+    process's cognee Kuzu worker holds an exclusive file lock on
+    ``cognee_graph_kuzu`` for the container's lifetime, so github_sync and
+    linear_sync died on "Could not set lock on file" every single hour (#88,
+    #46). The subprocess existed to free that lock on exit, which was backwards.
+
+    Running here also retires the loop-binding hazard (#69) rather than working
+    around it: one process and one loop means cognee binds its cached engine
+    exactly once.
+    """
+    return await _run_stages_async(evolve_stages_async(), label="Evolve")
 
 
 def _run_stages(stages: list[tuple[str, bool, Callable[[], int]]], *, label: str) -> int:
@@ -440,6 +519,17 @@ def _run_stages(stages: list[tuple[str, bool, Callable[[], int]]], *, label: str
             failed.append(name)
             logger.error("%s stage %s: FAILED with exit code %s", label, name, code)
 
+    return _stage_verdict(label, succeeded, failed, skipped)
+
+
+def _stage_verdict(
+    label: str, succeeded: list[str], failed: list[str], skipped: list[str]
+) -> int:
+    """Log the pass summary and return its exit code.
+
+    Shared by the sync and in-loop stage runners so the #89 rule (any failed
+    stage means a failed pass) cannot drift between the two.
+    """
     logger.info(
         "%s finished: succeeded=%s failed=%s skipped=%s",
         label,
@@ -448,6 +538,50 @@ def _run_stages(stages: list[tuple[str, bool, Callable[[], int]]], *, label: str
         ",".join(skipped) or "none",
     )
     return 1 if failed else 0
+
+
+async def _run_stages_async(
+    stages: list[tuple[str, bool, Callable[[], Awaitable[int]]]], *, label: str
+) -> int:
+    """Run every enabled stage on the CALLER's event loop; continue past failures.
+
+    The in-loop twin of :func:`_run_stages`, used by the web process's evolve
+    scheduler (#88). It cannot reuse the sync version: those runners funnel
+    through ``run_async``, which falls back to ``asyncio.run`` and raises inside
+    a running loop. Running here instead of in a subprocess is the fix for the
+    Kuzu lock, because cognee holds an exclusive OS file lock on the graph for
+    the lifetime of whichever process opens it, and in this deployment that is
+    always the web.
+    """
+    succeeded: list[str] = []
+    failed: list[str] = []
+    skipped: list[str] = []
+    for name, enabled, runner in stages:
+        if not enabled:
+            skipped.append(name)
+            logger.info("%s stage %s: skipped (disabled via env)", label, name)
+            continue
+        logger.info("%s stage %s: starting", label, name)
+        try:
+            code = await runner()
+        except Exception as exc:
+            logger.error(
+                "%s stage %s: FAILED with %s: %s",
+                label,
+                name,
+                exc.__class__.__name__,
+                exc,
+            )
+            failed.append(name)
+            continue
+        if code == 0:
+            succeeded.append(name)
+            logger.info("%s stage %s: ok", label, name)
+        else:
+            failed.append(name)
+            logger.error("%s stage %s: FAILED with exit code %s", label, name, code)
+
+    return _stage_verdict(label, succeeded, failed, skipped)
 
 
 def run_pipeline() -> int:

--- a/scripts/run_self_improve.py
+++ b/scripts/run_self_improve.py
@@ -8,6 +8,7 @@ falls back to an in-process pass otherwise.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -123,7 +124,14 @@ def _log_result(result: dict[str, Any]) -> None:
     )
 
 
-def run() -> int:
+async def arun() -> int:
+    """The body of :func:`run`, awaitable on the caller's own event loop.
+
+    The evolve scheduler runs this inside the web process's loop (#88), where
+    ``run_async`` is unusable: it falls back to ``asyncio.run``, which raises
+    inside a running loop. Blocking HTTP moves to a thread so the web's request
+    loop is not stalled.
+    """
     dry_run = _bool(os.getenv("CITADEL_SELF_IMPROVE_DRY_RUN"), default=False)
     payload = {"dry_run": dry_run}
     endpoint = _target_endpoint()
@@ -137,7 +145,8 @@ def run() -> int:
             )
             return 1
         logger.info("Starting scheduled self-improvement through %s", endpoint)
-        status_code, result = _post_json(
+        status_code, result = await asyncio.to_thread(
+            _post_json,
             endpoint,
             payload=payload,
             access_key=access_key,
@@ -148,9 +157,7 @@ def run() -> int:
             return 1
     else:
         logger.info("Starting scheduled self-improvement in-process")
-        # run_async shares the evolve chain's single loop so cognee's cached engine
-        # is not bound to a throwaway loop (#69); standalone it is asyncio.run.
-        result = run_async(_run_local(dry_run=dry_run))
+        result = await _run_local(dry_run=dry_run)
 
     if result.get("ok") is False:
         logger.error("Self-improvement pass failed: %s", result)
@@ -158,6 +165,15 @@ def run() -> int:
 
     _log_result(result)
     return 0
+
+
+def run() -> int:
+    """Synchronous entrypoint for the CLI and the standalone cron service.
+
+    run_async shares the evolve chain's single loop so cognee's cached engine
+    is not bound to a throwaway loop (#69); standalone it is asyncio.run.
+    """
+    return run_async(arun())
 
 
 def main() -> None:

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -68,17 +68,6 @@ async def test_stop_evolve_scheduler_handles_none() -> None:
     await server._stop_evolve_scheduler(None)
 
 
-class _FakeProc:
-    def __init__(self, returncode: int = 0) -> None:
-        self.returncode = returncode
-
-    async def wait(self) -> int:
-        return self.returncode
-
-    def terminate(self) -> None:  # pragma: no cover - only on cancel
-        pass
-
-
 class _FakeCitadel:
     def __init__(self, cognify_calls: list[bool]) -> None:
         self._cognify_calls = cognify_calls
@@ -95,17 +84,49 @@ class _FakeCitadel:
         }
 
 
-async def test_evolve_scheduler_loop_runs_subprocess_then_cognifies(monkeypatch: Any) -> None:
+def _patch_phase1(monkeypatch: Any, *, code: int = 0, raises: bool = False) -> list[bool]:
+    """Replace Phase 1 with a stub and report whether it saw add-only mode.
+
+    Patches scripts.run_railway.run_evolve_in_loop, which kb.server imports by
+    name when the scheduler coroutine starts, so this must be set before the
+    task is created.
+    """
+    from kb.cognee_client import _suppress_inline_cognify
+    import scripts.run_railway as run_railway
+
+    suppressed: list[bool] = []
+
+    async def fake_phase1() -> int:
+        suppressed.append(_suppress_inline_cognify())
+        if raises:
+            raise RuntimeError("phase 1 exploded")
+        return code
+
+    monkeypatch.setattr(run_railway, "run_evolve_in_loop", fake_phase1)
+    return suppressed
+
+
+async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
+    monkeypatch: Any,
+) -> None:
+    """Phase 1 runs in THIS process now, not a subprocess (#88).
+
+    A second process can never open the Kuzu graph: cognee holds an exclusive
+    file lock for the lifetime of whichever process opens it, and that is always
+    the web. github_sync and linear_sync failed on that lock every hour.
+    """
     import kb.server as server
 
-    sub_envs: list[dict[str, Any]] = []
     cognify_calls: list[bool] = []
+    suppressed = _patch_phase1(monkeypatch)
 
-    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
-        sub_envs.append(kwargs.get("env", {}))
-        return _FakeProc(0)
+    spawned: list[Any] = []
 
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    async def forbidden_exec(*args: Any, **kwargs: Any) -> Any:
+        spawned.append(args)
+        raise AssertionError("the evolve scheduler must not spawn a subprocess")
+
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", forbidden_exec)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
     task = asyncio.create_task(server._evolve_scheduler_loop(0.001))
@@ -119,27 +140,44 @@ async def test_evolve_scheduler_loop_runs_subprocess_then_cognifies(monkeypatch:
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
-    assert len(sub_envs) >= 2
-    # Phase 1: heavy stages in a subprocess with cognify disabled (frees the lock).
-    assert sub_envs[0]["CITADEL_RUN_MODE"] == "evolve"
-    assert sub_envs[0]["CITADEL_EVOLVE_COGNIFY_ENABLED"] == "false"
-    # ...and add-only so its per-ingest background cognify never writes Kuzu (#47).
-    assert sub_envs[0]["CITADEL_SUPPRESS_INLINE_COGNIFY"] == "true"
-    # Phase 2: cognify ran in-loop after the subprocess.
+    assert spawned == [], "no subprocess may be spawned"
+    # Phase 1 ran, and saw add-only mode so its per-ingest background cognify
+    # cannot storm the writer lock — what the subprocess env used to express.
+    assert suppressed and all(suppressed)
+    # Phase 2: cognify ran in-loop afterwards.
     assert len(cognify_calls) >= 2
     # The verify canary verdict is recorded for /readyz (#27).
     assert server._LAST_CANARY is not None and server._LAST_CANARY["ok"] is True
 
 
-async def test_evolve_scheduler_loop_cognifies_even_if_subprocess_fails(monkeypatch: Any) -> None:
+async def test_add_only_mode_does_not_leak_outside_the_pass() -> None:
+    """The suppression is scoped to the task tree, never process-wide (#88).
+
+    It used to be an env var on a subprocess. In the web process an env var
+    would make a teammate's ingest arriving mid-pass go add-only too.
+    """
+    from kb.cognee_client import _suppress_inline_cognify, suppress_inline_cognify
+
+    assert _suppress_inline_cognify() is False
+
+    async def observer() -> bool:
+        return _suppress_inline_cognify()
+
+    with suppress_inline_cognify():
+        assert _suppress_inline_cognify() is True
+        # Child tasks created inside the context inherit it...
+        assert await asyncio.create_task(observer()) is True
+
+    assert _suppress_inline_cognify() is False
+    # ...and a task created outside it never sees it.
+    assert await asyncio.create_task(observer()) is False
+
+
+async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(monkeypatch: Any) -> None:
     import kb.server as server
 
     cognify_calls: list[bool] = []
-
-    async def boom_exec(*args: Any, **kwargs: Any) -> _FakeProc:
-        raise RuntimeError("spawn boom")
-
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", boom_exec)
+    _patch_phase1(monkeypatch, raises=True)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
     task = asyncio.create_task(server._evolve_scheduler_loop(0.001))
@@ -153,7 +191,7 @@ async def test_evolve_scheduler_loop_cognifies_even_if_subprocess_fails(monkeypa
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
-    # A failed stages-subprocess (caught) must not skip the in-loop cognify.
+    # A raising Phase 1 (caught) must not skip the in-loop cognify.
     assert len(cognify_calls) >= 2
 
 
@@ -164,18 +202,14 @@ async def test_evolve_scheduler_logs_error_when_stages_exit_nonzero(
 
     Production ran for days with github_sync and linear_sync failing on the
     Kuzu lock every hour while this logged "stages finished (exit=0)" at INFO.
-    Now the subprocess returns nonzero and the scheduler says so at ERROR.
+    Now a partial failure returns nonzero and the scheduler says so at ERROR.
     """
     import logging
 
     import kb.server as server
 
     cognify_calls: list[bool] = []
-
-    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProc:
-        return _FakeProc(1)
-
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    _patch_phase1(monkeypatch, code=1)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
     with caplog.at_level(logging.ERROR, logger=server.logger.name):

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -483,3 +483,33 @@ def test_evolve_runs_cognee_stage_bodies_on_one_loop(monkeypatch: Any) -> None:
     assert run_railway.run("evolve") == 0
     assert len(seen) == 2
     assert seen[0] == seen[1]  # repo_content_sync and linear_sync shared one loop
+
+
+def test_evolve_stage_lists_stay_in_sync() -> None:
+    """The sync and in-loop evolve stage lists must not drift (#88).
+
+    evolve_stages() drives the CLI/cron entrypoint and evolve_stages_async()
+    drives the web scheduler. They are separate literals, so this pins that they
+    name the same stages, in the same order, with the same enabled flags.
+    cognify is the one deliberate exception: the scheduler runs it itself as
+    Phase 2, which the old subprocess expressed via an env toggle.
+    """
+    sync_stages = [(name, enabled) for name, enabled, _ in run_railway.evolve_stages()]
+    async_stages = [
+        (name, enabled) for name, enabled, _ in run_railway.evolve_stages_async()
+    ]
+
+    assert [name for name, _ in sync_stages if name != "cognify"] == [
+        name for name, _ in async_stages
+    ]
+    assert "cognify" in dict(sync_stages), "the sync list still owns the cognify stage"
+    for name, enabled in async_stages:
+        assert dict(sync_stages)[name] == enabled, f"{name} toggle drifted"
+
+
+def test_evolve_async_stages_are_all_coroutine_functions() -> None:
+    """A sync callable here would silently never run inside the web loop."""
+    import inspect
+
+    for name, _, runner in run_railway.evolve_stages_async():
+        assert inspect.iscoroutinefunction(runner), f"{name} is not awaitable"


### PR DESCRIPTION
Closes #88. Closes #69.

## Root cause

The evolve scheduler spawned `python -m scripts.run_railway` as a subprocess. **That subprocess could never open the graph.** cognee opens Kuzu read-write with an exclusive OS file lock and holds it for the lifetime of whichever process opens it, and in this deployment that is always the web:

```
Evolve stage github_sync: FAILED with RuntimeError: IO exception: Could not set lock on file :
  /data/.cognee_system/databases/cognee_graph_kuzu (Lock is held by PID 44)
Evolve stage linear_sync: FAILED with RuntimeError: ... (Lock is held by PID 44)
```

`PID 44` was constant across cycles hours apart while the web server is PID 1, because it is the web's own cognee Kuzu **worker child**: `graph_database_subprocess_enabled` defaults to `True` (`graph/config.py:60`), the child opens the database (`cognee_db_workers/kuzu_worker.py:36`), and the adapter is pinned for the container's lifetime by `@closing_lru_cache` on `_create_graph_engine` (`get_graph_engine.py:244`). Confirmed locally with the same wheels via `lsof`: the spawn child holds the file, the parent does not.

The subprocess existed to "free the Kuzu lock on exit" (`kb/server.py:253`). That was backwards. It was the one that could not acquire it.

## Why the existing mitigation never worked

`kb/cognee_client.py:335-337` claimed:

> Add is a fast write to the relational + vector stores; it does NOT touch the Kuzu graph (cognify is the graph write).

**False for cognee 1.2.2.** `cognee/modules/pipelines/operations/run_tasks.py:166` calls `graph_engine = await get_graph_engine()` at the end of every pipeline run, purely to evaluate `hasattr(graph_engine, "push_to_s3")`. So `cognee.add` is a Kuzu opener.

And the `CITADEL_SUPPRESS_INLINE_COGNIFY` guard sits at line 353 — **fourteen lines after** the `cognee.add` on line 339 that actually throws. The mitigation was positioned after the failure it was meant to prevent.

## The change

Phase 1 now runs on the web's own event loop. One process, one Kuzu owner.

That also **retires #69 rather than working around it**: the loop-binding hazard existed because stages ran on throwaway loops in a separate process. One process and one loop means cognee binds its cached engine exactly once.

Three details worth reviewing:

1. **One implementation per stage.** The async form is the primitive; the sync entrypoint wraps it in `run_async`. The CLI and standalone cron paths are byte-for-byte unchanged in behaviour.

2. **`_run_stages_async` is a separate loop from `_run_stages`, deliberately.** They cannot be unified: the sync runners funnel through `run_async`, which falls back to `asyncio.run` and raises inside a running loop, so routing the sync path through an outer loop would break `pipeline` mode. They share `_stage_verdict` so the #89 rule (any failed stage fails the pass) cannot drift between them, and `test_evolve_stage_lists_stay_in_sync` pins the two stage lists together.

3. **Add-only mode is now a context variable, not an env var.** On a subprocess an env var was correct. In the web process it is process-wide, so a teammate's ingest arriving during the ~30s pass would silently go add-only too. A contextvar is scoped to the task tree and asyncio propagates it into child tasks and `asyncio.to_thread`, which is exactly the reach the stages need. `test_add_only_mode_does_not_leak_outside_the_pass` pins both directions.

Blocking HTTP inside the two script stages moved to `asyncio.to_thread` so the pass does not stall the request loop.

## What to watch after deploy

The stage work now runs on the web loop. github_sync spends ~24s on ~57 sequential GitHub calls, but those are inside `asyncio.to_thread`, so they should not block the loop. Given #105 (event-loop starvation) is still open, this is the thing to watch on the first cycle.

## Tests

`963 passed, 1 skipped`, ruff clean.

Rewriting the scheduler tests exposed a real problem in the old ones: they patched `create_subprocess_exec`, which this change removes from the path, so they had been running the **real** stages. The suite went 12s to 39s until they were fixed. The new `test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies` asserts positively that **no subprocess is spawned**.

New: the no-subprocess test, the contextvar leak test in both directions, the stage-list drift test, and a guard that every async runner really is a coroutine function (a sync callable there would silently never run).