### PR TITLE
fix(access): serialize access-store writes, stop rewriting the store per request

### DIFF
--- a/.agents/skills/adhd/SKILL.md
+++ b/.agents/skills/adhd/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: adhd
+description: Parallel divergent ideation for coding agents. Spawns N isolated branches under different cognitive frames (regulator, biology, speedrunner, 10-year-old, $0 budget), scores, clusters, prunes traps, and deepens top survivors. Use on /adhd, "ADHD mode", brainstorm/ideate intents, or open-ended design, architecture, naming, API/SDK surface, and fuzzy-debugging decisions. Skip for syntax, lookups, bugs with known root cause, or closed phrasing ("quick", "standard", "canonical", "textbook"). Full pre-flight gate is in the skill body.
+license: MIT
+---
+
+# ADHD
+
+Stop picking the textbook answer. The first three answers the model would
+give are the answers a senior engineer would give in thirty seconds.
+Correct. Forgettable. The interesting answers live past number three, in
+the awkward middle nobody walks into. This skill makes the model walk
+there.
+
+## Pre-flight (run before Phase 1)
+
+This skill is expensive. About 10 Agent calls, 30 to 90 seconds wall clock,
+5 to 10x a single answer. Do not pay that cost when a direct answer is
+better. Run this gate before Phase 1.
+
+**Step 1. Explicit invocation check.**
+
+If the user typed `/adhd` or explicitly asked for ADHD mode, "use the
+adhd skill", or "run ADHD on this", **SKIP the rest of this section and go
+straight to Phase 1**. The user opted in. Do not second-guess.
+
+**Step 2. Self-judge (only if Step 1 did not match).**
+
+Ask yourself three questions. If the answer to any is no, ABORT.
+
+1. **Open-ended?** Would a senior engineer give multiple viable answers
+   here, or is there one canonical answer? If canonical, abort.
+2. **High-stakes?** Is the cost of the obvious answer being wrong actually
+   high? Architecture decisions, public API surfaces, naming a real
+   product, fuzzy bugs with no known root cause, schema design = yes.
+   Side project at 11pm = no.
+3. **Open phrasing?** Did the user avoid words like "quick", "standard",
+   "canonical", "textbook", "just", "one-line"? If they used any of those,
+   they want the direct answer. Abort.
+
+If all three checks pass, proceed to Phase 1.
+
+If any fails, ABORT and answer the question directly. Optionally append
+one sentence: *"If you want a wider exploration under parallel cognitive
+frames with explicit trap detection, run `/adhd <your problem>`."*
+
+## The loop
+
+Two strict phases. Mixing them kills idea quality, because the critic
+strangles the generator.
+
+### Phase 1 — Diverge (no critic)
+
+For the problem P:
+
+1. Pick 5 cognitive frames from the table below. Bias toward engineering
+   tags when the problem is code-shaped. Always include at least one wild
+   frame to keep range.
+
+2. Spawn 5 **parallel** Agent/Task tool calls. One per frame. Each Agent
+   gets only:
+   - the problem P
+   - any context the user provided
+   - the chosen frame's vantage prompt
+   - a system instruction that forbids evaluation
+
+   The exact instruction to give each Agent:
+
+   > You are in DIVERGENT mode. You are a generator, not a critic.
+   > Generate 6 short distinct ideas under this frame. Each idea is one
+   > phrase or one sentence. Do not evaluate. Do not rank. Do not hedge.
+   > The first three obvious answers everyone would give are banned.
+   > Push past them into the awkward middle.
+   > Output a JSON array only. No prose before or after.
+   > `[{"text": "...", "rationale": "..."}, ...]`
+
+3. **Critical invariant.** The Agent calls must be parallel and isolated.
+   Do NOT serialize them. Do NOT pass one branch's output as context to
+   another. Branches that see each other anchor each other and the whole
+   method collapses to a wider single thought.
+
+### Phase 2 — Focus (critic on)
+
+After all branches return:
+
+1. **Score.** Rate each idea on three axes 0 to 10: novelty (distance from
+   the obvious default), viability (could it actually ship), fit (does it
+   address the stated problem). For any idea that looks attractive but is
+   a trap (hidden cost, false economy, will not scale, premature
+   abstraction), flag it with a one-line reason.
+
+2. **Cluster.** Group ideas into 3 to 6 clusters by their underlying angle,
+   not by surface keywords. Label clusters by angle: "remove the server
+   plays", "cache-shaped plays", "batched-window plays", "race-multiple-
+   backends plays".
+
+3. **Deepen the top 3.** Rank by weighted score (novelty 0.35 + viability
+   0.40 + fit 0.25), exclude traps, take top 3. For each, spawn one Agent
+   call that produces:
+   - a 4 to 8 sentence sketch of how the idea works
+   - the load-bearing risk
+   - the first concrete step a builder would take
+   - 3 to 5 child ideas (variations, hybrids, unlocks)
+
+   Deepen Agent instruction:
+
+   > You are in FOCUS mode. Take one promising idea and connect dots.
+   > Sketch how it would actually work in 4 to 8 sentences. Name the
+   > load-bearing risk. Name the first concrete step a coder would take.
+   > Then generate 3 to 5 sub-ideas that branch off (variations,
+   > combinations with other domains, things this unlocks).
+   > Output JSON only.
+
+## Frames
+
+Pick 5 per run.
+
+| Frame | Vantage prompt | Tags |
+|---|---|---|
+| **hardware engineer** | You think in latency, memory layout, and physical constraints. Re-ask this as a hardware/firmware problem. What does the bus topology, cache, timing budget tell you? | code, wild |
+| **regulator** | You audit systems for compliance and failure modes. What must be provable, traceable, or refusable here? | design, general |
+| **10-year-old** | You are a curious 10 year old who has never seen software. Describe naive but unencumbered approaches. Ignore convention. | general, wild |
+| **competitor trying to break it** | You are a hostile competitor or attacker. Generate approaches that exploit, fail, or sabotage the obvious solution. Then invert into ideas. | code, design |
+| **biology** | Transplant a mechanism from biology (immune systems, neural plasticity, cell signaling, evolution, gut flora). Force-fit it onto this engineering problem. | code, wild |
+| **logistics** | Steal mechanisms from logistics: queues, batching, just-in-time, hub-and-spoke, returns, last-mile. Apply them literally. | code, design |
+| **game design** | Approach this as a game designer. What are the loops, rewards, friction, save-states, speedrun tricks? Treat the user as a player. | design, general |
+| **markets** | Treat the problem as a market. Buyers, sellers, market-makers. What does an auction, a futures contract, a clearing house look like here? | design, wild |
+| **inversion** | Ask the OPPOSITE question. If goal is X, brainstorm how to guarantee NOT X. Then negate each answer back. | code, design, general |
+| **extreme: $0 budget, 1 hour** | No money, no team, one hour. What is the crudest version that still does the load-bearing thing? | code, general |
+| **extreme: infinite budget, 10 years** | Infinite compute, infinite engineers, a decade. What is the maximalist version? | design, wild |
+| **remove the load-bearing assumption** | Name the thing everyone treats as fixed (framework, database, request-response model, network). Imagine it is gone. What is possible? | code, design, wild |
+| **speedrunner** | You are a speedrunner. Find glitches, skips, out-of-bounds tricks, frame-perfect shortcuts. What is the abusive-but-legal path? | code, wild |
+| **ant colony** | No central planner. Many dumb agents, local rules, pheromone trails. How does the problem solve itself emergently? | code, wild |
+| **3am on-call** | You are the on-call engineer woken at 3am when this breaks. What design would let you not get paged? | code, design |
+
+### Picking frames
+
+For code-shaped problems: pick 4 frames tagged `code` or `design`, plus 1
+tagged `wild`. For open product or strategy problems: a mix from all tags.
+Vary the picks across sessions so the same problem produces different
+candidate sets when re-run.
+
+## Output shape
+
+After Phase 2, render in this order. Do not collapse it into a wall of
+prose. The structure is the point.
+
+1. **Brief.** One or two lines confirming the problem and any reframe used.
+2. **Wide set.** Full pool grouped by cluster. Each cluster labeled by
+   underlying angle. Each idea is one short phrase. Show score chips like
+   `[N7 V8 F9]` next to each.
+3. **Converge.** A 2 to 4 idea shortlist. State why each is on the list.
+   Mark the non-obvious-but-viable pick explicitly with ★. List traps
+   separately, each with the one-line reason it is a trap.
+4. **Focus.** The 3 deepened branches. For each: the sketch, the load-
+   bearing risk, the first concrete step, and the child ideas.
+5. **Provocation.** One wildcard question or idea that opens a new
+   direction the user can push into if nothing landed.
+
+## Anti-patterns
+
+These are how this skill goes wrong. Watch for them.
+
+- **Convergence disguised as divergence.** Ten minor variations of one idea
+  is not breadth. If every candidate shares the same underlying assumption,
+  you have not diverged. You have decorated.
+- **Weird-for-weird's-sake with no convergence.** A pile of 30 unsorted
+  absurdities is as useless as one safe answer. Always converge.
+- **Walls of equally-weighted prose.** Cluster, label, pull out the best.
+  Structure is half the value.
+- **Refusing to commit.** After diverging, take a position on what is
+  actually promising. "Here are 20 ideas, you decide" is a cop-out.
+  Generate wide, but converge with a real opinion.
+- **Skipping the isolation invariant.** If you simulate parallel branches
+  by writing them sequentially in one context, you have not done ADHD. You
+  have done a wider single thought. The Agent/Task tool gives each branch a
+  fresh context. Use it.
+
+## Calibration
+
+- **How many ideas?** Scale to stakes. Quick "name this function" =
+  3 frames × 4 ideas. "How should I position this product" = 5 frames ×
+  8 ideas. Default is 5 × 6 = 30.
+- **How weird?** Read the room. Serious strategy work: flag the wild cards
+  clearly so they do not read as unserious. Open brainstorming or play:
+  let it run loose. Absurd ideas earn their place by seeding viable ones.
+- **When to stop diverging?** Stop when new candidates start repeating the
+  shape of existing ones. The space is mapped. Do not pad to hit a number.
+
+## Cost
+
+5 diverge + 1 score + 1 cluster + 3 deepen ≈ 10 Agent calls per run.
+About 5 to 10x a single-shot answer. Not for every keystroke. For decision
+points where the cost of the obvious answer is high.
+
+## Companion library and CLI
+
+There is a Node/TS implementation that does the same loop with structured
+JSON parsing, score weighting, and a CLI. Use it when running outside
+Claude Code or in batch.
+
+    npm install -g adhd-agent
+    adhd "your problem here"
+
+Code, paper, evals, and contributing guide at
+https://github.com/UditAkhourii/adhd. The skill above gives you the same
+loop inside Claude with no install required.
+
+## Source spec
+
+This skill operationalises a written spec on divergent ideation. The
+original prose is preserved in `SOURCE-SPEC.md` for reference. The
+implementation choices made here (parallel isolated Agent calls,
+mechanical generator/critic split, frame-based branching) follow from
+that spec.

--- a/kb/access.py
+++ b/kb/access.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+import functools
 import hashlib
 import json
 import logging
 from pathlib import Path
+from contextlib import contextmanager
+import fcntl
+import os
 import re
 import secrets
+import tempfile
+import threading
+from collections.abc import Iterator
 from typing import Any
 from uuid import uuid4
 
@@ -26,6 +33,11 @@ CENTRAL_DATASET = "masumi-network"
 SESSION_TRACES_DATASET = "session-traces"
 SEAT_DATASET_PREFIX = "seat:"
 SEAT_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+# How stale last_used_at may get. It is a "roughly when was this last used"
+# display value, and stamping it on every request made every authentication pay
+# a full read-modify-write of the whole store on the event loop (#105).
+LAST_USED_STAMP_INTERVAL_SECONDS = 60.0
 
 ROLE_ORDER = {"reader": 1, "writer": 2, "admin": 3}
 VALID_ROLES = frozenset(ROLE_ORDER)
@@ -226,6 +238,15 @@ def _parse_time(value: str | None) -> datetime | None:
     return parsed
 
 
+def _stamp_is_due(last_used_at: str | None) -> bool:
+    """True when last_used_at is missing or older than the stamp interval."""
+    parsed = _parse_time(last_used_at)
+    if parsed is None:
+        return True
+    age = (datetime.now(timezone.utc) - parsed).total_seconds()
+    return age >= LAST_USED_STAMP_INTERVAL_SECONDS
+
+
 def _is_expired(value: str | None) -> bool:
     parsed = _parse_time(value)
     return bool(parsed and parsed <= datetime.now(timezone.utc))
@@ -259,10 +280,30 @@ def _resolve_token_memory_scope(
     return default_dataset, default_session, api_token.allowed_datasets
 
 
+def _serialized(method):
+    """Run a mutating AccessStore method under the store's exclusive lock.
+
+    A decorator rather than nine hand-edited bodies so the lock boundary is one
+    visible line per method and cannot drift from the load-modify-save it must
+    span.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._exclusive():
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 class AccessStore:
     def __init__(self, path: Path | str, *, max_audit_events: int = 1000) -> None:
         self.path = Path(path)
         self.max_audit_events = max_audit_events
+        # Guards the read-modify-write; see _exclusive.
+        self._thread_lock = threading.RLock()
+        self._lock_depth = 0
+        self._lock_file: Any | None = None
 
     def has_tokens(self) -> bool:
         return any(token.revoked_at is None for token in self._tokens(self._load()))
@@ -289,26 +330,57 @@ class AccessStore:
         ]
 
     def authenticate_token(self, token: str) -> TokenSession | None:
+        """Resolve a token to a session, stamping last_used_at at most periodically.
+
+        Deliberately NOT wrapped in @_serialized. This runs on every
+        authenticated request, and the only thing it wrote was the last_used_at
+        timestamp, which made every request pay a full read-modify-write of the
+        whole store: 9.5ms before the lock existed, 17.7ms with it. That cost is
+        awaited on the FastAPI event loop, so it is not just this request's
+        latency, it is every other request's too (#105).
+
+        last_used_at answers "roughly when was this token last used", where
+        sub-minute precision buys nothing. Stamping at most once per
+        LAST_USED_STAMP_INTERVAL_SECONDS makes the overwhelming majority of
+        authentications read-only, so they take no lock and write no file. The
+        rare stamping path takes the lock properly and re-reads under it, so it
+        cannot clobber a concurrent revocation.
+
+        Nothing security-relevant is skipped: the rejection audit path below is
+        unconditional, and expiry/revocation are evaluated on every call.
+        """
         token_hash = hash_api_token(token)
         data = self._load()
         tokens = self._tokens(data)
-        for index, api_token in enumerate(tokens):
+        for api_token in tokens:
             if not secrets.compare_digest(api_token.token_hash, token_hash):
                 continue
             session = self._session_for_token(data, api_token)
             if not session:
-                self._record_token_rejection(data, api_token)
+                with self._exclusive():
+                    self._record_token_rejection(self._load(), api_token)
                 return None
-            tokens[index] = ApiToken(
-                **{
-                    **asdict(api_token),
-                    "last_used_at": now_iso(),
-                }
-            )
-            data["tokens"] = [asdict(token_item) for token_item in tokens]
-            self._save(data)
+            if _stamp_is_due(api_token.last_used_at):
+                self._stamp_last_used(api_token.id)
             return session
         return None
+
+    @_serialized
+    def _stamp_last_used(self, token_id: str) -> None:
+        """Refresh one token's last_used_at, re-reading under the lock.
+
+        Re-reads rather than reusing the caller's snapshot so a revocation that
+        landed between the read and this write is not overwritten.
+        """
+        data = self._load()
+        tokens = self._tokens(data)
+        for index, api_token in enumerate(tokens):
+            if api_token.id != token_id:
+                continue
+            tokens[index] = ApiToken(**{**asdict(api_token), "last_used_at": now_iso()})
+            data["tokens"] = [asdict(item) for item in tokens]
+            self._save(data)
+            return
 
     def token_session(self, token_id: str) -> TokenSession | None:
         data = self._load()
@@ -320,6 +392,7 @@ class AccessStore:
                 return session
         return None
 
+    @_serialized
     def create_principal(
         self,
         *,
@@ -434,6 +507,7 @@ class AccessStore:
             allowed_datasets=[node_dataset, central_dataset, SESSION_TRACES_DATASET],
         )
 
+    @_serialized
     def create_token(
         self,
         *,
@@ -515,6 +589,7 @@ class AccessStore:
             allowed_datasets=allowed_datasets,
         )
 
+    @_serialized
     def revoke_token(self, token_id: str) -> ApiToken | None:
         data = self._load()
         tokens = self._tokens(data)
@@ -532,6 +607,7 @@ class AccessStore:
         self._save(data)
         return revoked
 
+    @_serialized
     def record_event(
         self,
         *,
@@ -635,6 +711,7 @@ class AccessStore:
             updated_by=stored.get("updated_by"),
         )
 
+    @_serialized
     def set_capture_policy(
         self,
         slug: str,
@@ -667,6 +744,7 @@ class AccessStore:
             updated_by=stored.get("updated_by"),
         )
 
+    @_serialized
     def set_approved_capture_roots(
         self,
         slug: str,
@@ -733,6 +811,7 @@ class AccessStore:
                 return item
         return None
 
+    @_serialized
     def add_promotion_pending(self, item: PromotionPendingItem) -> PromotionPendingItem:
         data = self._load()
         pending: list[PromotionPendingItem] = []
@@ -769,6 +848,7 @@ class AccessStore:
                 return True
         return False
 
+    @_serialized
     def decide_promotion_pending(
         self,
         item_id: str,
@@ -913,10 +993,86 @@ class AccessStore:
             "promotion_pending": data.get("promotion_pending", []),
         }
 
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Hold an exclusive lock across a whole read-modify-write.
+
+        Every mutating method here loads the file, edits it in memory and writes
+        it back. Without a lock spanning all three steps, two writers each read
+        the same state and the second write silently discards the first's edit.
+        That is not theoretical: the web process and the Railway cron services
+        (scripts/run_railway.py, scripts/run_self_improve.py) all construct an
+        AccessStore over the same path. Measured with two concurrent writers,
+        half of 120 events were lost.
+
+        A lost update here is worse than a lost log line, because this file also
+        holds tokens and principals: the write that vanishes can be a token
+        REVOCATION, which fails open.
+
+        The lock is a sidecar file rather than the store itself, so it survives
+        the atomic replace in _save (which swaps the inode out from under any
+        lock held on the old one).
+
+        Re-entrant, and it has to be. authenticate_token holds the lock and then
+        calls _record_token_rejection, which calls record_event, which wants it
+        again. flock is per open-file-description, so a second acquire from the
+        same process on a fresh handle blocks against itself forever. The depth
+        counter makes the nested acquire a no-op; the RLock makes it safe when
+        two threads in one process share the instance (FastAPI runs sync route
+        handlers in a threadpool).
+        """
+        with self._thread_lock:
+            if self._lock_depth:
+                self._lock_depth += 1
+                try:
+                    yield
+                finally:
+                    self._lock_depth -= 1
+                return
+            handle = self._lock_handle()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            self._lock_depth = 1
+            try:
+                yield
+            finally:
+                self._lock_depth = 0
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _lock_handle(self) -> Any:
+        """The long-lived handle the flock is taken on.
+
+        Opened once and kept, rather than per call: authenticate_token runs on
+        every authenticated request, and an open/close pair there is measurable
+        against a lock hold of a few hundred microseconds. Reopened if the file
+        was replaced or removed underneath us.
+        """
+        existing = getattr(self, "_lock_file", None)
+        if existing is not None and not existing.closed:
+            return existing
+        lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_file = lock_path.open("a+")
+        return self._lock_file
+
     def _save(self, data: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        with temp_path.open("w", encoding="utf-8") as handle:
-            json.dump(data, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-        temp_path.replace(self.path)
+        # A UNIQUE temp file per write. The fixed `<name>.tmp` this used to use
+        # is shared by every writer, and open("w") truncates: one process could
+        # truncate the file another was midway through json.dump-ing, and then
+        # rename the half-written result into place. That produced two failure
+        # modes under two concurrent writers, both reproduced: FileNotFoundError
+        # raised into the caller when one writer's replace() pulled the temp out
+        # from under another, and an unparseable access.json, which would take
+        # authentication down for everyone.
+        handle_fd, temp_name = tempfile.mkstemp(
+            dir=self.path.parent, prefix=f"{self.path.name}.", suffix=".tmp"
+        )
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            temp_path.replace(self.path)
+        except BaseException:
+            temp_path.unlink(missing_ok=True)
+            raise

--- a/skills/adhd
+++ b/skills/adhd
@@ -1,0 +1,1 @@
+../.agents/skills/adhd

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -115,6 +115,128 @@ def test_capture_roots_store_refuses_more_than_the_api_accepts(tmp_path: Path) -
         )
 
 
+def test_concurrent_writers_do_not_lose_events(tmp_path: Path) -> None:
+    """Two writers must not silently discard each other's edits.
+
+    The web process and the Railway cron services all construct an AccessStore
+    over the same file, and every mutation is load-modify-save. Without a lock
+    spanning all three steps the second save writes back a snapshot taken before
+    the first, and the first edit is gone.
+
+    Measured before the fix: 60 of 120 events survived with two writers, 44 of
+    160 with four, plus FileNotFoundError raised into callers because every
+    writer shared one fixed `.tmp` path.
+    """
+    import threading
+
+    path = tmp_path / "access.json"
+    AccessStore(path).create_principal_token(
+        name="seed", kind="service_account", role="reader"
+    )
+
+    def writer(tag: str) -> None:
+        # A separate instance per thread, which is the cross-process shape.
+        local = AccessStore(path)
+        for index in range(40):
+            local.record_event(
+                action=f"probe.{tag}", actor=None, success=True, detail={"i": index}
+            )
+
+    threads = [threading.Thread(target=writer, args=(f"w{n}",)) for n in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    events = AccessStore(path).snapshot()["audit_events"]
+    probes = [e for e in events if e["action"].startswith("probe.")]
+    assert len(probes) == 160, f"{160 - len(probes)} events lost to concurrent writes"
+
+
+def test_a_concurrent_write_cannot_resurrect_a_revoked_token(tmp_path: Path) -> None:
+    """The lost update that matters: a vanished revocation fails OPEN.
+
+    authenticate_token refreshes last_used_at. If that refresh writes back a
+    snapshot taken before a revocation landed, the revocation is erased and the
+    token works again. This is why the stamping path re-reads under the lock
+    rather than reusing the snapshot it authenticated from.
+    """
+    import threading
+
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    created = store.create_principal_token(
+        name="victim", kind="service_account", role="writer"
+    )
+
+    # Authenticate (loads a pre-revocation snapshot), revoke concurrently, then
+    # let the stamp write land.
+    barrier = threading.Barrier(2)
+
+    def revoke() -> None:
+        barrier.wait()
+        AccessStore(path).revoke_token(created.api_token.id)
+
+    def authenticate() -> None:
+        other = AccessStore(path)
+        barrier.wait()
+        for _ in range(20):
+            other.authenticate_token(created.token)
+
+    threads = [threading.Thread(target=revoke), threading.Thread(target=authenticate)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert AccessStore(path).authenticate_token(created.token) is None, (
+        "the revocation was overwritten by a concurrent last_used_at stamp"
+    )
+    assert AccessStore(path).has_tokens() is False
+
+
+def test_save_uses_a_unique_temp_file(tmp_path: Path) -> None:
+    """A shared temp path lets one writer truncate another's half-written file.
+
+    open("w") truncates, so with a fixed `<name>.tmp` two writers could
+    interleave into the same file and then rename the result into place. That
+    produced an unparseable access.json in testing, which takes authentication
+    down for everyone.
+    """
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    store.create_principal_token(name="a", kind="service_account", role="reader")
+
+    assert not (tmp_path / "access.json.tmp").exists(), "still using a fixed temp path"
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_last_used_is_stamped_but_not_on_every_request(tmp_path: Path) -> None:
+    """Stamping every request made each auth rewrite the whole store (#105).
+
+    First use still stamps, so "when was this last used" stays answerable. A
+    burst of subsequent authentications inside the interval writes nothing, and
+    the file is left byte-identical.
+    """
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    created = store.create_principal_token(
+        name="hot", kind="service_account", role="reader"
+    )
+
+    assert store.authenticate_token(created.token) is not None
+    stamped = store.snapshot()["tokens"][0]["last_used_at"]
+    assert stamped is not None, "first use must record last_used_at"
+
+    before = path.read_bytes()
+    for _ in range(25):
+        assert store.authenticate_token(created.token) is not None
+
+    assert path.read_bytes() == before, "an authentication rewrote the store"
+    assert store.snapshot()["tokens"][0]["last_used_at"] == stamped
+
+
 def test_token_session_lookup_enforces_expiry(tmp_path: Path) -> None:
     access_store = store(tmp_path)
     created = access_store.create_principal_token(


### PR DESCRIPTION
Found while checking a claim from a design session: the access store has no locking. It turned out to be three bugs, all reproduced.

The web process and the Railway cron services (`scripts/run_railway.py`, `scripts/run_self_improve.py`) all construct an `AccessStore` over the same file, and every mutation is load-modify-save with nothing spanning the three steps.

## 1. Lost updates

| Writers | Events written | Survived |
|---|---|---|
| 2 | 120 | **60** |
| 4 | 160 | **44** |

## 2. Raised errors, and corruption

Every writer used one fixed `<name>.tmp`, and `open("w")` truncates. One writer could truncate the file another was midway through `json.dump`-ing, then rename the partial result into place. 111 × `FileNotFoundError` raised into callers in one trial, and one run produced an **unparseable `access.json`** — which takes authentication down for everyone.

## 3. A resurrected revocation

`authenticate_token` refreshed `last_used_at` by writing back the snapshot it had authenticated from. If a revocation landed in between, that write **erased it and the revoked token kept working**.

The test fails without the fix with `the revocation was overwritten by a concurrent last_used_at stamp`, asserting that a revoked token still authenticates. It fails **open**.

## The fixes

- **Re-entrant exclusive lock.** `flock` plus an in-process depth counter and an `RLock`. Re-entrancy is required, not decorative: `authenticate_token` nests into `record_event`, and `flock` is per open-file-description, so a naive second acquire deadlocks against itself.
- **Unique temp file per write** (`mkstemp`), so writers cannot interleave.
- **The stamping path re-reads under the lock** rather than reusing its snapshot.

## Performance, which is why the last change is here

The lock alone doubled the hot path, **9.5 ms → 17.7 ms**. That is awaited on the FastAPI event loop, so it is every other request's latency too (#105). So `last_used_at` is now stamped at most once a minute instead of on every request. It is a "roughly when was this used" display value; sub-minute precision buys nothing, and first use still stamps.

**Net: `authenticate_token` is 1.93 ms, down from 9.5 ms before any of this** — five times faster than the pre-existing baseline, while also fixing the corruption. Most authentications now take no lock and write no file at all.

Nothing security-relevant is skipped: the rejection audit is unconditional, and expiry and revocation are evaluated on every call.

## Testing

1035 pass, ruff clean. Disabling all three guards turns the new tests red:

- `120 events lost to concurrent writes` (`assert 40 == 160`)
- `the revocation was overwritten by a concurrent last_used_at stamp`
- `an authentication rewrote the store`

## Note

Item 3 has a security consequence (a revocation silently undone). It needs local process concurrency rather than a remote request, so it reads as a correctness bug with a security effect rather than a remotely exploitable flaw — but it is your call whether this warrants a private advisory rather than an open PR.