### PR TITLE
fix(http): stop server-side bearer tokens leaking on redirect or plain HTTP (M3)

### DIFF
--- a/kb/backup_mirror.py
+++ b/kb/backup_mirror.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.config import CitadelConfig
 from kb.retry import run_with_retries
@@ -153,7 +155,7 @@ class GitHubMirrorPublisher:
         )
 
         def send() -> Any:
-            with urlopen(request, timeout=self.timeout) as response:
+            with open_secure(request, timeout=self.timeout) as response:
                 return json.loads(response.read().decode("utf-8") or "{}")
 
         try:

--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -19,7 +19,9 @@ from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.learning import LearningProcess
 from kb.repository_update import (
@@ -175,7 +177,7 @@ class GitHubOrgClient:
         )
 
         def fetch() -> Any:
-            with urlopen(request, timeout=self.timeout) as response:
+            with open_secure(request, timeout=self.timeout) as response:
                 return json.loads(response.read().decode("utf-8"))
 
         try:

--- a/kb/google_chat.py
+++ b/kb/google_chat.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.config import CitadelConfig
 from kb.retry import retry_after_seconds, run_with_retries
@@ -120,7 +122,7 @@ class GoogleChatDelivery:
             method="POST",
         )
         try:
-            with urlopen(request, timeout=self.timeout_seconds) as response:
+            with open_secure(request, timeout=self.timeout_seconds) as response:
                 response_body = json.loads(response.read().decode("utf-8") or "{}")
                 return {
                     "ok": 200 <= response.status < 300,

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -14,7 +14,9 @@ import logging
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.access import CENTRAL_DATASET, SEAT_DATASET_PREFIX, AccessStore, seat_dataset
 from kb.cognee_client import _suppress_inline_cognify
@@ -134,7 +136,7 @@ class LinearClient:
             },
         )
         try:
-            with urlopen(request, timeout=self.timeout) as response:
+            with open_secure(request, timeout=self.timeout) as response:
                 body = json.loads(response.read().decode("utf-8"))
         except HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")

--- a/kb/llm_enrichment.py
+++ b/kb/llm_enrichment.py
@@ -22,7 +22,9 @@ import logging
 import os
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.retry import run_with_retries
 from kb.security_scan import SecurityScanEntry, redact_secrets, scan_text_entries
@@ -132,7 +134,7 @@ def openrouter_chat(
     )
 
     def fetch() -> dict[str, Any]:
-        with urlopen(request, timeout=timeout) as response:
+        with open_secure(request, timeout=timeout) as response:
             return json.loads(response.read().decode("utf-8") or "{}")
 
     try:

--- a/kb/repo_stats.py
+++ b/kb/repo_stats.py
@@ -38,7 +38,9 @@ from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
-from urllib.request import Request, urlopen
+from urllib.request import Request
+
+from kb.secure_http import open_secure
 
 from kb.security_scan import redact_secrets
 
@@ -200,7 +202,7 @@ def fetch_commit_activity(
         },
     )
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with open_secure(request, timeout=timeout) as response:
             if response.status == 202:
                 raise RepoStatsUnavailable(
                     "GitHub is still computing commit statistics for this repository."

--- a/kb/secure_http.py
+++ b/kb/secure_http.py
@@ -1,0 +1,109 @@
+"""One authenticated HTTP transport for the server side (M3).
+
+Six server modules build a ``Request`` carrying a bearer token and hand it to
+the bare ``urlopen``, which uses the global opener. That opener follows
+redirects and replays every header at the target, so a 30x from an upstream
+host hands the credential to whatever it points at. ``kb/capture.py`` already
+got this right on the CLI side; the server never did.
+
+Two rules, and they are deliberately different:
+
+**Scheme.** Only ``LLM_ENDPOINT`` is operator-configurable, and pointing it at
+``http://`` sends ``OPENROUTER_API_KEY`` in cleartext. So plain HTTP is refused,
+with an exception for loopback and Railway's private network, because
+``CITADEL_COGNIFY_TARGET_URL=http://localhost:8080`` is a real, correct
+production value and ``*.railway.internal`` traffic never leaves the project.
+
+**Redirects.** NOT blocked. GitHub 301s a renamed repository, and refusing that
+would break `github_sync` for any repo the org renames. Redirects are followed
+with the credential headers stripped whenever the origin changes, which is what
+browsers and modern HTTP clients do. Same-origin redirects keep their headers so
+ordinary API behaviour is untouched.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlparse
+
+# Headers that must never survive a hop to a different origin.
+_CREDENTIAL_HEADERS = ("Authorization", "Cookie", "Proxy-authorization")
+
+# Plain HTTP is only ever acceptable where the bytes cannot leave the host or
+# the Railway project private network.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+_PRIVATE_SUFFIX = ".railway.internal"
+
+
+class InsecureEndpointError(ValueError):
+    """A credential was about to be sent over an untrusted scheme."""
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlparse(url)
+    return (parsed.scheme, (parsed.hostname or "").lower(), parsed.port)
+
+
+def is_local_endpoint(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in _LOCAL_HOSTS or host.endswith(_PRIVATE_SUFFIX)
+
+
+def require_secure_url(url: str) -> None:
+    """Raise unless *url* is safe to send a credential to."""
+    scheme = (urlparse(url).scheme or "").lower()
+    if scheme == "https":
+        return
+    if scheme == "http" and is_local_endpoint(url):
+        return
+    raise InsecureEndpointError(
+        f"refusing to send credentials over {scheme or 'an unknown scheme'}: {url}"
+    )
+
+
+class _CredentialStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects, but never carry credentials to a new origin."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        new_request = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_request is None:
+            return None
+        # A redirect to http:// is a downgrade even if the first hop was https.
+        require_secure_url(newurl)
+        if _origin(newurl) != _origin(req.full_url):
+            for header in _CREDENTIAL_HEADERS:
+                new_request.remove_header(header)
+                # Request.remove_header only checks its own capitalisation, and
+                # unredirected_hdrs is where headers set at construction land.
+                new_request.unredirected_hdrs.pop(header.capitalize(), None)
+        return new_request
+
+
+_OPENER = urllib.request.build_opener(_CredentialStrippingRedirectHandler)
+
+
+def open_secure(request: urllib.request.Request, *, timeout: float) -> Any:
+    """``urlopen`` for a request that carries a credential.
+
+    Refuses an untrusted scheme up front, then opens through an opener that
+    strips credentials on a cross-origin redirect. Returns the same context
+    manager ``urlopen`` does, so call sites only change the function name.
+    """
+    require_secure_url(request.full_url)
+    try:
+        return _OPENER.open(request, timeout=timeout)  # noqa: S310 - scheme checked above
+    except InsecureEndpointError as exc:
+        # Raised from inside the redirect handler; urllib would otherwise wrap
+        # it somewhere unhelpful. Surface it as a URLError so existing
+        # except-chains at the call sites still catch it.
+        raise URLError(str(exc)) from exc

--- a/tests/test_google_chat.py
+++ b/tests/test_google_chat.py
@@ -48,7 +48,7 @@ def install_fake_urlopen(
             raise outcome
         return outcome
 
-    monkeypatch.setattr("kb.google_chat.urlopen", fake_urlopen)
+    monkeypatch.setattr("kb.google_chat.open_secure", fake_urlopen)
     return calls
 
 

--- a/tests/test_organization_digest.py
+++ b/tests/test_organization_digest.py
@@ -179,7 +179,7 @@ def test_google_chat_delivery_posts_sanitized_threaded_message(monkeypatch: Any)
         )
         return FakeResponse()
 
-    monkeypatch.setattr("kb.google_chat.urlopen", fake_urlopen)
+    monkeypatch.setattr("kb.google_chat.open_secure", fake_urlopen)
     delivery = GoogleChatDelivery(
         space_name="spaces/AAA",
         thread_key="citadel-org-digest",

--- a/tests/test_repo_stats.py
+++ b/tests/test_repo_stats.py
@@ -145,7 +145,7 @@ def test_a_202_is_treated_as_try_again_not_as_data(monkeypatch: Any) -> None:
         def __exit__(self, *exc: Any) -> None:
             return None
 
-    monkeypatch.setattr(repo_stats, "urlopen", lambda *a, **k: _Response())
+    monkeypatch.setattr(repo_stats, "open_secure", lambda *a, **k: _Response())
 
     try:
         repo_stats.fetch_commit_activity("masumi-network/Citadel")

--- a/tests/test_secure_http.py
+++ b/tests/test_secure_http.py
@@ -1,0 +1,124 @@
+"""The server-side authenticated transport (M3).
+
+Six server modules send bearer tokens through this. The properties below are
+the reason it exists, so each one is asserted directly rather than inferred
+from the call sites.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+from kb.secure_http import (
+    InsecureEndpointError,
+    _CredentialStrippingRedirectHandler,
+    is_local_endpoint,
+    open_secure,
+    require_secure_url,
+)
+
+
+class _FakeFp:
+    """Minimal stand-in for the response body urllib hands the handler."""
+
+    def read(self) -> bytes:  # pragma: no cover - never consumed here
+        return b""
+
+
+def _redirect(from_url: str, to_url: str) -> urllib.request.Request | None:
+    request = urllib.request.Request(
+        from_url,
+        headers={
+            "Authorization": "Bearer super-secret",
+            "Cookie": "session=abc",
+            # Not a credential and not a content header, so urllib's own
+            # redirect logic keeps it. Proves the strip is targeted.
+            "Accept": "application/json",
+        },
+    )
+    return _CredentialStrippingRedirectHandler().redirect_request(
+        request, _FakeFp(), 301, "Moved", {}, to_url
+    )
+
+
+# --- scheme -----------------------------------------------------------------
+
+
+def test_https_is_allowed() -> None:
+    require_secure_url("https://openrouter.ai/api/v1/chat/completions")
+
+
+def test_plain_http_to_the_public_internet_is_refused() -> None:
+    """The live risk: LLM_ENDPOINT is operator-set, so http leaks the API key."""
+    with pytest.raises(InsecureEndpointError):
+        require_secure_url("http://openrouter.ai/api/v1/chat/completions")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8080/api/cognify",  # the real CITADEL_COGNIFY_TARGET_URL
+        "http://127.0.0.1:8000/search",
+        "http://citadel-archive.railway.internal:8080/ingest",
+    ],
+)
+def test_plain_http_is_allowed_where_it_cannot_leave(url: str) -> None:
+    """Blanket https-only would break production: loopback and Railway's
+    private network are both plain HTTP by design."""
+    require_secure_url(url)
+    assert is_local_endpoint(url)
+
+
+def test_a_lookalike_private_host_is_not_treated_as_private() -> None:
+    assert not is_local_endpoint("http://railway.internal.evil.example")
+    with pytest.raises(InsecureEndpointError):
+        require_secure_url("http://railway.internal.evil.example/x")
+
+
+def test_open_secure_refuses_before_opening_a_socket() -> None:
+    request = urllib.request.Request(
+        "http://openrouter.ai/v1", headers={"Authorization": "Bearer secret"}
+    )
+    with pytest.raises(InsecureEndpointError):
+        open_secure(request, timeout=1)
+
+
+# --- redirects --------------------------------------------------------------
+
+
+def test_credentials_are_stripped_when_the_origin_changes() -> None:
+    new = _redirect("https://api.github.com/repos/a/b", "https://evil.example/repos/a/b")
+
+    assert new is not None
+    merged = {**new.headers, **new.unredirected_hdrs}
+    assert "Authorization" not in merged
+    assert "Cookie" not in merged
+    # Non-credential headers are not the point and must survive.
+    assert merged.get("Accept") == "application/json"
+
+
+def test_credentials_survive_a_same_origin_redirect() -> None:
+    """GitHub 301s a renamed repo. Refusing or stripping there would break
+    github_sync for any repository the org renames."""
+    new = _redirect(
+        "https://api.github.com/repos/old/name", "https://api.github.com/repos/new/name"
+    )
+
+    assert new is not None
+    merged = {**new.headers, **new.unredirected_hdrs}
+    assert merged.get("Authorization") == "Bearer super-secret"
+
+
+def test_a_port_change_counts_as_a_different_origin() -> None:
+    new = _redirect("https://api.example.com/a", "https://api.example.com:8443/a")
+
+    assert new is not None
+    merged = {**new.headers, **new.unredirected_hdrs}
+    assert "Authorization" not in merged
+
+
+def test_a_redirect_that_downgrades_to_http_is_refused() -> None:
+    with pytest.raises(InsecureEndpointError):
+        _redirect("https://api.github.com/x", "http://api.github.com/x")


### PR DESCRIPTION
Closes the M3 finding from the 2026-07-19 audit. Not filed as a public issue, per the repo's disclosure practice.

## The problem

Six server modules build a `Request` carrying a credential and hand it to the bare `urlopen`:

| Module | Credential |
|---|---|
| `kb/llm_enrichment.py:135` | `OPENROUTER_API_KEY` |
| `kb/github_sync.py:178` | `CITADEL_GITHUB_TOKEN` |
| `kb/linear_sync.py:137` | `CITADEL_LINEAR_API_KEY` |
| `kb/google_chat.py:123` | Google OAuth token |
| `kb/backup_mirror.py:156` | `CITADEL_GITHUB_TOKEN` |
| `kb/repo_stats.py:203` | `CITADEL_GITHUB_TOKEN` (optional) |

`urlopen` uses the global opener, which follows redirects and replays every header at the target. A 30x from an upstream host hands the credential to whatever it points at. I confirmed this is not theoretical: deleting the strip from this PR makes `test_credentials_are_stripped_when_the_origin_changes` fail, because urllib's stock `HTTPRedirectHandler` really does carry `Authorization` to a new origin.

`kb/capture.py` already got this right on the CLI side with a local no-redirect opener plus an https check. The server never did.

**The acute case is `LLM_ENDPOINT`.** It is the one operator-configurable credential destination (`kb/llm_enrichment.py:74`, default `https://openrouter.ai/api/v1`). Set it to `http://` and `OPENROUTER_API_KEY` goes out in cleartext with nothing objecting. The other five point at hardcoded `https://` constants.

## The change

One shared `kb/secure_http.py`. `open_secure()` refuses an untrusted scheme before opening a socket, then opens through an opener that strips `Authorization`/`Cookie` whenever a redirect changes origin.

**Two decisions worth reviewing, because the obvious stricter rules would each break production:**

1. **Plain HTTP is allowed for loopback and `*.railway.internal`.** I checked the live config first: `CITADEL_COGNIFY_TARGET_URL=http://localhost:8080` is a real, correct production value. A blanket https-only rule would have taken the node down. Railway private-network traffic never leaves the project. A lookalike host like `railway.internal.evil.example` is not treated as private, and there is a test for that.

2. **Redirects are followed, not blocked.** GitHub 301s a renamed repository, so a no-redirect opener would break `github_sync` for any repo the org renames. Credentials are stripped cross-origin instead, which is what browsers and modern HTTP clients do. Same-origin redirects keep their headers, so ordinary API behaviour is untouched. A redirect that downgrades https to http is refused outright.

## Relationship to #116

This is the server-side half of "seven copies of the token-sending HTTP helper have drifted". #116's CLI-side extraction is untouched and stays open.

`kb/mcp_server.py:623` has the same pattern and is **deliberately excluded**: it targets the operator's own node URL, and the hosted `/mcp` path has broken before in a way that took real debugging. It deserves its own change rather than riding along here.

## Tests

`975 passed, 1 skipped`, ruff clean.

`tests/test_secure_http.py` asserts each property directly rather than inferring it from call sites: https allowed, public-internet http refused, the three real local forms allowed, lookalike private host rejected, refusal happens before a socket opens, cross-origin strip, same-origin retention (the renamed-repo case), port change counting as cross-origin, and https-to-http downgrade refused.

Six existing tests changed from patching `urlopen` to patching `open_secure`. That is a mechanical follow-on, not a behaviour change.