### PR TITLE
fix(search): make docs mode and the dashboard tell the truth

### DIFF
--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -206,28 +206,68 @@ class MeshState:
             self._edge(source_id, repo_id, "observed")
             self._edge(repo_id, dataset_id, "summarized")
 
-    async def snapshot(self, config: CitadelConfig) -> dict[str, Any]:
+    async def snapshot(
+        self, config: CitadelConfig, *, corpus: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Dashboard projection, plus corpus totals when the caller supplies them.
+
+        Everything on ``MeshState`` is in-memory and resets with the process, and
+        ``rehydrate`` deliberately does not reseed the accumulating counters. That
+        is correct for activity — "searches this uptime" is a live signal — but it
+        was also being reported as ``documents`` and ``indexed_chunks``, which read
+        as corpus totals. On a service that redeploys on every merge to main the
+        dashboard therefore showed 1 document and 1 indexed chunk against a real
+        15641 indexed / 308 tracked: understated by four orders of magnitude, in
+        the direction that makes a working vault look dead.
+
+        ``corpus`` carries the authoritative figures (the same ones ``/readyz``
+        and ``citadel status`` already report). When present they are reported as
+        the totals and the in-memory versions move under ``since_restart``, which
+        is what they have always actually measured.
+        """
         async with self._lock:
             self._ensure_base_graph(config)
             indexes = self._indexes(config)
+            since_restart = {
+                "documents": self.documents,
+                "searches": self.searches,
+                "feedback": self.feedback_items,
+                "upgrades": self.upgrades,
+                "errors": self.errors,
+                "indexed_chunks": self.indexed_chunks,
+                "projection_nodes": len(self.nodes),
+                "projection_edges": len(self.edges),
+            }
+            corpus = corpus or {}
+            authoritative_nodes = corpus.get("indexed_docs")
+            authoritative_docs = corpus.get("tracked_sources")
             return {
                 "revision": self.revision,
                 "generated_at": utc_now(),
                 "tenant_id": config.tenant_id,
                 "default_dataset": config.default_dataset,
                 "stats": {
-                    "nodes": len(self.nodes),
+                    "nodes": (
+                        authoritative_nodes if authoritative_nodes is not None else len(self.nodes)
+                    ),
                     "edges": len(self.edges),
-                    "documents": self.documents,
+                    "documents": (
+                        authoritative_docs if authoritative_docs is not None else self.documents
+                    ),
                     "searches": self.searches,
                     "feedback": self.feedback_items,
                     "upgrades": self.upgrades,
                     "errors": self.errors,
-                    "indexed_chunks": self.indexed_chunks,
+                    "indexed_chunks": (
+                        authoritative_nodes
+                        if authoritative_nodes is not None
+                        else self.indexed_chunks
+                    ),
                     "pending_chunks": self.pending_chunks,
                     "failed_chunks": self.failed_chunks,
                     "last_indexed_at": self.last_indexed_at,
                     "latest_event_id": self.revision,
+                    "since_restart": since_restart,
                 },
                 "indexes": indexes,
                 "nodes": list(self.nodes.values()),

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -86,7 +86,20 @@ def _matches_extension(path: str, extensions: tuple[str, ...]) -> bool:
     return any(lowered.endswith(ext.lower()) for ext in extensions)
 
 
-def format_repo_content_document(file: RepoContentFile, *, checked_at: str) -> str:
+def format_repo_content_document(file: RepoContentFile) -> str:
+    """Render a repo file as a vault document.
+
+    Deliberately carries NO retrieval timestamp. It used to include
+    ``Retrieved: {checked_at}``, which made the body of an unchanged file
+    different on every sync. That defeated content-hash dedup at ingest and the
+    text-keyed dedup at query time, so each re-sync added another copy: one
+    README was occupying 8 of 8 result slots under 8 document ids, and half the
+    average result set was repeats of a single file.
+
+    ``Commit`` and ``Blob`` already pin the exact version this text came from,
+    and they are stable while the file is unchanged, which is the property that
+    makes a document deduplicable. When the file changes they change with it.
+    """
     return "\n".join(
         [
             f"# {file.repo}/{file.path}",
@@ -95,7 +108,6 @@ def format_repo_content_document(file: RepoContentFile, *, checked_at: str) -> s
             f"Source: {file.html_url}",
             f"Commit: {file.ref}",
             f"Blob: {file.sha}",
-            f"Retrieved: {checked_at}",
             "",
             "---",
             "",
@@ -643,7 +655,7 @@ class RepoContentSyncer:
                         )
                         continue
 
-                    document = format_repo_content_document(file, checked_at=checked_at)
+                    document = format_repo_content_document(file)
                     if dry_run:
                         ingested_files += 1
                         repo_result["ingested"] += 1

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -18,7 +18,25 @@ SPEC_PATH_RE = re.compile(
     re.IGNORECASE,
 )
 ACTIVITY_RE = re.compile(
-    r"(daily\s+digest|organization\s+update|github\s+org|linear\s+sync)",
+    # `linear\s+\w*\s*sync` rather than `linear\s+sync`: the digest this is meant
+    # to catch is titled "Linear workspace sync", and the intervening word made
+    # it classify as `other`, which is not ambient — so the one document holding
+    # 120 issue titles was never excluded from docs-mode results.
+    r"(daily\s+digest|organization\s+update|github\s+org|linear(\s+\w+)?\s+sync)",
+    re.IGNORECASE,
+)
+# The header `format_repo_content_document` writes. It is the one structural
+# provenance marker any hit actually carries: hits expose no tags, an empty
+# `provenance`, and null `source_node_set`/`source_pipeline`, so body text is
+# the only signal available. A document that names its repo, its source URL,
+# its commit and its blob is source-linked repository documentation, whatever
+# else its text may coincidentally match.
+REPO_CONTENT_HEADER_RE = re.compile(
+    r"^#\s+[\w.-]+/[\w.-]+/\S+\s*\n\s*\n"
+    r"Repository:\s*\S+\s*\n"
+    r"Source:\s*https?://\S+\s*\n"
+    r"Commit:\s*\S+\s*\n"
+    r"Blob:\s*\S+",
     re.IGNORECASE,
 )
 # Cardano policy IDs are 56 hex chars; asset names / units are often longer hex.
@@ -120,7 +138,15 @@ def infer_doc_type(item: dict[str, Any]) -> str:
         return DOC_TYPE_TRACE
     text = _hit_text(item)
     lowered = text.lower()
-    # Activity/issue material is checked FIRST. A digest aggregates titles written
+    # Checked before the ambient patterns, and only this one may be, because it
+    # is structural rather than keyword-based: the full Repository/Source/Commit/
+    # Blob header is written by the repo-content syncer and cannot be produced by
+    # a digest quoting an issue title. Without it, a README that merely mentions
+    # "linear sync" classified as ambient activity and was filtered out of
+    # docs-mode results.
+    if REPO_CONTENT_HEADER_RE.search(text):
+        return DOC_TYPE_CANONICAL
+    # Activity/issue material is checked next. A digest aggregates titles written
     # by anyone (a public-repo issue called "MIP-003 endpoint schema" lands in the
     # org digest verbatim), so testing the spec patterns first let ambient
     # material relabel itself as documentation and slip past exclude_ambient.
@@ -485,12 +511,13 @@ def filter_hits(
         # is attested-only now, so this deliberately no longer consults it.
         filtered = [h for h in filtered if _hit_doc_type(h) in DOC_SHAPED_TYPES]
     if exclude_ambient:
-        filtered = [
-            h
-            for h in filtered
-            if _hit_doc_type(h) not in AMBIENT_DOC_TYPES
-            and _hit_trust_tier(h) != TRUST_REFERENCE
-        ]
+        # Content-shaped only, for the same reason canonical_only above stopped
+        # consulting the tier: `reference-only` is the single tier the server can
+        # attest today, so every hit carries it and the trust half of this
+        # condition was unsatisfiable. `mode="docs"` therefore returned zero
+        # results for every query, including ones whose answer was an ingested
+        # .md file sitting in the vault.
+        filtered = [h for h in filtered if _hit_doc_type(h) not in AMBIENT_DOC_TYPES]
     return filtered
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -4220,7 +4220,9 @@ async def resolve_knowledge_conflict(
 async def indexes(request: Request) -> Any:
     require_access(request, "reader", "kb:read")
     citadel = get_citadel()
-    snapshot = await get_mesh().snapshot(citadel.config)
+    # Pass the authoritative corpus figures so the dashboard reports the vault's
+    # real size rather than whatever has happened since the last deploy.
+    snapshot = await get_mesh().snapshot(citadel.config, corpus=await _corpus_health())
     return jsonable_encoder({"indexes": snapshot["indexes"], "stats": snapshot["stats"]})
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -81,6 +81,7 @@ from kb.repo_content_sync import RepoContentSyncer
 from kb.search_feedback import build_search_telemetry, presence_only_telemetry
 from kb.search_format import (
     CODE_TIMEOUT,
+    DOC_TYPE_CANONICAL,
     DOC_TYPE_TRACE,
     apply_query_ranking,
     compact_search_filters,
@@ -2606,8 +2607,20 @@ def with_result_metadata(
     # ``reference-only`` is attested by the dataset, so it outranks anything the
     # body text would suggest — otherwise a trace whose text mentions /skills/
     # classifies as a skill doc and reads as verified knowledge.
+    #
+    # The one exception is source-linked repository documentation, which carries
+    # a full Repository/Source/Commit/Blob header written by the repo-content
+    # syncer. A shared-trace marker is assigned by matching chunk TEXT against
+    # the session-traces dataset (search_across_datasets), so any document a
+    # trace happens to quote verbatim inherits ``reference-only`` and was then
+    # relabelled a trace. That is how every hit on this node — READMEs, SKILL.md,
+    # design specs — came back as ``session-trace`` and why ``mode="docs"``
+    # matched nothing. Structural provenance in the body beats a text collision.
+    inferred = infer_doc_type(preview)
     doc_type = (
-        DOC_TYPE_TRACE if metadata.get("trust") == "reference-only" else infer_doc_type(preview)
+        DOC_TYPE_TRACE
+        if metadata.get("trust") == "reference-only" and inferred != DOC_TYPE_CANONICAL
+        else inferred
     )
     metadata["doc_type"] = doc_type
     metadata["content_hint"] = infer_content_hint(preview, doc_type)

--- a/scripts/bench/simulate_doc_cap.py
+++ b/scripts/bench/simulate_doc_cap.py
@@ -1,0 +1,170 @@
+"""Measure redundancy in a result set, and what a per-source cap would fix.
+
+Fetches a deeper candidate pool once per question, then scores recall@5 under
+several caps from the SAME responses. Because every variant is computed from
+one set of hits, corpus drift cannot explain a difference between them — which
+matters on this node, where recall@5 moved 0.40 -> 0.70 in a morning with
+nothing deployed.
+
+What this found on 2026-07-31, and why the headline metric is not recall:
+
+    cap    recall@5    MRR
+    none      0.750  0.725
+    1         0.750  0.725
+    2         0.750  0.725
+
+    worst-case single-source share of the uncapped top-5: mean 0.49, max 1.00
+
+A cap changes recall by nothing, because when one source monopolises the slots
+it is usually the source that answers the question — it is already at rank 1.
+The damage is elsewhere: on average HALF the returned context is repeats of one
+file, and at worst all five slots are the same file. An agent asking for five
+documents receives about two and a half distinct ones.
+
+So recall@5 = 0.75 and the context is still half wasted. Report unique-source
+share beside recall or the number flatters itself.
+
+The cause is upstream of ranking: `format_repo_content_document` stamps
+`Retrieved: <timestamp>` into the ingested body, so re-syncing an unchanged
+file yields textually distinct content and a fresh document row. That defeats
+content-hash dedup at ingest and the text-keyed `search_result_dedup_key` at
+query time, and every forced sync multiplies the corpus again.
+
+Usage:
+    python scripts/bench/simulate_doc_cap.py --pool 20 --repeats 2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from search_bench import (  # noqa: E402
+    DEFAULT_NODE,
+    hit_paths,
+    load_ground_truth,
+    load_questions,
+    rank_of_expected,
+    search,
+    shingles,
+)
+
+
+def source_key(item: dict) -> str:
+    """Identify the SOURCE a hit came from, not the row it is stored in.
+
+    `document_id` is the wrong key and measuring with it gave a false all-clear.
+    `format_repo_content_document` stamps `Retrieved: <timestamp>` into the
+    ingested body, so every re-sync of an unchanged file produces textually
+    distinct content and a fresh document row. One README was occupying 8 of 8
+    slots under 8 different document_ids, and a document_id-keyed cap called
+    that perfectly diverse.
+
+    The first line carries `# owner/repo/path` for repo content, which survives
+    re-ingestion. Fall back to document_id only when that is absent.
+    """
+    text = item.get("text") or ""
+    first_line = text.split("\n", 1)[0].strip()
+    if first_line.startswith("# ") and "/" in first_line:
+        return first_line[2:].strip()
+    return str(item.get("document_id") or id(item))
+
+
+def apply_cap(results: list[dict], cap: int | None, final_k: int) -> list[dict]:
+    """Take the top `final_k` hits, allowing at most `cap` per source."""
+    if cap is None:
+        return results[:final_k]
+    seen: dict[str, int] = {}
+    kept: list[dict] = []
+    for item in results:
+        key = source_key(item)
+        if seen.get(key, 0) >= cap:
+            continue
+        seen[key] = seen.get(key, 0) + 1
+        kept.append(item)
+        if len(kept) >= final_k:
+            break
+    return kept
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--node-url", default=os.getenv("CITADEL_NODE_URL", DEFAULT_NODE))
+    parser.add_argument("--questions", default=str(HERE / "golden_questions.json"))
+    parser.add_argument("--pool", type=int, default=20, help="candidates to fetch")
+    parser.add_argument("--final-k", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    token = os.getenv("CITADEL_MCP_ACCESS_TOKEN") or os.getenv("CITADEL_ACCESS_TOKEN")
+    if not token:
+        print("CITADEL_MCP_ACCESS_TOKEN is not set", file=sys.stderr)
+        return 2
+
+    questions = [q for q in load_questions(Path(args.questions)) if q.get("expected_recall") == 1]
+    caps: list[int | None] = [None, 1, 2, 3]
+    ranks: dict[str, list[int | None]] = {str(cap): [] for cap in caps}
+    slot_share: list[float] = []
+
+    for question in questions:
+        fingerprints = load_ground_truth(question["expect_any"])
+        per_cap_best: dict[str, list[int]] = {str(cap): [] for cap in caps}
+        for _ in range(args.repeats):
+            body, _elapsed, error = search(
+                args.node_url, token, question["question"], args.pool, args.timeout
+            )
+            if error or body is None:
+                continue
+            results = list(body.get("results") or [])
+            if results:
+                # How much of the untruncated top-5 one document already owns.
+                head = results[: args.final_k]
+                docs = [source_key(r) for r in head]
+                slot_share.append(max(docs.count(d) for d in set(docs)) / len(head))
+            for cap in caps:
+                kept = apply_cap(results, cap, args.final_k)
+                sub = {"results": kept}
+                rank, _how = rank_of_expected(
+                    hit_paths(sub),
+                    [(item.get("text") or "") for item in kept],
+                    question["expect_any"],
+                    fingerprints,
+                )
+                if rank is not None:
+                    per_cap_best[str(cap)].append(rank)
+        for cap in caps:
+            best = per_cap_best[str(cap)]
+            ranks[str(cap)].append(min(best) if best else None)
+
+    print(f"questions={len(questions)} pool={args.pool} final_k={args.final_k} "
+          f"repeats={args.repeats}\n")
+    print(f"{'cap':>6}  {'recall@5':>9}  {'MRR':>6}")
+    summary = {}
+    for cap in caps:
+        rows = ranks[str(cap)]
+        hits = sum(1 for r in rows if r is not None and r <= args.final_k)
+        recall = hits / len(rows) if rows else 0.0
+        mrr = statistics.fmean([1.0 / r if r else 0.0 for r in rows]) if rows else 0.0
+        label = "none" if cap is None else str(cap)
+        print(f"{label:>6}  {recall:>9.3f}  {mrr:>6.3f}")
+        summary[label] = {"recall_at_5": round(recall, 4), "mrr": round(mrr, 4)}
+
+    if slot_share:
+        print(f"\nworst-case single-document share of the uncapped top-{args.final_k}: "
+              f"mean {statistics.fmean(slot_share):.2f}, max {max(slot_share):.2f}")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/simulate_doc_cap.py
+++ b/scripts/bench/simulate_doc_cap.py
@@ -52,7 +52,6 @@ from search_bench import (  # noqa: E402
     load_questions,
     rank_of_expected,
     search,
-    shingles,
 )
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from kb.config import CitadelConfig
 from kb.mesh import MeshState
 from kb.models import FeedbackResult, IngestResult
@@ -300,3 +302,59 @@ async def test_timeline_tracks_chunks_and_resume_filters() -> None:
     assert [event["id"] for event in chunk_events["events"]] == [2, 1]
     assert chunk_events["stats"]["indexed_chunks"] == 4
     assert chunk_events["stats"]["last_indexed_at"] == chunk_events["events"][0]["created_at"]
+
+
+# --- the dashboard reported the vault as empty -----------------------------
+#
+# 2026-07-31: /api/indexes reported documents=1 and indexed_chunks=1 against a
+# real 15641 indexed / 308 tracked. Every MeshState counter is in-memory and
+# rehydrate deliberately does not reseed them, so on a service that redeploys
+# on every merge to main they measured uptime, not corpus.
+
+
+@pytest.mark.asyncio
+async def test_snapshot_reports_authoritative_corpus_totals() -> None:
+    config = CitadelConfig()
+    mesh = MeshState()
+    mesh.documents = 1
+    mesh.indexed_chunks = 1
+    mesh.searches = 386
+
+    snapshot = await mesh.snapshot(
+        config, corpus={"ok": True, "tracked_sources": 308, "indexed_docs": 15641}
+    )
+    stats = snapshot["stats"]
+
+    assert stats["documents"] == 308
+    assert stats["indexed_chunks"] == 15641
+    assert stats["nodes"] == 15641
+    # The in-memory values are still available, correctly labelled.
+    assert stats["since_restart"]["documents"] == 1
+    assert stats["since_restart"]["indexed_chunks"] == 1
+    # Activity counters are genuinely uptime-scoped and stay where they are.
+    assert stats["searches"] == 386
+
+
+@pytest.mark.asyncio
+async def test_snapshot_falls_back_when_corpus_is_unavailable() -> None:
+    """_corpus_health fails soft and returns None counts; do not report None."""
+    config = CitadelConfig()
+    mesh = MeshState()
+    mesh.documents = 4
+
+    snapshot = await mesh.snapshot(
+        config, corpus={"ok": True, "tracked_sources": None, "indexed_docs": None}
+    )
+
+    assert snapshot["stats"]["documents"] == 4
+
+
+@pytest.mark.asyncio
+async def test_snapshot_without_corpus_keeps_the_old_shape() -> None:
+    config = CitadelConfig()
+    mesh = MeshState()
+    mesh.documents = 7
+
+    snapshot = await mesh.snapshot(config)
+
+    assert snapshot["stats"]["documents"] == 7

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -133,10 +133,33 @@ def test_format_repo_content_document() -> None:
         content="# Title",
         html_url="https://example.com",
     )
-    document = format_repo_content_document(file, checked_at="2026-06-16T00:00:00Z")
+    document = format_repo_content_document(file)
     assert "masumi-network/sokosumi-cli/README.md" in document
     assert "Commit: commit123" in document
     assert "# Title" in document
+
+
+def test_repo_content_document_is_stable_for_an_unchanged_file() -> None:
+    """Two syncs of an unchanged file must produce byte-identical documents.
+
+    A `Retrieved: <timestamp>` line used to make every re-sync textually
+    distinct, which defeated dedup at both ingest and query time and let one
+    README occupy 8 of 8 result slots under 8 document ids.
+    """
+    file = RepoContentFile(
+        repo="masumi-network/sokosumi-cli",
+        path="README.md",
+        sha="abc",
+        ref="commit123",
+        content="# Title",
+        html_url="https://example.com",
+    )
+
+    first = format_repo_content_document(file)
+    second = format_repo_content_document(file)
+
+    assert first == second
+    assert "Retrieved:" not in first, "a per-sync timestamp reintroduces duplicates"
 
 
 def test_discover_repo_paths_includes_root_and_tree_files() -> None:

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -294,3 +294,112 @@ def test_compact_search_filters_omits_empty() -> None:
         "mode": "docs",
         "dataset": "notes",
     }
+
+
+# --- docs mode returned zero for everything -------------------------------
+#
+# 2026-07-31: `mode="docs"` matched nothing on prod, for any query, including
+# ones whose answer was an ingested .md file. Three independent causes, each
+# sufficient on its own. All three are pinned below.
+
+REPO_DOC_TEXT = (
+    "# masumi-network/sokosumi/README.md\n"
+    "\n"
+    "Repository: masumi-network/sokosumi\n"
+    "Source: https://github.com/masumi-network/sokosumi/blob/f401d38/README.md\n"
+    "Commit: f401d3896820ff35a82cf707818e308b67f5bce2\n"
+    "Blob: a4b30a4548af239f695ba3cba1935b545e96d675\n"
+    "\n"
+    "---\n"
+    "\n"
+    "# Sokosumi Monorepo\n\nSokosumi is a marketplace platform.\n"
+)
+
+
+def test_repo_content_header_classifies_as_documentation() -> None:
+    """Cause 3: infer_doc_type had no repo-content rule and returned 'other'."""
+    assert infer_doc_type({"text": REPO_DOC_TEXT}) == "canonical-docs"
+
+
+def test_repo_doc_survives_a_shared_trace_text_collision() -> None:
+    """Cause 1: a text collision with session-traces relabelled real docs.
+
+    The marker is assigned by matching chunk TEXT against the session-traces
+    dataset, so any document a trace quoted verbatim inherited reference-only
+    and was reclassified a trace. Structural provenance must win.
+    """
+    hit = {"text": REPO_DOC_TEXT, "_citadel": {"trust": "reference-only"}}
+
+    assert infer_doc_type(hit) == "canonical-docs"
+
+
+def test_exclude_ambient_does_not_consult_the_trust_tier() -> None:
+    """Cause 2: the trust half of the condition was unsatisfiable.
+
+    `reference-only` is the only tier the server can attest, so every hit
+    carries it and requiring `trust_tier != reference-only` removed everything.
+    """
+    hits = [
+        normalize_search_hit({"text": REPO_DOC_TEXT}, index=0),
+        normalize_search_hit({"text": "GitHub org daily digest"}, index=1),
+    ]
+    for hit in hits:
+        hit["trust_tier"] = "reference-only"
+
+    kept = filter_hits(hits, exclude_ambient=True)
+
+    assert len(kept) == 1, kept
+    assert kept[0]["doc_type"] == "canonical-docs"
+
+
+def test_docs_mode_returns_the_documentation_and_drops_the_issue() -> None:
+    """End to end: the shape that returned zero results on prod."""
+    payload = {
+        "results": [
+            # Both Linear shapes exactly as the syncer writes them.
+            {
+                "text": (
+                    "# Linear SOK-623: coworker init UX\n\n"
+                    "- **State:** In Review (started)\n"
+                    "- **Team:** Sokosumi\n"
+                    "- **URL:** https://linear.app/masumi/issue/SOK-623/coworker-init-ux"
+                )
+            },
+            {"text": REPO_DOC_TEXT},
+            {"text": "# Linear workspace sync\n\nSynced 200 issues.\n\n- **SOK-670** [Triage] x"},
+        ]
+    }
+
+    shaped = shape_search_payload(payload, query="Sokosumi monorepo structure", mode="docs")
+
+    assert shaped["docs_mode"] is True
+    assert len(shaped["results"]) == 1, shaped["results"]
+    assert "sokosumi/README.md" in shaped["results"][0]["text"]
+
+
+def test_the_linear_workspace_digest_counts_as_ambient() -> None:
+    """It is titled "Linear workspace sync", not "Linear sync".
+
+    ACTIVITY_RE required the two words adjacent, so the single document holding
+    120 issue titles classified as `other` — which is not ambient — and was
+    never excluded. It is the strongest magnet in the corpus.
+    """
+    digest = {"text": "# Linear workspace sync\n\nSynced 200 issues.\n\n- **SOK-670** [Triage] x"}
+
+    assert infer_doc_type(digest) == "activity"
+    assert filter_hits([normalize_search_hit(digest, index=0)], exclude_ambient=True) == []
+
+
+def test_a_trace_still_cannot_dress_itself_as_documentation() -> None:
+    """The guard this fix relaxes must still hold for actual traces.
+
+    A session trace mentioning /skills/ must not read as a skill doc just
+    because the body says so — it lacks the structural header.
+    """
+    trace = {
+        "text": "ran the agent against /skills/masumi/SKILL.md and it worked",
+        "_citadel": {"dataset": "session-traces"},
+    }
+
+    assert infer_doc_type(trace) == "session-trace"
+    assert infer_trust_tier(trace) == "reference-only"


### PR DESCRIPTION
Phase 2 work. Every change here was driven by a measurement that refuted the
fix I was about to write, so the numbers are included.

## mode="docs" returned zero results for every query

Including queries whose answer was an ingested `.md` file. Three independent
causes, each sufficient alone — fixing any one changed nothing, which is why
the first two attempts would have shipped as no-ops.

1. **Every hit classified as `session-trace`.** Measured: 100 of 100 sampled
   hits — READMEs, SKILL.md, design specs, Linear issues. A shared-trace marker
   is assigned by matching chunk TEXT against the session-traces dataset, so any
   document a trace quoted verbatim inherited `reference-only` and was
   relabelled. The marker is stripped from the response, so it is invisible from
   outside.
2. **`exclude_ambient` also required `trust_tier != reference-only`** — the only
   tier the server can attest, so the condition was unsatisfiable.
   `canonical_only` directly above was already fixed for this and carries a
   comment explaining why; this one was missed.
3. **`infer_doc_type` had no rule for repository content**, returning `other`
   for `sokosumi/README.md` (verified against a real prod hit). `other` is not
   in `DOC_SHAPED_TYPES`, so `canonical_only` excluded every GitHub markdown
   document regardless of the above.

Hits carry no tags, an empty `provenance` and a null `source_node_set`, so body
text is the only signal available. The repo-content header
(`Repository`/`Source`/`Commit`/`Blob`) is structural rather than keyword-based
and cannot be produced by a digest quoting an issue title, so it now classifies
as documentation and outranks a text collision. The guard it relaxes still
holds: a trace mentioning `/skills/` has no such header and stays a trace.

Also widens `ACTIVITY_RE` from `linear\s+sync`. The digest it exists to catch is
titled "Linear **workspace** sync", so the one document holding 120 issue titles
classified as `other`, was never excluded, and is the strongest magnet in the
corpus.

## The dashboard reported the vault as empty

| metric | real | `/api/indexes` said |
|---|---|---|
| indexed chunks | 15,641 | **1** |
| documents | 308 | **1** |
| nodes / edges | 15,754 / 110,268 | 547 / 1,465 |

Every `MeshState` counter is in-memory and resets with the process, and
`rehydrate` deliberately does not reseed the accumulating ones. Correct for
activity, wrong for `documents` and `indexed_chunks`, which read as totals — and
Railway redeploys on every merge to main.

Observed live: minutes after a deploy the endpoint showed `searches: 0`,
`latest_event_id: 3`; after one benchmark run, `searches: 386`,
`latest_event_id: 519`, with `documents` and `indexed_chunks` still at 1.

`_corpus_health()` already computes the authoritative figures and `/readyz` and
`citadel status` already report them, so nothing new is derived. In-memory
values move to `stats.since_restart`, which is what they always measured.

## Duplication: one README existed 29 times

`format_repo_content_document` stamped `Retrieved: {checked_at}` into the body,
so an unchanged file produced different text every sync, defeating content-hash
dedup at ingest and text-keyed dedup at query time. Measured: one query returned
`sokosumi/README.md` in 8 of 8 slots under 8 document ids; across the golden set
the worst-case single-source share of the top-5 is mean 0.49, max 1.00.

Note what this does *not* show up as: recall@5 is 0.750 with or without a
per-source cap, because the monopolising document is usually the one answering
the question and is already at rank 1. The cost is context, not retrieval — an
agent asking for five documents gets about two and a half.

This stops new duplicates. It does not remove existing copies, and it should
not: see below.

## What is deliberately not here

A duplicate purge. CONTEXT.md:172 says Structured Knowledge is revised in place
and "prior versions stay recoverable through the Vault Backup Mirror". That
mirror reports `enabled: false` and `latest_export: null` on prod, and its
`tracked_files()` covers three operational state files — no documents, no graph.
Deleting vault content today would be irreversible against a documented safety
net that is not implemented. Filed rather than fixed.

## Tests

1048 pass, up from 1039. The 6 failures and 3 errors are pre-existing
`ModuleNotFoundError: No module named 'cognee'` in the local interpreter; CI has
cognee and runs green.