### PR TITLE
fix(search): a timed-out search is not an audit success

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -5929,7 +5929,12 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     record_mcp_audit(
         request,
         actor=actor,
-        success=True,
+        # A search that blew its budget returned empty-fast; the caller got no
+        # hits. Recording it as a success meant /api/audit?view=failures never
+        # showed it and any success-rate metric read 100% while users saw
+        # nothing — which is how the "~20% silent failure" in #50 stayed
+        # unquantified. The detail dict already carried timed_out; nothing read it.
+        success=not timed_out,
         dataset=search_datasets[0],
         detail={
             "operation": "search",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5700,3 +5700,57 @@ def test_the_weak_key_guard_can_be_overridden_explicitly(monkeypatch) -> None:
     )
 
     server_module.enforce_access_key_strength()
+
+
+def test_a_timed_out_search_is_audited_as_a_failure(monkeypatch) -> None:
+    """A search that returned nothing must not be recorded as a success (#50).
+
+    The audit detail already carried timed_out, but success was hardcoded True,
+    so /api/audit?view=failures never listed a timed-out search and any
+    success-rate metric read 100% while callers got zero hits. That is why the
+    "~20% silent failure rate" in #50 could never be quantified from the data
+    the node itself records.
+    """
+    import asyncio as aio
+    import dataclasses
+
+    class SlowCitadel(FakeCitadel):
+        config = dataclasses.replace(FakeCitadel.config, search_timeout_seconds=0.01)
+
+        async def search(self, query: str, **kwargs: Any) -> list[Any]:
+            await aio.sleep(0.3)
+            return [{"id": "x"}]
+
+    audited: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        server_module,
+        "record_mcp_audit",
+        lambda request, **kw: audited.append(kw),
+    )
+
+    client = authed_client("test-reader")
+    app.state.citadel = SlowCitadel()
+
+    body = client.post("/search", json={"query": "q", "top_k": 3}).json()
+
+    assert body.get("timed_out") is True
+    assert audited, "the search must be audited at all"
+    entry = audited[-1]
+    assert entry["detail"]["timed_out"] is True
+    assert entry["success"] is False, "a timed-out search is not a success"
+
+
+def test_a_normal_search_is_still_audited_as_a_success() -> None:
+    """The guard against over-correcting: only the timeout path flips."""
+    audited: list[dict[str, Any]] = []
+    original = server_module.record_mcp_audit
+    server_module.record_mcp_audit = lambda request, **kw: audited.append(kw)
+    try:
+        client = authed_client("test-reader")
+        app.state.citadel = FakeCitadel()
+        body = client.post("/search", json={"query": "q", "top_k": 3}).json()
+    finally:
+        server_module.record_mcp_audit = original
+
+    assert body.get("timed_out") in (None, False)
+    assert audited and audited[-1]["success"] is True


### PR DESCRIPTION
Refs #50. The code half of the "~20% silent failure rate", which no env change can fix.

## The bug

`kb/server.py` calls `record_mcp_audit(..., success=True, ...)` on the normal return path of `POST /search` — including when `_search_within_budget` blew its budget and degraded to empty-fast.

The detail dict already carried `"timed_out": timed_out`. **Nothing read it.**

Consequences:
- `/api/audit?view=failures` never listed a timed-out search
- any success-rate metric built on the audit read 100% while callers got zero hits

That is precisely why #50's "~20% silent failure rate" could never be quantified from the data the node records about itself. The HTTP body was always honest (`timed_out`, `truncated`, a `note`); the audit trail was not.

Same family as #89, #114 and #138: the failure path handled carefully, the *reporting* of it wrong.

## The change

`success=not timed_out`. One line.

Deliberately narrow. The 500 path already records `success=False`, and a normal search still records `success=True` — there is a test for each so this cannot over-correct into marking healthy searches as failures.

## Tests

`987 passed, 1 skipped`, ruff clean. Verified by reverting to `success=True` and watching only `test_a_timed_out_search_is_audited_as_a_failure` go red.

- `test_a_timed_out_search_is_audited_as_a_failure` — asserts `detail["timed_out"] is True` **and** `success is False`
- `test_a_normal_search_is_still_audited_as_a_success` — the over-correction guard

## Not in this PR

The dominant cost in #50 is environmental: `AUTO_FEEDBACK` defaults True in cognee, adding one structured-output LLM call per `cognee.search`, and a seat query fans out to three datasets — so three such calls per user query. `AUTO_FEEDBACK=false` is an env change, measured to take that to zero. See the analysis on #50.