### PR TITLE
fix(sync): stop recording an ingest that may never have reached the graph

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -443,13 +443,30 @@ class CogneePublicClient:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            return  # no running loop (sync caller); nothing to schedule
+            # Silent here meant content was recorded as ingested and never
+            # reached the graph, with nothing in the logs either way. cognee.add
+            # writes the relational and vector stores; ONLY cognify writes Kuzu.
+            # Skipping it makes a document that exists as a row and cannot be
+            # retrieved. Say so.
+            logger.error(
+                "cognify NOT scheduled for %s: no running event loop. The data "
+                "is stored but will not be searchable until a cognify runs.",
+                wanted,
+            )
+            return
 
         async def _run() -> None:
             try:
                 await self.cognify(datasets=wanted)
             except Exception:  # noqa: BLE001 - background task: log, never crash the loop
                 logger.exception("background cognify for datasets %s failed", wanted)
+            else:
+                # Log SUCCESS too. Previously only failures were logged, so a
+                # cognify that never ran — because the process exited before this
+                # detached task was scheduled — was indistinguishable in the logs
+                # from one that completed. That is how a whole repository stayed
+                # missing from the index while every surface reported it synced.
+                logger.info("background cognify finished for datasets %s", wanted)
 
         task = loop.create_task(_run())
         _BACKGROUND_COGNIFY_TASKS.add(task)

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -86,6 +86,28 @@ def _matches_extension(path: str, extensions: tuple[str, ...]) -> bool:
     return any(lowered.endswith(ext.lower()) for ext in extensions)
 
 
+def _cognee_data_ids(outcome: Any) -> list[str]:
+    """Pull the data ids cognee assigned out of an ingest outcome.
+
+    Best-effort and shape-tolerant: cognee's result is a nested dict whose exact
+    layout is not part of any contract we control. An empty list simply means
+    the next sync re-ingests this file, which is the safe direction — it repairs
+    rather than silently trusting a claim it cannot check.
+    """
+    ids: list[str] = []
+    for result in getattr(outcome, "all_ingests", ()) or ():
+        payload = getattr(result, "cognee_result", None)
+        if not isinstance(payload, dict):
+            continue
+        added = payload.get("added")
+        if not isinstance(added, dict):
+            continue
+        for info in added.get("data_ingestion_info") or ():
+            if isinstance(info, dict) and info.get("data_id"):
+                ids.append(str(info["data_id"]))
+    return list(dict.fromkeys(ids))
+
+
 def format_repo_content_document(file: RepoContentFile) -> str:
     """Render a repo file as a vault document.
 
@@ -602,10 +624,25 @@ class RepoContentSyncer:
                         continue
 
                     previous = tracked.get(key) if isinstance(tracked.get(key), dict) else {}
+                    # An entry must also carry the id cognee assigned. Without
+                    # it, "unchanged" only means "we told ourselves we ingested
+                    # this", which is exactly how 12 files stayed permanently
+                    # skipped while absent from the index: ingest reports
+                    # accepted as soon as cognee.add() returns, but the graph
+                    # write is a detached background cognify that can silently
+                    # never run. Entries written before this field existed are
+                    # therefore treated as needing re-ingestion, which repairs
+                    # the state on the next sync instead of requiring force.
+                    #
+                    # Re-ingesting an unchanged file is now cheap and safe:
+                    # ADR-0016 removed the retrieval timestamp, so the rendered
+                    # document is byte-identical and cognee's content-addressed
+                    # ingestion resolves it to the same id rather than a copy.
                     unchanged = (
                         not force
                         and previous.get("sha") == file.sha
                         and previous.get("content_hash") == file.content_hash
+                        and bool(previous.get("cognee_data_ids"))
                     )
                     if unchanged:
                         _record_skip(repo_result, "unchanged")
@@ -691,6 +728,11 @@ class RepoContentSyncer:
                             "sha": file.sha,
                             "content_hash": file.content_hash,
                             "last_ingested_at": checked_at,
+                            # What cognee actually assigned. Stored so a later
+                            # run can check its own claim against the index; a
+                            # state file holding only sha and content_hash can
+                            # never verify what it asserted.
+                            "cognee_data_ids": _cognee_data_ids(outcome),
                         }
                         # Checkpoint immediately. State used to be written only
                         # after every repo finished, so a run killed part-way

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -11,6 +11,7 @@ from kb.github_sync import GitHubAPIError
 from kb.models import IngestResult
 from kb.repo_content_sync import (
     DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS,
+    STATE_VERSION,
     RepoContentFile,
     RepoContentGitHubClient,
     RepoContentSyncer,
@@ -39,8 +40,19 @@ class FakeLearningProcess:
     async def learn(self, data: str, **kwargs: Any) -> Any:
         self.calls.append({"data": data, **kwargs})
 
+        # A realistic cognee payload. The syncer now requires evidence of what
+        # cognee actually assigned before it will treat a file as done, so a
+        # fake that reports "accepted" with no data id models precisely the
+        # unverifiable claim that left 12 files permanently skipped.
+        self._seq = getattr(self, "_seq", 0) + 1
+        cognee_result = {
+            "added": {"data_ingestion_info": [{"data_id": f"data-{self._seq}"}]}
+        }
+
         class Outcome:
-            ingest = IngestResult(True, "accepted", kwargs.get("dataset", "x"), ())
+            ingest = IngestResult(
+                True, "accepted", kwargs.get("dataset", "x"), (), cognee_result
+            )
             chunk_ingests = ()
             improve = {"ok": True} if kwargs.get("run_improve") else None
 
@@ -644,3 +656,76 @@ async def test_state_is_checkpointed_per_file_so_a_killed_run_resumes(
     assert result["files_ingested"] == 1
     assert result["files_skipped_by_reason"].get("unchanged") == 1
     assert len(resumed_learning.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_state_entry_without_a_cognee_id_is_re_ingested(tmp_path: Path) -> None:
+    """State repair, and the reason 12 files stayed missing from the index.
+
+    Ingest reports `accepted` as soon as cognee.add() returns, but add() writes
+    only the relational and vector stores — the graph write is a DETACHED
+    background cognify that can silently never run (no event loop, or the
+    process exits first). A state entry holding just sha + content_hash
+    therefore records "we told ourselves we ingested this", and `unchanged`
+    made that permanent: the file was never retried, while being absent from
+    the index.
+
+    Requiring evidence of what cognee assigned repairs such entries on the next
+    ordinary sync rather than needing a forced re-sync. Safe to re-ingest now
+    that ADR-0016 made an unchanged file render byte-identically, so cognee's
+    content-addressed ingestion resolves it to the same id instead of a copy.
+    """
+    state_path = tmp_path / "state.json"
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(state_path),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=False,
+    )
+
+    # A legacy entry: correct sha and hash, no evidence it ever reached the graph.
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": STATE_VERSION,
+                "files": {
+                    "masumi-network/sokosumi-cli/README.md": {
+                        "sha": "abc",
+                        "content_hash": FakeRepoContentClient()
+                        .fetch_file_text(
+                            "masumi-network/sokosumi-cli", "README.md", ref="commit123"
+                        )
+                        .content_hash,
+                        "last_ingested_at": "2026-06-01T00:00:00Z",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    result = await syncer.run()
+
+    assert result["files_ingested"] == 2, result["files_skipped_by_reason"]
+    repaired = json.loads(state_path.read_text(encoding="utf-8"))["files"]
+    entry = repaired["masumi-network/sokosumi-cli/README.md"]
+    assert entry["cognee_data_ids"], "repaired entry must record what cognee assigned"
+
+    # And once repaired, it goes quiet again rather than re-ingesting forever.
+    second = await syncer.run()
+    assert second["files_ingested"] == 0
+    assert second["files_skipped_by_reason"] == {"unchanged": 2}


### PR DESCRIPTION
An entire source repository — 12 `sokosumi-docs` files — is absent from the
index while every surface reports it synced, and no ordinary sync will ever
retry it. This fixes the cause and makes the existing damage repair itself.

## Root cause

`remember()` awaits `cognee.add()`, which writes the relational and vector
stores **only** — its own comment says it does not touch Kuzu. The graph write
is `_schedule_background_cognify()`, which does `loop.create_task(_run())` and
returns **without awaiting**. `ingest()` reports `accepted=True` purely because
`add()` did not throw. The syncer records sha + content_hash, and `unchanged`
makes that permanent whether or not cognify ever ran.

Two silent paths, neither logged:

- **no running event loop** — `schedule_cognify` returned bare, cognify never happened
- **process exits first** — the detached task dies with the in-memory task set

`_run()` logged only on exception, so a cognify that never ran looked exactly
like one that completed.

This also explains a symptom that looked separate: hits whose `document_id`
exists in `dataset_data` but does not resolve as a graph node. Same split —
`add()` wrote the row, cognify never made the node. **One bug, not two.**

## The fix, and why it repairs itself

A tracked entry must now carry `cognee_data_ids` — what cognee actually
assigned. Entries written before this field existed lack it, so they count as
needing re-ingestion and **repair on the next ordinary sync**. No forced
re-sync, which is otherwise the only recovery and would have been unsafe.

Re-ingesting unchanged files is cheap and safe **only because of ADR-0016**:
with the retrieval timestamp gone the document renders byte-identically, so
cognee's content-addressed ingestion resolves it to the same id rather than
minting a copy. Before that change this repair would have duplicated the corpus.

Cognify success is now logged, not just failure, so "it never ran" is visible
instead of only discoverable by searching for a sentence and finding nothing.

## A regression of mine, closed here

#172's per-file checkpoint widened this. Previously a killed run wrote no state
and files were retried; afterwards a file was locked in the instant `add()`
returned. It did not cause this instance — those 12 were tracked before today —
but it made the class more likely.

## How this was found

The widened golden set (#177) scored `product_docs` at 0.22 against 0.70-1.00
everywhere else. Verbatim-sentence searches returned 0/6 for that repo and 2/3
to 3/3 for the other three. The security scanner was ruled out (0 findings), MDX
handling was ruled out by reading cognee's ingestion path, and a real
incremental sync returned `{'unchanged': 69}` — proving the syncer would never
retry them.

## Tests

A new test writes a legacy state entry with correct sha and hash but no cognee
id, asserts the file is re-ingested and the entry repaired, then asserts a
second run goes quiet rather than re-ingesting forever.

The fake learning process had to grow a realistic cognee payload — one that
reports "accepted" with no data id models precisely the unverifiable claim this
change rejects.

1074 pass. The 6 failures and 3 errors are the pre-existing local
`ModuleNotFoundError: No module named 'cognee'`; CI has cognee and runs green.