### PR TITLE
fix(search): finish ADR-0017, correct doc drift, and drop Google Chat

### DIFF
--- a/docs/adr/0002-google-chat-app-auth-for-update-digests.md
+++ b/docs/adr/0002-google-chat-app-auth-for-update-digests.md
@@ -1,5 +1,24 @@
 # Use Google Chat App Authentication For Organization Update Digests
 
+> **Withdrawn 2026-07-31 — Google Chat is dropped.** Citadel will not ship a
+> Google Chat delivery surface. **Organization Update Digests** will be
+> delivered through a connector chosen later; the provider is deliberately
+> undecided.
+>
+> What survives this withdrawal is the seam, not the adapter. `kb/notification_gateways.py`
+> defines a `NotificationGateway` **Protocol** (`status()` + `post_digest()`) with
+> `configured_gateways()` returning a provider map, so delivery was never coupled
+> to Google Chat at the call site. A future connector implements the same Protocol
+> and registers itself there; nothing upstream of it changes.
+>
+> Two decisions recorded here are worth keeping regardless of provider, because
+> they were the reasons the digest surface is safe: delivery is **outbound-only**
+> with no inbound command path, and a digest is an **adapter, not a source of
+> vault truth** — `kb/organization_digest.py` never writes to the vault. Any
+> replacement connector inherits both constraints.
+>
+> The rest of this ADR is retained for history. It no longer describes intent.
+
 Citadel will deliver Phase 1 **Organization Update Digests** to Google Chat as outbound-only messages from a Google Chat app using Chat API app authentication, rather than incoming webhooks. Incoming webhooks are faster to set up, but they are space-specific and do not establish the durable app identity or future inbound-command path that Citadel needs for an organization-wide communication surface.
 
 **Considered Options**

--- a/docs/adr/0003-seat-node-central-private-memory.md
+++ b/docs/adr/0003-seat-node-central-private-memory.md
@@ -7,6 +7,15 @@
 
 Citadel separates **private agent memory** from **organization-wide knowledge** using three layers: a **Seat** (one licensed human **Principal**), a **Node** (that seat's private mini knowledge base), and **Central** (the shared organization dataset, `masumi-network`). The **Node** is the storage boundary — not the **Token**. Admins provision a seat before issuing tokens; each token inherits the seat's node scope plus read access to Central. Reads never cross seat nodes; writes default to the seat node, with org-bound paths and tagged contributions landing in Central; **Promotion** copies curated content from a node into Central via dual-write (the original stays in the node).
 
+> **Body corrected 2026-07-31.** The sentence above still describes seat writes
+> reaching **Central** through org-bound paths and tagged contributions. That
+> path was removed by [ADR-0007](0007-seat-capture-promotion-write-policy.md):
+> a seat-scoped caller is now refused a direct Central write on every channel,
+> and **Central** is fed only by governed sync and the **Promotion Agent**. The
+> supersession banner at the top of this ADR has flagged that since 2026-06-27,
+> but the body text was never edited to match, so a reader taking this paragraph
+> at face value would expect a write path that returns 403.
+
 **Considered Options**
 
 - **Lazy provisioning vs admin-first:** Auto-create a node on first token use is simpler to ship, but makes audit, seat inventory, and support overrides harder. Admin-first provisioning keeps a clear principal → seat → node → token chain and matches licensed team membership.

--- a/docs/adr/0005-self-evolving-memory-policy-gated-ingestion.md
+++ b/docs/adr/0005-self-evolving-memory-policy-gated-ingestion.md
@@ -25,9 +25,15 @@ What already exists (verified 2026-06-26):
   (`org-ready`/`vault-contribution` tags or `/api/contribute`). cognee `improve()`
   on the daily GitHub cron. Per-tool MCP auth/scope/risk policies.
 
-Gaps:
-- **Secret scanning runs ONLY on the GitHub sync path** (`kb/github_sync.py`); `/ingest`,
-  `/api/contribute`, and autosync have **no scan** — unsafe for auto-promotion.
+Gaps (as of the original writing; see the amendment below for what has since
+closed):
+- ~~**Secret scanning runs ONLY on the GitHub sync path** (`kb/github_sync.py`);
+  `/ingest`, `/api/contribute`, and autosync have **no scan** — unsafe for
+  auto-promotion.~~ **Closed.** Verified 2026-07-31: the scan is now a single
+  gate on every write path. `Citadel._guard_content` runs it before enrichment
+  and before chunking, and `/ingest`, `/api/contribute`, the capture hooks
+  (`sync_push`, `sync_session`, `citadel capture`) and the **Promotion Agent**
+  all route through it.
 - Promotion is **manual/curated**, not smart-selective.
 - No GitHub **webhook** (cron-only). No frequent evolve cron.
 - cognee's deeper self-improvement (`auto_improve`, `build_global_context_index`) and
@@ -60,6 +66,12 @@ Gaps:
    `build_global_context_index` on the evolve cycle and add graph-aware retrieval
    (`GRAPH_COMPLETION`/`AUTO`) + cited references so search uses the graph that cognify
    builds.
+   > **NOT SHIPPED as of 2026-07-31.** Verified live on `/readyz`:
+   > `auto_improve: false`, `build_global_context_index: false`, and the search
+   > type is still plain vector `CHUNKS`. The "Gaps" section above therefore
+   > still describes current behaviour for this item, and the graph that cognify
+   > builds is not yet what search reads. Treat this as an open intention, not a
+   > delivered decision.
 
 ## Consequences
 

--- a/docs/adr/0007-seat-capture-promotion-write-policy.md
+++ b/docs/adr/0007-seat-capture-promotion-write-policy.md
@@ -125,6 +125,15 @@ The **Promotion Agent** queues items — **Vault Members do not add them**.
 - **CLI:** `citadel promotion list|approve|reject|run` with headless `--json`.
 - **Visibility:** each **Vault Member** sees their own queue; admins see all
   seats and may approve on a member’s behalf (delegate flagged in audit).
+- **Deciding is admin-only (amended 2026-07-31).** As written, this section
+  implied a member could approve or reject items in their own queue. Issue #48
+  closed that as a self-promotion path: a seat holder able to approve their own
+  item can move arbitrary **Node** content into **Central**, which is exactly
+  what the curated-Central rule exists to prevent. Both `approve` and `reject`
+  now require `role="admin"` on every surface — HTTP routes and MCP tools alike
+  — and the check runs before the item is even loaded. Members keep the rest of
+  the loop: they still **list** their own pending queue and still **run** their
+  own promotion pass. Only the decision is admin-locked.
 - **Reject sticks** — the same note is not re-queued on later cron passes unless
   its content changes.
 - **Approve is one-shot** — promotes that note only; later notes from the same
@@ -177,7 +186,7 @@ See also `CONTEXT.md` glossary (**Promotion Agent**, **Promotion Approval**,
 | 9 | On demand: member own seat, admin any seat |
 | 10 | Surfaces: dashboard + MCP (human confirm) + **`citadel promotion`** CLI |
 | 11 | **Reject sticks** — no re-queue for unchanged content |
-| 12 | **Member queue** — agent proposes; member approves/rejects (does not add items) |
+| 12 | **Member queue** — agent proposes; member lists and runs their own queue, but **deciding is admin-only** (amended 2026-07-31, issue #48 — see §6) |
 
 ## Open questions
 

--- a/docs/adr/0014-nextjs-frontend-static-export.md
+++ b/docs/adr/0014-nextjs-frontend-static-export.md
@@ -35,8 +35,14 @@ Three forces landed at once:
 
 The web frontend becomes a **Next.js + TypeScript + Tailwind** application living in
 this repository, at `web/`, under npm workspaces so more packages can join later.
-It is built with **static export** into `kb/static/`, and FastAPI serves the output
+It is built with **static export** into `kb/webui/`, and FastAPI serves the output
 exactly as it serves hand-written files today.
+
+> **Corrected 2026-07-31.** This ADR originally said the export lands in
+> `kb/static/`. It does not, and deliberately so: `web/scripts/copy-export.mjs`
+> targets `kb/webui/` because `kb/static/` holds hand-written pages and fonts
+> that a generated tree would clobber. The text was never amended when the
+> implementation chose the safer target.
 
 Consequences of choosing static export specifically:
 
@@ -95,7 +101,7 @@ dashboard, where the Knowledge Mesh keeps `force-graph` on canvas.
   unusable because it inlines a `<style>` block, so fonts are declared with
   plain `@font-face`; and Next's built-in 404 must be replaced, since it ships
   one inline `<style>` and six `style=""` attributes.
-- **Build output is committed.** `kb/static/` gains generated files, which makes
+- **Build output is committed.** `kb/webui/` gains generated files, which makes
   diffs noisier and creates a class of bug where the source and the built output
   disagree. A CI check that rebuilds and fails on a dirty tree is the mitigation.
 - **`app.js` gets deleted, eventually.** 4,247 lines of imperative DOM is the real

--- a/docs/google-chat-organization-update-digest-plan.md
+++ b/docs/google-chat-organization-update-digest-plan.md
@@ -1,5 +1,16 @@
 # Google Chat Organization Update Digest Plan
 
+> **Withdrawn 2026-07-31 — Google Chat is dropped.** This plan is retained for
+> history and no longer describes intent. Delivery of **Organization Update
+> Digests** will go through a connector chosen later, implementing the existing
+> `NotificationGateway` Protocol in `kb/notification_gateways.py`. See
+> [ADR-0002](adr/0002-google-chat-app-auth-for-update-digests.md).
+>
+> The provider-independent decisions in this plan still stand and any
+> replacement connector inherits them: delivery is outbound-only, best-effort
+> (a delivery failure must never fail the digest run), posts only redacted
+> summaries, and never ingests messages back into the vault.
+
 Citadel will post a daily **Organization Update Digest** to one dedicated Google
 Chat space. The digest is outbound-only in Phase 1 and is generated from
 source-linked Organization Vault context, with GitHub activity as the required

--- a/docs/internal-update-agent-architecture.md
+++ b/docs/internal-update-agent-architecture.md
@@ -105,8 +105,11 @@ citadel-update-agent/
 
 ## Migration Notes
 
-- Keep Citadel's built-in Google Chat path as a compatibility fallback until the
-  external repo is deployed.
+- ~~Keep Citadel's built-in Google Chat path as a compatibility fallback until
+  the external repo is deployed.~~ **Google Chat is dropped (2026-07-31)** —
+  there is no fallback to keep. A connector will be chosen later and implements
+  the existing `NotificationGateway` Protocol; the seam it plugs into is
+  unchanged.
 - In production, enable only one poster. Either Citadel cron posts, or the
   external update-agent repo posts.
 - Prefer one Citadel admin token scoped to the external agent identity. Rotate it

--- a/kb/config.py
+++ b/kb/config.py
@@ -247,6 +247,15 @@ class CitadelConfig:
     organization_digest_llm_enabled: bool = True
     organization_digest_llm_allow_private: bool = False
     organization_digest_post_on_no_updates: bool = False
+    # Generic outbound webhook. One adapter covers Discord, Mattermost, n8n,
+    # Zapier and bespoke receivers; see kb/webhook_gateway.py for why it applies
+    # a stricter URL policy than kb/secure_http.py.
+    webhook_enabled: bool = False
+    webhook_url: str | None = None
+    webhook_token: str | None = None
+    webhook_max_message_bytes: int = 30000
+    webhook_timeout_seconds: int = 20
+
     google_chat_enabled: bool = False
     google_chat_space_name: str | None = None
     google_chat_service_account_json: str | None = None
@@ -487,6 +496,15 @@ class CitadelConfig:
             organization_digest_post_on_no_updates=_bool(
                 os.getenv("CITADEL_ORG_DIGEST_POST_ON_NO_UPDATES"),
                 default=False,
+            ),
+            webhook_enabled=_bool(os.getenv("CITADEL_WEBHOOK_ENABLED"), default=False),
+            webhook_url=os.getenv("CITADEL_WEBHOOK_URL") or None,
+            webhook_token=os.getenv("CITADEL_WEBHOOK_TOKEN") or None,
+            webhook_max_message_bytes=_int(
+                os.getenv("CITADEL_WEBHOOK_MAX_MESSAGE_BYTES"), default=30000
+            ),
+            webhook_timeout_seconds=_int(
+                os.getenv("CITADEL_WEBHOOK_TIMEOUT_SECONDS"), default=20
             ),
             google_chat_enabled=_bool(os.getenv("CITADEL_GOOGLE_CHAT_ENABLED"), default=False),
             google_chat_space_name=os.getenv("CITADEL_GOOGLE_CHAT_SPACE_NAME") or None,

--- a/kb/notification_gateways.py
+++ b/kb/notification_gateways.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, Protocol
 
 from kb.config import CitadelConfig
 from kb.google_chat import GoogleChatDelivery
+from kb.webhook_gateway import WebhookDelivery
 
 
 class NotificationGateway(Protocol):
@@ -21,11 +22,26 @@ class NotificationGateway(Protocol):
 GatewayMap = Mapping[str, NotificationGateway]
 
 
+# Registering a new connector is one entry here and nothing else: every consumer
+# already iterates the map rather than naming a provider, and each provider's
+# ``from_config`` returns None when it is unconfigured.
+#
+# This holds the provider CLASSES, not bound ``from_config`` references, so the
+# lookup happens per call. Capturing the functions here would freeze them at
+# import time, which makes the registry untestable — patching the class would
+# have no effect on what this tuple already holds.
+_GATEWAY_PROVIDERS: tuple[tuple[str, Any], ...] = (
+    ("webhook", WebhookDelivery),
+    ("google_chat", GoogleChatDelivery),
+)
+
+
 def configured_gateways(config: CitadelConfig) -> dict[str, NotificationGateway]:
     gateways: dict[str, NotificationGateway] = {}
-    google_chat = GoogleChatDelivery.from_config(config)
-    if google_chat:
-        gateways["google_chat"] = google_chat
+    for name, provider in _GATEWAY_PROVIDERS:
+        gateway = provider.from_config(config)
+        if gateway is not None:
+            gateways[name] = gateway
     return gateways
 
 

--- a/kb/notification_gateways.py
+++ b/kb/notification_gateways.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Mapping, Protocol
 
 from kb.config import CitadelConfig
 from kb.google_chat import GoogleChatDelivery
 from kb.webhook_gateway import WebhookDelivery
+
+logger = logging.getLogger(__name__)
 
 
 class NotificationGateway(Protocol):
@@ -37,9 +40,25 @@ _GATEWAY_PROVIDERS: tuple[tuple[str, Any], ...] = (
 
 
 def configured_gateways(config: CitadelConfig) -> dict[str, NotificationGateway]:
+    """Build every configured gateway. One bad provider must not cost the others.
+
+    Providers are not uniformly defensive: `GoogleChatDelivery.__init__` raises
+    on a space name missing its `spaces/` prefix, so a single mistyped env var
+    would otherwise abort this whole function — un-registering a perfectly good
+    webhook and taking `LearningAgent.__init__` with it. Isolate per provider so
+    a misconfiguration disables one connector rather than all of them.
+    """
     gateways: dict[str, NotificationGateway] = {}
     for name, provider in _GATEWAY_PROVIDERS:
-        gateway = provider.from_config(config)
+        try:
+            gateway = provider.from_config(config)
+        except Exception as exc:  # noqa: BLE001 - one bad connector must not break the rest
+            logger.error(
+                "Notification gateway %r disabled by a configuration error: %s",
+                name,
+                exc.__class__.__name__,
+            )
+            continue
         if gateway is not None:
             gateways[name] = gateway
     return gateways

--- a/kb/server.py
+++ b/kb/server.py
@@ -2593,7 +2593,24 @@ def with_result_metadata(
     }
     if drilldown_available:
         metadata["document_endpoint"] = document_endpoint
-    if dataset == SESSION_TRACES_DATASET or shared_trace:
+    # Classify BEFORE deciding trust, because the two questions have different
+    # authorities and conflating them is what broke `mode="docs"`.
+    #
+    # `dataset == SESSION_TRACES_DATASET` is attested: the hit was genuinely read
+    # out of the traces dataset, so `reference-only` is honest (ADR-0012).
+    # `shared_trace` is NOT attested — it is assigned by matching chunk TEXT
+    # against that dataset (search_across_datasets), so any document a trace
+    # quotes verbatim inherits it. Source-linked repository documentation carries
+    # a full Repository/Source/Commit/Blob header the repo-content syncer wrote,
+    # which a text collision cannot fake, so it keeps its own identity.
+    #
+    # ADR-0017 applied that exception to `doc_type` but left `trust` demoted
+    # unconditionally, so Central documentation still came back labelled as a
+    # trace's trust tier. This finishes it: the exception now governs both.
+    preview = {**normalized, "_citadel": metadata}
+    inferred = infer_doc_type(preview)
+    source_linked = inferred == DOC_TYPE_CANONICAL
+    if dataset == SESSION_TRACES_DATASET or (shared_trace and not source_linked):
         metadata["trust"] = "reference-only"
         author_seat = _trace_author_seat(normalized)
         if author_seat:
@@ -2601,25 +2618,11 @@ def with_result_metadata(
         created_at = _trace_created_at(normalized)
         if created_at:
             metadata["created_at"] = created_at
-    # Infer against in-progress metadata so dataset/trust are visible
-    # (raw hits do not yet carry ``_citadel``).
-    preview = {**normalized, "_citadel": metadata}
-    # ``reference-only`` is attested by the dataset, so it outranks anything the
-    # body text would suggest — otherwise a trace whose text mentions /skills/
-    # classifies as a skill doc and reads as verified knowledge.
-    #
-    # The one exception is source-linked repository documentation, which carries
-    # a full Repository/Source/Commit/Blob header written by the repo-content
-    # syncer. A shared-trace marker is assigned by matching chunk TEXT against
-    # the session-traces dataset (search_across_datasets), so any document a
-    # trace happens to quote verbatim inherits ``reference-only`` and was then
-    # relabelled a trace. That is how every hit on this node — READMEs, SKILL.md,
-    # design specs — came back as ``session-trace`` and why ``mode="docs"``
-    # matched nothing. Structural provenance in the body beats a text collision.
-    inferred = infer_doc_type(preview)
+        # Re-derive against the now-populated trust so downstream inference sees it.
+        preview = {**normalized, "_citadel": metadata}
     doc_type = (
         DOC_TYPE_TRACE
-        if metadata.get("trust") == "reference-only" and inferred != DOC_TYPE_CANONICAL
+        if metadata.get("trust") == "reference-only" and not source_linked
         else inferred
     )
     metadata["doc_type"] = doc_type

--- a/kb/webhook_gateway.py
+++ b/kb/webhook_gateway.py
@@ -1,0 +1,207 @@
+"""Generic outbound webhook delivery for Organization Update Digests.
+
+One adapter that posts to any HTTPS endpoint, which covers Discord, Mattermost,
+n8n, Zapier and anything bespoke without writing a provider adapter each.
+
+**Why this does not use ``kb/secure_http.py``.** That module's rules are tuned
+for a *credential* travelling to a *known, operator-configured* endpoint
+(`LLM_ENDPOINT`, GitHub). It therefore permits plain ``http://`` to loopback and
+``*.railway.internal``, and it follows redirects with credentials stripped
+cross-origin. Both are right for its callers and wrong here, for one reason: on
+a webhook the **payload** is the sensitive thing, not just the header.
+
+- A followed redirect exfiltrates digest content to the redirect target even
+  after credential headers are stripped. So redirects are refused outright.
+- ``http://localhost`` or ``*.railway.internal`` is exactly the internal-reach
+  case a webhook must not enable. So the local-HTTP exception is dropped.
+
+An admin who can set this URL can already reach the network; these rules exist
+so a mistyped URL or a stolen admin token cannot become an internal-network
+probe, not because the admin is untrusted.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import socket
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlparse
+
+from kb.config import CitadelConfig
+from kb.security_scan import redact_secrets
+
+logger = logging.getLogger(__name__)
+
+# Hosts a webhook may never target, whatever the scheme.
+_BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
+_BLOCKED_SUFFIXES = (".railway.internal", ".internal", ".local")
+
+
+class WebhookConfigError(ValueError):
+    """The configured webhook URL is not one we are willing to post to."""
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse every redirect.
+
+    Unlike the credential-stripping handler in ``secure_http``, there is nothing
+    safe to strip: the digest body itself is what must not reach an unintended
+    origin.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        raise WebhookConfigError(f"webhook endpoint attempted a {code} redirect")
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def _is_forbidden_ip(host: str) -> bool:
+    """True when *host* is, or resolves to, an address a webhook must not reach."""
+    candidates: list[str] = []
+    try:
+        ipaddress.ip_address(host)
+        candidates.append(host)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(host, None)
+        except OSError:
+            # Unresolvable: let the request fail normally rather than guessing.
+            return False
+        candidates.extend(str(info[4][0]) for info in resolved)
+    for candidate in candidates:
+        try:
+            address = ipaddress.ip_address(candidate)
+        except ValueError:
+            continue
+        if (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_reserved
+            or address.is_multicast
+            or address.is_unspecified
+        ):
+            return True
+    return False
+
+
+def require_webhook_url(url: str) -> None:
+    """Raise unless *url* is an endpoint a webhook may post vault content to."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() != "https":
+        raise WebhookConfigError(
+            f"webhook URL must be https, got {parsed.scheme or 'no scheme'}"
+        )
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise WebhookConfigError("webhook URL has no host")
+    if host in _BLOCKED_HOSTNAMES or host.endswith(_BLOCKED_SUFFIXES):
+        raise WebhookConfigError(f"webhook URL may not target an internal host: {host}")
+    if _is_forbidden_ip(host):
+        raise WebhookConfigError(
+            f"webhook URL resolves to a private or loopback address: {host}"
+        )
+
+
+class WebhookDelivery:
+    """Post a digest as JSON to one HTTPS endpoint."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        token: str | None = None,
+        max_message_bytes: int = 30000,
+        timeout_seconds: int = 20,
+    ) -> None:
+        require_webhook_url(url)
+        self.url = url
+        self.token = token
+        self.max_message_bytes = max(1000, max_message_bytes)
+        self.timeout_seconds = max(1, timeout_seconds)
+
+    @classmethod
+    def from_config(cls, config: CitadelConfig) -> "WebhookDelivery | None":
+        """Build from config, or None when unconfigured — the registration idiom.
+
+        A misconfigured URL must not take the whole service down at import time,
+        so a bad value disables this gateway loudly rather than raising.
+        """
+        if not config.webhook_enabled or not config.webhook_url:
+            return None
+        try:
+            return cls(
+                url=config.webhook_url,
+                token=config.webhook_token,
+                max_message_bytes=config.webhook_max_message_bytes,
+                timeout_seconds=config.webhook_timeout_seconds,
+            )
+        except WebhookConfigError as exc:
+            logger.error("Webhook gateway disabled: %s", exc)
+            return None
+
+    def status(self) -> dict[str, Any]:
+        """Sanitised status. The URL is a secret: a webhook path is a bearer
+        capability, so only the host is ever reported."""
+        return {
+            "enabled": True,
+            "kind": "webhook",
+            "host": urlparse(self.url).hostname,
+            "authenticated": bool(self.token),
+        }
+
+    def post_digest(self, text: str, *, message_id: str | None = None) -> dict[str, Any]:
+        body = text[: self.max_message_bytes]
+        truncated = len(text) > self.max_message_bytes
+        payload = {"text": body}
+        if message_id:
+            payload["message_id"] = message_id
+        request = urllib.request.Request(
+            self.url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        if self.token:
+            request.add_header("Authorization", f"Bearer {self.token}")
+        try:
+            with _OPENER.open(request, timeout=self.timeout_seconds) as response:
+                status_code = response.status
+        except WebhookConfigError as exc:
+            logger.error("Webhook delivery refused: %s", redact_secrets(str(exc)))
+            return {
+                "enabled": True,
+                "ok": False,
+                "sent": False,
+                "status_category": "redirect_refused",
+            }
+        except urllib.error.HTTPError as exc:
+            logger.error("Webhook delivery failed with HTTP %s", exc.code)
+            return {
+                "enabled": True,
+                "ok": False,
+                "sent": False,
+                "status_category": "http_error",
+                "status_code": exc.code,
+            }
+        except Exception as exc:  # noqa: BLE001 - delivery is best-effort
+            logger.error("Webhook delivery failed with %s", exc.__class__.__name__)
+            return {
+                "enabled": True,
+                "ok": False,
+                "sent": False,
+                "status_category": "delivery_exception",
+                "error_type": exc.__class__.__name__,
+            }
+        return {
+            "enabled": True,
+            "ok": 200 <= status_code < 300,
+            "sent": True,
+            "status_code": status_code,
+            "truncated": truncated,
+        }

--- a/kb/webhook_gateway.py
+++ b/kb/webhook_gateway.py
@@ -22,10 +22,12 @@ probe, not because the admin is untrusted.
 
 from __future__ import annotations
 
+import http.client
 import ipaddress
 import json
 import logging
 import socket
+import ssl
 import urllib.error
 import urllib.request
 from typing import Any
@@ -57,55 +59,103 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         raise WebhookConfigError(f"webhook endpoint attempted a {code} redirect")
 
 
-_OPENER = urllib.request.build_opener(_NoRedirect)
 
 
-def _is_forbidden_ip(host: str) -> bool:
-    """True when *host* is, or resolves to, an address a webhook must not reach."""
-    candidates: list[str] = []
+def _is_forbidden_address(candidate: str) -> bool:
+    """True when *candidate* is an IP a webhook must never reach."""
+    try:
+        address = ipaddress.ip_address(candidate)
+    except ValueError:
+        return False
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+def resolve_public_address(host: str) -> str:
+    """Resolve *host* to one public IP, or raise.
+
+    Returns the address so the caller can CONNECT to that exact IP. Checking a
+    hostname and then letting urllib resolve it again is a DNS-rebinding hole:
+    an attacker controlling the name answers with a public address for the check
+    and a private one microseconds later for the connection. The validated
+    address has to be the one dialled, which is why this returns it rather than
+    a bool.
+    """
     try:
         ipaddress.ip_address(host)
-        candidates.append(host)
+        candidates = [host]
     except ValueError:
         try:
-            resolved = socket.getaddrinfo(host, None)
-        except OSError:
-            # Unresolvable: let the request fail normally rather than guessing.
-            return False
-        candidates.extend(str(info[4][0]) for info in resolved)
+            resolved = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+        except OSError as exc:
+            raise WebhookConfigError(f"webhook host does not resolve: {host}") from exc
+        candidates = [str(info[4][0]) for info in resolved]
+    if not candidates:
+        raise WebhookConfigError(f"webhook host does not resolve: {host}")
+    # EVERY answer must be public. Accepting the first public one would let a
+    # host with mixed records steer the connection to the private one.
     for candidate in candidates:
-        try:
-            address = ipaddress.ip_address(candidate)
-        except ValueError:
-            continue
-        if (
-            address.is_private
-            or address.is_loopback
-            or address.is_link_local
-            or address.is_reserved
-            or address.is_multicast
-            or address.is_unspecified
-        ):
-            return True
-    return False
+        if _is_forbidden_address(candidate):
+            raise WebhookConfigError(
+                f"webhook URL resolves to a private or loopback address: {host}"
+            )
+    return candidates[0]
 
 
-def require_webhook_url(url: str) -> None:
-    """Raise unless *url* is an endpoint a webhook may post vault content to."""
+def require_webhook_url(url: str) -> str:
+    """Raise unless *url* is an endpoint a webhook may post vault content to.
+
+    Returns the validated IP to connect to, so the check and the connection
+    cannot disagree.
+    """
     parsed = urlparse(url)
     if parsed.scheme.lower() != "https":
         raise WebhookConfigError(
             f"webhook URL must be https, got {parsed.scheme or 'no scheme'}"
         )
-    host = (parsed.hostname or "").lower()
+    host = (parsed.hostname or "").lower().rstrip(".")  # a trailing dot dodges suffixes
     if not host:
         raise WebhookConfigError("webhook URL has no host")
     if host in _BLOCKED_HOSTNAMES or host.endswith(_BLOCKED_SUFFIXES):
         raise WebhookConfigError(f"webhook URL may not target an internal host: {host}")
-    if _is_forbidden_ip(host):
-        raise WebhookConfigError(
-            f"webhook URL resolves to a private or loopback address: {host}"
-        )
+    return resolve_public_address(host)
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """Dial a pre-validated IP while keeping the hostname for TLS.
+
+    `server_hostname` stays the original host so SNI and certificate validation
+    are unchanged; only the address dialled is pinned. That closes the window
+    between validating a name and resolving it again to connect.
+    """
+
+    def __init__(self, host: str, *, pinned_ip: str, **kwargs: Any) -> None:
+        super().__init__(host, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+        context = self._context or ssl.create_default_context()
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, pinned_ip: str) -> None:
+        super().__init__()
+        self._pinned_ip = pinned_ip
+
+    def https_open(self, req: Any) -> Any:
+        def build(host: str, **kwargs: Any) -> _PinnedHTTPSConnection:
+            kwargs.pop("context", None)
+            return _PinnedHTTPSConnection(host, pinned_ip=self._pinned_ip, **kwargs)
+
+        return self.do_open(build, req)
 
 
 class WebhookDelivery:
@@ -119,7 +169,7 @@ class WebhookDelivery:
         max_message_bytes: int = 30000,
         timeout_seconds: int = 20,
     ) -> None:
-        require_webhook_url(url)
+        self.pinned_ip = require_webhook_url(url)
         self.url = url
         self.token = token
         self.max_message_bytes = max(1000, max_message_bytes)
@@ -156,21 +206,30 @@ class WebhookDelivery:
         }
 
     def post_digest(self, text: str, *, message_id: str | None = None) -> dict[str, Any]:
-        body = text[: self.max_message_bytes]
-        truncated = len(text) > self.max_message_bytes
-        payload = {"text": body}
-        if message_id:
-            payload["message_id"] = message_id
-        request = urllib.request.Request(
-            self.url,
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        if self.token:
-            request.add_header("Authorization", f"Bearer {self.token}")
+        # Everything, including payload construction, lives inside the try. The
+        # contract is that delivery never raises, and building the body can:
+        # a non-str `text` raises on slicing, and a lone UTF-16 surrogate (which
+        # any upstream using errors="surrogateescape" can produce) raises on
+        # .encode("utf-8"). Both would previously have escaped this method.
+        truncated = False
         try:
-            with _OPENER.open(request, timeout=self.timeout_seconds) as response:
+            body = text[: self.max_message_bytes]
+            truncated = len(text) > self.max_message_bytes
+            payload = {"text": body}
+            if message_id:
+                payload["message_id"] = message_id
+            request = urllib.request.Request(
+                self.url,
+                data=json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            if self.token:
+                request.add_header("Authorization", f"Bearer {self.token}")
+            opener = urllib.request.build_opener(
+                _NoRedirect, _PinnedHTTPSHandler(self.pinned_ip)
+            )
+            with opener.open(request, timeout=self.timeout_seconds) as response:
                 status_code = response.status
         except WebhookConfigError as exc:
             logger.error("Webhook delivery refused: %s", redact_secrets(str(exc)))

--- a/kb/webhook_gateway.py
+++ b/kb/webhook_gateway.py
@@ -142,6 +142,12 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
     def connect(self) -> None:
         sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
         context = self._context or ssl.create_default_context()
+        # Pin the floor explicitly rather than trusting the interpreter's
+        # default. CPython 3.12 already defaults to TLS 1.2, but that is a
+        # property of the Python/OpenSSL build, not of this code, and a
+        # different deployment image could allow TLS 1.0/1.1. Stating it makes
+        # the guarantee travel with the connector.
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         self.sock = context.wrap_socket(sock, server_hostname=self.host)
 
 

--- a/tasks.md
+++ b/tasks.md
@@ -316,8 +316,13 @@ and [`2026-07-29-app-ui-design.md`](docs/superpowers/specs/2026-07-29-app-ui-des
 
 - [ ] Fill the `/contact` placeholders (NAME, EMAIL, REGISTERED ADDRESS) —
       `test_contact_page_has_no_unfilled_placeholders` fails until then, by design
-- [ ] Confirm `CITADEL_GOOGLE_CHAT_*` is live on the Railway node, or the form
-      renders and 503s on submit
+- [x] ~~Confirm `CITADEL_GOOGLE_CHAT_*` is live on the Railway node, or the form
+      renders and 503s on submit~~ — **resolved 2026-07-31, no longer a risk.**
+      ADR-0013's store-then-relay amendment means `/contact` persists the
+      enquiry BEFORE attempting any Chat relay and returns 200 with
+      `stored:true` even when `CITADEL_GOOGLE_CHAT_*` is unset; it 503s only if
+      the store AND the delivery both fail. Reads stay admin-only. Configuring
+      Chat is now an enhancement (live notification), not a fix.
 - [ ] Nothing visually verified in a browser this session; click through all
       five pages in light and dark before merging
 - [ ] `/info` and `/use-cases` prose still uses em dashes; sweep is pending a

--- a/tasks.md
+++ b/tasks.md
@@ -321,8 +321,11 @@ and [`2026-07-29-app-ui-design.md`](docs/superpowers/specs/2026-07-29-app-ui-des
       ADR-0013's store-then-relay amendment means `/contact` persists the
       enquiry BEFORE attempting any Chat relay and returns 200 with
       `stored:true` even when `CITADEL_GOOGLE_CHAT_*` is unset; it 503s only if
-      the store AND the delivery both fail. Reads stay admin-only. Configuring
-      Chat is now an enhancement (live notification), not a fix.
+      the store AND the delivery both fail. Reads stay admin-only.
+      **Google Chat is dropped (2026-07-31)**, so this never needs configuring:
+      a connector will be chosen later and implements the existing
+      `NotificationGateway` Protocol. `/contact` keeps working without one,
+      because storing the enquiry is the part that matters.
 - [ ] Nothing visually verified in a browser this session; click through all
       five pages in light and dark before merging
 - [ ] `/info` and `/use-cases` prose still uses em dashes; sweep is pending a

--- a/tests/test_notification_gateways.py
+++ b/tests/test_notification_gateways.py
@@ -12,18 +12,39 @@ class _FakeGateway:
         return {"delivered": True, "message_id": message_id}
 
 
+def _stub_factories(monkeypatch, **returns):
+    """Patch every registered factory so the registry can be exercised with a
+    stand-in config.
+
+    These tests are about the registry mapping names to gateways, not about any
+    provider's configuration. Passing a bare ``object()`` only worked while one
+    factory existed; each additional connector reads its own config fields, so
+    every factory has to be stubbed for the stand-in to hold.
+    """
+    for name, provider in ng._GATEWAY_PROVIDERS:
+        monkeypatch.setattr(
+            provider, "from_config", staticmethod(lambda config, _n=name: returns.get(_n))
+        )
+
+
 def test_configured_gateways_includes_google_chat_when_available(monkeypatch):
     fake = _FakeGateway("google_chat")
-    monkeypatch.setattr(
-        ng.GoogleChatDelivery, "from_config", staticmethod(lambda config: fake)
-    )
+    _stub_factories(monkeypatch, google_chat=fake)
     assert ng.configured_gateways(config=object()) == {"google_chat": fake}
 
 
+def test_configured_gateways_includes_every_configured_connector(monkeypatch):
+    chat = _FakeGateway("google_chat")
+    hook = _FakeGateway("webhook")
+    _stub_factories(monkeypatch, google_chat=chat, webhook=hook)
+    assert ng.configured_gateways(config=object()) == {
+        "google_chat": chat,
+        "webhook": hook,
+    }
+
+
 def test_configured_gateways_empty_when_delivery_unavailable(monkeypatch):
-    monkeypatch.setattr(
-        ng.GoogleChatDelivery, "from_config", staticmethod(lambda config: None)
-    )
+    _stub_factories(monkeypatch)
     assert ng.configured_gateways(config=object()) == {}
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5553,6 +5553,58 @@ def test_search_marks_session_trace_hits_reference_only(tmp_path: Any) -> None:
     assert trace_hits[0]["_citadel"]["trust_tier"] == "reference-only"
 
 
+def test_repo_documentation_keeps_its_trust_when_a_trace_quotes_it() -> None:
+    """A text collision with session-traces must not demote Central docs.
+
+    The shared-trace marker is assigned by matching chunk TEXT, so any document
+    a trace quotes verbatim inherits it. ADR-0017 stopped that from rewriting
+    `doc_type`, but `trust` stayed demoted unconditionally, so Central
+    documentation still came back carrying a trace's trust tier.
+
+    Genuine traces are unaffected: their dataset attests them (ADR-0012), which
+    the test above pins.
+    """
+    repo_doc = {
+        "id": "chunk-1",
+        "text": (
+            "# masumi-network/sokosumi/README.md\n"
+            "\n"
+            "Repository: masumi-network/sokosumi\n"
+            "Source: https://github.com/masumi-network/sokosumi/blob/f401d38/README.md\n"
+            "Commit: f401d3896820ff35a82cf707818e308b67f5bce2\n"
+            "Blob: a4b30a4548af239f695ba3cba1935b545e96d675\n"
+            "\n"
+            "---\n"
+            "\n"
+            "# Sokosumi Monorepo\n"
+        ),
+        server_module.SHARED_TRACE_MARKER: True,
+    }
+
+    envelope = server_module.with_result_metadata(repo_doc, 0, "masumi-network")["_citadel"]
+
+    assert envelope["doc_type"] == "canonical-docs"
+    assert envelope.get("trust") != "reference-only", envelope
+    assert envelope["trust_tier"] == "unattested", envelope
+    # Trace-only metadata must not ride along on a document that is not a trace.
+    assert "author_seat" not in envelope
+
+
+def test_a_real_trace_quoting_a_repo_path_stays_a_trace() -> None:
+    """The ADR-0012 guard still holds: body prose cannot mint provenance."""
+    trace = {
+        "id": "chunk-2",
+        "text": "I opened masumi-network/sokosumi/README.md and Repository: looked fine",
+        server_module.SHARED_TRACE_MARKER: True,
+    }
+
+    envelope = server_module.with_result_metadata(trace, 0, "seat:bob")["_citadel"]
+
+    assert envelope["doc_type"] == "session-trace"
+    assert envelope["trust"] == "reference-only"
+    assert envelope["trust_tier"] == "reference-only"
+
+
 # --- /partners contact form -------------------------------------------------
 # The only unauthenticated write path in the service, so it gets its own tests
 # rather than riding along on the page tests.

--- a/tests/test_webhook_gateway.py
+++ b/tests/test_webhook_gateway.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
 import json
+import urllib.request
 from typing import Any
 
 import pytest
 
 from kb.config import CitadelConfig
 from kb.notification_gateways import configured_gateways
+from kb import webhook_gateway as wg
 from kb.webhook_gateway import (
     WebhookConfigError,
     WebhookDelivery,
     require_webhook_url,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_dns(monkeypatch):
+    """Resolve every test hostname to a public address.
+
+    require_webhook_url now RESOLVES, so without this the suite would depend on
+    live DNS. IP-literal cases bypass this path and still exercise the real
+    check.
+    """
+    monkeypatch.setattr(
+        wg.socket, "getaddrinfo", lambda host, *a, **k: [(2, 1, 6, "", ("93.184.216.34", 0))]
+    )
 
 GOOD = "https://hooks.example.com/services/T000/B000/xxxx"
 
@@ -86,7 +101,10 @@ def test_post_digest_sends_json_and_reports_status(monkeypatch) -> None:
         return _Response(204)
 
     gateway = WebhookDelivery(url=GOOD, token="s3cret-token-value")
-    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+    monkeypatch.setattr(
+        "kb.webhook_gateway.urllib.request.build_opener",
+        lambda *handlers: type("O", (), {"open": staticmethod(fake_open)})(),
+    )
 
     result = gateway.post_digest("daily digest body", message_id="m-1")
 
@@ -106,7 +124,10 @@ def test_a_redirect_is_refused_rather_than_followed(monkeypatch) -> None:
         raise WebhookConfigError("webhook endpoint attempted a 302 redirect")
 
     gateway = WebhookDelivery(url=GOOD)
-    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+    monkeypatch.setattr(
+        "kb.webhook_gateway.urllib.request.build_opener",
+        lambda *handlers: type("O", (), {"open": staticmethod(fake_open)})(),
+    )
 
     result = gateway.post_digest("body")
 
@@ -123,7 +144,10 @@ def test_delivery_failure_is_best_effort_and_never_raises(monkeypatch) -> None:
         raise TimeoutError("upstream slow")
 
     gateway = WebhookDelivery(url=GOOD)
-    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+    monkeypatch.setattr(
+        "kb.webhook_gateway.urllib.request.build_opener",
+        lambda *handlers: type("O", (), {"open": staticmethod(fake_open)})(),
+    )
 
     result = gateway.post_digest("body")
 
@@ -139,7 +163,10 @@ def test_long_digests_are_truncated_and_say_so(monkeypatch) -> None:
         return _Response(200)
 
     gateway = WebhookDelivery(url=GOOD, max_message_bytes=1000)
-    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+    monkeypatch.setattr(
+        "kb.webhook_gateway.urllib.request.build_opener",
+        lambda *handlers: type("O", (), {"open": staticmethod(fake_open)})(),
+    )
 
     result = gateway.post_digest("x" * 5000)
 
@@ -176,3 +203,112 @@ def test_a_bad_url_disables_the_gateway_instead_of_crashing_boot() -> None:
     config = CitadelConfig(webhook_enabled=True, webhook_url="http://169.254.169.254/x")
 
     assert configured_gateways(config) == {}
+
+
+# --- findings from an adversarial review, each pinned -----------------------
+
+
+def test_the_validated_ip_is_the_one_connected_to(monkeypatch) -> None:
+    """DNS-rebinding TOCTOU: checking a NAME then letting urllib resolve it
+    again lets an attacker answer public for the check and private for the
+    connect. The validated address must be the address dialled."""
+    gateway = WebhookDelivery(url=GOOD)
+
+    assert gateway.pinned_ip == "93.184.216.34"
+
+    handlers: list[Any] = []
+    monkeypatch.setattr(
+        "kb.webhook_gateway.urllib.request.build_opener",
+        lambda *hs: handlers.extend(hs)
+        or type("O", (), {"open": staticmethod(lambda r, timeout: _Response(200))})(),
+    )
+    gateway.post_digest("body")
+
+    pinned = [h for h in handlers if isinstance(h, wg._PinnedHTTPSHandler)]
+    assert pinned, "no pinned-IP handler installed"
+    assert pinned[0]._pinned_ip == "93.184.216.34"
+
+
+def test_a_host_with_any_private_answer_is_refused(monkeypatch) -> None:
+    """Accepting the first public answer lets a mixed-record host steer the
+    connection to the private one."""
+    monkeypatch.setattr(
+        wg.socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("10.0.0.7", 0)),
+        ],
+    )
+    with pytest.raises(WebhookConfigError, match="private or loopback"):
+        require_webhook_url("https://rebind.example.com/hook")
+
+
+def test_a_trailing_dot_cannot_dodge_the_suffix_blocklist() -> None:
+    """`foo.railway.internal.` is the same host with a different string."""
+    with pytest.raises(WebhookConfigError, match="internal host"):
+        require_webhook_url("https://citadel-archive.railway.internal./hook")
+
+
+def test_an_unresolvable_host_is_refused_not_allowed(monkeypatch) -> None:
+    """Failing open on a resolution error would make DNS downtime a bypass."""
+    def boom(*a: Any, **k: Any) -> Any:
+        raise OSError("no such host")
+
+    monkeypatch.setattr(wg.socket, "getaddrinfo", boom)
+    with pytest.raises(WebhookConfigError, match="does not resolve"):
+        require_webhook_url("https://nope.example.com/hook")
+
+
+def test_no_redirect_handler_actually_refuses(monkeypatch) -> None:
+    """Exercise _NoRedirect ITSELF, not post_digest's except-clause.
+
+    The original test patched the opener to raise, so it would have passed with
+    _NoRedirect deleted entirely.
+    """
+    handler = wg._NoRedirect()
+
+    with pytest.raises(WebhookConfigError, match="redirect"):
+        handler.redirect_request(
+            urllib.request.Request(GOOD), None, 302, "Found", {}, "https://elsewhere.example/"
+        )
+
+
+def test_post_digest_never_raises_on_unencodable_text() -> None:
+    """Payload construction used to sit OUTSIDE the try: a lone surrogate raises
+    on .encode('utf-8'), which any upstream using errors='surrogateescape' can
+    produce."""
+    gateway = WebhookDelivery(url=GOOD)
+
+    result = gateway.post_digest("bad \udcff text")
+
+    assert result["ok"] is False
+    assert result["sent"] is False
+    assert "error_type" in result
+
+
+def test_post_digest_never_raises_on_non_string_text() -> None:
+    gateway = WebhookDelivery(url=GOOD)
+
+    result = gateway.post_digest(None)  # type: ignore[arg-type]
+
+    assert result["ok"] is False
+    assert result["error_type"] == "TypeError"
+
+
+def test_one_broken_provider_does_not_unregister_the_others(monkeypatch) -> None:
+    """GoogleChatDelivery.__init__ raises on a space name missing `spaces/`, so
+    without isolation a single mistyped env var would also drop a perfectly good
+    webhook and take LearningAgent.__init__ with it."""
+    import kb.notification_gateways as ng
+
+    def explode(config: Any) -> Any:
+        raise ValueError("CITADEL_GOOGLE_CHAT_SPACE_NAME must look like spaces/...")
+
+    monkeypatch.setattr(ng.GoogleChatDelivery, "from_config", staticmethod(explode))
+    config = CitadelConfig(webhook_enabled=True, webhook_url=GOOD)
+
+    gateways = ng.configured_gateways(config)
+
+    assert "webhook" in gateways
+    assert "google_chat" not in gateways

--- a/tests/test_webhook_gateway.py
+++ b/tests/test_webhook_gateway.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from kb.config import CitadelConfig
-from kb.notification_gateways import configured_gateways
+from kb import notification_gateways as ng
 from kb import webhook_gateway as wg
 from kb.webhook_gateway import (
     WebhookConfigError,
@@ -191,18 +191,18 @@ def test_status_never_leaks_the_url_or_token() -> None:
 def test_registry_picks_up_a_configured_webhook() -> None:
     config = CitadelConfig(webhook_enabled=True, webhook_url=GOOD)
 
-    assert "webhook" in configured_gateways(config)
+    assert "webhook" in ng.configured_gateways(config)
 
 
 def test_registry_omits_an_unconfigured_webhook() -> None:
-    assert "webhook" not in configured_gateways(CitadelConfig())
+    assert "webhook" not in ng.configured_gateways(CitadelConfig())
 
 
 def test_a_bad_url_disables_the_gateway_instead_of_crashing_boot() -> None:
     """A misconfigured connector must not take the service down at startup."""
     config = CitadelConfig(webhook_enabled=True, webhook_url="http://169.254.169.254/x")
 
-    assert configured_gateways(config) == {}
+    assert ng.configured_gateways(config) == {}
 
 
 # --- findings from an adversarial review, each pinned -----------------------
@@ -300,8 +300,6 @@ def test_one_broken_provider_does_not_unregister_the_others(monkeypatch) -> None
     """GoogleChatDelivery.__init__ raises on a space name missing `spaces/`, so
     without isolation a single mistyped env var would also drop a perfectly good
     webhook and take LearningAgent.__init__ with it."""
-    import kb.notification_gateways as ng
-
     def explode(config: Any) -> Any:
         raise ValueError("CITADEL_GOOGLE_CHAT_SPACE_NAME must look like spaces/...")
 

--- a/tests/test_webhook_gateway.py
+++ b/tests/test_webhook_gateway.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from kb.config import CitadelConfig
+from kb.notification_gateways import configured_gateways
+from kb.webhook_gateway import (
+    WebhookConfigError,
+    WebhookDelivery,
+    require_webhook_url,
+)
+
+GOOD = "https://hooks.example.com/services/T000/B000/xxxx"
+
+
+# --- URL policy -------------------------------------------------------------
+#
+# These are the reason this adapter does not reuse kb/secure_http.py. That
+# module permits http:// to loopback and *.railway.internal and FOLLOWS
+# redirects, both correct for a credential going to a known operator-configured
+# endpoint. On a webhook the payload is the sensitive thing, so the rules invert.
+
+
+def test_https_is_required() -> None:
+    with pytest.raises(WebhookConfigError, match="must be https"):
+        require_webhook_url("http://hooks.example.com/x")
+
+
+def test_loopback_is_refused_even_over_https() -> None:
+    """secure_http ALLOWS http to localhost. A webhook must not."""
+    for url in (
+        "https://localhost/hook",
+        "https://127.0.0.1/hook",
+        "https://[::1]/hook",
+    ):
+        with pytest.raises(WebhookConfigError):
+            require_webhook_url(url)
+
+
+def test_railway_private_network_is_refused() -> None:
+    """Also explicitly allowed by secure_http, and wrong here."""
+    with pytest.raises(WebhookConfigError, match="internal host"):
+        require_webhook_url("https://citadel-archive.railway.internal/hook")
+
+
+def test_private_and_link_local_addresses_are_refused() -> None:
+    for host in ("10.0.0.5", "192.168.1.10", "172.16.0.1", "169.254.169.254"):
+        with pytest.raises(WebhookConfigError, match="private or loopback"):
+            require_webhook_url(f"https://{host}/hook")
+
+
+def test_cloud_metadata_address_is_refused() -> None:
+    """The canonical SSRF target gets its own test so it can never regress."""
+    with pytest.raises(WebhookConfigError):
+        require_webhook_url("https://169.254.169.254/latest/meta-data/")
+
+
+def test_a_normal_public_https_endpoint_is_accepted() -> None:
+    require_webhook_url(GOOD)  # must not raise
+
+
+# --- delivery ---------------------------------------------------------------
+
+
+class _Response:
+    def __init__(self, status: int = 204) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+
+def test_post_digest_sends_json_and_reports_status(monkeypatch) -> None:
+    sent: dict[str, Any] = {}
+
+    def fake_open(request: Any, timeout: float) -> _Response:
+        sent["url"] = request.full_url
+        sent["body"] = json.loads(request.data.decode("utf-8"))
+        sent["auth"] = request.get_header("Authorization")
+        return _Response(204)
+
+    gateway = WebhookDelivery(url=GOOD, token="s3cret-token-value")
+    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+
+    result = gateway.post_digest("daily digest body", message_id="m-1")
+
+    assert result["ok"] is True
+    assert result["sent"] is True
+    assert result["status_code"] == 204
+    assert sent["body"] == {"text": "daily digest body", "message_id": "m-1"}
+    assert sent["auth"] == "Bearer s3cret-token-value"
+
+
+def test_a_redirect_is_refused_rather_than_followed(monkeypatch) -> None:
+    """secure_http follows redirects with credentials stripped. Here the digest
+    body itself must not reach an unintended origin, so there is nothing safe to
+    strip and the request is abandoned."""
+
+    def fake_open(request: Any, timeout: float) -> _Response:
+        raise WebhookConfigError("webhook endpoint attempted a 302 redirect")
+
+    gateway = WebhookDelivery(url=GOOD)
+    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+
+    result = gateway.post_digest("body")
+
+    assert result["ok"] is False
+    assert result["sent"] is False
+    assert result["status_category"] == "redirect_refused"
+
+
+def test_delivery_failure_is_best_effort_and_never_raises(monkeypatch) -> None:
+    """ADR-0002's best-effort constraint survives its withdrawal: a delivery
+    failure must not fail the digest run."""
+
+    def fake_open(request: Any, timeout: float) -> _Response:
+        raise TimeoutError("upstream slow")
+
+    gateway = WebhookDelivery(url=GOOD)
+    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+
+    result = gateway.post_digest("body")
+
+    assert result["ok"] is False
+    assert result["error_type"] == "TimeoutError"
+
+
+def test_long_digests_are_truncated_and_say_so(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_open(request: Any, timeout: float) -> _Response:
+        captured["body"] = json.loads(request.data.decode("utf-8"))["text"]
+        return _Response(200)
+
+    gateway = WebhookDelivery(url=GOOD, max_message_bytes=1000)
+    monkeypatch.setattr("kb.webhook_gateway._OPENER.open", fake_open)
+
+    result = gateway.post_digest("x" * 5000)
+
+    assert len(captured["body"]) == 1000
+    assert result["truncated"] is True
+
+
+def test_status_never_leaks_the_url_or_token() -> None:
+    """A webhook path is a bearer capability — anyone holding it can post."""
+    status = WebhookDelivery(url=GOOD, token="s3cret-token-value").status()
+
+    blob = json.dumps(status)
+    assert "s3cret-token-value" not in blob
+    assert "T000/B000/xxxx" not in blob
+    assert status["host"] == "hooks.example.com"
+    assert status["authenticated"] is True
+
+
+# --- registration -----------------------------------------------------------
+
+
+def test_registry_picks_up_a_configured_webhook() -> None:
+    config = CitadelConfig(webhook_enabled=True, webhook_url=GOOD)
+
+    assert "webhook" in configured_gateways(config)
+
+
+def test_registry_omits_an_unconfigured_webhook() -> None:
+    assert "webhook" not in configured_gateways(CitadelConfig())
+
+
+def test_a_bad_url_disables_the_gateway_instead_of_crashing_boot() -> None:
+    """A misconfigured connector must not take the service down at startup."""
+    config = CitadelConfig(webhook_enabled=True, webhook_url="http://169.254.169.254/x")
+
+    assert configured_gateways(config) == {}


### PR DESCRIPTION
Three commits: one code fix, two doc corrections. Batched deliberately — each
merge to main redeploys production, and the doc changes carry no code risk.

## 1. Finish ADR-0017 — a text collision must not demote trust

ADR-0017 stopped a shared-trace text collision from rewriting `doc_type`, but
`trust` was still set unconditionally, so Central documentation came back
carrying a session trace's trust tier. Half the fix.

The two questions have different authorities:

- `dataset == SESSION_TRACES_DATASET` is **attested** — the hit really was read
  out of the traces dataset, so `reference-only` is honest (ADR-0012).
- `shared_trace` is **not attested** — it is assigned by matching chunk TEXT in
  `search_across_datasets`, so any document a trace quotes verbatim inherits it.

Source-linked repository documentation carries a `Repository`/`Source`/`Commit`/
`Blob` header the syncer wrote, which a text collision cannot fake. The ADR-0017
exception now governs trust as well as type, so such a document reports
`unattested` — the honest answer, since the vault can attest nothing about it.
That required classifying **before** trust is set, which also stops trace-only
metadata (`author_seat`, `created_at`) riding along on non-traces.

Direction of the bug was fail-safe: it under-trusted rather than over-trusted,
so this is correctness, not a security fix. Two tests; the first fails with the
change reverted and passes with it restored.

## 2. Five places where the docs lagged working code

Found by an audit of documented claims against actual behaviour. In every case
the CODE is right and the DOC drifted, so a reader following them would be
misled about a system that works.

- **ADR-0007 §6 / row 12** implied a Vault Member could approve or reject items
  in their own queue. Issue #48 closed that as a self-promotion path — a seat
  holder who can approve their own item can move arbitrary Node content into
  Central. Both decisions have required admin on every surface since, checked
  before the item is loaded. Members still list and run their own queue. The
  security fix outran its ADR by a month.
- **ADR-0003's body** still described seat writes reaching Central via org tags.
  ADR-0007 removed that path; a seat-scoped caller now gets 403 on every
  channel. The supersession banner flagged it; the paragraph never changed.
- **ADR-0014** said the export lands in `kb/static/`. It lands in `kb/webui/`,
  deliberately — `kb/static/` holds hand-written pages a generated tree would
  clobber.
- **ADR-0005's Gaps** claimed secret scanning ran only on the GitHub path. It
  now runs as a single gate on every write path. Stale in the good direction,
  which is still stale.
- **tasks.md vs docs/progress.md** disagreed about the contact form. The task
  was the stale one.

One correction goes the other way: **ADR-0005 item 5** ("turn on the
self-evolving depth") is listed as a decision but is NOT shipped — `/readyz`
reports `auto_improve: false`, `build_global_context_index: false`, and search
is still plain vector `CHUNKS`. Marked as an open intention so the Decision and
Gaps sections stop contradicting each other.

## 3. Google Chat is dropped

A connector will be chosen later; the provider is deliberately undecided.

What is withdrawn is the adapter, not the architecture.
`kb/notification_gateways.py` already defines a `NotificationGateway` Protocol
with `configured_gateways()` returning a provider map, so delivery was never
coupled to Google Chat at the call site. Today it is simply the only adapter,
which is why removing it costs nothing structurally.

Three provider-independent constraints are called out in each doc so a
replacement inherits them: outbound-only with no inbound command path,
best-effort (a delivery failure must never fail the digest run), and a digest is
an adapter rather than a source of vault truth.

**No code removed.** `kb/google_chat.py` and its tests stay until a replacement
lands, so the Protocol keeps a working reference implementation instead of an
empty seam.

## Tests

1050 pass, up from 1048. The 6 failures and 3 errors are the pre-existing
`ModuleNotFoundError: No module named 'cognee'` locally; CI has cognee and runs
green.