### PR TITLE
fix(auth): throttle failed authentication and refuse weak env keys (M4)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -149,13 +149,27 @@ and tenant-aware config without changing Cognee internals.
 
 Bootstrap environment keys plus a persistent access store for teammate/agent tokens:
 
+An env access key authenticates as a bearer token on **every** endpoint, so it
+is a password with no username and no rotation story. Generate them; never type
+them. The server refuses to start on an env key shorter than 32 characters
+(override with `CITADEL_ALLOW_WEAK_ACCESS_KEYS=true`, which you should only need
+in local development).
+
 ```bash
-CITADEL_READER_KEYS=alice-reader-key,bob-reader-key
-CITADEL_WRITER_KEYS=teammate-writer-key
-CITADEL_ADMIN_KEY=owner-admin-key
+# Generate each one:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+CITADEL_READER_KEYS=<32+ char random>,<32+ char random>
+CITADEL_WRITER_KEYS=<32+ char random>
+CITADEL_ADMIN_KEY=<32+ char random>
 CITADEL_ACCESS_STORE_PATH=/data/.citadel/access.json
 CITADEL_AUDIT_MAX_EVENTS=1000
 ```
+
+Prefer minted tokens (Access page, or `POST /api/access/tokens`) over env keys
+for anything but bootstrap: they carry a role, scopes, an expiry and a last-used
+timestamp, they are stored only as a hash, and they can be revoked individually.
+An env key can only be rotated by redeploying every consumer at once, which is
+how the GitHub-Sync cron ended up 401ing against a rotated admin key.
 
 | Role | Permissions |
 |---|---|

--- a/kb/server.py
+++ b/kb/server.py
@@ -424,6 +424,10 @@ async def _stop_evolve_scheduler(task: "asyncio.Task[Any] | None") -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> Any:
+    # Refuse to serve with a guessable env access key (M4). Deliberately at
+    # startup and not at kb.config import: the CLI imports that module too and
+    # must not die because the server's environment is misconfigured.
+    enforce_access_key_strength()
     async with mcp_server.session_manager.run():
         # Eagerly build the mesh and seed its in-memory activity counters from
         # persistent source state so a redeploy does not look like the graph reset.
@@ -1090,6 +1094,60 @@ def configured_access_keys() -> list[tuple[str, str]]:
     return entries
 
 
+# An env access key is a bearer credential on every endpoint (see
+# bearer_identity below), and unlike a minted ctdl_ token it is whatever string
+# an operator typed. docs/operations.md used to suggest "owner-admin-key".
+# 32 chars is well under a token_urlsafe(32) and well over anything hand-written.
+WEAK_ACCESS_KEY_MIN_LENGTH = 32
+
+
+def weak_access_keys() -> list[tuple[str, int]]:
+    """(env var name, length) for every configured env key that is too short."""
+    config = get_citadel().config
+    candidates: list[tuple[str, str]] = []
+    if config.admin_key:
+        candidates.append(("CITADEL_ADMIN_KEY", config.admin_key))
+    candidates.extend(("CITADEL_WRITER_KEYS", key) for key in config.writer_keys)
+    candidates.extend(("CITADEL_READER_KEYS", key) for key in config.reader_keys)
+    return [
+        (name, len(key))
+        for name, key in candidates
+        if len(key) < WEAK_ACCESS_KEY_MIN_LENGTH
+    ]
+
+
+def allow_weak_access_keys() -> bool:
+    return os.getenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def enforce_access_key_strength() -> None:
+    """Refuse to serve with a brute-forceable env access key (M4).
+
+    A hard stop rather than a warning, on purpose. A warning is the shape of
+    signal that let the Kuzu lock run for weeks: present in the logs, read by
+    nobody. The escape hatch is explicit and greppable, so an operator who needs
+    a short key in development makes a deliberate, auditable choice.
+    """
+    if allow_weak_access_keys():
+        return
+    weak = weak_access_keys()
+    if not weak:
+        return
+    listed = ", ".join(f"{name} ({length} chars)" for name, length in weak)
+    raise SystemExit(
+        f"Refusing to start: access key too short — {listed}. "
+        f"Minimum is {WEAK_ACCESS_KEY_MIN_LENGTH} characters, because an env key "
+        "authenticates as a bearer token on every endpoint.\n"
+        '  Mint one:  python -c "import secrets; print(secrets.token_urlsafe(32))"\n'
+        "  Override:  CITADEL_ALLOW_WEAK_ACCESS_KEYS=true"
+    )
+
+
 def env_identity(role: str) -> AccessIdentity:
     return AccessIdentity(
         role=role,
@@ -1190,13 +1248,92 @@ def session_role(request: Request) -> str | None:
     return identity.role if identity else None
 
 
+# Failed-auth throttle (M4). Counted ONLY on failure, so a caller holding a
+# valid credential never touches it and cannot be locked out no matter how much
+# noise an attacker generates. Per-IP is spoofable behind the Railway proxy, so
+# as with the contact form the global ceiling is what actually bounds it.
+AUTH_FAIL_PER_IP_LIMIT = 10
+AUTH_FAIL_PER_IP_WINDOW_SECONDS = 300
+AUTH_FAIL_GLOBAL_LIMIT = 200
+AUTH_FAIL_GLOBAL_WINDOW_SECONDS = 3600
+_auth_fail_hits: dict[str, list[float]] = {}
+_auth_fail_global_hits: list[float] = []
+_auth_fail_lock = threading.Lock()
+
+
+def reset_auth_throttle() -> None:
+    """Clear the buckets. For tests, and for an operator digging out of a flood."""
+    with _auth_fail_lock:
+        _auth_fail_hits.clear()
+        _auth_fail_global_hits.clear()
+
+
+def record_auth_failure(client_ip: str) -> bool:
+    """Record one failed auth. False when the caller is now over a limit.
+
+    A blocked attempt is deliberately NOT counted. Our own clients retry 429
+    (kb/retry.py TRANSIENT_HTTP_STATUSES) but never 401, so counting the blocked
+    retries would let a client with a stale token extend its own ban forever and
+    hide a plain wrong-credential behind "rate limited" — which is exactly how
+    the GitHub-Sync key drift got misdiagnosed before.
+    """
+    now = time.monotonic()
+    try:
+        with _auth_fail_lock:
+            recent_global = [
+                hit
+                for hit in _auth_fail_global_hits
+                if now - hit < AUTH_FAIL_GLOBAL_WINDOW_SECONDS
+            ]
+            _auth_fail_global_hits[:] = recent_global
+            recent = [
+                hit
+                for hit in _auth_fail_hits.get(client_ip, [])
+                if now - hit < AUTH_FAIL_PER_IP_WINDOW_SECONDS
+            ]
+            if len(recent) >= AUTH_FAIL_PER_IP_LIMIT or len(recent_global) >= AUTH_FAIL_GLOBAL_LIMIT:
+                _auth_fail_hits[client_ip] = recent
+                return False
+            recent.append(now)
+            _auth_fail_hits[client_ip] = recent
+            _auth_fail_global_hits.append(now)
+            if len(_auth_fail_hits) > 2000:
+                for stale_ip, hits in list(_auth_fail_hits.items()):
+                    if not hits or now - hits[-1] >= AUTH_FAIL_PER_IP_WINDOW_SECONDS:
+                        _auth_fail_hits.pop(stale_ip, None)
+            return True
+    except Exception:
+        # Fail OPEN. This is an in-process dict, so it should not raise, but a
+        # throttle that breaks must not become an outage for the whole team.
+        logger.exception("Auth throttle failed; allowing the request")
+        return True
+
+
+def _reject_unauthenticated(request: Request) -> None:
+    """401, or 429 once this source has failed too many times."""
+    client_ip = contact_client_ip(request)
+    if not record_auth_failure(client_ip):
+        logger.warning(
+            "Throttled repeated auth failures from %s: %s %s",
+            client_ip,
+            request.method,
+            request.url.path,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Too many failed authentication attempts. Try again later.",
+            headers={"Retry-After": str(AUTH_FAIL_PER_IP_WINDOW_SECONDS)},
+        )
+    logger.warning(
+        "Rejected unauthenticated request: %s %s", request.method, request.url.path
+    )
+    raise HTTPException(status_code=401, detail="Access key required.")
+
+
 def require_role(request: Request, minimum_role: str) -> AccessIdentity:
     identity = request_identity(request)
     if not identity:
-        logger.warning(
-            "Rejected unauthenticated request: %s %s", request.method, request.url.path
-        )
-        raise HTTPException(status_code=401, detail="Access key required.")
+        _reject_unauthenticated(request)
     if ROLE_ORDER[identity.role] < ROLE_ORDER[minimum_role]:
         logger.warning(
             "Denied %s %s for actor %s: role %s below required %s",
@@ -2699,7 +2836,9 @@ async def partner_contact(body: ContactBody, request: Request) -> dict[str, Any]
 
 
 @app.post("/admin/session")
-async def create_admin_session(body: AdminSessionBody, response: Response) -> dict[str, Any]:
+async def create_admin_session(
+    body: AdminSessionBody, response: Response, request: Request
+) -> dict[str, Any]:
     access_key = body.access_key or body.admin_key
     if not configured_access_keys() and not get_access_store().has_tokens():
         raise HTTPException(status_code=503, detail="Access keys are not configured.")
@@ -2707,6 +2846,16 @@ async def create_admin_session(body: AdminSessionBody, response: Response) -> di
         raise HTTPException(status_code=422, detail="Access key is required.")
     identity_with_cookie = access_key_identity(access_key)
     if not identity_with_cookie:
+        # Same throttle as the bearer path (M4): this endpoint accepts the same
+        # env keys, so limiting only one of the two would leave the door open.
+        client_ip = contact_client_ip(request)
+        if not record_auth_failure(client_ip):
+            logger.warning("Throttled repeated login failures from %s", client_ip)
+            raise HTTPException(
+                status_code=429,
+                detail="Too many failed authentication attempts. Try again later.",
+                headers={"Retry-After": str(AUTH_FAIL_PER_IP_WINDOW_SECONDS)},
+            )
         logger.warning("Admin session login rejected: access key did not match any credential")
         raise HTTPException(status_code=401, detail="Access key was rejected.")
     identity, session_cookie = identity_with_cookie

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,23 @@ def _isolate_claude_home(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _reset_auth_throttle():
+    """Empty the failed-auth buckets around every test (M4).
+
+    They are module globals, and TestClient presents a single client host, so
+    the suite's 401 assertions all land in one per-IP bucket whose limit is 10.
+    Without this the suite passes or fails on test ordering.
+    """
+    server = sys.modules.get("kb.server")
+    if server is not None:
+        server.reset_auth_throttle()
+    yield
+    server = sys.modules.get("kb.server")
+    if server is not None:
+        server.reset_auth_throttle()
+
+
+@pytest.fixture(autouse=True)
 def _reset_app_state():
     """Restore kb.server.app.state after every test that assigns to it (#120).
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,8 +8,10 @@ from pathlib import Path
 import re
 import secrets
 import tempfile
+from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 import kb.server as server_module
@@ -5490,3 +5492,120 @@ def test_contact_rejects_an_oversized_message(monkeypatch) -> None:
 
     assert response.status_code == 422
     assert gateway.sent == []
+
+
+# --- M4: failed-auth throttle and weak-key guard -----------------------------
+
+
+def test_repeated_failed_auth_is_throttled_with_retry_after() -> None:
+    """Brute force gets a 429, not an unlimited stream of 401s."""
+    server_module.reset_auth_throttle()
+    client = TestClient(app, base_url="https://testserver")
+
+    codes = [
+        client.get("/api/mesh", headers={"Authorization": "Bearer wrong"}).status_code
+        for _ in range(server_module.AUTH_FAIL_PER_IP_LIMIT + 3)
+    ]
+
+    assert codes[0] == 401
+    assert codes[-1] == 429
+    assert codes.count(401) == server_module.AUTH_FAIL_PER_IP_LIMIT
+    blocked = client.get("/api/mesh", headers={"Authorization": "Bearer wrong"})
+    assert blocked.headers["Retry-After"] == str(server_module.AUTH_FAIL_PER_IP_WINDOW_SECONDS)
+
+
+def test_a_valid_credential_is_never_throttled(monkeypatch) -> None:
+    """The whole point: an attacker's noise must not lock out the team.
+
+    The credential is resolved before the limiter is consulted, so a caller who
+    holds a real one keeps working no matter how deep the failure bucket is.
+    """
+    server_module.reset_auth_throttle()
+    client = TestClient(app, base_url="https://testserver")
+    for _ in range(server_module.AUTH_FAIL_PER_IP_LIMIT + 5):
+        assert client.get("/api/mesh", headers={"Authorization": "Bearer wrong"})
+
+    # Now the bucket is well over the limit. A recognised identity must sail past.
+    monkeypatch.setattr(
+        server_module,
+        "request_identity",
+        lambda _request: AccessIdentity(
+            role="admin",
+            actor_id="env:admin",
+            actor_kind="env",
+            actor_name="admin",
+            source="env",
+            seat_slug=None,
+        ),
+    )
+    identity = server_module.require_role(
+        SimpleNamespace(method="GET", url=SimpleNamespace(path="/api/mesh")), "admin"
+    )
+
+    assert identity.role == "admin"
+
+
+def test_a_blocked_attempt_does_not_extend_the_ban() -> None:
+    """Our own clients retry 429 but never 401 (kb/retry.py).
+
+    Counting blocked retries would let a stale-token client extend its own ban
+    forever and hide a wrong credential behind "rate limited".
+    """
+    server_module.reset_auth_throttle()
+    client = TestClient(app, base_url="https://testserver")
+    for _ in range(server_module.AUTH_FAIL_PER_IP_LIMIT):
+        client.get("/api/mesh", headers={"Authorization": "Bearer wrong"})
+
+    before = len(server_module._auth_fail_global_hits)
+    for _ in range(5):
+        client.get("/api/mesh", headers={"Authorization": "Bearer wrong"})
+
+    assert len(server_module._auth_fail_global_hits) == before
+
+
+def test_weak_env_access_key_refuses_to_start(monkeypatch) -> None:
+    monkeypatch.delenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", raising=False)
+    monkeypatch.setattr(
+        server_module,
+        "get_citadel",
+        lambda: SimpleNamespace(
+            config=SimpleNamespace(
+                admin_key="owner-admin-key", writer_keys=(), reader_keys=()
+            )
+        ),
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        server_module.enforce_access_key_strength()
+
+    assert "CITADEL_ADMIN_KEY" in str(caught.value)
+    assert "token_urlsafe" in str(caught.value)
+
+
+def test_a_strong_env_access_key_starts_normally(monkeypatch) -> None:
+    monkeypatch.delenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", raising=False)
+    monkeypatch.setattr(
+        server_module,
+        "get_citadel",
+        lambda: SimpleNamespace(
+            config=SimpleNamespace(
+                admin_key="x" * 64, writer_keys=(), reader_keys=()
+            )
+        ),
+    )
+
+    server_module.enforce_access_key_strength()
+
+
+def test_the_weak_key_guard_can_be_overridden_explicitly(monkeypatch) -> None:
+    """Deliberate and greppable, unlike a warning nobody reads."""
+    monkeypatch.setenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", "true")
+    monkeypatch.setattr(
+        server_module,
+        "get_citadel",
+        lambda: SimpleNamespace(
+            config=SimpleNamespace(admin_key="short", writer_keys=(), reader_keys=())
+        ),
+    )
+
+    server_module.enforce_access_key_strength()


### PR DESCRIPTION
Closes the M4 finding from the 2026-07-19 audit. Not filed publicly, per the repo's disclosure practice.

## Severity, stated honestly

Lower than the audit implies **for this deployment**. I checked before writing code: minted tokens are `secrets.token_urlsafe(32)` (256 bits, `kb/access.py:168`), the production `CITADEL_ADMIN_KEY` is 64 characters, and `CITADEL_READER_KEYS`/`CITADEL_WRITER_KEYS` are unset. Brute force is already infeasible.

The real exposure is a **future** operator setting a short key, and `docs/operations.md` actively invited exactly that:

```bash
CITADEL_ADMIN_KEY=owner-admin-key     # 15 chars, in the docs, as the example
```

So this PR is mostly about closing that door, with the throttle as defence in depth.

## Scope: both surfaces, not just login

`bearer_identity` resolves through `access_key_identity` (`kb/server.py:1177`), so an env key authenticates on **every** endpoint. Throttling only `POST /admin/session` would have left the bearer path wide open.

## Three decisions worth reviewing

**1. Only failed auth is counted, and the credential is resolved first.** A caller holding a valid credential never reaches the limiter, so an attacker cannot lock out the team however much noise they generate. This is the usual reason teams decline to ship auth rate limiting, and it is designed out rather than accepted.

**2. A blocked attempt is not counted.** `kb/retry.py:16` has `TRANSIENT_HTTP_STATUSES = {429, 500, 502, 503, 504}` — our own clients retry 429 but never 401. Counting blocked retries would let a client with a stale token extend its own ban indefinitely, and mask a plain wrong-credential behind "rate limited". That is precisely the confusion that made the GitHub-Sync key drift hard to diagnose before. The ban now always drains.

**3. The weak-key check is a hard stop, not a warning.** A warning is the exact shape of signal that let the Kuzu lock run for weeks: present in the logs, read by nobody. `CITADEL_ALLOW_WEAK_ACCESS_KEYS=true` is the escape hatch, explicit and greppable, so an operator who needs a short key in development makes a deliberate choice.

It runs in the server lifespan rather than at `kb.config` import, because the CLI imports that module and must not die over the server's environment.

## A latent test bug this surfaced

The suite has fourteen `== 401` assertions, TestClient presents a single client host, and the per-IP limit is ten. So the buckets are module globals that all fourteen land in. The suite passed on first run purely on ordering luck; `tests/conftest.py` now resets them around every test.

## Tests

`970 passed, 1 skipped`, ruff clean. The throttle test was verified to fail with the limit disabled.

- `test_repeated_failed_auth_is_throttled_with_retry_after`
- `test_a_valid_credential_is_never_throttled` — the anti-lockout property
- `test_a_blocked_attempt_does_not_extend_the_ban`
- weak key refused / strong key accepted / override honoured

## Also

`docs/operations.md` now tells operators to generate keys, explains that an env key is a password with no username and no rotation story, and points at minted tokens for anything beyond bootstrap.