### PR TITLE
ci: exempt bots from DCO, and stop Dependabot unpinning cognee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,23 @@ updates:
     labels:
       - "type/chore"
       - "area/ci"
+    ignore:
+      # cognee is pinned to 1.2.x ON PURPOSE. ADR-0009 dataset attribution and
+      # the seat provisioning added for #147 read cognee PRIVATE internals
+      # (cognee.modules.data.models, get_default_user, create_authorized_dataset)
+      # that a minor bump can move, and DatasetNotFoundError is matched by class
+      # NAME. The comment above the pin in requirements.txt says the pin exists
+      # to stop Railway pulling one unattended; Dependabot does not read
+      # comments, and proposed >=1.2.2,<1.5.0 in PR #167.
+      #
+      # Worse, CI could not have caught it: CI installs with
+      # `uv sync --all-extras --dev` (pyproject + uv.lock) while Railway
+      # installs from requirements.txt, so that PR was green against a cognee
+      # version it would not have deployed.
+      #
+      # Upgrading cognee is a deliberate exercise: bump it, run the real-store
+      # tests in tests/test_cognee_client.py, and check assert_cognee_dataset_api().
+      - dependency-name: "cognee"
     groups:
       dev-dependencies:
         patterns:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -63,6 +63,25 @@ jobs:
             body="$(printf '%s' "${message_b64}" | base64 -d)"
             email_lc="$(printf '%s' "${email}" | tr '[:upper:]' '[:lower:]')"
 
+            # Bot commits are exempt, and they have to be. A bot cannot agree to
+            # the DCO: there is no person to certify origin, which is the only
+            # thing the sign-off asserts. Dependabot does emit a trailer, but it
+            # signs as <support@github.com> while authoring as
+            # <49699333+dependabot[bot]@users.noreply.github.com>, so the
+            # fixed-string match below can never succeed and every dependency PR
+            # fails a gate it has no way to pass. Nine were stuck this way the
+            # hour after Dependabot was switched on.
+            #
+            # Matched on the noreply.github.com bot-author form rather than a
+            # name allowlist, so a human cannot dodge the check by putting
+            # "[bot]" in their own address.
+            case "${email_lc}" in
+              *"[bot]@users.noreply.github.com")
+                echo "  bot   ${sha:0:8}  ${email}"
+                continue
+                ;;
+            esac
+
             # Two-stage match avoids escaping the author's address into a
             # regex: stage one finds well-formed trailers, stage two does a
             # fixed-string comparison against this commit's author.


### PR DESCRIPTION
Cleanup of two things that appeared within an hour of #129 switching Dependabot on. Both are self-inflicted.

## 1. Every Dependabot PR fails DCO

Nine dependency PRs (#160-#168) are stuck. `DCO sign-off` became a required check when the ruleset was flipped after #129, and no Dependabot PR can pass it.

A bot cannot agree to the DCO: there is no person to certify origin, which is the only thing a sign-off asserts. Dependabot does emit a trailer, but it signs as `<support@github.com>` while authoring as `<49699333+dependabot[bot]@users.noreply.github.com>`, and the check fixed-string matches the trailer against the author. It can never succeed.

Exempts commits authored from the `*[bot]@users.noreply.github.com` form. Matched on that shape rather than a name allowlist so a human cannot dodge the check by putting `[bot]` in their address:

| Author | Result |
|---|---|
| `49699333+dependabot[bot]@users.noreply.github.com` | exempt |
| `29110+renovate[bot]@users.noreply.github.com` | exempt |
| `sarthiborkar7@gmail.com` | **checked** |
| `112841873+Sarthib7@users.noreply.github.com` | **checked** |
| `evil[bot]@attacker.com` | **checked** |
| `sneaky+[bot]@gmail.com` | **checked** |

## 2. Dependabot tried to unpin cognee

`requirements.txt` pins cognee to 1.2.x, with a comment directly above it saying the pin exists *"to stop Railway pulling one unattended on the next build"*, because ADR-0009 attribution and the #147 seat provisioning read cognee **private** internals and `DatasetNotFoundError` is matched by class **name**.

Dependabot does not read comments. #167 proposed `>=1.2.2,<1.5.0`.

**CI could not have caught it.** CI installs with `uv sync --all-extras --dev` (pyproject + `uv.lock`); Railway installs from `requirements.txt`. #167 changed only `requirements.txt`, so its green checks tested a cognee version it would never have deployed. Adding an `ignore` rule so it stops being re-proposed; upgrading cognee stays a deliberate exercise with the real-store tests.

## After this merges

#160-#166 and #168 should go green on DCO and can be merged as a batch. #167 is being closed separately.