### PR TITLE
docs: record the session_trace facade removal as a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,24 @@ All notable changes to `citadel-archive` are documented here. Format follows
   could attribute a trace to a colleague); and the dataset name no longer
   satisfies `repo=` / `path=` scoping (Central is named after the org).
 
+### Removed
+
+- **`kb.session_trace` no longer re-exports the distill helpers, and
+  `share_session_tags` is gone**
+  ([#130](https://github.com/masumi-network/Citadel/pull/130), thanks
+  @WAHIB-EL-KHADIRI). `DeadEnd`, `SessionTraceRecord`, `ToolErrorPair`,
+  `distill_node_note`, `distill_trace`, `format_compact_context`,
+  `iter_transcript_entries` and `redact_commands` were forwarded through
+  `kb.session_trace` and imported through it by nothing. Import them from
+  `kb.session_trace_distill`, which is where every in-tree caller already got
+  them. `share_session_tags` had no callers at all and is deleted outright
+  rather than moved. `enrich_shared_trace` and `force_shared_trace_author_seat`
+  are unaffected.
+
+  Called out because these names shipped in `v0.4.0` on PyPI, so this is a
+  breaking change for anything importing them out of tree, even though nothing
+  in this repository did.
+
 ## [0.4.0] — 2026-07-22
 
 ### Added


### PR DESCRIPTION
Follow-up to #130, as promised in that review so @WAHIB-EL-KHADIRI was not blocked on it.

#130 is correct and merged. The only gap was framing: it reads as an internal cleanup, and in this repository it is one — nothing imported those names through `kb.session_trace`.

But `git show v0.4.0:kb/session_trace.py` has all nine in `__all__` (`share_session_tags` at line 80, listed at line 38), and `.github/workflows/publish.yml` publishes `citadel-archive` to PyPI on every `v*` tag. So `from kb.session_trace import distill_trace` resolves against the released package and breaks on upgrade.

That is a breaking change for out-of-tree consumers and belongs under `### Removed`, with the replacement import path spelled out.

Docs only, no code.