### PR TITLE
feat(contact): store partner enquiries instead of losing them

### DIFF
--- a/docs/adr/0013-public-contact-endpoint.md
+++ b/docs/adr/0013-public-contact-endpoint.md
@@ -67,3 +67,41 @@ Constraints that make the endpoint safe enough to expose:
 - If the Chat gateway is unconfigured in an environment, the form is visibly
   broken (503 on submit) rather than quietly useless. That is deliberate, but it
   means the gateway is now part of what `/contact` depends on to work.
+
+## Amendment, 2026-07-30: enquiries are stored before they are relayed
+
+The last consequence above is exactly what happened, and it was worse in
+practice than on paper. The Chat gateway was never configured in production, so
+from the day the public site shipped every enquiry answered 503 and was lost.
+Nothing in the logs said so either: `contact_gateway()` only warns when
+`from_config` *raises*, and the disabled-by-default path returns `None` in
+silence.
+
+"Visibly broken" turned out to mean visible to the sender, who sees an error and
+leaves, and invisible to us.
+
+**What changes.** `POST /contact` now writes the enquiry to a capped JSON file on
+the state volume (`kb/contact_store.py`, `CITADEL_CONTACT_STORE_PATH`) *before*
+attempting the Chat relay, and returns 200 when the write succeeded even if no
+gateway is configured or delivery fails. `GET /api/contact/enquiries` reads the
+queue, admin only. 503 survives for the case where the enquiry can be neither
+stored nor delivered.
+
+**Why this is consistent with the decision above, not a reversal.** The rule was
+never "do not persist"; it was that *an enquiry is never accepted into a void*.
+A file on disk is not a void. A 503 that loses the message is closer to one.
+
+**What does not change.** Destination 1 in the Context section, landing enquiries
+in the vault, stays rejected for exactly the reasons given: unauthenticated text
+must not reach the substrate agents read as authority. The store is a fourth
+destination, deliberately outside the knowledge path, with no search over it and
+no promotion path out of it. A test (`test_contact_is_never_written_to_the_vault`)
+holds that line.
+
+**Cost accepted.** The service now has one unauthenticated write path that
+persists, which the original decision explicitly prized not having. The
+mitigations that made the relay safe all still apply (rate limits, length caps,
+honeypot, scrubbing), and the store is capped at 500 entries so the endpoint
+cannot grow the volume without bound. Note that the stored rows are personal
+data (name, email), so they carry retention obligations that a Chat message
+also carried but that are now ours to honor directly.

--- a/kb/config.py
+++ b/kb/config.py
@@ -85,6 +85,17 @@ def _access_store_path(value: str | None) -> str:
     return str(Path(root) / "access.json")
 
 
+def _contact_store_path(value: str | None) -> str:
+    if value:
+        return value
+    root = (
+        os.getenv("CITADEL_STATE_DIRECTORY")
+        or os.getenv("SYSTEM_ROOT_DIRECTORY")
+        or ("/data/.citadel" if Path("/data").exists() else ".citadel")
+    )
+    return str(Path(root) / "contacts.json")
+
+
 def _obsidian_sync_state_path(value: str | None) -> str:
     if value:
         return value
@@ -149,6 +160,7 @@ class CitadelConfig:
     reader_keys: tuple[str, ...] = field(default_factory=tuple)
     writer_keys: tuple[str, ...] = field(default_factory=tuple)
     access_store_path: str = ".citadel/access.json"
+    contact_store_path: str = ".citadel/contacts.json"
     obsidian_sync_state_path: str = ".citadel/obsidian_sync_state.json"
     conflicts_store_path: str = ".citadel/conflicts.json"
     conflicts_max_records: int = 500
@@ -270,6 +282,7 @@ class CitadelConfig:
             reader_keys=tuple(_csv(os.getenv("CITADEL_READER_KEYS"))),
             writer_keys=tuple(_csv(os.getenv("CITADEL_WRITER_KEYS"))),
             access_store_path=_access_store_path(os.getenv("CITADEL_ACCESS_STORE_PATH")),
+            contact_store_path=_contact_store_path(os.getenv("CITADEL_CONTACT_STORE_PATH")),
             obsidian_sync_state_path=_obsidian_sync_state_path(
                 os.getenv("CITADEL_OBSIDIAN_SYNC_STATE_PATH")
             ),

--- a/kb/contact_store.py
+++ b/kb/contact_store.py
@@ -1,0 +1,67 @@
+"""Durable storage for public /contact enquiries (ADR-0013, amended).
+
+Deliberately NOT the vault. ADR-0013 rejected landing enquiries as Structured
+Knowledge and that rejection stands: unauthenticated public text must never
+reach the substrate agents read as authority. This is a plain capped JSON file
+on the state volume, sitting beside the access store, readable only by an admin.
+
+It exists because the Google Chat gateway is unconfigured, so every enquiry was
+answering 503 and vanishing. ADR-0013's own rule is that an enquiry is never
+accepted into a void; a file on disk is not a void, and a 503 shown to a partner
+who then gives up is a worse outcome than one that fails to reach Chat.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Enough that nothing is lost between someone reading the queue, small enough
+# that an unauthenticated endpoint cannot grow the state volume without bound.
+# The per-IP and global rate limits in kb/server.py are the first cap; this is
+# the backstop if those are defeated by a spread of source addresses.
+MAX_STORED_ENQUIRIES = 500
+
+
+class ContactStore:
+    """Append-only, capped, newest-last store of partner enquiries."""
+
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+
+    def _load(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # A corrupt file must not take the public endpoint down with it.
+            logger.exception("Contact store unreadable at %s; treating as empty", self.path)
+            return []
+        entries = raw.get("enquiries") if isinstance(raw, dict) else None
+        return entries if isinstance(entries, list) else []
+
+    def append(self, entry: dict[str, Any]) -> None:
+        """Persist one enquiry. Raises on write failure so the caller can 503."""
+        entries = self._load()
+        entries.append(entry)
+        if len(entries) > MAX_STORED_ENQUIRIES:
+            entries = entries[-MAX_STORED_ENQUIRIES:]
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump({"enquiries": entries}, handle, indent=2)
+            handle.write("\n")
+        temp_path.replace(self.path)
+
+    def recent(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Newest first, for the admin view."""
+        entries = self._load()
+        return list(reversed(entries[-max(1, limit) :]))
+
+    def count(self) -> int:
+        return len(self._load())

--- a/kb/server.py
+++ b/kb/server.py
@@ -49,6 +49,7 @@ from kb.conflicts import KnowledgeConflictStore, obsidian_push_conflict_candidat
 from kb.tags import normalize_tags
 from kb.cognee_client import assert_cognee_dataset_api
 from kb.config import CitadelConfig
+from kb.contact_store import ContactStore
 from kb.github_sync import GitHubOrgSyncer
 from kb.google_chat import GoogleChatConfigError, GoogleChatDelivery
 from kb.linear_sync import LinearSyncer
@@ -1038,6 +1039,14 @@ def get_access_store() -> AccessStore:
         max_audit_events=config.audit_max_events,
     )
     return app.state.access_store
+
+
+def get_contact_store() -> ContactStore:
+    existing = getattr(app.state, "contact_store", None)
+    if isinstance(existing, ContactStore):
+        return existing
+    app.state.contact_store = ContactStore(get_citadel().config.contact_store_path)
+    return app.state.contact_store
 
 
 def get_obsidian_sync() -> ObsidianSyncStore:
@@ -2672,8 +2681,35 @@ async def partner_contact(body: ContactBody, request: Request) -> dict[str, Any]
     if not contact_rate_limit_ok(client_ip):
         raise HTTPException(status_code=429, detail="Too many messages. Try again later.")
 
+    # Persist BEFORE attempting delivery (ADR-0013, amended). Google Chat is
+    # unconfigured on this node, so the old "no gateway is a 503" rule was
+    # turning every partner enquiry away and keeping no record of it. The ADR's
+    # actual requirement is that an enquiry is never accepted into a void; a
+    # capped file on the state volume is not a void. The vault is still not a
+    # destination — unauthenticated text must not reach the substrate agents
+    # read as authority, which is the part of ADR-0013 that stands unchanged.
+    from datetime import datetime, timezone
+
+    stored = False
+    try:
+        get_contact_store().append(
+            {
+                "received_at": datetime.now(timezone.utc).isoformat(),
+                "name": scrub_contact_field(body.name),
+                "email": scrub_contact_field(body.email),
+                "organization": scrub_contact_field(body.organization),
+                "message": scrub_contact_field(body.message),
+            }
+        )
+        stored = True
+    except Exception:
+        logger.exception("Partner contact could not be stored")
+
     gateway = contact_gateway()
     if gateway is None:
+        if stored:
+            logger.info("Partner contact stored from %s (no Chat gateway configured)", client_ip)
+            return {"delivered": True, "stored": True}
         raise HTTPException(
             status_code=503,
             detail="The contact channel is not configured on this node. Please email us instead.",
@@ -2690,12 +2726,32 @@ async def partner_contact(body: ContactBody, request: Request) -> dict[str, Any]
         await asyncio.to_thread(gateway.post_digest, text)
     except Exception:
         logger.exception("Partner contact delivery failed")
+        if stored:
+            # Chat is down but the enquiry is on disk, so it is not lost and the
+            # sender should not be told to try again and send it twice.
+            return {"delivered": True, "stored": True}
         raise HTTPException(
             status_code=502,
             detail="We could not deliver that right now. Please email us instead.",
         ) from None
     logger.info("Partner contact delivered from %s", client_ip)
-    return {"delivered": True}
+    return {"delivered": True, "stored": stored}
+
+
+@app.get("/api/contact/enquiries")
+async def list_contact_enquiries(request: Request, limit: int = 50) -> dict[str, Any]:
+    """Read the stored partner enquiries. Admin only.
+
+    The queue exists because Google Chat is unconfigured (ADR-0013, amended).
+    Once the gateway is set up this stays useful as the durable record behind a
+    Chat message that someone scrolls past.
+    """
+    require_access(request, "admin", "access:read")
+    store = get_contact_store()
+    return {
+        "enquiries": store.recent(min(max(1, limit), 200)),
+        "total": store.count(),
+    }
 
 
 @app.post("/admin/session")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5413,19 +5413,56 @@ def test_contact_delivers_to_the_chat_gateway(monkeypatch) -> None:
     response = client.post("/contact", json=_enquiry())
 
     assert response.status_code == 200
-    assert response.json() == {"delivered": True}
+    assert response.json() == {"delivered": True, "stored": True}
     assert len(gateway.sent) == 1
     assert "Ada Lovelace" in gateway.sent[0]
     assert "DIGITAL-2026-AI-07" in gateway.sent[0]
 
 
-def test_contact_fails_closed_when_the_gateway_is_unconfigured(monkeypatch) -> None:
-    """A missing gateway must refuse, never accept into a void.
+def _contact_store_at(monkeypatch, tmp_path) -> Any:
+    """Point the endpoint at a throwaway enquiry store."""
+    from kb.contact_store import ContactStore
 
-    An enquiry from a consortium coordinator that disappears silently is worse
-    than an error message: nobody learns it was lost.
+    store = ContactStore(str(tmp_path / "contacts.json"))
+    monkeypatch.setattr(server_module, "get_contact_store", lambda: store)
+    return store
+
+
+def test_contact_is_stored_when_the_gateway_is_unconfigured(monkeypatch, tmp_path) -> None:
+    """No gateway must not mean the enquiry is lost (ADR-0013, amended).
+
+    Google Chat is unconfigured in production, so the old fail-closed 503 turned
+    away every partner enquiry and kept no record. ADR-0013's rule is that an
+    enquiry is never accepted into a void; a file on the state volume is not a
+    void, and the sender should not be told to go away.
     """
     _reset_contact_limits()
+    store = _contact_store_at(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_module, "contact_gateway", lambda: None)
+    client = TestClient(app, base_url="https://testserver")
+
+    response = client.post("/contact", json=_enquiry())
+
+    assert response.status_code == 200
+    assert response.json() == {"delivered": True, "stored": True}
+    saved = store.recent()
+    assert len(saved) == 1
+    assert saved[0]["name"] == "Ada Lovelace"
+    assert "DIGITAL-2026-AI-07" in saved[0]["message"]
+    assert saved[0]["received_at"]
+
+
+def test_contact_still_fails_closed_when_it_can_neither_store_nor_deliver(
+    monkeypatch, tmp_path
+) -> None:
+    """The fail-closed rule survives; it just has a second chance first."""
+    _reset_contact_limits()
+    store = _contact_store_at(monkeypatch, tmp_path)
+
+    def explode(_entry: Any) -> None:
+        raise OSError("disk is gone")
+
+    monkeypatch.setattr(store, "append", explode)
     monkeypatch.setattr(server_module, "contact_gateway", lambda: None)
     client = TestClient(app, base_url="https://testserver")
 
@@ -5433,6 +5470,60 @@ def test_contact_fails_closed_when_the_gateway_is_unconfigured(monkeypatch) -> N
 
     assert response.status_code == 503
     assert "not configured" in response.json()["detail"]
+
+
+def test_contact_is_kept_when_chat_delivery_fails(monkeypatch, tmp_path) -> None:
+    """A stored enquiry must not ask the sender to send it a second time."""
+    _reset_contact_limits()
+    store = _contact_store_at(monkeypatch, tmp_path)
+
+    class BrokenGateway:
+        thread_key = "citadel-partner-contact"
+
+        def post_digest(self, text: str, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("chat is down")
+
+    monkeypatch.setattr(server_module, "contact_gateway", lambda: BrokenGateway())
+    client = TestClient(app, base_url="https://testserver")
+
+    response = client.post("/contact", json=_enquiry())
+
+    assert response.status_code == 200
+    assert response.json() == {"delivered": True, "stored": True}
+    assert len(store.recent()) == 1
+
+
+def test_contact_enquiries_endpoint_is_admin_only(monkeypatch, tmp_path) -> None:
+    _contact_store_at(monkeypatch, tmp_path)
+    client = TestClient(app, base_url="https://testserver")
+
+    assert client.get("/api/contact/enquiries").status_code in {401, 403}
+
+
+def test_contact_is_never_written_to_the_vault(monkeypatch, tmp_path) -> None:
+    """The part of ADR-0013 that did NOT change.
+
+    Unauthenticated public text must never reach the substrate agents read as
+    authority. Storing enquiries on disk is a fourth destination, not a reversal
+    of the vault rejection.
+    """
+    _reset_contact_limits()
+    _contact_store_at(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_module, "contact_gateway", lambda: None)
+
+    ingested: list[Any] = []
+
+    class Tripwire:
+        async def ingest(self, *args: Any, **kwargs: Any) -> Any:
+            ingested.append((args, kwargs))
+            raise AssertionError("a contact enquiry must never reach the vault")
+
+    monkeypatch.setattr(server_module, "get_citadel", lambda: Tripwire())
+    client = TestClient(app, base_url="https://testserver")
+
+    client.post("/contact", json=_enquiry())
+
+    assert ingested == []
 
 
 def test_contact_honeypot_is_dropped_without_delivery(monkeypatch) -> None:


### PR DESCRIPTION
Unblocks the contact form while Google Chat is still pending.

## The problem

Google Chat was **never configured in this project** — not on the web service, not on the sync service. So from the day the public site shipped, every `/contact` submission answered:

```
503 The contact channel is not configured on this node. Please email us instead.
```

Nothing was stored, so those enquiries are unrecoverable.

The logs said nothing either. `contact_gateway()` only warns when `from_config` *raises*; the disabled-by-default path returns `None` in silence. ADR-0013 predicted this state and called it "visibly broken" — in practice that meant visible to the sender, who sees an error and leaves, and invisible to us.

## The change

`POST /contact` writes the enquiry to a capped JSON file on the state volume (`kb/contact_store.py`, `CITADEL_CONTACT_STORE_PATH`, default alongside the access store) **before** attempting the Chat relay, and returns 200 when the write succeeded even with no gateway configured.

`GET /api/contact/enquiries` reads the queue, admin only.

Two smaller behaviours worth noting:
- 503 survives, for the case where the enquiry can be **neither** stored nor delivered. The fail-closed rule is intact, it just gets a second chance first.
- A stored enquiry whose Chat delivery fails now returns 200, so the sender is not told to submit it a second time.

## Why this is an ADR amendment, not a violation

ADR-0013's rule was never "do not persist". It was that **an enquiry is never accepted into a void** — and a file on disk is not a void. A 503 that loses the message is much closer to one. The ADR carries an amendment section saying so.

**The part that does not change:** destination 1 in that ADR, landing enquiries in the vault, stays rejected for exactly the stated reason — unauthenticated text must not reach the substrate agents read as authority. The store is a fourth destination, outside the knowledge path, with no search over it and no promotion path out of it. `test_contact_is_never_written_to_the_vault` installs a tripwire on `get_citadel()` and fails if anything tries.

## Costs accepted, stated plainly

- The service now has one unauthenticated write path that **persists**, which the original decision explicitly prized not having. All the mitigations that made the relay safe still apply (per-IP and global rate limits, length caps at the model boundary, honeypot, formatting scrub), and the store is capped at 500 entries so the endpoint cannot grow the volume without bound.
- The stored rows are **personal data** (name, email). A Chat message carried the same obligation, but it is now ours to honor directly, and there is no retention or deletion policy in this PR. Worth a follow-up given utxo AG is the applying entity for EU work.

## Tests

`968 passed, 1 skipped`, ruff clean.

Two existing tests changed because this deliberately changes their behaviour: `test_contact_fails_closed_when_the_gateway_is_unconfigured` is replaced by `test_contact_is_stored_when_the_gateway_is_unconfigured` plus `test_contact_still_fails_closed_when_it_can_neither_store_nor_deliver`, which keeps the original rule under its real condition.

New: storage on unconfigured gateway, fail-closed when both fail, retention when Chat delivery throws, admin-only on the read endpoint, and the vault tripwire.