### PR TITLE
docs(adr): record three decisions from the 2026-07-31 verification pass

### DIFF
--- a/docs/adr/0016-ingested-documents-are-byte-stable.md
+++ b/docs/adr/0016-ingested-documents-are-byte-stable.md
@@ -1,0 +1,54 @@
+# Ingested Documents Are Byte-Stable For An Unchanged Source
+
+- Status: Accepted
+- Date: 2026-07-31
+- Supersedes: nothing. Precondition for [ADR-0010](0010-structured-knowledge-durable-source-of-truth.md).
+
+A document rendered from a source that has not changed must be byte-identical to
+the last time it was rendered. Rendering must depend only on the source's
+content and version, never on when the render happened.
+
+`format_repo_content_document` stamped `Retrieved: {checked_at}` into the body of
+every **Source Snapshot** it produced. An unchanged file therefore produced
+different text on every sync. Content-hash matching at ingest could not
+recognise it as the same document, and the text-keyed dedup on the read path
+could not collapse the copies, so each sync added another. On 2026-07-31
+`masumi-network/sokosumi/README.md` existed as 29 distinct documents, one query
+returned it in 8 of 8 result slots under 8 document ids, and across a 20-question
+golden set the worst-case single-source share of the top five was mean 0.49,
+max 1.00 — half the average result set was repeats of one file.
+
+`Commit` and `Blob` already pin the exact version the text came from and stay
+stable while the file is unchanged, which is the property that makes a document
+deduplicable at all. When the file changes they change with it, so removing the
+timestamp loses nothing that identifies the snapshot.
+
+**Considered Options**
+
+- **Keep the timestamp, dedup on the read path instead:** collapse same-source
+  hits at query time and leave storage alone. Rejected — it treats the symptom
+  for one consumer while the vault keeps growing copies, and every other reader
+  (mesh, drill-down, promotion, backup) still sees them.
+- **Keep the timestamp, exclude it from the content hash:** narrower, but the
+  body is what gets chunked and embedded, so the copies remain textually
+  distinct to the vector store and to any future contradiction check. The hash
+  is not the only thing that has to agree.
+- **Move retrieval time into document metadata rather than deleting it:** the
+  honest place for it, and worth doing when a **Source Snapshot** carries
+  structured provenance. Deferred rather than rejected: hits currently expose an
+  empty `provenance`, so there is nowhere to put it that survives retrieval.
+- **Drop the timestamp (chosen):** the version is already pinned twice over.
+
+**Consequences**
+
+- Any renderer of vault documents is subject to this rule, not just repo
+  content: no wall-clock, no run id, no counter in the body.
+- Re-ingesting an unchanged source is now detectable as a no-op, which is the
+  precondition for revising a page in place instead of filing a new
+  contribution.
+- It does not remove copies already stored. Those predate this decision and
+  cannot be deleted safely while [ADR-0001](0001-github-vault-backup-mirror.md)
+  is unimplemented and prior versions are unrecoverable.
+- A test asserts two renders of an unchanged file are byte-identical and that no
+  `Retrieved:` line returns; that test is the guard against this class of
+  regression rather than against the one string.

--- a/docs/adr/0017-structural-provenance-outranks-inherited-trust.md
+++ b/docs/adr/0017-structural-provenance-outranks-inherited-trust.md
@@ -1,0 +1,64 @@
+# Structural Provenance Outranks Inherited Trust In Classification
+
+- Status: Accepted
+- Date: 2026-07-31
+- Extends: [ADR-0012](0012-attested-trust-vs-content-hint.md), [ADR-0011](0011-shared-session-traces.md).
+
+When a hit carries the structural header a governed sync writes — repository,
+source URL, commit and blob — that provenance determines its `doc_type`, even if
+the hit also inherited `reference-only` trust from a **Shared Session Trace**
+match. Trust still governs what a reader may rely on; it no longer decides what
+a document *is*.
+
+ADR-0012 established that trust is attested from the dataset a hit was read out
+of, never from body text, so that a trace mentioning `/skills/` cannot dress
+itself as a skill document. Classification then took a shortcut: anything
+carrying `reference-only` was labelled a trace.
+
+That shortcut collapsed once the shared-trace marker was assigned by matching
+chunk *text* against the session-traces dataset. Any document a trace quoted
+verbatim inherited `reference-only` and was reclassified. Measured on
+2026-07-31: **100 of 100 sampled hits** came back `session-trace` — READMEs,
+`SKILL.md` files, design specs, Linear issues, everything. `session-trace` is an
+ambient type, so `mode="docs"` filtered every result away and returned nothing
+for every query, including ones whose answer was an ingested `.md` file sitting
+in the vault.
+
+A text collision is evidence that two documents share words. It is not evidence
+about where either came from. The `Repository`/`Source`/`Commit`/`Blob` header is
+written by the repo-content syncer, is structural rather than keyword-based, and
+cannot be produced by a digest quoting an issue title — so it is the stronger
+signal about origin, and it wins.
+
+**Considered Options**
+
+- **Attribute by dataset instead of by text:** the correct fix, and it is what
+  the shared-trace marker is really reaching for. Blocked today because hits
+  expose no reliable per-hit dataset attribution on the read path; that is
+  tracked separately. Text is currently the only signal available.
+- **Drop the shared-trace marker entirely:** would restore classification and
+  reintroduce exactly what ADR-0011 added it for — a volunteered trace,
+  dual-written to the author's **Node**, coming back as ordinary knowledge.
+- **Let `exclude_ambient` consult only `doc_type`, leave classification alone:**
+  necessary but provably insufficient. Verified: with classification unchanged,
+  every hit is still `session-trace`, still ambient, still filtered.
+- **Narrow the exception to structural provenance (chosen):** keeps ADR-0012's
+  guarantee where it matters — body *prose* still cannot mint trust — while
+  letting a governed sync's own header identify its output.
+
+**Consequences**
+
+- Only a full structural header qualifies. A body that merely mentions a repo
+  name, or contains a `Source:` line, does not.
+- The guard ADR-0012 installed still holds, with a test: a session trace
+  mentioning `/skills/` has no such header and stays a trace at
+  `reference-only`.
+- `exclude_ambient` no longer consults `trust_tier`, for the reason
+  `canonical_only` stopped consulting it — `reference-only` is the only tier the
+  server can attest, so requiring anything else was unsatisfiable and removed
+  every hit.
+- Measured effect on a 20-question golden set, same corpus in both runs:
+  Linear slots in returned context 24/100 → 0/76, repository documents kept
+  63 → 63, recall@5 unchanged at 0.75, MRR 0.725 → 0.75.
+- Classification is load-bearing again, so its failures are now visible as
+  wrong `doc_type` rather than as a silently empty result set.

--- a/docs/adr/0018-corpus-totals-are-authoritative-not-uptime.md
+++ b/docs/adr/0018-corpus-totals-are-authoritative-not-uptime.md
@@ -1,0 +1,56 @@
+# Corpus Totals Come From The Corpus, Not From Process Uptime
+
+- Status: Accepted
+- Date: 2026-07-31
+- Relates to: [ADR-0015](0015-one-process-owns-the-graph.md).
+
+Any figure a surface presents as a size of the **Organization Vault** must be
+read from the vault. A counter that resets when the process restarts may be
+reported as activity, and must be labelled as such.
+
+**Vault Activity** is defined in CONTEXT.md as ephemeral and restart-transient,
+and `MeshState` implements it correctly: in-memory counters, deliberately not
+reseeded on rehydrate so a later sync cannot double-count. The error was in what
+was published from them. `documents` and `indexed_chunks` were served from those
+same in-memory counters through `/api/indexes`, where they read as corpus
+totals.
+
+On a service that redeploys on every merge to `main`, those totals were
+near-permanently near zero. Measured on 2026-07-31: `/api/indexes` reported
+`documents: 1` and `indexed_chunks: 1` against a real 15641 indexed / 308
+tracked, and `nodes: 547` against a graph of 15754 nodes and 110268 edges —
+understated by roughly four orders of magnitude, in the direction that makes a
+working vault look dead. Watched live across one benchmark run, `searches` went
+0 → 386 and `latest_event_id` 3 → 519 while `documents` and `indexed_chunks`
+stayed at 1 throughout: the counters were measuring uptime, and only uptime.
+
+`_corpus_health()` already computes the authoritative figures, and `/readyz` and
+`citadel status` already report them. Nothing new is derived; the projection
+just stops publishing its own accumulators as totals.
+
+**Considered Options**
+
+- **Persist the mesh counters:** contradicts ADR-0015 and the **Vault Activity**
+  definition, and reintroduces the double-counting the no-reseed rule exists to
+  prevent. The counters are not wrong; their labelling was.
+- **Seed the counters from source state at rehydrate:** the option the rehydrate
+  docstring already rejects, for the same double-counting reason.
+- **Leave the endpoint and fix the dashboard client:** the wrong seam. Every
+  consumer of `/api/indexes` would need the same correction, and a public
+  landing page reading it would advertise a dead product.
+- **Report authoritative totals, keep uptime values under `since_restart`
+  (chosen):** each number says what it measures.
+
+**Consequences**
+
+- `/api/indexes` `stats.nodes`, `stats.documents` and `stats.indexed_chunks` are
+  corpus figures. `stats.since_restart` carries the in-memory values, including
+  the projection's own node and edge counts.
+- Genuinely uptime-scoped counters — `searches`, `feedback`, `upgrades`,
+  `errors` — stay where they are and keep their meaning.
+- `_corpus_health()` fails soft and may return null counts; the snapshot then
+  falls back to the in-memory values rather than publishing null. A test pins
+  that, because a surface reporting `null` size is a worse failure than one
+  reporting a stale size.
+- Any future surface quoting a vault size takes it from the same source. The
+  rule is about where a number comes from, not about this one endpoint.


### PR DESCRIPTION
Three decisions taken during today's verification pass, all with their fixes
already merged (#172, #173), so the reasoning is recorded rather than inferred
from diffs later.

- **ADR-0016 — ingested documents are byte-stable for an unchanged source.** A
  `Retrieved:` timestamp in the body made every re-sync textually distinct,
  defeating content-hash dedup at ingest and text-keyed dedup at query time. One
  README existed as 29 documents and took 8 of 8 slots in a single query.
  Written as a general rule: no wall-clock, run id or counter in a rendered
  document, whatever the source.

- **ADR-0017 — structural provenance outranks inherited trust in
  classification.** Extends ADR-0012. Trust still governs what a reader may rely
  on; it stopped deciding what a document *is*, after a text collision with
  session-traces made 100 of 100 sampled hits classify as `session-trace` and
  `mode="docs"` return nothing for every query. The ADR-0012 guard still holds
  and has a test: a trace mentioning `/skills/` has no structural header and
  stays a trace.

- **ADR-0018 — corpus totals come from the corpus, not process uptime.**
  `/api/indexes` reported 1 document against 308 tracked because it published
  `MeshState`'s in-memory counters as totals. Those counters are correct as
  **Vault Activity** per ADR-0015 and CONTEXT.md; only their labelling was
  wrong.

Each records the options considered, including the ones rejected for reasons a
future reader would otherwise have to rediscover — why the counters are not
simply persisted, why fixing the dashboard client instead of the endpoint is the
wrong seam, and why excluding the timestamp from the hash alone is insufficient.

A fourth decision from today is deliberately **not** filed yet. `docs/adr` is
public and it would describe a defect that is not yet fixed; it lands with its
fix.