### PR TITLE
fix(access): provision and backfill seat cognee dataset rows (#147)

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -742,6 +742,7 @@ class CogneePublicClient:
         await self._ensure_cognee_ready(cognee)
         from cognee.modules.data.methods import create_authorized_dataset, get_datasets
         from cognee.modules.users.methods import get_default_user
+        from sqlalchemy.exc import IntegrityError
 
         user = await get_default_user()
         # Read FIRST, purely to decide what to report. Mirror create_dataset's
@@ -760,7 +761,21 @@ class CogneePublicClient:
         # while its searches keep failing on PermissionDeniedError rather than
         # DatasetNotFoundError. Calling through costs four guarded no-op queries
         # on a healthy seat and repairs the broken one.
-        await create_authorized_dataset(name, user)
+        try:
+            await create_authorized_dataset(name, user)
+        except IntegrityError:
+            # Lost a creation race. create_dataset is SELECT-then-INSERT on a
+            # deterministic uuid5 id (get_unique_dataset_id) and handles no
+            # IntegrityError, so two writers for the same name collide on the
+            # primary key. That is reachable here rather than theoretical:
+            # Railway runs evolve and linear-sync as separate OS processes
+            # against the same Postgres, and linear_sync writes into
+            # seat:<slug>, so a boot backfill can meet an in-flight cognee.add.
+            #
+            # The row exists either way, which is the whole point of the call,
+            # and the loser reports False because it did not create it.
+            logger.info("ensure_dataset lost a creation race for %s", name)
+            return False
         return was_missing
 
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -711,6 +711,50 @@ class CogneePublicClient:
                 counts[str(dataset_name)] = int(total or 0)
         return counts
 
+    async def ensure_dataset(self, name: str) -> bool:
+        """Provision the cognee Dataset row for ``name``, returning whether it was new.
+
+        cognee only creates a Dataset row on the WRITE path: ``cognee.add``
+        resolves the name and calls ``create_authorized_dataset``. The read path
+        does not, so it raises ``DatasetNotFoundError`` instead. A seat whose
+        holder has never successfully ingested therefore has no row, and every
+        search against their node fails (#147). Provision at seat creation
+        rather than waiting for a write that may never come.
+
+        The permission rows are not optional. The read path resolves a name in
+        two steps, and only the first one is about the row existing:
+        ``get_dataset_ids`` matches on name, owner and tenant, then
+        ``get_specific_user_permission_datasets`` filters by ACL. With the row
+        but no ACL a search fails just as hard, only with ``PermissionDeniedError``
+        instead. ``create_authorized_dataset`` writes both.
+
+        Idempotent on both halves, so backfilling an already-healthy seat is a
+        no-op: ``create_dataset`` selects on (name, owner, tenant) before it
+        inserts, and ``give_permission_on_dataset`` looks for the ACL row before
+        adding it.
+
+        Relational store only. This never opens the graph, so it cannot collide
+        with the single Kuzu writer or with an in-flight cognify.
+        """
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.modules.data.methods import create_authorized_dataset, get_datasets
+        from cognee.modules.users.methods import get_default_user
+
+        user = await get_default_user()
+        # Mirror create_dataset's own uniqueness filter. get_datasets only
+        # narrows by owner, so the tenant check has to happen here or a seat in
+        # another tenant would read as already provisioned.
+        existing = await get_datasets(user.id)
+        if any(
+            dataset.name == name and dataset.tenant_id == user.tenant_id for dataset in existing
+        ):
+            return False
+        await create_authorized_dataset(name, user)
+        return True
+
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:
         """Delete nodes by id from BOTH the graph and the chunk vector store (#15).
 

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -744,16 +744,24 @@ class CogneePublicClient:
         from cognee.modules.users.methods import get_default_user
 
         user = await get_default_user()
-        # Mirror create_dataset's own uniqueness filter. get_datasets only
-        # narrows by owner, so the tenant check has to happen here or a seat in
-        # another tenant would read as already provisioned.
+        # Read FIRST, purely to decide what to report. Mirror create_dataset's
+        # own uniqueness filter: get_datasets narrows by owner only, so the
+        # tenant check has to happen here or a seat in another tenant reads as
+        # already provisioned.
         existing = await get_datasets(user.id)
-        if any(
+        was_missing = not any(
             dataset.name == name and dataset.tenant_id == user.tenant_id for dataset in existing
-        ):
-            return False
+        )
+        # Then provision UNCONDITIONALLY. Returning early on a present row would
+        # leave a half-provisioned seat broken forever: the row and its four ACL
+        # rows are written by different statements, and give_permission_on_dataset
+        # gives up after three attempts, so a partial failure is reachable. That
+        # seat has a row, fails the existence check, and never gets repaired,
+        # while its searches keep failing on PermissionDeniedError rather than
+        # DatasetNotFoundError. Calling through costs four guarded no-op queries
+        # on a healthy seat and repairs the broken one.
         await create_authorized_dataset(name, user)
-        return True
+        return was_missing
 
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:
         """Delete nodes by id from BOTH the graph and the chunk vector store (#15).

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -211,6 +211,18 @@ class PromotionEnumerationError(RuntimeError):
     """
 
 
+class SeatDatasetMissingError(PromotionEnumerationError):
+    """The seat has no cognee Dataset row at all, so nothing can read it (#147).
+
+    A subclass, not a sibling, so anything already catching
+    PromotionEnumerationError keeps working. The point is the name: callers log
+    ``exc.__class__.__name__``, and "every search failed" and "this seat was
+    never provisioned" want different responses. The first is an outage to
+    investigate. The second is one backfill run, and the seat has never worked
+    for its holder even once.
+    """
+
+
 class PromotionEngine:
     """Selective seat-to-Central promotion (ADR-0005 step 2)."""
 
@@ -266,9 +278,19 @@ class PromotionEngine:
             # made the caller count the seat as a clean zero: production logged
             # "seats=11 promoted=0 failures=0" while all 22 searches were dying
             # on the Kuzu lock and on DatasetNotFoundError.
+            distinct = sorted(set(errors))
+            if distinct == ["DatasetNotFoundError"]:
+                # Matched on the class NAME rather than the class so this module
+                # keeps working without cognee importable; enumerate already
+                # records names, not exceptions.
+                raise SeatDatasetMissingError(
+                    f"{seat_dataset} has no cognee dataset row: all {attempted} "
+                    "seed queries raised DatasetNotFoundError. The seat predates "
+                    "dataset provisioning at creation; backfill it (#147)."
+                )
             raise PromotionEnumerationError(
                 f"all {attempted} seed queries failed for {seat_dataset}: "
-                f"{', '.join(sorted(set(errors)))}"
+                f"{', '.join(distinct)}"
             )
         return candidates[:cap]
 

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -280,9 +280,14 @@ class PromotionEngine:
             # on the Kuzu lock and on DatasetNotFoundError.
             distinct = sorted(set(errors))
             if distinct == ["DatasetNotFoundError"]:
-                # Matched on the class NAME rather than the class so this module
-                # keeps working without cognee importable; enumerate already
-                # records names, not exceptions.
+                # Matched on the class NAME, and it has to stay that way. cognee
+                # 1.2.2 defines DatasetNotFoundError TWICE, in
+                # api/v1/exceptions/exceptions.py and in
+                # modules/data/exceptions/exceptions.py, and raises both on
+                # paths a search can reach (search.py:294, recall.py:595). An
+                # isinstance check against either import silently misses the
+                # other. Name-matching also keeps this module importable without
+                # cognee, which no kb module requires at import time.
                 raise SeatDatasetMissingError(
                     f"{seat_dataset} has no cognee dataset row: all {attempted} "
                     "seed queries raised DatasetNotFoundError. The seat predates "

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -280,14 +280,20 @@ class PromotionEngine:
             # on the Kuzu lock and on DatasetNotFoundError.
             distinct = sorted(set(errors))
             if distinct == ["DatasetNotFoundError"]:
-                # Matched on the class NAME, and it has to stay that way. cognee
-                # 1.2.2 defines DatasetNotFoundError TWICE, in
-                # api/v1/exceptions/exceptions.py and in
-                # modules/data/exceptions/exceptions.py, and raises both on
-                # paths a search can reach (search.py:294, recall.py:595). An
-                # isinstance check against either import silently misses the
-                # other. Name-matching also keeps this module importable without
-                # cognee, which no kb module requires at import time.
+                # Matched on the class NAME because no kb module imports cognee
+                # at module scope, and an except/isinstance check needs the
+                # symbol there. enumerate already records names, not exceptions.
+                #
+                # The cost is that a cognee rename would silently stop the
+                # discrimination without failing anything, so
+                # test_promotion_matches_cognees_real_exception_name pins the
+                # real class name to this literal.
+                #
+                # Both search-reachable raise sites, search.py:294 and
+                # recall.py:595, import DatasetNotFoundError from
+                # cognee.modules.data.exceptions. cognee 1.2.2 does define a
+                # second class of the same name in api/v1/exceptions, but no
+                # path a search reaches raises it.
                 raise SeatDatasetMissingError(
                     f"{seat_dataset} has no cognee dataset row: all {attempted} "
                     "seed queries raised DatasetNotFoundError. The seat predates "

--- a/kb/server.py
+++ b/kb/server.py
@@ -3372,6 +3372,30 @@ async def create_access_seat(body: CreateSeatBody, request: Request) -> dict[str
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    # create_seat only computes the seat's dataset NAME; cognee creates the row
+    # itself lazily, and only on the write path. Until something is ingested the
+    # row does not exist, and every search for this seat dies on
+    # DatasetNotFoundError (#147). Provision it here so a seat works from the
+    # moment it is handed over.
+    #
+    # Deliberately not fatal. The seat and its token are already persisted by
+    # this point, so raising would leave a half-created seat behind and the
+    # admin no way to tell which half. Report the outcome instead: the audit
+    # event and the response both carry it, and the backfill can pick up any
+    # seat that landed unprovisioned.
+    provisioned: bool | None = None
+    try:
+        cognee_client = getattr(get_citadel(), "cognee", None)
+        ensure_dataset = getattr(cognee_client, "ensure_dataset", None)
+        if callable(ensure_dataset):
+            await ensure_dataset(created.principal.default_dataset)
+            provisioned = True
+    except Exception:
+        provisioned = False
+        logger.exception(
+            "seat dataset provisioning failed for %s", created.principal.default_dataset
+        )
+
     get_access_store().record_event(
         action="access.seat.create",
         actor=actor,
@@ -3382,11 +3406,13 @@ async def create_access_seat(body: CreateSeatBody, request: Request) -> dict[str
             "seat_slug": created.principal.seat_slug,
             "token_id": created.api_token.id if created.api_token else None,
             "role": created.principal.role,
+            "node_dataset_provisioned": provisioned,
         },
     )
     payload: dict[str, Any] = {
         "ok": True,
         "principal": jsonable_encoder(created.principal),
+        "node_dataset_provisioned": provisioned,
     }
     if created.token and created.api_token:
         payload["token"] = created.token

--- a/kb/server.py
+++ b/kb/server.py
@@ -40,6 +40,7 @@ from kb.access import (
     default_scopes,
     hash_api_token,
     is_seat_dataset,
+    seat_dataset,
     validate_seat_slug,
 )
 from kb.capture_policy import SeatCapturePolicy, capture_policy_payload
@@ -460,6 +461,13 @@ async def lifespan(app: FastAPI) -> Any:
             logger.exception(
                 "Failed to bootstrap %s dataset; seat search/share may fail until provisioned",
                 SESSION_TRACES_DATASET,
+            )
+        try:
+            await backfill_seat_datasets(get_citadel(), get_access_store())
+        except Exception:
+            logger.exception(
+                "Seat dataset backfill failed; seats created before provisioning "
+                "may still fail every search (#147)"
             )
         evolve_task = _start_evolve_scheduler()
         repo_stats_task = _start_repo_stats_scheduler()
@@ -2367,6 +2375,52 @@ async def ensure_session_traces_dataset(citadel: Citadel) -> None:
             SESSION_TRACES_DATASET,
             result.reason,
         )
+
+
+async def backfill_seat_datasets(citadel: Citadel, store: AccessStore) -> dict[str, int]:
+    """Give every existing seat the cognee Dataset row its searches need (#147).
+
+    Seats created before provisioning existed have a dataset NAME and no row,
+    so every search for them raises DatasetNotFoundError. Six of eleven live
+    seats were in that state and had never had a working vault.
+
+    A boot pass rather than a script, for the same reason
+    ``ensure_session_traces_dataset`` above is one: it needs cognee's event
+    loop, and running it here makes the repair self-healing instead of
+    something an operator has to remember. ``ensure_dataset`` is idempotent and
+    also repairs a row whose ACLs are missing, so re-running every boot is both
+    safe and the point.
+
+    Relational store only, so this never opens the graph and cannot contend
+    with the single Kuzu writer during startup.
+
+    Per-seat failures are swallowed deliberately: one seat that cannot be
+    provisioned must not stop the other ten, and must not stop the node
+    booting. They are counted and logged.
+    """
+    counts = {"seats": 0, "created": 0, "failed": 0}
+    cognee_client = getattr(citadel, "cognee", None)
+    ensure_dataset = getattr(cognee_client, "ensure_dataset", None)
+    if not callable(ensure_dataset):
+        return counts
+
+    for slug in store.seat_slugs():
+        counts["seats"] += 1
+        try:
+            if await ensure_dataset(seat_dataset(slug)):
+                counts["created"] += 1
+        except Exception:
+            counts["failed"] += 1
+            logger.exception("Seat dataset backfill failed for seat:%s", slug)
+
+    if counts["created"] or counts["failed"]:
+        logger.info(
+            "Seat dataset backfill: seats=%d created=%d failed=%d",
+            counts["seats"],
+            counts["created"],
+            counts["failed"],
+        )
+    return counts
 
 
 def known_datasets(config: Any) -> list[str]:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -461,6 +461,98 @@ async def test_read_node_dataset_map_joined_query_over_real_models(
     }
 
 
+@pytest.mark.asyncio
+async def test_ensure_dataset_creates_a_missing_row_and_is_idempotent(
+    monkeypatch: Any,
+) -> None:
+    """ensure_dataset provisions a seat's Dataset row exactly once (#147).
+
+    Against the REAL cognee Dataset model on a throwaway sqlite, so a version
+    bump that moves or renames the columns the existence check reads (name,
+    owner_id, tenant_id) fails here rather than silently re-provisioning every
+    seat on every call.
+
+    create_authorized_dataset itself is stubbed. It is cognee's function and
+    cognee guards it; what is being pinned is our decision of WHEN to call it.
+    """
+    from contextlib import asynccontextmanager
+    from importlib import import_module
+    from uuid import uuid4
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import cognee.modules.data.methods as methods_pkg
+    import cognee.modules.users.methods as users_methods
+    from cognee.modules.data.models import Dataset
+
+    user_id, tenant_id = uuid4(), uuid4()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Dataset.__table__.create)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        session.add(
+            Dataset(id=uuid4(), name="seat:alice", owner_id=user_id, tenant_id=tenant_id)
+        )
+        # Same NAME, different tenant. Must not read as already provisioned,
+        # because the read path matches on tenant too.
+        session.add(
+            Dataset(id=uuid4(), name="seat:carol", owner_id=user_id, tenant_id=uuid4())
+        )
+        await session.commit()
+
+    class _FakeRelEngine:
+        @asynccontextmanager
+        async def get_async_session(self) -> Any:
+            async with maker() as session:
+                yield session
+
+    async def get_default_user() -> Any:
+        return SimpleNamespace(id=user_id, tenant_id=tenant_id)
+
+    created: list[str] = []
+
+    async def fake_create_authorized_dataset(name: str, user: Any) -> Any:
+        created.append(name)
+        async with maker() as session:
+            session.add(
+                Dataset(id=uuid4(), name=name, owner_id=user.id, tenant_id=user.tenant_id)
+            )
+            await session.commit()
+
+    # get_datasets binds get_relational_engine at ITS module import, so patching
+    # the relational package would not reach it.
+    monkeypatch.setattr(
+        import_module("cognee.modules.data.methods.get_datasets"),
+        "get_relational_engine",
+        lambda: _FakeRelEngine(),
+    )
+    monkeypatch.setattr(users_methods, "get_default_user", get_default_user)
+    monkeypatch.setattr(
+        methods_pkg, "create_authorized_dataset", fake_create_authorized_dataset
+    )
+
+    client = CogneePublicClient()
+    monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
+
+    async def _ready(_cognee: Any) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_ensure_cognee_ready", _ready)
+
+    # Already provisioned: no second row, no call.
+    assert await client.ensure_dataset("seat:alice") is False
+    # Missing entirely: provisioned.
+    assert await client.ensure_dataset("seat:dave") is True
+    # And now idempotent, which is what makes a backfill safe to re-run.
+    assert await client.ensure_dataset("seat:dave") is False
+    # Present under a DIFFERENT tenant, so still missing for this one.
+    assert await client.ensure_dataset("seat:carol") is True
+
+    await engine.dispose()
+    assert created == ["seat:dave", "seat:carol"]
+
+
 def test_assert_cognee_dataset_api_imports_real_symbols() -> None:
     # A cognee bump that moves the private dataset-attribution internals must
     # fail HERE (loud, in CI), not silently fail-closed in prod. This imports

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -633,6 +633,48 @@ async def test_ensure_dataset_makes_a_seat_resolvable_to_cognee(
 
 
 @pytest.mark.asyncio
+async def test_ensure_dataset_survives_losing_a_creation_race(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    """A concurrent provisioner must not blow up this one (#147).
+
+    create_dataset is SELECT-then-INSERT on a deterministic uuid5 id and
+    handles no IntegrityError, so two writers for the same name collide on the
+    primary key. Reachable rather than theoretical: Railway runs evolve and
+    linear-sync as separate OS processes against one Postgres, and linear_sync
+    writes into seat:<slug>, so a boot backfill can meet an in-flight
+    cognee.add. Unhandled, the first collision aborts the whole sweep and every
+    later seat is silently skipped.
+    """
+    from cognee.infrastructure.databases.relational import create_db_and_tables
+    from cognee.modules.data.methods import get_authorized_dataset_by_name
+    from cognee.modules.users.methods import get_default_user
+
+    await create_db_and_tables()
+    # Warm the default user first. get_default_user CREATES it lazily, and
+    # racing that collides on users.email long before dataset creation is
+    # reached. That is a separate cognee-wide race on every entry point, not
+    # one this change introduces, and guarding it here would only hide which
+    # race the test is actually about. In the boot backfill the user is warm
+    # anyway: ensure_session_traces_dataset runs first, and the loop is
+    # sequential within a process.
+    user = await get_default_user()
+    client = _real_cognee_client(monkeypatch)
+
+    results = await asyncio.gather(
+        *(client.ensure_dataset("seat:racer") for _ in range(3)),
+        return_exceptions=True,
+    )
+
+    raised = [r for r in results if isinstance(r, BaseException)]
+    assert not raised, f"a lost race must not propagate: {raised}"
+    assert sum(1 for r in results if r is True) <= 1, "at most one creator"
+
+    # The row is there regardless of who won, which is the point of the call.
+    assert await get_authorized_dataset_by_name("seat:racer", user, "read") is not None
+
+
+@pytest.mark.asyncio
 async def test_ensure_dataset_repairs_a_row_that_has_no_acl(
     cognee_sqlite: Any, monkeypatch: Any
 ) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -540,17 +540,141 @@ async def test_ensure_dataset_creates_a_missing_row_and_is_idempotent(
 
     monkeypatch.setattr(client, "_ensure_cognee_ready", _ready)
 
-    # Already provisioned: no second row, no call.
+    # Already provisioned for this tenant.
     assert await client.ensure_dataset("seat:alice") is False
-    # Missing entirely: provisioned.
+    # Missing entirely.
     assert await client.ensure_dataset("seat:dave") is True
-    # And now idempotent, which is what makes a backfill safe to re-run.
+    # Now present, so reported as not-new, which is what a backfill counts.
     assert await client.ensure_dataset("seat:dave") is False
-    # Present under a DIFFERENT tenant, so still missing for this one.
+    # Present under a DIFFERENT tenant, so still missing for this one. This is
+    # the assertion the real-cognee tests below do not cover.
     assert await client.ensure_dataset("seat:carol") is True
 
     await engine.dispose()
-    assert created == ["seat:dave", "seat:carol"]
+    # Provisioning runs on EVERY call, including the two that reported False.
+    # The return value describes what was found, not whether we called through:
+    # an early return would strand a seat whose row exists but whose ACL rows
+    # are missing, which test_ensure_dataset_repairs_a_row_that_has_no_acl pins.
+    assert created == ["seat:alice", "seat:dave", "seat:dave", "seat:carol"]
+
+
+@pytest.fixture
+def cognee_sqlite(tmp_path: Any, monkeypatch: Any) -> Any:
+    """Point cognee's REAL relational engine at a throwaway sqlite.
+
+    The caches are lru_cached module-wide, so they are cleared on the way in AND
+    on the way out; skipping the second clear poisons every later test in the
+    session with this tmp_path.
+    """
+    from cognee.base_config import get_base_config
+    from cognee.infrastructure.databases.relational.config import get_relational_config
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+
+    for key, value in {
+        "DB_PROVIDER": "sqlite",
+        "DB_NAME": "citadel_test.db",
+        "SYSTEM_ROOT_DIRECTORY": str(tmp_path / "system"),
+        "DATA_ROOT_DIRECTORY": str(tmp_path / "data"),
+        "CACHE_ROOT_DIRECTORY": str(tmp_path / "cache"),
+        "COGNEE_LOGS_DIR": str(tmp_path / "logs"),
+        "DEFAULT_USER_EMAIL": "citadel_test@example.com",
+        "DEFAULT_USER_PASSWORD": "citadel-test-password",
+        "LLM_API_KEY": "unused-by-this-test",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    def _clear() -> None:
+        get_base_config.cache_clear()
+        get_relational_config.cache_clear()
+        create_relational_engine.cache_clear()
+
+    _clear()
+    yield
+    _clear()
+
+
+def _real_cognee_client(monkeypatch: Any) -> CogneePublicClient:
+    client = CogneePublicClient()
+
+    async def _ready(_cognee: Any) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_ensure_cognee_ready", _ready)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_makes_a_seat_resolvable_to_cognee(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    """The claim that matters: cognee's own read-path resolver finds the seat (#147).
+
+    The stubbed test above pins when we call through. This one pins that the
+    call works, against the real relational stack, by asserting the exact
+    resolver the search path uses flips from None to the dataset.
+    """
+    from cognee.infrastructure.databases.relational import create_db_and_tables
+    from cognee.modules.data.methods import get_authorized_dataset_by_name
+    from cognee.modules.users.methods import get_default_user
+
+    await create_db_and_tables()
+    user = await get_default_user()
+    client = _real_cognee_client(monkeypatch)
+
+    assert await get_authorized_dataset_by_name("seat:alice", user, "read") is None
+
+    assert await client.ensure_dataset("seat:alice") is True
+    resolved = await get_authorized_dataset_by_name("seat:alice", user, "read")
+    assert resolved is not None and resolved.name == "seat:alice"
+
+    assert await client.ensure_dataset("seat:alice") is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_dataset_repairs_a_row_that_has_no_acl(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    """The half-provisioned seat: row present, ACL rows absent (#147).
+
+    create_authorized_dataset commits the Dataset row and THEN writes four
+    permission rows in separate sessions, and give_permission_on_dataset gives
+    up after three attempts, so a partial write is reachable. The read path
+    filters by ACL, so such a seat is exactly as broken as one with no row, and
+    an ensure_dataset that returned early on a present row could never repair
+    it.
+    """
+    from cognee.infrastructure.databases.relational import (
+        create_db_and_tables,
+        get_relational_engine,
+    )
+    from cognee.modules.data.methods import (
+        get_authorized_dataset_by_name,
+        get_unique_dataset_id,
+    )
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.users.methods import get_default_user
+
+    await create_db_and_tables()
+    user = await get_default_user()
+
+    name = "seat:halfway"
+    dataset_id = await get_unique_dataset_id(dataset_name=name, user=user)
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        session.add(
+            Dataset(id=dataset_id, name=name, owner_id=user.id, tenant_id=user.tenant_id)
+        )
+        await session.commit()
+
+    assert await get_authorized_dataset_by_name(name, user, "read") is None
+
+    await _real_cognee_client(monkeypatch).ensure_dataset(name)
+
+    assert (
+        await get_authorized_dataset_by_name(name, user, "read")
+    ) is not None, "seat still unsearchable after ensure_dataset"
 
 
 def test_assert_cognee_dataset_api_imports_real_symbols() -> None:

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -413,6 +413,74 @@ async def test_enumerate_stays_best_effort_when_one_query_fails(tmp_path: Path) 
     assert candidates, "a surviving query's results must still be returned"
 
 
+async def test_enumerate_names_an_unprovisioned_seat_distinctly(tmp_path: Path) -> None:
+    """"This seat has no dataset" is a different problem from "search is broken" (#147).
+
+    The driver in scripts/run_railway.py logs exc.__class__.__name__, so the two
+    cases were indistinguishable in production even though one is an outage to
+    investigate and the other is one backfill run. Six of eleven seats were the
+    second kind and read as the first for weeks.
+    """
+
+    class DatasetNotFoundError(Exception):
+        """Stands in for cognee's, which is matched by name, not by class."""
+
+    total = len(promotion.DEFAULT_SEED_QUERIES)
+    engine = _exploding_engine(
+        tmp_path, fail_first=total, exc=DatasetNotFoundError("No datasets found.")
+    )
+
+    with pytest.raises(promotion.SeatDatasetMissingError) as caught:
+        await engine.enumerate(SEAT, 20)
+
+    assert SEAT in str(caught.value)
+    assert "backfill" in str(caught.value)
+    # Still a PromotionEnumerationError, so existing handlers keep catching it.
+    assert isinstance(caught.value, promotion.PromotionEnumerationError)
+
+
+async def test_enumerate_keeps_the_generic_error_for_mixed_failures(tmp_path: Path) -> None:
+    """A seat that is BOTH unprovisioned and erroring is not a provisioning story.
+
+    Only an unmixed run of DatasetNotFoundError means "just backfill it". If
+    anything else is in the mix the seat needs looking at, so it must not be
+    filed under the cheap remedy.
+    """
+    if len(promotion.DEFAULT_SEED_QUERIES) < 2:  # pragma: no cover - guards the fixture
+        pytest.skip("needs at least two seed queries")
+
+    class DatasetNotFoundError(Exception):
+        pass
+
+    class _MixedCitadel:
+        """First query dies on the lock, every later one on a missing dataset."""
+
+        def __init__(self, config: CitadelConfig) -> None:
+            self.config = config
+            self.calls = 0
+
+        async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("kuzu locked")
+            raise DatasetNotFoundError("No datasets found.")
+
+    config = _config()
+    engine = PromotionEngine(
+        _MixedCitadel(config),
+        FakeLearning(),
+        AccessStore(str(tmp_path / "access.json")),
+        config,
+    )
+
+    with pytest.raises(promotion.PromotionEnumerationError) as caught:
+        await engine.enumerate(SEAT, 20)
+
+    assert not isinstance(caught.value, promotion.SeatDatasetMissingError)
+    assert "RuntimeError" in str(caught.value)
+    assert "DatasetNotFoundError" in str(caught.value)
+
+
 async def test_enumerate_returns_empty_without_raising_when_searches_succeed(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -439,6 +439,25 @@ async def test_enumerate_names_an_unprovisioned_seat_distinctly(tmp_path: Path) 
     assert isinstance(caught.value, promotion.PromotionEnumerationError)
 
 
+def test_promotion_matches_cognees_real_exception_name() -> None:
+    """Pin the literal kb/promotion.py matches to cognee's actual class (#147).
+
+    The discriminator compares exc.__class__.__name__ to the string
+    "DatasetNotFoundError" because no kb module imports cognee at module scope.
+    Nothing else in the suite touches the real class, so a cognee rename would
+    turn the discrimination off silently: every unprovisioned seat would go
+    back to reading as a generic failure and no test would notice.
+
+    Imported from cognee.modules.data.exceptions specifically. That is the one
+    both search-reachable raise sites use (search.py:294, recall.py:595).
+    cognee 1.2.2 also defines a same-named class in api/v1/exceptions that no
+    search path raises.
+    """
+    from cognee.modules.data.exceptions import DatasetNotFoundError
+
+    assert DatasetNotFoundError.__name__ == "DatasetNotFoundError"
+
+
 async def test_enumerate_keeps_the_generic_error_for_mixed_failures(tmp_path: Path) -> None:
     """A seat that is BOTH unprovisioned and erroring is not a provisioning story.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3691,6 +3691,69 @@ def test_create_seat_survives_a_failed_dataset_provision(tmp_path: Any) -> None:
     assert payload["node_dataset_provisioned"] is False, "a failure must be visible"
 
 
+async def test_backfill_seat_datasets_provisions_every_existing_seat(tmp_path: Any) -> None:
+    """Seats that predate provisioning get their row on the next boot (#147).
+
+    A boot pass rather than a script, so the repair is self-healing. One seat
+    that cannot be provisioned must not stop the rest, and must not stop the
+    node booting, so failures are counted rather than raised.
+    """
+    from kb.server import backfill_seat_datasets
+
+    store = AccessStore(tmp_path / "access.json")
+    for slug in ("alice", "bob", "carol"):
+        store.create_seat(name=slug.title(), slug=slug, issue_token=False)
+
+    seen: list[str] = []
+
+    class _Cognee:
+        async def ensure_dataset(self, name: str) -> bool:
+            seen.append(name)
+            if name == "seat:bob":
+                raise RuntimeError("relational store unavailable")
+            # carol was already provisioned by an earlier boot.
+            return name != "seat:carol"
+
+    counts = await backfill_seat_datasets(SimpleNamespace(cognee=_Cognee()), store)
+
+    assert seen == ["seat:alice", "seat:bob", "seat:carol"], "every seat must be attempted"
+    assert counts == {"seats": 3, "created": 1, "failed": 1}
+
+
+def test_backfill_seat_datasets_is_wired_into_boot() -> None:
+    """The backfill is only useful if boot actually calls it (#147).
+
+    The two tests around this one exercise the function directly, so deleting
+    the call from the lifespan leaves them green and the six broken seats
+    unrepaired. Nothing else covers it: ensure_session_traces_dataset, which
+    this copies, has no test referencing it at all.
+
+    Reading the lifespan source is a blunt instrument and only proves the call
+    is present, not that it runs. Running the real lifespan would drag in mesh
+    rehydrate, both schedulers and cognee startup, which is a different and much
+    slower test. This catches the failure that actually happens, someone tidying
+    the call away, which is otherwise silent.
+    """
+    import inspect
+
+    from kb import server
+
+    source = inspect.getsource(server.lifespan)
+    assert "backfill_seat_datasets" in source, "boot no longer backfills seat datasets"
+
+
+async def test_backfill_seat_datasets_is_a_noop_without_a_cognee_client(tmp_path: Any) -> None:
+    """Boot must not break where the client has no ensure_dataset to call."""
+    from kb.server import backfill_seat_datasets
+
+    store = AccessStore(tmp_path / "access.json")
+    store.create_seat(name="Alice", slug="alice", issue_token=False)
+
+    counts = await backfill_seat_datasets(SimpleNamespace(cognee=object()), store)
+
+    assert counts == {"seats": 0, "created": 0, "failed": 0}
+
+
 def test_seat_token_searches_node_and_central(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3624,6 +3624,73 @@ def test_create_seat_api_provisions_node_and_writer_token(tmp_path: Any) -> None
     assert invalid.status_code == 422
 
 
+def test_create_seat_provisions_the_cognee_dataset_row(tmp_path: Any) -> None:
+    """A new seat gets its cognee Dataset row, not just a dataset name (#147).
+
+    cognee only creates the row on the write path, so before this a seat whose
+    holder had never ingested anything had no row at all and every search for
+    them raised DatasetNotFoundError. Six of eleven live seats were in that
+    state.
+
+    What this pins is the wiring: the handler reaches the client and passes the
+    seat's own dataset. It cannot pin that a row appears, because cognee is
+    faked throughout this suite. The row creation itself is cognee's
+    create_authorized_dataset, covered by its select-then-insert.
+    """
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    provisioned: list[str] = []
+
+    class _Cognee:
+        async def ensure_dataset(self, name: str) -> bool:
+            provisioned.append(name)
+            return True
+
+    class _Citadel(FakeCitadel):
+        cognee = _Cognee()
+
+    app.state.citadel = _Citadel()
+    response = client.post(
+        "/api/access/seats",
+        json={"name": "Alice Smith", "slug": "alice"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["node_dataset_provisioned"] is True
+    assert provisioned == ["seat:alice"], "the seat's dataset row was never provisioned"
+
+
+def test_create_seat_survives_a_failed_dataset_provision(tmp_path: Any) -> None:
+    """Provisioning is best-effort on purpose, and says so when it fails.
+
+    The seat and its token are already persisted by the time provisioning runs,
+    so raising here would leave a half-created seat and no way to tell which
+    half. The seat is returned, and the failure is reported rather than
+    swallowed, so a backfill can find it.
+    """
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+
+    class _Cognee:
+        async def ensure_dataset(self, name: str) -> bool:
+            raise RuntimeError("relational store unavailable")
+
+    class _Citadel(FakeCitadel):
+        cognee = _Cognee()
+
+    app.state.citadel = _Citadel()
+    response = client.post(
+        "/api/access/seats",
+        json={"name": "Bob", "slug": "bob"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["token"].startswith("ctdl_"), "the seat must still be usable"
+    assert payload["node_dataset_provisioned"] is False, "a failure must be visible"
+
+
 def test_seat_token_searches_node_and_central(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()


### PR DESCRIPTION
Closes #147.

Six of eleven seats have no cognee `Dataset` row, so every search for them raises `DatasetNotFoundError`. Those people have never had a working vault.

`AccessStore.create_seat` computes the seat's dataset **name** and nothing else; `kb/access.py` never imports cognee. cognee creates the row lazily on the **write** path only, so a seat whose holder never successfully ingested has no row at all.

## What changed

| Commit | Change |
|---|---|
| `348c807` | `CogneePublicClient.ensure_dataset(name)`, called from the seat-create handler |
| `fc5a301` | `SeatDatasetMissingError` so promotion names this state instead of reporting a generic failure |
| `eac8f36` | Provision unconditionally, so a row with missing ACL rows gets repaired |
| `0cf7cf7` | Boot pass over every existing seat, which is the backfill |
| `3d78992` | Survive a lost creation race; correct a false comment |

## Two things worth reviewing closely

**A bare `create_dataset` would not have fixed this.** The read path resolves a name in two stages: `get_dataset_ids` matches name, owner and tenant, then `get_specific_user_permission_datasets` filters by ACL, and `search_function` re-checks via `authorized_search` with no non-authorized branch. A row without ACL rows fails just as hard, with `PermissionDeniedError` instead. So this calls `create_authorized_dataset`, which writes the row and read/write/delete/share.

**Provisioning is best-effort by design.** The seat and its token are already persisted when it runs, so raising would leave a half-created seat and no way to tell which half. The outcome goes to the audit event and the response as `node_dataset_provisioned`, and the boot backfill catches anything that failed.

## Testing

1019 pass, ruff clean. Every part was reverted to confirm the tests fail:

- disable the handler call → both server tests red
- drop the tenant term → the idempotency test red
- reinstate the early return → `seat still unsearchable after ensure_dataset`
- delete the boot call → the wiring test red
- remove the `IntegrityError` guard → `UNIQUE constraint failed: datasets.id`

The tests that carry the claim run against a **real** cognee relational stack on throwaway sqlite and assert cognee's own resolver, `get_authorized_dataset_by_name`, flips from `None` to the dataset. The handler tests only pin the wiring, and say so.

## Known limits

- Whether the six seats lack the row, lack only the ACL rows, or a mix is not verifiable without reading the production store. The unconditional call repairs both, so it is no longer load-bearing.
- The boot-wiring test reads the lifespan source. It proves the call is present, not that it runs. Running the real lifespan pulls in mesh rehydrate, both schedulers and cognee startup.
- Racing `get_default_user()` collides on `users.email` before dataset creation is reached. That is cognee-wide on every entry point, not introduced here, and is left alone deliberately.

## Follow-ups, not in this PR

- `issue_access_seat_token` does not provision. It is the re-link flow serving exactly this population; with the boot backfill a re-linked seat is only broken until the next deploy.
- `PermissionDeniedError` could be a second discriminator for the half-provisioned state.
- `_ensure_cognee_ready` calls `getattr(cognee, "run_startup_migrations", None)`, which does not exist in cognee 1.2.2, so it is a silent no-op. Pre-existing and unrelated, but it is why the backfill must run after `ensure_session_traces_dataset`.