### PR TITLE
fix(ingest): stop silently dropping documentation, and make a full sync completable

### DIFF
--- a/kb/learning.py
+++ b/kb/learning.py
@@ -238,6 +238,26 @@ class LearningProcess:
             return None
         return self.conflicts.record(candidate)
 
+    async def improve_once(
+        self,
+        *,
+        dataset: str | None = None,
+        session_ids: list[str] | None = None,
+    ) -> Any:
+        """Run a single improve pass, decoupled from any one document.
+
+        `learn(run_improve=True)` improves after every document, which is right
+        for a one-off capture and ruinous for a batch importer: a full cognee
+        improve pass costs roughly two minutes, so a 60-file sync spent about
+        two hours improving and was killed by the platform's 300 s request
+        ceiling before it could record any of it. Batch callers pass
+        `run_improve=False` per document and call this once at the end.
+        """
+        return await self._improve(
+            dataset=dataset or self.config.default_dataset,
+            session_ids=session_ids,
+        )
+
     async def _improve(
         self,
         *,

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -524,6 +524,22 @@ class RepoContentSyncer:
         blocked_files = 0
         improved = False
         skip_totals: dict[str, int] = {}
+        blocked_reasons: dict[str, int] = {}
+
+        def _checkpoint(tracked_files: dict[str, Any]) -> None:
+            """Persist progress so a killed run resumes where it stopped."""
+            if dry_run:
+                return
+            state["version"] = STATE_VERSION
+            state["files"] = tracked_files
+            try:
+                self._save_state(state)
+            except OSError as exc:
+                # A checkpoint failure must not abort a sync that is otherwise
+                # working; worst case is the old behaviour of redoing files.
+                logger.warning(
+                    "Repo content sync could not checkpoint state: %s", exc.__class__.__name__
+                )
 
         def _record_skip(repo_result: dict[str, Any], reason: str) -> None:
             nonlocal skipped_files
@@ -541,6 +557,7 @@ class RepoContentSyncer:
                 "skipped": 0,
                 "skipped_reasons": {},
                 "blocked": 0,
+                "blocked_paths": [],
                 "errors": [],
             }
             try:
@@ -595,6 +612,35 @@ class RepoContentSyncer:
                     if scan.get("blocked"):
                         blocked_files += 1
                         repo_result["blocked"] += 1
+                        # A block silently drops a file from the vault. Without
+                        # the path and the rule, a scanner false positive is
+                        # invisible: the ledger says "blocked: 7" and nothing
+                        # else, and reconstructing which seven meant
+                        # re-implementing the scan by hand. Categories and
+                        # severities are already redacted by public_dict().
+                        categories = sorted(
+                            {
+                                str(finding.get("category"))
+                                for finding in scan.get("findings", [])
+                            }
+                        )
+                        for category in categories:
+                            blocked_reasons[category] = blocked_reasons.get(category, 0) + 1
+                        repo_result["blocked_paths"].append(
+                            {
+                                "path": path,
+                                "highest_severity": scan.get("highest_severity"),
+                                "finding_count": scan.get("finding_count"),
+                                "categories": categories,
+                            }
+                        )
+                        logger.warning(
+                            "Repo content sync BLOCKED %s: severity=%s findings=%s rules=%s",
+                            key,
+                            scan.get("highest_severity"),
+                            scan.get("finding_count"),
+                            ",".join(categories) or "unknown",
+                        )
                         continue
 
                     document = format_repo_content_document(file, checked_at=checked_at)
@@ -621,7 +667,9 @@ class RepoContentSyncer:
                             Path(path).suffix.lstrip(".") or "text",
                         ],
                         operation="repo_content_sync",
-                        run_improve=self.config.repo_content_sync_run_improve,
+                        # Improve ONCE after the whole sync, not per file. See
+                        # LearningProcess.improve_once for why.
+                        run_improve=False,
                         detect_conflicts=False,
                     )
                     if any(result.accepted for result in outcome.all_ingests):
@@ -632,13 +680,32 @@ class RepoContentSyncer:
                             "content_hash": file.content_hash,
                             "last_ingested_at": checked_at,
                         }
-                        if outcome.improved:
-                            improved = True
+                        # Checkpoint immediately. State used to be written only
+                        # after every repo finished, so a run killed part-way
+                        # ingested files into cognee and recorded none of them,
+                        # and the next run redid the same work. A killed run
+                        # must be able to resume, not restart.
+                        _checkpoint(tracked)
                     else:
                         _record_skip(repo_result, "ingest_rejected")
             except GitHubAPIError as exc:
                 repo_result["errors"].append({"error": str(exc)[:240]})
             repo_results.append(repo_result)
+
+        # One improve pass for the whole sync. Per-file improve made a full
+        # forced sync cost ~2 min/file, so 60 files needed ~2 h against a 300 s
+        # platform request ceiling and could never finish.
+        if not dry_run and ingested_files and self.config.repo_content_sync_run_improve:
+            outcome = await self.learning.improve_once(
+                dataset=self.config.repo_content_sync_dataset,
+                session_ids=[self.config.repo_content_sync_session],
+            )
+            improved = not (isinstance(outcome, dict) and outcome.get("ok") is False)
+            if not improved:
+                logger.warning(
+                    "Repo content sync ingested %d file(s) but the improve pass failed",
+                    ingested_files,
+                )
 
         if not dry_run:
             state["version"] = STATE_VERSION
@@ -654,11 +721,14 @@ class RepoContentSyncer:
         )
 
         logger.info(
-            "Repo content sync finished: repos=%d ingested=%d skipped=%d blocked=%d dry_run=%s",
+            "Repo content sync finished: repos=%d discovered=%d ingested=%d skipped=%d "
+            "blocked=%d blocked_rules=%s dry_run=%s",
             len(repo_results),
+            sum(int(result.get("paths_discovered") or 0) for result in repo_results),
             ingested_files,
             skipped_files,
             blocked_files,
+            blocked_reasons or "-",
             dry_run,
         )
         return {
@@ -673,6 +743,7 @@ class RepoContentSyncer:
             "files_skipped": skipped_files,
             "files_skipped_by_reason": skip_totals,
             "files_blocked": blocked_files,
+            "files_blocked_by_reason": blocked_reasons,
             "improved": improved,
             "dry_run": dry_run,
             "repositories": repo_results,

--- a/kb/repository_update.py
+++ b/kb/repository_update.py
@@ -539,39 +539,61 @@ def _active_repositories(
     )
 
 
+def _title_suffix(pull_request: dict[str, Any]) -> str:
+    """`: <title>` when the payload actually carries one, else nothing.
+
+    The org events feed's `pull_request` object holds only base/head/id/number/
+    url, so a title is usually absent. Emitting the literal string "(no title)"
+    put that phrase on every PR line in the daily digest, and the digest is
+    cognified into the vault as durable knowledge. Saying less is better than
+    saying something false.
+    """
+    title = _short(pull_request.get("title"), length=100)
+    return f": {title}" if title else ""
+
+
 def _event_summary(event_type: str, payload: dict[str, Any]) -> str:
     if event_type == "PushEvent":
         commits = payload.get("commits") or []
-        # GitHub's events feed reports the full push size separately from the
-        # (possibly truncated) inline commit array. Prefer the real count so the
-        # digest never claims "Pushed 0 commit(s)" when commits exist.
+        # `/orgs/{org}/events` returns an ABBREVIATED payload: its PushEvent
+        # carries only before/head/push_id/ref/repository_id, with no `size`,
+        # `distinct_size` or `commits`. An earlier fix here preferred `size`
+        # over `len(commits)` to avoid claiming "Pushed 0 commits", but since
+        # none of those keys exist on this endpoint it always fell through to
+        # len([]) == 0 and every push in the digest read "Pushed 0 commits".
+        # When the count is genuinely unknown, do not invent one.
         count = payload.get("size")
         if count is None:
             count = payload.get("distinct_size")
-        if count is None:
+        if count is None and commits:
             count = len(commits)
         messages = [_short(commit.get("message"), length=80) for commit in commits[:2]]
         ref = str(payload.get("ref") or "").removeprefix("refs/heads/")
         detail = "; ".join(message for message in messages if message)
-        plural = "" if count == 1 else "s"
-        return f"Pushed {count} commit{plural} to {ref or 'a branch'}" + (
-            f": {detail}" if detail else ""
-        )
+        target = ref or "a branch"
+        if count is None:
+            head = str(payload.get("head") or "")
+            summary = f"Pushed to {target}"
+            if head:
+                summary += f" (head {head[:12]})"
+        else:
+            plural = "" if count == 1 else "s"
+            summary = f"Pushed {count} commit{plural} to {target}"
+        return summary + (f": {detail}" if detail else "")
     if event_type == "PullRequestEvent":
         pull_request = payload.get("pull_request") or {}
         action = payload.get("action", "updated")
         if action == "closed" and pull_request.get("merged"):
             action = "merged"
-        title = _short(pull_request.get("title"), length=100) or "(no title)"
-        return f"{action} pull request #{pull_request.get('number')}: {title}"
+        number = pull_request.get("number") or payload.get("number")
+        return f"{action} pull request #{number}" + _title_suffix(pull_request)
     if event_type == "PullRequestReviewEvent":
         pull_request = payload.get("pull_request") or {}
         review = payload.get("review") or {}
-        title = _short(pull_request.get("title"), length=100) or "(no title)"
         return (
             f"{payload.get('action', 'reviewed')} review "
             f"{review.get('state', 'submitted')} on pull request "
-            f"#{pull_request.get('number')}: {title}"
+            f"#{pull_request.get('number')}" + _title_suffix(pull_request)
         )
     if event_type == "PullRequestReviewCommentEvent":
         pull_request = payload.get("pull_request") or {}

--- a/kb/security_scan.py
+++ b/kb/security_scan.py
@@ -105,7 +105,24 @@ REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 URL_PATTERN = re.compile(r"https?://[^\s<>'\"`]+", re.IGNORECASE)
-RISKY_SCHEME_PATTERN = re.compile(r"(?i)\b(?:javascript|data|vbscript):|file://")
+
+# A dangerous scheme is only dangerous as a URI, so each alternative requires
+# what must actually follow the colon.
+#
+# The previous pattern matched the bare word ``data:`` anywhere, which is a
+# JavaScript/JSON property key far more often than a data URI. That blocked
+# seven documentation files whose only offence was ``mockResolvedValue({ data:
+# [...] })`` inside a fenced code block, and the block was silent, so nobody
+# could see it happening. A data URI is required to carry a MIME type (or the
+# ``data:,`` / ``data:;base64,`` degenerate forms), and javascript:/vbscript:
+# payloads run straight into their code with no space.
+RISKY_SCHEME_PATTERN = re.compile(
+    r"(?i)"
+    r"\b(?:javascript|vbscript):[^\s<>'\"]"
+    r"|\bdata:[a-z0-9.+-]+/[a-z0-9.+-]+"
+    r"|\bdata:[;,]"
+    r"|file://"
+)
 BIDI_CONTROL_CODES = {
     "\u202a",
     "\u202b",
@@ -233,10 +250,97 @@ def _scan_entry(entry: SecurityScanEntry) -> list[SecurityScanFinding]:
     return findings
 
 
+# Right-hand sides of a `token = ...` assignment that are code or placeholders
+# rather than a literal credential. Every one of these was observed blocking a
+# real documentation file: `process.env.SOKOSUMI_API_KEY`, `getApiKeyFromEnv()`,
+# `os.environ.get("RAILWAY_API_KEY")`, `request.query_params.get('api_key')` and
+# `YOUR_KEY`. None of them is a secret; all of them are how you correctly avoid
+# hard-coding one.
+_CODE_OR_PLACEHOLDER_VALUE = re.compile(
+    r"""(?ix)
+    ^(?:
+        process\.env\b
+      | import\.meta\.env\b
+      | os\.environ\b
+      | os\.getenv\b
+      | deno\.env\b
+      | system\.getenv\b
+      | getenv\b
+      | (?:your|my|the|some|a)[_-]
+      | x{3,}
+      | \.{3}
+      | \*{3,}
+      | changeme
+      | example
+      | placeholder
+      | redacted
+      | <
+      | \$
+      | \{
+      | %
+    )
+    """
+)
+# A dotted identifier chain (`process.env.SOKOSUMI_API_KEY;`, `config.api.token`)
+# is a reference to a secret, never the secret itself.
+_IDENTIFIER_CHAIN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+[;,]?$")
+# A bare SCREAMING_SNAKE name is an env-var placeholder, not a credential.
+_ENV_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,}[;,]?$")
+# Lowercase words joined by _ or -, with no digits: `hashed_token`, `refresh_token`.
+# These are identifiers and test fixtures, not credentials.
+_WORDY_IDENTIFIER = re.compile(r"^[a-z]+(?:[_-][a-z]+)*$")
+# Below this length a wordy all-lowercase value is treated as an identifier.
+# Above it, it is more plausibly a passphrase and stays flagged, which is what
+# keeps `not-a-real-secret-value` (23 chars) caught.
+_WORDY_IDENTIFIER_MAX = 20
+
+
+def _is_credential_like(value: str) -> bool:
+    """Does this assignment's right-hand side look like a literal secret?
+
+    The `secret_assignment` rule fires on any `token|secret|api_key` assignment
+    with 8+ non-space characters after it, which also matches ordinary code that
+    reads a credential from the environment. Every false positive observed on
+    real files was a code expression or a placeholder, so those are what this
+    excludes.
+
+    It deliberately does NOT judge how random the value looks. An earlier
+    attempt here required a digit, or length plus mixed case, and that let
+    `password=not-a-real-secret-value` through — 23 lowercase characters is a
+    perfectly ordinary passphrase. Entropy is not the difference between a
+    secret and `process.env.API_KEY`; being a literal rather than an expression
+    is. The length floor stays at the rule's original 8 so nothing that used to
+    be caught stops being caught for a new reason.
+    """
+    candidate = value.strip().strip("'\"`").rstrip(";,")
+    if len(candidate) < 8:
+        return False
+    # Function calls, indexing and interpolation are code, not literals.
+    if any(char in candidate for char in "()[]{}<>$`"):
+        return False
+    if _CODE_OR_PLACEHOLDER_VALUE.match(candidate):
+        return False
+    if _IDENTIFIER_CHAIN.match(candidate):
+        return False
+    if _ENV_NAME.match(candidate):
+        return False
+    if len(candidate) < _WORDY_IDENTIFIER_MAX and _WORDY_IDENTIFIER.match(candidate):
+        # `token: "hashed_token"` in a test mock. The trade-off is explicit: a
+        # short all-lowercase passphrase with no digits would now be missed by
+        # THIS generic heuristic. Every high-confidence pattern (github_token,
+        # aws_access_key, stripe_live_secret, slack_token, private_key_marker,
+        # citadel token) is unaffected, and real generated credentials carry
+        # digits or mixed case and so never reach this branch.
+        return False
+    return True
+
+
 def _scan_secrets(entry: SecurityScanEntry, text: str) -> list[SecurityScanFinding]:
     findings: list[SecurityScanFinding] = []
     for category, severity, pattern in SECRET_PATTERNS:
         for match in pattern.finditer(text):
+            if category == "secret_assignment" and not _is_credential_like(match.group(1)):
+                continue
             findings.append(
                 _finding(
                     severity=severity,

--- a/scripts/bench/.gitignore
+++ b/scripts/bench/.gitignore
@@ -1,0 +1,4 @@
+# Cached copies of other repos' files, refetched by fetch_ground_truth.py.
+# Not vendored: they would go stale against their source repos and the script
+# reproduces them in one command.
+ground_truth/

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,69 @@
+# Citadel benchmark harness
+
+Repeatable measurements for the Citadel node. Every number here is meant to be
+re-runnable by someone who does not trust it, which is the bar for anything that
+ends up on a public page.
+
+Read-only. Nothing in this directory writes to the vault.
+
+## Running it
+
+```bash
+export CITADEL_MCP_ACCESS_TOKEN=...          # a seat token with kb:search
+export GITHUB_TOKEN=...                      # only for refreshing ground truth
+
+python scripts/bench/fetch_ground_truth.py   # once, or when the corpus changes
+python scripts/bench/search_bench.py --repeats 3 --top-k 5 --out results.json
+```
+
+## What it measures
+
+| metric | meaning |
+|---|---|
+| `recall_at_k` | fraction of questions where the document that answers it appears in the top k |
+| `mrr` | mean reciprocal rank over the same questions |
+| `blocked_probe_hit_rate` | fraction of *deliberately unanswerable* questions that returned their target anyway |
+| `latency_ms_p50` / `p95` | server-side search latency over all samples |
+
+## How a hit is scored
+
+Ground truth is the source document that should answer the question. A returned
+chunk counts as that document if either:
+
+1. its first line is the repo-content header `# <owner>/<repo>/<path>`, or
+2. it shares at least `MIN_SHARED_SHINGLES` distinct 12-word runs with the
+   cached copy of the file.
+
+Rule 2 exists because only the first chunk of a document carries its source
+path. Without it, every later chunk scores as a miss.
+
+`MIN_SHARED_SHINGLES` is 3, not 1. During calibration, a threshold of 1 matched
+`sokosumi-cli/AGENTS.md` against `sokosumi/AGENTS.md` on a single shared line of
+template boilerplate, and scored a false positive. Three independent shared runs
+did not. If you add near-duplicate documents to the golden set, re-check this.
+
+## The blocked probes
+
+Question ids beginning with `b` target documents the ingest-time security
+scanner rejects, so their answers are not in the vault. They are expected to
+miss, and `blocked_probe_hit_rate` should be 0.
+
+They are not filler. They turn "the scanner drops 13% of repo content" from a
+sync-log statistic into a measured retrieval loss, and they are the regression
+test for any change to the scanner: if a blocked probe starts hitting, either
+the block was lifted or the content arrived through a path that skips the gate.
+
+## Reading the results honestly
+
+- `dataset` on a hit is not trustworthy **when you pass one explicitly**.
+  Requesting `dataset=masumi-network` and `dataset=seat:sarthi` returns
+  byte-identical hits (same `content_sha256`) with the label rewritten to match
+  the request. On a default search the per-hit label does track the
+  `sections` routing, so it is not always an echo. Never derive isolation
+  claims from this field.
+- `mode="docs"` returned zero results for a question whose answer is in an
+  ingested `.md` file. Treat that filter as unverified until it is fixed.
+- `_citadel.provenance` is `{}` on every hit observed so far, and
+  `document_name` is `text_<md5>`. That is why scoring falls back to the body.
+- Latency here excludes CLI process startup. `citadel search` adds roughly 0.4 s
+  of Python import and connection setup on top.

--- a/scripts/bench/fetch_ground_truth.py
+++ b/scripts/bench/fetch_ground_truth.py
@@ -1,0 +1,63 @@
+"""Cache the ground-truth documents named by the golden question set.
+
+Retrieval scoring must not depend on a hit carrying its source path: only the
+first chunk of a repo-content document does. Caching the real file text lets the
+benchmark match a hit by content overlap instead, which survives chunking.
+
+Usage:
+    GITHUB_TOKEN=... python scripts/bench/fetch_ground_truth.py
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CACHE = HERE / "ground_truth"
+
+
+def fetch(repo_path: str, token: str | None) -> str | None:
+    owner, repo, path = repo_path.split("/", 2)
+    url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAILED {repo_path}: {exc.__class__.__name__}")
+        return None
+    content = body.get("content")
+    if not content:
+        return None
+    return base64.b64decode(content).decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+    questions = json.loads((HERE / "golden_questions.json").read_text(encoding="utf-8"))
+    CACHE.mkdir(exist_ok=True)
+    wanted: set[str] = set()
+    for question in questions["questions"]:
+        wanted.update(question["expect_any"])
+
+    for repo_path in sorted(wanted):
+        target = CACHE / (repo_path.replace("/", "__"))
+        if target.exists():
+            continue
+        text = fetch(repo_path, token)
+        if text is None:
+            continue
+        target.write_text(text, encoding="utf-8")
+        print(f"  cached {repo_path} ({len(text)} chars)")
+
+    print(f"\n{len(list(CACHE.iterdir()))} ground-truth documents cached in {CACHE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/golden_questions.json
+++ b/scripts/bench/golden_questions.json
@@ -1,0 +1,223 @@
+{
+  "version": 1,
+  "created_at": "2026-07-31",
+  "corpus": "repo_content sync of masumi-network/{sokosumi,Sokosumi-MCP,sokosumi-cli,sokosumi-docs}",
+  "notes": [
+    "Ground truth is the source path a hit must resolve to. Hits carry their path",
+    "in the first line of the chunk body: '# masumi-network/<repo>/<path>'.",
+    "expect_any lists every acceptable path; several skills are published from two",
+    "repos, so more than one document legitimately answers the question.",
+    "Questions marked expected_recall 0 target documents the security scanner",
+    "blocks at ingest time. They should MISS. If they ever start hitting, either",
+    "the block was lifted or the answer leaked in from another document."
+  ],
+  "questions": [
+    {
+      "id": "q01",
+      "question": "What is the structure of the Sokosumi monorepo?",
+      "expect_any": ["masumi-network/sokosumi/README.md"],
+      "category": "repo_overview",
+      "expected_recall": 1
+    },
+    {
+      "id": "q02",
+      "question": "How does a cloud agent connect to the database in Sokosumi?",
+      "expect_any": ["masumi-network/sokosumi/docs/agents/cloud-agent-database.md"],
+      "category": "architecture",
+      "expected_recall": 1
+    },
+    {
+      "id": "q03",
+      "question": "Which issue tracker does the Sokosumi project use?",
+      "expect_any": ["masumi-network/sokosumi/docs/agents/issue-tracker.md"],
+      "category": "process",
+      "expected_recall": 1
+    },
+    {
+      "id": "q04",
+      "question": "What triage labels are used on Sokosumi issues?",
+      "expect_any": ["masumi-network/sokosumi/docs/agents/triage-labels.md"],
+      "category": "process",
+      "expected_recall": 1
+    },
+    {
+      "id": "q05",
+      "question": "How do vendor workspace grants work in the Coworker API?",
+      "expect_any": ["masumi-network/sokosumi/docs/coworker/vendor-workspace-grants-api.md"],
+      "category": "api",
+      "expected_recall": 1
+    },
+    {
+      "id": "q06",
+      "question": "What is the Hermes orchestrator actor and what is it responsible for?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/orchestrator/hermes-orchestrator-actor.md",
+        "masumi-network/sokosumi/docs/hermes-orchestrator-approve-overrides.md"
+      ],
+      "category": "architecture",
+      "expected_recall": 1
+    },
+    {
+      "id": "q07",
+      "question": "What does the coworker chat cold-start benchmark measure?",
+      "expect_any": ["masumi-network/sokosumi/docs/coworker/benchmarks/README.md"],
+      "category": "benchmark",
+      "expected_recall": 1
+    },
+    {
+      "id": "q08",
+      "question": "How are Better Auth cookie prefixes derived from the git commit ref?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-03-24-better-auth-cookie-prefix-commit-ref-design.md",
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-03-24-better-auth-cookie-prefix-commit-ref.md"
+      ],
+      "category": "design_spec",
+      "expected_recall": 1
+    },
+    {
+      "id": "q09",
+      "question": "Why was OpenRouter removed from the Sokosumi web app?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-19-remove-openrouter-from-web-design.md"
+      ],
+      "category": "design_spec",
+      "expected_recall": 1
+    },
+    {
+      "id": "q10",
+      "question": "What is the chat_room schema and the chats API namespace design?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-27-chats-api-and-chat-room-schema-design.md",
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-28-chat-rooms-cutover-deprecate-conversations-design.md"
+      ],
+      "category": "design_spec",
+      "expected_recall": 1
+    },
+    {
+      "id": "q11",
+      "question": "How does the OAuth refresh token opt-in work?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-23-oauth-refresh-token-opt-in-design.md"
+      ],
+      "category": "design_spec",
+      "expected_recall": 1
+    },
+    {
+      "id": "q12",
+      "question": "Why was credit pricing authority moved into Core?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-18-zero-margin-pricing-core-authority-design.md"
+      ],
+      "category": "design_spec",
+      "expected_recall": 1
+    },
+    {
+      "id": "q13",
+      "question": "What does the Elena skill do?",
+      "expect_any": [
+        "masumi-network/Sokosumi-MCP/skills/elena/SKILL.md",
+        "masumi-network/sokosumi-cli/skills/elena/SKILL.md"
+      ],
+      "category": "skill",
+      "expected_recall": 1
+    },
+    {
+      "id": "q14",
+      "question": "How do I install the Sokosumi shortcuts?",
+      "expect_any": ["masumi-network/Sokosumi-MCP/skills/install-shortcuts/SKILL.md"],
+      "category": "skill",
+      "expected_recall": 1
+    },
+    {
+      "id": "q15",
+      "question": "What is the Sokosumi CLI and what does it do?",
+      "expect_any": ["masumi-network/sokosumi-cli/README.md"],
+      "category": "repo_overview",
+      "expected_recall": 1
+    },
+    {
+      "id": "q16",
+      "question": "How is the Sokosumi skill distributed to users?",
+      "expect_any": [
+        "masumi-network/sokosumi-cli/skills/sokosumi/references/distribution.md"
+      ],
+      "category": "skill",
+      "expected_recall": 1
+    },
+    {
+      "id": "q17",
+      "question": "What are coworkers in Sokosumi?",
+      "expect_any": [
+        "masumi-network/sokosumi-docs/content/docs/documentation/coworkers.mdx",
+        "masumi-network/sokosumi/docs/coworker-metadata.md"
+      ],
+      "category": "product_docs",
+      "expected_recall": 1
+    },
+    {
+      "id": "q18",
+      "question": "How does image generation work in Sokosumi?",
+      "expect_any": [
+        "masumi-network/sokosumi-docs/content/docs/documentation/image-generation.mdx"
+      ],
+      "category": "product_docs",
+      "expected_recall": 1
+    },
+    {
+      "id": "q19",
+      "question": "How do I assign a job to a project in Sokosumi?",
+      "expect_any": [
+        "masumi-network/sokosumi-docs/content/docs/documentation/projects.mdx"
+      ],
+      "category": "product_docs",
+      "expected_recall": 1
+    },
+    {
+      "id": "q20",
+      "question": "How do I connect to the Sokosumi MCP server?",
+      "expect_any": [
+        "masumi-network/sokosumi-docs/content/docs/mcp/index.mdx",
+        "masumi-network/Sokosumi-MCP/README.md",
+        "masumi-network/Sokosumi-MCP/skills/sokosumi/SKILL.md"
+      ],
+      "category": "product_docs",
+      "expected_recall": 1
+    },
+    {
+      "id": "b01",
+      "question": "How do I debug a failing Sokosumi MCP connection?",
+      "expect_any": ["masumi-network/Sokosumi-MCP/docs/DEBUG_CONNECTION.md"],
+      "category": "blocked_probe",
+      "expected_recall": 0,
+      "blocked_reason": "secret_assignment x5"
+    },
+    {
+      "id": "b02",
+      "question": "What are the agent guidelines for working in the Sokosumi CLI repository?",
+      "expect_any": ["masumi-network/sokosumi-cli/AGENTS.md"],
+      "category": "blocked_probe",
+      "expected_recall": 0,
+      "blocked_reason": "secret_assignment x2"
+    },
+    {
+      "id": "b03",
+      "question": "What is the implementation plan for the admin user overview, SOK-565?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-06-12-admin-user-overview.md"
+      ],
+      "category": "blocked_probe",
+      "expected_recall": 0,
+      "blocked_reason": "unsafe_url_scheme (data: in a JS snippet)"
+    },
+    {
+      "id": "b04",
+      "question": "What is the implementation plan for the task credit pause and timeline UX?",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-07-27-task-credit-pause-timeline-ux.md"
+      ],
+      "category": "blocked_probe",
+      "expected_recall": 0,
+      "blocked_reason": "unsafe_url_scheme (data: in a JS snippet)"
+    }
+  ]
+}

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -1,0 +1,257 @@
+"""Retrieval benchmark for the Citadel search path.
+
+Runs a golden question set against a Node and reports recall@k, MRR and latency.
+Read-only: it issues searches and writes nothing to the vault.
+
+Ground truth is the source path of the document that should answer a question.
+Repo-content chunks carry that path on the first line of the chunk body, as
+``# masumi-network/<repo>/<path>``, so a hit can be resolved back to its file
+without relying on structured metadata (which repo-content hits do not carry).
+
+Usage:
+    export CITADEL_MCP_ACCESS_TOKEN=...
+    python scripts/bench/search_bench.py --repeats 3 --top-k 5
+
+    # compare against a floor: same questions, no vault
+    python scripts/bench/search_bench.py --baseline-only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_NODE = "https://citadel-archive-production.up.railway.app"
+HERE = Path(__file__).resolve().parent
+GROUND_TRUTH = HERE / "ground_truth"
+SOURCE_HEADER = re.compile(r"^#\s+([\w.-]+/[\w.-]+/\S+)", re.MULTILINE)
+SHINGLE_WORDS = 12
+# Near-duplicate documents (two AGENTS.md files from the same template) share
+# boilerplate runs, so a single shared shingle produced a false positive during
+# calibration. Three independent shared runs did not.
+MIN_SHARED_SHINGLES = 3
+
+
+def load_questions(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return list(data["questions"])
+
+
+def shingles(text: str, size: int = SHINGLE_WORDS) -> set[str]:
+    """Word n-grams, normalised, for content-overlap matching.
+
+    Only the first chunk of a document carries its source path, so path matching
+    alone scores every later chunk as a miss. A shared 12-word run is specific
+    enough that a coincidental match between unrelated documents is negligible.
+    """
+    words = re.sub(r"\s+", " ", text.lower()).split(" ")
+    if len(words) < size:
+        return set()
+    return {" ".join(words[i : i + size]) for i in range(len(words) - size + 1)}
+
+
+def load_ground_truth(expected: list[str]) -> dict[str, set[str]]:
+    fingerprints: dict[str, set[str]] = {}
+    for repo_path in expected:
+        cached = GROUND_TRUTH / repo_path.replace("/", "__")
+        if cached.exists():
+            fingerprints[repo_path] = shingles(cached.read_text(encoding="utf-8"))
+    return fingerprints
+
+
+def hit_paths(result: dict[str, Any]) -> list[str]:
+    """Resolve each hit to the source path it came from, preserving rank order."""
+    paths: list[str] = []
+    for item in result.get("results") or []:
+        text = item.get("text") or ""
+        match = SOURCE_HEADER.search(text)
+        paths.append(match.group(1) if match else "")
+    return paths
+
+
+def search(
+    node_url: str, token: str, query: str, top_k: int, timeout: float
+) -> tuple[dict[str, Any] | None, float, str | None]:
+    payload = json.dumps({"query": query, "top_k": top_k}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{node_url.rstrip('/')}/search",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        return body, (time.perf_counter() - started) * 1000.0, None
+    except urllib.error.HTTPError as exc:
+        return None, (time.perf_counter() - started) * 1000.0, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - a benchmark should record, not raise
+        return None, (time.perf_counter() - started) * 1000.0, exc.__class__.__name__
+
+
+def rank_of_expected(
+    paths: list[str],
+    texts: list[str],
+    expected: list[str],
+    fingerprints: dict[str, set[str]],
+) -> tuple[int | None, str]:
+    """1-indexed rank of the first hit that is one of the expected documents.
+
+    A hit counts by source path (first chunks) or by sharing a 12-word run with
+    the cached ground-truth file (later chunks). Returns the rank and how it was
+    matched, so a run can be audited rather than trusted.
+    """
+    for index, (path, text) in enumerate(zip(paths, texts), start=1):
+        if path in expected:
+            return index, "path"
+        hit_shingles = shingles(text)
+        if not hit_shingles:
+            continue
+        for repo_path in expected:
+            if repo_path not in fingerprints:
+                continue
+            if len(hit_shingles & fingerprints[repo_path]) >= MIN_SHARED_SHINGLES:
+                return index, "content"
+    return None, "none"
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(round(fraction * (len(ordered) - 1))))
+    return ordered[index]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--node-url", default=os.getenv("CITADEL_NODE_URL", DEFAULT_NODE))
+    parser.add_argument("--questions", default=str(HERE / "golden_questions.json"))
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=1, help="runs per question")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--out", default=None, help="write JSON results here")
+    args = parser.parse_args()
+
+    token = os.getenv("CITADEL_MCP_ACCESS_TOKEN") or os.getenv("CITADEL_ACCESS_TOKEN")
+    if not token:
+        print("CITADEL_MCP_ACCESS_TOKEN is not set", file=sys.stderr)
+        return 2
+
+    questions = load_questions(Path(args.questions))
+    rows: list[dict[str, Any]] = []
+    latencies: list[float] = []
+
+    for question in questions:
+        expected = question["expect_any"]
+        fingerprints = load_ground_truth(expected)
+        ranks: list[int | None] = []
+        errors: list[str] = []
+        observed: list[str] = []
+        matched_by = "none"
+        datasets: list[str] = []
+        for _ in range(args.repeats):
+            body, elapsed_ms, error = search(
+                args.node_url, token, question["question"], args.top_k, args.timeout
+            )
+            latencies.append(elapsed_ms)
+            if error or body is None:
+                errors.append(error or "empty")
+                ranks.append(None)
+                continue
+            paths = hit_paths(body)
+            texts = [(item.get("text") or "") for item in body.get("results") or []]
+            datasets = [
+                (item.get("_citadel") or {}).get("dataset") or ""
+                for item in body.get("results") or []
+            ]
+            observed = paths
+            rank, how = rank_of_expected(paths, texts, expected, fingerprints)
+            if rank is not None:
+                matched_by = how
+            ranks.append(rank)
+        best = [rank for rank in ranks if rank is not None]
+        rows.append(
+            {
+                "id": question["id"],
+                "category": question["category"],
+                "question": question["question"],
+                "expected_recall": question.get("expected_recall", 1),
+                "expect_any": expected,
+                "ground_truth_cached": sorted(fingerprints),
+                "ranks": ranks,
+                "best_rank": min(best) if best else None,
+                "matched_by": matched_by,
+                "hit_paths": observed,
+                "hit_datasets": datasets,
+                "errors": errors,
+            }
+        )
+        state = f"rank {min(best)} ({matched_by})" if best else "MISS"
+        print(f"{question['id']:>4}  {state:<18}  {question['question'][:58]}")
+
+    positives = [row for row in rows if row["expected_recall"] == 1]
+    probes = [row for row in rows if row["expected_recall"] == 0]
+
+    def recall_at(rows_: list[dict[str, Any]], k: int) -> float:
+        if not rows_:
+            return 0.0
+        hits = sum(
+            1 for row in rows_ if row["best_rank"] is not None and row["best_rank"] <= k
+        )
+        return hits / len(rows_)
+
+    mrr = (
+        statistics.fmean(
+            [1.0 / row["best_rank"] if row["best_rank"] else 0.0 for row in positives]
+        )
+        if positives
+        else 0.0
+    )
+
+    summary = {
+        "node_url": args.node_url,
+        "top_k": args.top_k,
+        "repeats": args.repeats,
+        "questions_total": len(rows),
+        "questions_positive": len(positives),
+        "questions_blocked_probe": len(probes),
+        "recall_at_1": round(recall_at(positives, 1), 4),
+        "recall_at_3": round(recall_at(positives, 3), 4),
+        "recall_at_5": round(recall_at(positives, 5), 4),
+        "mrr": round(mrr, 4),
+        "blocked_probe_hit_rate": round(recall_at(probes, args.top_k), 4),
+        "latency_ms_p50": round(percentile(latencies, 0.50), 1),
+        "latency_ms_p95": round(percentile(latencies, 0.95), 1),
+        "latency_ms_mean": round(statistics.fmean(latencies), 1) if latencies else 0.0,
+        "latency_samples": len(latencies),
+        "errors": sum(len(row["errors"]) for row in rows),
+    }
+
+    print("\n--- summary ---")
+    for key, value in summary.items():
+        print(f"{key:>26}: {value}")
+
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps({"summary": summary, "rows": rows}, indent=2), encoding="utf-8"
+        )
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -128,6 +128,47 @@ def rank_of_expected(
     return None, "none"
 
 
+def corpus_fingerprint(node_url: str, token: str, timeout: float) -> dict[str, Any]:
+    """Record what the corpus looked like for this run.
+
+    Two runs of this benchmark are only comparable if the corpus did not move
+    underneath them. On 2026-07-31 recall@5 went 0.40 -> 0.60 between two runs
+    with no code deployed: an evolve cognify pass and a partially-completed sync
+    had both landed in between, and without this the jump was indistinguishable
+    from a real improvement. Always report these alongside the metrics.
+    """
+    fingerprint: dict[str, Any] = {}
+    for name, path in (("state", "/api/state"), ("indexes", "/api/indexes")):
+        request = urllib.request.Request(
+            f"{node_url.rstrip('/')}{path}",
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            fingerprint[name] = {"error": exc.__class__.__name__}
+            continue
+        if name == "state":
+            fingerprint["documents_tracked"] = (body.get("totals") or {}).get("documents")
+            fingerprint["sources"] = [
+                {
+                    "name": source.get("name"),
+                    "type": source.get("type"),
+                    "documents": source.get("documents"),
+                    "last_synced_at": source.get("last_synced_at"),
+                }
+                for source in body.get("sources") or []
+            ]
+            fingerprint["version"] = body.get("version")
+        else:
+            stats = body.get("stats") or {}
+            # Reported as-is. These reset on process restart, so they measure
+            # uptime as much as content; they are a change signal, not a total.
+            fingerprint["indexes_stats"] = stats
+    return fingerprint
+
+
 def percentile(values: list[float], fraction: float) -> float:
     if not values:
         return 0.0
@@ -152,6 +193,7 @@ def main() -> int:
         return 2
 
     questions = load_questions(Path(args.questions))
+    corpus = corpus_fingerprint(args.node_url, token, args.timeout)
     rows: list[dict[str, Any]] = []
     latencies: list[float] = []
 
@@ -245,9 +287,18 @@ def main() -> int:
     for key, value in summary.items():
         print(f"{key:>26}: {value}")
 
+    print("\n--- corpus at run time (compare before trusting a delta) ---")
+    print(f"{'documents_tracked':>26}: {corpus.get('documents_tracked')}")
+    for source in corpus.get("sources") or []:
+        print(
+            f"{source['type']:>26}: {source['documents']} docs, "
+            f"synced {source['last_synced_at']}"
+        )
+
     if args.out:
         Path(args.out).write_text(
-            json.dumps({"summary": summary, "rows": rows}, indent=2), encoding="utf-8"
+            json.dumps({"summary": summary, "corpus": corpus, "rows": rows}, indent=2),
+            encoding="utf-8",
         )
         print(f"\nwrote {args.out}")
     return 0

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -30,6 +30,11 @@ class FakeCitadel:
 class FakeLearningProcess:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.improve_calls: list[dict[str, Any]] = []
+
+    async def improve_once(self, **kwargs: Any) -> Any:
+        self.improve_calls.append(kwargs)
+        return {"ok": True}
 
     async def learn(self, data: str, **kwargs: Any) -> Any:
         self.calls.append({"data": data, **kwargs})
@@ -486,3 +491,133 @@ def test_a_binding_cap_keeps_the_shallower_file_on_both_paths() -> None:
 
     assert probe_paths == ["skills/zzz.md"], "the walk takes the prefix's own files first"
     assert tree_paths == probe_paths, f"selection drifted under the cap: {tree_paths} != {probe_paths}"
+
+
+# --- resumability -----------------------------------------------------------
+#
+# 2026-07-31: a forced sync was killed by Railway's 300 s request ceiling after
+# ingesting files, and state was only written after the whole loop, so nothing
+# recorded them. Root cause of the two hours: run_improve fired a full cognee
+# improve pass per file (~2 min each). Both halves are pinned below.
+
+
+@pytest.mark.asyncio
+async def test_improve_runs_once_for_the_whole_sync_not_once_per_file(
+    tmp_path: Path,
+) -> None:
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(tmp_path / "state.json"),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=True,
+    )
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    result = await syncer.run()
+
+    assert result["files_ingested"] == 2
+    # No per-file improve...
+    assert all(call.get("run_improve") is False for call in learning.calls)
+    # ...and exactly one improve for the whole run.
+    assert len(learning.improve_calls) == 1
+    assert learning.improve_calls[0]["dataset"] == "masumi-network"
+    assert learning.improve_calls[0]["session_ids"] == ["masumi-repo-content"]
+    assert result["improved"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_improve_pass_when_nothing_was_ingested(tmp_path: Path) -> None:
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(tmp_path / "state.json"),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=True,
+    )
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    await syncer.run()
+    learning.improve_calls.clear()
+    second = await syncer.run()  # everything unchanged now
+
+    assert second["files_ingested"] == 0
+    assert learning.improve_calls == []
+
+
+@pytest.mark.asyncio
+async def test_state_is_checkpointed_per_file_so_a_killed_run_resumes(
+    tmp_path: Path,
+) -> None:
+    """A run that dies mid-loop must not lose the files it already ingested."""
+    state_path = tmp_path / "state.json"
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(state_path),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=False,
+    )
+
+    class DiesAfterFirstFile(FakeLearningProcess):
+        async def learn(self, data: str, **kwargs: Any) -> Any:
+            if self.calls:
+                raise RuntimeError("killed mid-sync, like a 300s request timeout")
+            return await super().learn(data, **kwargs)
+
+    learning = DiesAfterFirstFile()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(RuntimeError):
+        await syncer.run()
+
+    # The first file's success survived the crash.
+    assert state_path.exists(), "no checkpoint written before the crash"
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert len(persisted["files"]) == 1, persisted
+
+    # A fresh run skips what was already done instead of redoing it.
+    resumed_learning = FakeLearningProcess()
+    resumed = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=resumed_learning,  # type: ignore[arg-type]
+    )
+    result = await resumed.run()
+
+    assert result["files_ingested"] == 1
+    assert result["files_skipped_by_reason"].get("unchanged") == 1
+    assert len(resumed_learning.calls) == 1

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -154,3 +154,157 @@ def test_redact_secrets_keeps_benign_text_intact() -> None:
     benign = "GitHub sync finished for masumi-network: 12 repos scanned"
 
     assert redact_secrets(benign) == benign
+
+
+# --- unsafe_url_scheme: the `data:` false positive -------------------------
+#
+# On 2026-07-31 the repo-content sync was silently dropping 9 of 69 files.
+# Seven were killed by RISKY_SCHEME_PATTERN matching the bare word `data:`
+# inside a fenced JavaScript block. No test covered this rule at all, in
+# either direction, which is why it shipped.
+
+
+def test_javascript_object_key_named_data_is_not_a_url_scheme() -> None:
+    """`data:` as a JS/JSON property key must not read as a data URI."""
+    doc = (
+        "## Test plan\n\n"
+        "```ts\n"
+        "listAdminTasksMock.mockResolvedValue({\n"
+        "  data: [\n"
+        '    { id: "task_1" },\n'
+        "  ],\n"
+        "  meta: { timestamp: now },\n"
+        "});\n"
+        "```\n"
+    )
+
+    result = scan(doc)
+
+    assert "unsafe_url_scheme" not in categories(result)
+    assert result["blocked"] is False
+
+
+def test_prose_mentioning_data_and_javascript_is_not_blocked() -> None:
+    doc = "Input data: the user record. Written in javascript: see the appendix."
+
+    assert "unsafe_url_scheme" not in categories(scan(doc))
+
+
+def test_real_data_uri_is_still_blocked() -> None:
+    """The rule must still fire on an actual data URI."""
+    result = scan("<img src='data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='>")
+
+    assert "unsafe_url_scheme" in categories(result)
+    assert result["blocked"] is True
+
+
+def test_degenerate_data_uri_forms_are_still_blocked() -> None:
+    assert "unsafe_url_scheme" in categories(scan("data:;base64,PHN2Zz4="))
+    assert "unsafe_url_scheme" in categories(scan("data:,Hello%2C%20World"))
+
+
+def test_javascript_and_vbscript_payloads_are_still_blocked() -> None:
+    assert "unsafe_url_scheme" in categories(scan("<a href='javascript:alert(1)'>x</a>"))
+    assert "unsafe_url_scheme" in categories(scan("<a href='vbscript:msgbox(1)'>x</a>"))
+
+
+def test_file_scheme_is_still_blocked() -> None:
+    assert "unsafe_url_scheme" in categories(scan("see file:///etc/passwd for details"))
+
+
+# --- secret_assignment: code that reads a secret is not a secret ------------
+#
+# The same sync dropped Sokosumi-MCP/docs/DEBUG_CONNECTION.md (5 findings) and
+# sokosumi-cli/AGENTS.md (2). Every one was code correctly avoiding a
+# hard-coded credential. Each string below is taken verbatim from those files.
+
+
+def test_env_lookups_are_not_secret_assignments() -> None:
+    for snippet in (
+        'const apiKey = process.env.SOKOSUMI_API_KEY;',
+        "const apiKey = getApiKeyFromEnv();",
+        'api_key = os.environ.get("RAILWAY_API_KEY")',
+        "api_key = request.query_params.get('api_key')",
+        "https://your-app.up.railway.app?api_key=YOUR_KEY",
+    ):
+        assert "secret_assignment" not in categories(scan(snippet)), snippet
+
+
+def test_short_and_placeholder_values_are_not_secret_assignments() -> None:
+    for snippet in (
+        "token = xxxxxxxxxxxx",
+        "api_key = <your-key-here>",
+        "password = changeme-please",
+        "secret = ${VAULT_SECRET}",
+        "token = config.auth.token",
+    ):
+        assert "secret_assignment" not in categories(scan(snippet)), snippet
+
+
+def test_literal_credentials_are_still_secret_assignments() -> None:
+    """Narrowing the rule must not let a real hard-coded credential through."""
+    for snippet in (
+        GENERIC_ASSIGNMENT,
+        # Synthetic throughout. Never paste a real credential into a fixture:
+        # it lands in git history, and the value is burned the moment it does.
+        'api_key = "abcd1234efgh5678ijkl9012mnop3456"',
+        "token: Tok3nLikeAGeneratedValue0123456789",
+        # all-alpha but long and mixed case, like a generated DB password
+        'password = "QwertyuiopAsdfghjklZxcvbn"',
+    ):
+        assert "secret_assignment" in categories(scan(snippet)), snippet
+
+
+def test_documentation_files_that_were_wrongly_blocked_now_pass() -> None:
+    """End-to-end shape of the two real files, as one scan."""
+    doc = (
+        "# Sokosumi CLI - Agent Guidelines\n\n"
+        "```ts\n"
+        "const apiKey = getApiKeyFromEnv();\n"
+        "// Bad - Direct process.env access\n"
+        "const apiKey = process.env.SOKOSUMI_API_KEY;\n"
+        "```\n\n"
+        "```py\n"
+        'api_key = os.environ.get("RAILWAY_API_KEY")\n'
+        "if api_key:\n"
+        '    api_keys["current"] = api_key\n'
+        "```\n\n"
+        "```ts\n"
+        "mockResolvedValue({ data: [] });\n"
+        "```\n"
+    )
+
+    result = scan(doc)
+
+    assert result["blocked"] is False, result["findings"]
+
+
+def test_identifier_valued_assignments_in_test_fixtures_are_not_secrets() -> None:
+    """`token: "hashed_token"` in a mock is a fixture identifier, not a secret."""
+    for snippet in (
+        'oauthAccessTokenFindUniqueMock.mockResolvedValue({ token: "hashed_token" })',
+        "const secret = refresh_token",
+        "api_key = access-token",
+    ):
+        assert "secret_assignment" not in categories(scan(snippet)), snippet
+
+
+def test_long_lowercase_passphrases_are_still_secrets() -> None:
+    """The identifier carve-out is length-bounded and must not swallow these."""
+    assert "secret_assignment" in categories(scan("password=not-a-real-secret-value"))
+    assert "secret_assignment" in categories(scan("token = correct-horse-battery-staple"))
+
+
+def test_high_confidence_patterns_are_untouched_by_the_carve_outs() -> None:
+    """Narrowing the generic rule must not weaken the specific detectors."""
+    for value, expected in (
+        (GITHUB_TOKEN, "github_token"),
+        (AWS_KEY, "aws_access_key"),
+        (STRIPE_KEY, "stripe_live_secret"),
+        (SLACK_TOKEN, "slack_token"),
+        (PRIVATE_KEY, "private_key_marker"),
+    ):
+        result = scan(f"token = {value}")
+        assert expected in categories(result), value
+        assert result["blocked"] is True
+


### PR DESCRIPTION
Phase 1 verification found that ingestion runs fast and cheap while quietly
losing content and ranking badly. These are the defects that were root-caused
to a line and reproduced, plus the harness that measures them.

No issue linked: every one of these was found during this verification pass and
has no existing backlog entry. Happy to file them retroactively if the backlog
should stay the source of truth.

## What was wrong

**13% of repo content never reached the vault.** 9 of 69 files were rejected at
ingest. Seven died because `RISKY_SCHEME_PATTERN` matched the bare word `data:`,
so `mockResolvedValue({ data: [...] })` in a fenced code block read as a data
URI. The other two tripped `secret_assignment`, whose seven matches were all
`process.env.X`, `os.environ.get(...)`, `getApiKeyFromEnv()` and `YOUR_KEY` —
not one was a credential. `sokosumi-cli/AGENTS.md` was among the casualties.

Nothing recorded any of it. The code counted a block and `continue`d, so the
ledger said `blocked: 7` and nothing else; identifying the files meant
re-implementing the scan by hand.

**A forced sync could not complete.** Railway killed it at exactly `300010ms`
(HTTP 499, `502` at the caller) with a 1800s client timeout. It was working when
killed: `improve: synced 0 edges` fired three times in five minutes, about one
file every two minutes, because `run_improve` ran a full cognee improve pass per
file. 60 files needed roughly two hours. Worse, state was persisted only after
the whole loop, so the run ingested files and recorded none of them, leaving
`last_checked_at` unchanged and guaranteeing the next run redid the work.

**The daily digest was noise.** Every push read "Pushed 0 commits", every PR
"(no title)", and that text is cognified into the vault as durable knowledge.
`/orgs/{org}/events` returns an abbreviated payload with no `size`,
`distinct_size`, `commits` or `pull_request.title`. An earlier fix attempt is
still in the code with a comment claiming it prevents exactly this; it was
written against the documented full payload and never worked.

## Result

| | before | after |
|---|---|---|
| repo-content ingest coverage | 60/69 (87%) | **69/69 (100%)** |
| forced full sync | impossible (~2h vs 300s ceiling) | one improve pass, resumable |
| a killed run | ingests and forgets | checkpoints per file |
| blocked file | silent | logs path, severity, rule |

Verified end to end against the live repos:

```
repos=4 discovered=69 ingested=69 skipped=0 blocked=0 blocked_rules=- dry_run=True
```

## On not weakening the scanner

The narrowing is deliberately not an entropy test. A first attempt required a
digit or mixed case and let `password=not-a-real-secret-value` through, which
the existing suite caught. Being a literal rather than a code expression is the
distinction that matters, and the length floor stays at the rule's original 8.

One trade-off is explicit in the code: the length-bounded identifier carve-out
means a short all-lowercase passphrase with no digits is now missed by that
generic heuristic. Every high-confidence detector is untouched, and a test
asserts `github_token`, `aws_access_key`, `stripe_live_secret`, `slack_token`
and `private_key_marker` each still fire and still block.

## Benchmark harness

`scripts/bench/` runs a golden question set and reports recall@k, MRR and
latency. First run against prod: recall@1 0.35, **recall@5 0.40**, MRR 0.375,
latency **p50 508.7ms / p95 595.6ms** over 72 samples, 0 errors. Latency is
good; relevance is the problem, and that is the next piece of work.

Four questions target scanner-blocked documents and are expected to miss. They
are the regression test for any scanner change: if one starts hitting, either
the block was lifted or content arrived through a path that skips the gate.

The README records what not to trust: an explicitly passed `dataset` rewrites
the label on hits without filtering them (identical `content_sha256` under two
dataset names), `_citadel.provenance` is `{}` on every hit observed, and
`mode="docs"` returns zero results for a question whose answer is in an ingested
`.md` file.

## Not in this PR

- `/api/indexes` reports since-process-start counters (`documents: 1`) and a
  projection graph, while the real graph is 15,754 nodes / 110,268 edges.
- `mode="docs"` returning nothing.
- Retrieval relevance itself, including a Linear workspace digest chunk holding
  200 issue titles that matches nearly any query.

## Tests

1038 pass, up from 1032. The 6 failures and 3 errors are pre-existing
`ModuleNotFoundError: No module named 'cognee'` in the local interpreter and are
unrelated to these changes.