### PR TITLE
test(bench): measure search modes in the retrieval harness

### DIFF
--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -185,7 +185,21 @@ def main() -> int:
     parser.add_argument("--repeats", type=int, default=1, help="runs per question")
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--out", default=None, help="write JSON results here")
+    parser.add_argument(
+        "--mode",
+        default=None,
+        help=(
+            "apply a search mode (e.g. 'docs') the way the MCP layer does. "
+            "POST /search takes no mode; it is applied by shape_search_payload, "
+            "so this calls the server's own function on the raw hits."
+        ),
+    )
     args = parser.parse_args()
+
+    shape = None
+    if args.mode:
+        sys.path.insert(0, str(HERE.parent.parent))
+        from kb.search_format import shape_search_payload as shape  # noqa: PLC0415
 
     token = os.getenv("CITADEL_MCP_ACCESS_TOKEN") or os.getenv("CITADEL_ACCESS_TOKEN")
     if not token:
@@ -214,6 +228,8 @@ def main() -> int:
                 errors.append(error or "empty")
                 ranks.append(None)
                 continue
+            if shape is not None:
+                body = shape(body, query=question["question"], mode=args.mode)
             paths = hit_paths(body)
             texts = [(item.get("text") or "") for item in body.get("results") or []]
             datasets = [


### PR DESCRIPTION
Follow-up to #173, which fixed `mode="docs"`. This lets the harness prove it.

`POST /search` takes no `mode` — it is applied by `shape_search_payload` at the
MCP layer — so `--mode docs` calls the server's own shaping function on the raw
hits rather than reimplementing the filter.

Measured against prod after #173 deployed. Both runs report an identical corpus
fingerprint (308 documents, same source sync timestamps), so the delta is not
drift:

|                | baseline | `mode=docs` |
|----------------|---------:|------------:|
| recall@5       |     0.75 |        0.75 |
| MRR            |    0.725 |        0.75 |
| Linear slots   |   24/100 |        0/76 |
| repo docs kept |       63 |          63 |

A quarter of the returned context disappears and not one documentation hit goes
with it. The answer moves up rather than out.

Classification is meaningful again: baseline hits split 64 `canonical-docs` to
36 `session-trace`. Before #173 every one of 100 sampled hits was
`session-trace`, which is why docs mode returned nothing.