### PR TITLE
fix(server): log a background scheduler task that dies

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -111,6 +111,26 @@ MCP_ENDPOINT_PATH = "/mcp/"
 # the event loop does not garbage-collect them mid-flight.
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
+
+def _forget_background_task(task: "asyncio.Task[Any]") -> None:
+    """Drop a finished task, and say so out loud if it died.
+
+    A bare ``set.discard`` done-callback loses the exception: a scheduler that
+    raises on its first line just stops existing, and the only trace is
+    asyncio's "Task exception was never retrieved" whenever the object happens
+    to be collected. That is the same silent-failure shape as #89, and it got
+    more likely once the evolve scheduler started importing and running the
+    stage code itself rather than shelling out (#88).
+    """
+    _BACKGROUND_TASKS.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "Background task %s died: %s", task.get_name(), exc, exc_info=exc
+        )
+
 # Most recent evolve-scheduler cognify canary verdict (verify=True), surfaced via
 # /readyz so an always-on health probe goes RED when end-to-end ingest+cognify+
 # search stops working — not only when node/auth are down (#27). None until the
@@ -325,10 +345,10 @@ def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":
     """Launch the 6h evolve cron when enabled.
 
     A separate Railway service cannot host this: the stages work against the Kuzu
-    graph + JSON access store on the local ``/data`` volume, and Railway volumes
-    attach to a single service. The scheduler runs the heavy stages as a
-    subprocess on the web container and then cognifies in-loop (see
-    :func:`_evolve_scheduler_loop` for why the split is required). Off by default
+    graph + JSON access store on the local ``/data`` volume, Railway volumes
+    attach to a single service, and a second process cannot open the graph at all
+    while this one holds cognee's exclusive Kuzu lock (#88). The scheduler runs
+    the stages in this loop and then cognifies, both here. Off by default
     (``CITADEL_EVOLVE_SCHEDULER_ENABLED``).
     """
     config = get_citadel().config
@@ -336,9 +356,9 @@ def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":
         return None
     interval = max(60, config.evolve_interval_seconds)
     logger.info("Evolve scheduler enabled: interval=%ss", interval)
-    task = asyncio.create_task(_evolve_scheduler_loop(interval))
+    task = asyncio.create_task(_evolve_scheduler_loop(interval), name="evolve-scheduler")
     _BACKGROUND_TASKS.add(task)
-    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    task.add_done_callback(_forget_background_task)
     return task
 
 

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -227,3 +227,35 @@ async def test_evolve_scheduler_logs_error_when_stages_exit_nonzero(
     failures = [r for r in caplog.records if "stages finished with failures" in r.message]
     assert failures, "a nonzero stages exit must be logged at ERROR"
     assert failures[0].levelno == logging.ERROR
+
+
+async def test_a_dying_scheduler_task_is_logged(monkeypatch: Any, caplog: Any) -> None:
+    """A scheduler that dies on its first line must not vanish silently.
+
+    The done-callback used to be a bare set.discard, which swallows the
+    exception: the task would simply stop existing. That is the same
+    silent-failure shape as #89, and it matters more now that the scheduler
+    imports and runs the stage code itself instead of shelling out (#88).
+    """
+    import logging
+
+    import kb.server as server
+
+    async def boom(_interval: float) -> None:
+        raise RuntimeError("scheduler could not start")
+
+    monkeypatch.setattr(server, "_evolve_scheduler_loop", boom)
+    monkeypatch.setattr(
+        server, "get_citadel", lambda: _fake_citadel(enabled=True, interval=999_999)
+    )
+
+    with caplog.at_level(logging.ERROR, logger=server.logger.name):
+        task = server._start_evolve_scheduler()
+        assert task is not None
+        with contextlib.suppress(RuntimeError):
+            await task
+        await asyncio.sleep(0)  # let the done-callback run
+
+    died = [r for r in caplog.records if "died" in r.message]
+    assert died, "a scheduler task that raised must be logged at ERROR"
+    assert "evolve-scheduler" in died[0].getMessage()


### PR DESCRIPTION
Follow-up to #140, found while verifying that deploy was safe.

## The gap

```python
task.add_done_callback(_BACKGROUND_TASKS.discard)
```

`set.discard` never touches `task.exception()`, so a task that raises simply stops existing. The only trace is asyncio's `Task exception was never retrieved`, emitted whenever the object happens to be garbage collected, which may be never.

Concretely: if `_evolve_scheduler_loop` raised on its first line, the evolve scheduler would be dead for the life of the container and the logs would say nothing. You would find out when you noticed the vault had stopped growing.

This is the same silent-failure shape as #89, which is the whole theme of the last few PRs.

## Why now

#140 made it more likely. The scheduler used to shell out to a subprocess, so a failure in the stage code killed a child and the parent logged the exit code. Now the scheduler imports `scripts.run_railway` and runs the stage code in its own coroutine, so an `ImportError` or a bad stage kills **the scheduler itself**.

I checked the specific risk before writing this and the import does resolve from a neutral cwd, so #140 is safe to deploy. But "I checked this one path manually" is not a substitute for the failure being visible.

## The change

A `_forget_background_task` callback that discards as before, ignores cancellation, and logs at ERROR with a traceback if the task died. The evolve task also gets `name="evolve-scheduler"` so the message identifies it.

Scoped to the evolve scheduler deliberately. The same bare-`discard` pattern is at `kb/server.py:390` (repo stats) and `:4095`; both would benefit, but they are not what #140 touched and I did not want to widen this.

Also corrects `_start_evolve_scheduler`'s docstring, which still described the subprocess #140 removed. That drift is mine.

## Tests

`test_a_dying_scheduler_task_is_logged`, verified to fail when the callback is reverted to `_BACKGROUND_TASKS.discard`.

`964 passed, 1 skipped`. Ruff clean.