### PR TITLE
perf(repo-sync): read each repo tree once instead of probing for it

### DIFF
--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -126,6 +126,42 @@ class RepoContentGitHubClient(GitHubOrgClient):
             raise GitHubAPIError(f"Could not resolve commit SHA for {full_name}@{ref}.")
         return commit_sha
 
+    def fetch_tree(self, full_name: str, *, ref: str) -> tuple[list[str], bool] | None:
+        """Every file path in the repo, in ONE request. (paths, truncated) or None.
+
+        Replaces probing. The old discovery asked GitHub one question per root
+        path and one per directory in a depth-4 walk, so a repo with none of the
+        wanted files still cost ~7 requests that all 404'd — several hundred
+        failed calls an hour across the org, and the bulk of the error log.
+
+        Returns None when the tree cannot be read, so the caller can fall back to
+        probing rather than silently syncing nothing.
+        """
+        try:
+            data = self._get_json(
+                f"/repos/{quote(full_name, safe='/')}/git/trees/{quote(ref, safe='')}",
+                {"recursive": "1"},
+            )
+        except GitHubAPIError as exc:
+            logger.warning(
+                "Tree read failed for %s@%s (%s); falling back to path probing",
+                full_name,
+                ref[:12],
+                exc.status or exc.__class__.__name__,
+            )
+            return None
+        if not isinstance(data, dict) or not isinstance(data.get("tree"), list):
+            logger.warning("Unexpected tree payload for %s; falling back to probing", full_name)
+            return None
+        paths = [
+            str(entry["path"])
+            for entry in data["tree"]
+            if isinstance(entry, dict) and entry.get("type") == "blob" and entry.get("path")
+        ]
+        # GitHub truncates very large trees. A truncated tree is missing files,
+        # so say so and let the caller decide rather than treating it as whole.
+        return paths, bool(data.get("truncated"))
+
     def file_exists(self, full_name: str, path: str, *, ref: str) -> bool:
         try:
             data = self._get_json(
@@ -176,6 +212,54 @@ class RepoContentGitHubClient(GitHubOrgClient):
         return []
 
 
+def _select_from_tree(
+    paths: list[str],
+    *,
+    root_paths: tuple[str, ...],
+    tree_prefixes: tuple[str, ...],
+    tree_extensions: tuple[str, ...],
+    max_files: int,
+    max_depth: int,
+) -> list[str]:
+    """Pick the wanted files out of a full repo tree, with zero further requests.
+
+    Mirrors the probing order exactly so the selection is unchanged: every root
+    path that exists, in configured order, then each tree prefix in order.
+    """
+    present = set(paths)
+    selected: list[str] = []
+    seen: set[str] = set()
+
+    for path in root_paths:
+        normalized = path.strip().lstrip("/")
+        if not normalized or normalized in seen:
+            continue
+        if normalized in present:
+            selected.append(normalized)
+            seen.add(normalized)
+        if len(selected) >= max_files:
+            return selected
+
+    for prefix in tree_prefixes:
+        if len(selected) >= max_files:
+            break
+        root = prefix.strip().strip("/")
+        if not root:
+            continue
+        for entry_path in paths:
+            if len(selected) >= max_files:
+                return selected
+            if entry_path in seen or not entry_path.startswith(f"{root}/"):
+                continue
+            # The probing walk stopped at max_depth levels below the prefix.
+            if entry_path[len(root) + 1 :].count("/") + 1 > max_depth:
+                continue
+            if _matches_extension(entry_path, tree_extensions):
+                selected.append(entry_path)
+                seen.add(entry_path)
+    return selected
+
+
 def discover_repo_paths(
     client: RepoContentGitHubClient,
     full_name: str,
@@ -187,6 +271,26 @@ def discover_repo_paths(
     max_files: int,
     max_depth: int = 4,
 ) -> list[str]:
+    tree = client.fetch_tree(full_name, ref=ref)
+    if tree is not None:
+        paths, truncated = tree
+        if truncated:
+            # Missing entries would look like missing files, which is exactly the
+            # silent-empty shape. Probe instead of quietly syncing a partial repo.
+            logger.warning(
+                "Tree for %s is truncated by GitHub; falling back to path probing",
+                full_name,
+            )
+        else:
+            return _select_from_tree(
+                paths,
+                root_paths=root_paths,
+                tree_prefixes=tree_prefixes,
+                tree_extensions=tree_extensions,
+                max_files=max_files,
+                max_depth=max_depth,
+            )
+
     selected: list[str] = []
     seen: set[str] = set()
 

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -212,6 +212,25 @@ class RepoContentGitHubClient(GitHubOrgClient):
         return []
 
 
+def _in_probe_order(paths: list[str], root: str) -> list[str]:
+    """The paths under ``root``, ordered the way the directory walk reached them.
+
+    GitHub returns a recursive tree depth-first, so a file three levels down
+    arrives before a sibling of its top directory. The walk this replaces was
+    breadth-first: every file directly under the prefix, then the next level.
+    Both orders hold the same files, so the difference stays invisible until
+    ``max_files`` binds, at which point each path keeps a different subset and
+    the vault quietly starts holding different content.
+
+    Sorts on components rather than the raw string because '-' sorts before
+    '/': a directory ``a`` and a file ``a-b.md`` come out in the opposite order
+    otherwise, which is not what listing the directory returned.
+    """
+    marker = f"{root}/"
+    under = [path for path in paths if path.startswith(marker)]
+    return sorted(under, key=lambda path: (path[len(marker) :].count("/"), path.split("/")))
+
+
 def _select_from_tree(
     paths: list[str],
     *,
@@ -223,8 +242,10 @@ def _select_from_tree(
 ) -> list[str]:
     """Pick the wanted files out of a full repo tree, with zero further requests.
 
-    Mirrors the probing order exactly so the selection is unchanged: every root
-    path that exists, in configured order, then each tree prefix in order.
+    Selection order matches the probing walk this replaces: every root path that
+    exists, in configured order, then each tree prefix in order, and within a
+    prefix breadth-first by depth. That last part has to be restored explicitly
+    (see ``_in_probe_order``) because the tree arrives depth-first.
     """
     present = set(paths)
     selected: list[str] = []
@@ -246,10 +267,10 @@ def _select_from_tree(
         root = prefix.strip().strip("/")
         if not root:
             continue
-        for entry_path in paths:
+        for entry_path in _in_probe_order(paths, root):
             if len(selected) >= max_files:
                 return selected
-            if entry_path in seen or not entry_path.startswith(f"{root}/"):
+            if entry_path in seen:
                 continue
             # The probing walk stopped at max_depth levels below the prefix.
             if entry_path[len(root) + 1 :].count("/") + 1 > max_depth:

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -443,3 +443,46 @@ def test_max_files_cap_is_respected_identically_on_both_paths() -> None:
         discover_repo_paths(via_tree, "o/r", ref="sha", **kw)
         == discover_repo_paths(via_probe, "o/r", ref="sha", **kw)
     )
+
+
+def _depth_ordered_client() -> FakeRepoContentClient:
+    """A prefix whose nested file arrives BEFORE its top-level one.
+
+    This is the shape the rich fixture cannot express: its only file directly
+    under ``skills/`` has the wrong extension, so it is filtered out before the
+    cap can ever choose between the two depths. Here ``skills/a`` sorts before
+    ``skills/zzz.md``, so the recursive tree lists ``skills/a/SKILL.md`` first
+    while the directory walk saw ``skills/zzz.md`` first.
+    """
+    client = FakeRepoContentClient()
+    client.files = {
+        "o/r/skills/a/SKILL.md": {"sha": "1", "content": "x"},
+        "o/r/skills/zzz.md": {"sha": "2", "content": "x"},
+    }
+    client.directories = {
+        "o/r/skills": [
+            {"path": "skills/a", "type": "dir"},
+            {"path": "skills/zzz.md", "type": "file"},
+        ],
+        "o/r/skills/a": [{"path": "skills/a/SKILL.md", "type": "file"}],
+    }
+    return client
+
+
+def test_a_binding_cap_keeps_the_shallower_file_on_both_paths() -> None:
+    """The cap must truncate the same list probing would have truncated.
+
+    Selection drift is silent in production: paths_discovered still reports the
+    cap, nothing is logged, and the files that fall off the end simply stop
+    being refreshed while different ones start being ingested.
+    """
+    via_tree = _depth_ordered_client()
+    via_probe = _depth_ordered_client()
+    via_probe.tree_fails = True
+    kw = {**_DISCOVERY_KW, "tree_prefixes": ("skills/",), "max_files": 1}
+
+    tree_paths = discover_repo_paths(via_tree, "o/r", ref="sha", **kw)
+    probe_paths = discover_repo_paths(via_probe, "o/r", ref="sha", **kw)
+
+    assert probe_paths == ["skills/zzz.md"], "the walk takes the prefix's own files first"
+    assert tree_paths == probe_paths, f"selection drifted under the cap: {tree_paths} != {probe_paths}"

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -71,6 +71,20 @@ class FakeRepoContentClient(RepoContentGitHubClient):
                 {"path": "skills/sokosumi/SKILL.md", "type": "file"},
             ],
         }
+        # The single-tree read (one request per repo). Without this override the
+        # fake inherits the REAL fetch_tree and the test hits api.github.com.
+        self.tree_truncated = False
+        self.tree_fails = False
+        self.tree_calls = 0
+        self.probe_calls = 0
+
+    def fetch_tree(self, full_name: str, *, ref: str) -> tuple[list[str], bool] | None:
+        self.tree_calls += 1
+        if self.tree_fails:
+            return None
+        prefix = f"{full_name}/"
+        paths = [key[len(prefix) :] for key in self.files if key.startswith(prefix)]
+        return sorted(paths), self.tree_truncated
 
     def fetch_default_branch(self, full_name: str) -> str:
         return "main"
@@ -79,6 +93,7 @@ class FakeRepoContentClient(RepoContentGitHubClient):
         return "commit123"
 
     def file_exists(self, full_name: str, path: str, *, ref: str) -> bool:
+        self.probe_calls += 1
         return f"{full_name}/{path}" in self.files
 
     def fetch_file_text(self, full_name: str, path: str, *, ref: str) -> RepoContentFile | None:
@@ -95,6 +110,7 @@ class FakeRepoContentClient(RepoContentGitHubClient):
         )
 
     def list_directory(self, full_name: str, path: str, *, ref: str) -> list[dict[str, Any]]:
+        self.probe_calls += 1
         return self.directories.get(f"{full_name}/{path}", [])
 
 
@@ -303,3 +319,127 @@ def test_resolved_repos_autojoin_disabled_skips_discovery() -> None:
     syncer = RepoContentSyncer(FakeCitadel(config), client=TrackingClient(), state_path="unused")
     assert syncer._resolved_repos() == ["masumi-network/sokosumi-cli"]
     assert fetch_calls == []
+
+
+# --- single-tree discovery: the refactor must be behaviour-preserving --------
+
+
+def _rich_client() -> FakeRepoContentClient:
+    """A repo shape with every edge the two code paths could disagree on."""
+    client = FakeRepoContentClient()
+    client.files = {
+        "o/r/README.md": {"sha": "1", "content": "x"},
+        "o/r/AGENTS.md": {"sha": "2", "content": "x"},
+        "o/r/skills/a/SKILL.md": {"sha": "3", "content": "x"},
+        "o/r/skills/a/b/deep.md": {"sha": "4", "content": "x"},
+        "o/r/skills/a/b/c/d/too-deep.md": {"sha": "5", "content": "x"},
+        "o/r/skills/notes.txt": {"sha": "6", "content": "x"},  # wrong extension
+        "o/r/docs/guide.md": {"sha": "7", "content": "x"},
+        "o/r/skillsets/decoy.md": {"sha": "8", "content": "x"},  # prefix lookalike
+    }
+    client.directories = {
+        "o/r/skills": [
+            {"path": "skills/a", "type": "dir"},
+            {"path": "skills/notes.txt", "type": "file"},
+        ],
+        "o/r/skills/a": [
+            {"path": "skills/a/SKILL.md", "type": "file"},
+            {"path": "skills/a/b", "type": "dir"},
+        ],
+        "o/r/skills/a/b": [
+            {"path": "skills/a/b/deep.md", "type": "file"},
+            {"path": "skills/a/b/c", "type": "dir"},
+        ],
+        "o/r/skills/a/b/c": [{"path": "skills/a/b/c/d", "type": "dir"}],
+        "o/r/skills/a/b/c/d": [{"path": "skills/a/b/c/d/too-deep.md", "type": "file"}],
+        "o/r/docs": [{"path": "docs/guide.md", "type": "file"}],
+        "o/r/skillsets": [{"path": "skillsets/decoy.md", "type": "file"}],
+    }
+    return client
+
+
+_DISCOVERY_KW = dict(
+    root_paths=("README.md", "AGENTS.md", "MISSING.md"),
+    tree_prefixes=("skills/", "docs/"),
+    tree_extensions=(".md",),
+    max_files=10,
+    max_depth=3,
+)
+
+
+def test_tree_and_probe_discovery_select_the_same_files() -> None:
+    """The refactor must not change WHICH files get synced, only how we find them.
+
+    A silent change in selection would be invisible in production: the vault
+    would just quietly hold different content.
+    """
+    via_tree = _rich_client()
+    via_probe = _rich_client()
+    via_probe.tree_fails = True  # force the old path
+
+    tree_paths = discover_repo_paths(via_tree, "o/r", ref="sha", **_DISCOVERY_KW)
+    probe_paths = discover_repo_paths(via_probe, "o/r", ref="sha", **_DISCOVERY_KW)
+
+    assert tree_paths == probe_paths, f"selection drifted: {tree_paths} != {probe_paths}"
+    assert tree_paths == [
+        "README.md",
+        "AGENTS.md",
+        "skills/a/SKILL.md",
+        "skills/a/b/deep.md",
+        "docs/guide.md",
+    ]
+    # The edges: wrong extension, too deep, and a prefix lookalike are all excluded.
+    assert "skills/notes.txt" not in tree_paths
+    assert "skills/a/b/c/d/too-deep.md" not in tree_paths
+    assert "skillsets/decoy.md" not in tree_paths
+
+
+def test_the_tree_path_makes_one_request_instead_of_many() -> None:
+    """The point of the change: stop firing requests that 404."""
+    via_tree = _rich_client()
+    via_probe = _rich_client()
+    via_probe.tree_fails = True
+
+    discover_repo_paths(via_tree, "o/r", ref="sha", **_DISCOVERY_KW)
+    discover_repo_paths(via_probe, "o/r", ref="sha", **_DISCOVERY_KW)
+
+    assert via_tree.tree_calls == 1
+    assert via_tree.probe_calls == 0, "the tree path must not probe at all"
+    assert via_probe.probe_calls >= 7, "the old path really did fire this many"
+
+
+def test_a_truncated_tree_falls_back_instead_of_syncing_a_partial_repo() -> None:
+    """A truncated tree is missing files, which looks identical to 'no files'.
+
+    That is the silent-empty shape, so it must fall back rather than quietly
+    sync less than the repo actually has.
+    """
+    client = _rich_client()
+    client.tree_truncated = True
+
+    paths = discover_repo_paths(client, "o/r", ref="sha", **_DISCOVERY_KW)
+
+    assert client.probe_calls > 0, "truncation must fall back to probing"
+    assert paths == ["README.md", "AGENTS.md", "skills/a/SKILL.md", "skills/a/b/deep.md", "docs/guide.md"]
+
+
+def test_an_unreadable_tree_falls_back_and_still_finds_everything() -> None:
+    client = _rich_client()
+    client.tree_fails = True
+
+    paths = discover_repo_paths(client, "o/r", ref="sha", **_DISCOVERY_KW)
+
+    assert client.probe_calls > 0
+    assert "README.md" in paths and "skills/a/SKILL.md" in paths
+
+
+def test_max_files_cap_is_respected_identically_on_both_paths() -> None:
+    via_tree = _rich_client()
+    via_probe = _rich_client()
+    via_probe.tree_fails = True
+    kw = {**_DISCOVERY_KW, "max_files": 3}
+
+    assert (
+        discover_repo_paths(via_tree, "o/r", ref="sha", **kw)
+        == discover_repo_paths(via_probe, "o/r", ref="sha", **kw)
+    )


### PR DESCRIPTION
**Stacked on #145** — merge that first, then this. #145 alone was the lazy fix; it changed a log level. This removes the cause.

## The cause

`discover_repo_paths` fires requests it knows will fail:

- one `file_exists` per configured root path (`AGENTS.md`, `SKILL.md`, `CONTEXT.md`, …)
- one `list_directory` per directory, breadth-first to depth 4, per tree prefix (`skills/`, `docs/`, `content/docs/`, `plugins/`)

A repo with none of the wanted files still costs ~7 requests, all 404. Across 55 repos that is several hundred failed calls an hour, hourly, forever — and it was the bulk of the production error log.

GitHub returns the entire file list in **one** call. `fetch_tree` reads `/git/trees/{sha}?recursive=1` once per repo; every existence question is then answered in memory.

## Fallbacks, both deliberate

- **Tree unreadable** → fall back to probing rather than sync nothing.
- **Tree truncated** (GitHub caps very large trees) → also fall back. A truncated tree is *missing files*, which is indistinguishable from a repo that has none. Quietly syncing a partial repo is exactly the silent-empty shape this codebase keeps producing, so it probes instead.

## What actually needed proving

Not the speed — the **selection**. If the tree path picks different files than probing did, the vault quietly holds different content and nothing surfaces it.

`test_tree_and_probe_discovery_select_the_same_files` runs both paths over one fixture containing every edge they could disagree on:

| Edge | File |
|---|---|
| wrong extension | `skills/notes.txt` |
| beyond `max_depth` | `skills/a/b/c/d/too-deep.md` |
| prefix lookalike | `skillsets/decoy.md` vs prefix `skills/` |
| nested match | `skills/a/b/deep.md` |

Both paths return the identical list. `max_files` capping is asserted identical too.

All four branches of the new selector were mutation-tested — removing the depth check, weakening the prefix match to `startswith(root)`, dropping the extension filter, and disabling the truncation guard each turn the correct test red.

## A defect this change introduced, and fixed

`FakeRepoContentClient` did not override `fetch_tree`, so it inherited the **real** one. The pre-existing discovery test was making a live request to `api.github.com`, getting a 404 for a fixture repo, and passing via my fallback. A green suite was proving nothing about the new path.

The fake now serves the tree from its own fixture. Verified hermetic: zero `Tree read failed` warnings across the whole suite.

## Tests

`971 passed, 1 skipped`, ruff clean. Five new tests: selection equivalence, request-count (1 vs ≥7), truncation fallback, unreadable-tree fallback, and identical `max_files` capping.