### PR TITLE
fix(github): stop logging expected 404 probes as errors

### DIFF
--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -68,7 +68,17 @@ def _matches_any(name: str, patterns: tuple[str, ...]) -> bool:
 
 
 class GitHubAPIError(RuntimeError):
-    pass
+    """A GitHub API call failed. ``status`` is the HTTP code, or None if it never got one.
+
+    Callers need the code, not the message: repo_content_sync probes optional
+    paths and a 404 is its expected "not present" answer. It used to test
+    ``"404" in str(exc)``, which also matches a 404 appearing anywhere in a repo
+    name or an error body.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 class GitHubOrgClient:
@@ -182,8 +192,16 @@ class GitHubOrgClient:
             return run_with_retries(fetch, operation=f"github_sync.get {path}")
         except HTTPError as exc:
             detail = redact_secrets(exc.read().decode("utf-8", errors="replace")[:300], self.token)
-            logger.error("GitHub API request %s failed: HTTPError %s", path, exc.code)
-            raise GitHubAPIError(f"GitHub API returned {exc.code}: {detail}") from exc
+            # A 404 is the expected answer when probing for an optional path:
+            # repo_content_sync asks every repo for AGENTS.md, SKILL.md,
+            # CONTEXT.md, skills/, docs/, content/docs/ and plugins/, and most
+            # repos have none of them. Logging those at ERROR produced several
+            # hundred lines an hour and buried every real failure.
+            log = logger.debug if exc.code == 404 else logger.error
+            log("GitHub API request %s failed: HTTPError %s", path, exc.code)
+            raise GitHubAPIError(
+                f"GitHub API returned {exc.code}: {detail}", status=exc.code
+            ) from exc
         except URLError as exc:
             logger.error(
                 "GitHub API request %s failed: %s: %s",

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -133,7 +133,7 @@ class RepoContentGitHubClient(GitHubOrgClient):
                 {"ref": ref},
             )
         except GitHubAPIError as exc:
-            if "404" in str(exc):
+            if exc.status == 404:
                 return False
             raise
         return isinstance(data, dict) and data.get("type") == "file"
@@ -212,7 +212,7 @@ def discover_repo_paths(
             try:
                 entries = client.list_directory(full_name, current, ref=ref)
             except GitHubAPIError as exc:
-                if "404" in str(exc):
+                if exc.status == 404:
                     break
                 raise
             for entry in entries:

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -428,3 +429,55 @@ async def test_github_sync_reports_authenticated_flag(tmp_path: Any) -> None:
 
     client.token = "ghp_example"  # type: ignore[attr-defined]
     assert (await syncer.status())["authenticated"] is True
+
+
+def test_a_404_probe_is_not_logged_as_an_error(monkeypatch, caplog) -> None:
+    """repo_content_sync asks every repo for optional paths; most 404.
+
+    Those probes produced several hundred ERROR lines an hour in production and
+    buried every real failure. A 404 is the expected answer here, so it belongs
+    at DEBUG; anything else stays ERROR.
+    """
+    import logging
+    from urllib.error import HTTPError
+
+    import kb.github_sync as gh
+
+    def boom(*_args, **_kwargs):
+        raise HTTPError("https://api.github.com/x", 404, "Not Found", {}, io.BytesIO(b"{}"))
+
+    client = gh.GitHubOrgClient(token=None)
+    monkeypatch.setattr(gh, "run_with_retries", lambda fetch, operation="": fetch())
+    monkeypatch.setattr(gh, "open_secure", boom, raising=False)
+    monkeypatch.setattr(gh, "urlopen", boom, raising=False)
+
+    with caplog.at_level(logging.DEBUG, logger=gh.logger.name):
+        with pytest.raises(gh.GitHubAPIError) as caught:
+            client._get_json("/repos/o/r/contents/SKILL.md", {})
+
+    assert caught.value.status == 404
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], f"a 404 probe must not log at ERROR, got: {[r.message for r in errors]}"
+    assert any(r.levelno == logging.DEBUG for r in caplog.records)
+
+
+def test_a_real_failure_is_still_logged_as_an_error(monkeypatch, caplog) -> None:
+    import logging
+    from urllib.error import HTTPError
+
+    import kb.github_sync as gh
+
+    def boom(*_args, **_kwargs):
+        raise HTTPError("https://api.github.com/x", 500, "Server Error", {}, io.BytesIO(b"{}"))
+
+    client = gh.GitHubOrgClient(token=None)
+    monkeypatch.setattr(gh, "run_with_retries", lambda fetch, operation="": fetch())
+    monkeypatch.setattr(gh, "open_secure", boom, raising=False)
+    monkeypatch.setattr(gh, "urlopen", boom, raising=False)
+
+    with caplog.at_level(logging.DEBUG, logger=gh.logger.name):
+        with pytest.raises(gh.GitHubAPIError) as caught:
+            client._get_json("/repos/o/r/contents/SKILL.md", {})
+
+    assert caught.value.status == 500
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR]


### PR DESCRIPTION
The production error log is currently unreadable, and this is why.

## What the log looks like now

```
GitHub API request /repos/masumi-network/sokosumi/contents/SKILL.md failed: HTTPError 404
GitHub API request /repos/masumi-network/sokosumi/contents/CONTEXT.md failed: HTTPError 404
GitHub API request /repos/masumi-network/sokosumi/contents/skills failed: HTTPError 404
... roughly 385 of these per hour ...
```

`repo_content_sync` probes every repo for `AGENTS.md`, `SKILL.md`, `CONTEXT.md`, `skills/`, `docs/`, `content/docs/` and `plugins/`. Most repos have none of them. A 404 is the **expected answer to a probe**, and the caller says so explicitly:

```python
# kb/repo_content_sync.py:136 and :215
except GitHubAPIError as exc:
    if "404" in str(exc):
        return False    # not present, carry on
    raise
```

But `GitHubOrgClient._get_json` logged every `HTTPError` at ERROR. At ~7 paths × 55 repos, every cycle wrote several hundred ERROR lines. The one genuine error in the same window (`organization_digest.llm_agent_read ... HTTP Error 400`) is a single line buried among them.

## The change

A 404 logs at DEBUG. Every other status stays at ERROR.

## Second bug, fixed while here

`GitHubAPIError` now carries `status`, and both callers use `exc.status == 404` instead of `"404" in str(exc)`.

The string test matches a `404` appearing **anywhere** in the message — including a repository name or the first 300 characters of an error body, which is what the exception embeds. A 500 whose body happened to contain "404" would have been silently treated as a missing file. Same silent-success family as the rest of today.

## Tests

`966 passed, 1 skipped`, ruff clean. The 404 test was verified to fail when the DEBUG downgrade is reverted.

- `test_a_404_probe_is_not_logged_as_an_error` — asserts no ERROR record and that `status == 404`
- `test_a_real_failure_is_still_logged_as_an_error` — a 500 must stay loud

## Not fixed here

`organization_digest.llm_agent_read LLM call failed with HTTPError: HTTP Error 400: Bad Request` is a real failure that fires every cycle. It needs its own investigation; this PR only stops it being invisible.