### PR TITLE
fix: three defects that made a healthy vault look empty

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -67,6 +67,25 @@ def assert_cognee_dataset_api() -> None:
     from cognee.modules.data.models import Dataset, DatasetData  # noqa: F401
     from cognee.modules.users.methods import get_default_user  # noqa: F401
 
+    # Symbol imports alone were not enough. `cognee.add()` returns a
+    # PipelineRunInfo model whose `data_ingestion_info` is an ATTRIBUTE;
+    # `_cognee_data_ids` read it as a dict key, always got nothing, and left the
+    # repo-content sync unable to converge. Nothing failed loudly because the
+    # shape is only ever read best-effort. Pin the field's EXISTENCE here so a
+    # cognee bump that renames or moves it fails at boot and in CI rather than
+    # degrading into a silent livelock.
+    from cognee.modules.pipelines.models.PipelineRunInfo import (
+        PipelineRunCompleted,
+        PipelineRunInfo,
+    )
+
+    for model in (PipelineRunInfo, PipelineRunCompleted):
+        if "data_ingestion_info" not in getattr(model, "model_fields", {}):
+            raise RuntimeError(
+                f"cognee {model.__name__} no longer declares data_ingestion_info; "
+                "kb.repo_content_sync._cognee_data_ids needs updating"
+            )
+
 
 _SUPPRESS_INLINE_COGNIFY: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "citadel_suppress_inline_cognify", default=False

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+from collections.abc import Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 import json
@@ -89,22 +90,40 @@ def _matches_extension(path: str, extensions: tuple[str, ...]) -> bool:
 def _cognee_data_ids(outcome: Any) -> list[str]:
     """Pull the data ids cognee assigned out of an ingest outcome.
 
-    Best-effort and shape-tolerant: cognee's result is a nested dict whose exact
-    layout is not part of any contract we control. An empty list simply means
-    the next sync re-ingests this file, which is the safe direction — it repairs
-    rather than silently trusting a claim it cannot check.
+    ``cognee.add()`` returns a ``PipelineRunInfo`` pydantic model (concretely a
+    ``PipelineRunCompleted``), and ``data_ingestion_info`` is an ATTRIBUTE on it.
+    ``CogneePublicClient.remember`` wraps that object unmodified as
+    ``{"added": <PipelineRunInfo>}``, so it is never a dict at this point.
+
+    The previous version gated on ``isinstance(added, dict)`` and reasoned that
+    an empty list was safe because the next sync would re-ingest the file. That
+    was wrong in both halves. The gate was always taken, so this returned ``[]``
+    for every file ever ingested, and an empty list is NOT safe: it leaves the
+    ``unchanged`` guard permanently unsatisfiable, the next run re-ingests, the
+    process-lifetime dedupe in :meth:`Citadel.ingest` rejects it as
+    ``duplicate_in_process``, and that rejection writes no state at all. The
+    result was a livelock in which no sync could ever converge.
+
+    Read the attribute first and fall back to a mapping, so a future cognee that
+    returns a plain dict still works. Never gate on the container type alone.
     """
     ids: list[str] = []
     for result in getattr(outcome, "all_ingests", ()) or ():
         payload = getattr(result, "cognee_result", None)
-        if not isinstance(payload, dict):
+        added = payload.get("added") if isinstance(payload, Mapping) else None
+        if added is None:
             continue
-        added = payload.get("added")
-        if not isinstance(added, dict):
-            continue
-        for info in added.get("data_ingestion_info") or ():
-            if isinstance(info, dict) and info.get("data_id"):
-                ids.append(str(info["data_id"]))
+        info_list = getattr(added, "data_ingestion_info", None)
+        if info_list is None and isinstance(added, Mapping):
+            info_list = added.get("data_ingestion_info")
+        for info in info_list or ():
+            data_id = (
+                info.get("data_id")
+                if isinstance(info, Mapping)
+                else getattr(info, "data_id", None)
+            )
+            if data_id:
+                ids.append(str(data_id))
     return list(dict.fromkeys(ids))
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -3244,6 +3244,19 @@ async def me_summary(request: Request) -> dict[str, Any]:
             readable_document_count = sum(
                 int(counts.get(name) or 0) for name in readable_datasets
             )
+            # Prefer the durable count for the Node total too. `document_count`
+            # above walks the mesh projection, which is rebuilt in memory and
+            # empties on every process restart, so on a service that redeploys
+            # per merge it reads 0 for a seat holding thousands of notes. That
+            # zero then propagated into `capture_done` below and flipped `empty`
+            # true, so the seat home rendered its "nothing captured yet" state
+            # over a full Node.
+            #
+            # Read isolation is unchanged: `node` is THIS caller's own seat Node
+            # from seat_node_dataset(identity), so no other seat's dataset is
+            # ever read here.
+            if node:
+                document_count = int(counts.get(node) or 0) or document_count
     except Exception:
         # Null, not zero. Zero is a claim that the caller can read nothing.
         logger.exception("me/summary readable document count failed")

--- a/kb/server.py
+++ b/kb/server.py
@@ -4059,7 +4059,16 @@ def scope_mesh_snapshot(
 async def mesh(request: Request) -> Any:
     identity = require_access(request, "reader", "kb:read")
     citadel = get_citadel()
-    snapshot = await get_mesh().snapshot(citadel.config)
+    # Pass the authoritative corpus figures, or the dashboard reports the
+    # in-memory counters as though they were totals (ADR-0018). `snapshot` grew a
+    # `corpus` parameter for exactly this, but this endpoint, the one the
+    # dashboard actually reads, was never updated to supply it. In production it
+    # still returned `documents: 1, indexed_chunks: 1` against a real 17991
+    # indexed, which is what makes a healthy vault look empty on login.
+    # `_corpus_health` is the same source /readyz and `citadel status` use, and
+    # is fail-soft: on a transient read error it returns None totals and
+    # `snapshot` falls back to the in-memory values rather than raising here.
+    snapshot = await get_mesh().snapshot(citadel.config, corpus=await _corpus_health())
     return jsonable_encoder(scope_mesh_snapshot(snapshot, identity))
 
 

--- a/kb/service.py
+++ b/kb/service.py
@@ -90,15 +90,24 @@ class Citadel:
                 "Ingest rejected for dataset %s: duplicate_in_process", target_dataset
             )
             return IngestResult(False, "duplicate_in_process", target_dataset, merged_tags)
+        # Claimed BEFORE the await so two concurrent ingests of identical content
+        # cannot both pass the check, and released again if the write fails. It
+        # used to be added and never removed, so one failed remember() marked that
+        # content "seen" for the life of the process: every retry then returned
+        # duplicate_in_process, and a caller that only records state on success
+        # (repo_content_sync) could never recover the file.
         self._seen_ingest_keys.add(ingest_key)
-
-        result = await self.cognee.remember(
-            data,
-            dataset_name=target_dataset,
-            session_id=session_id,
-            tags=merged_tags,
-            defer_cognify=defer_cognify,
-        )
+        try:
+            result = await self.cognee.remember(
+                data,
+                dataset_name=target_dataset,
+                session_id=session_id,
+                tags=merged_tags,
+                defer_cognify=defer_cognify,
+            )
+        except BaseException:
+            self._seen_ingest_keys.discard(ingest_key)
+            raise
         return IngestResult(True, "accepted", target_dataset, merged_tags, result)
 
     def _guard_content(self, data: str, dataset: str) -> None:

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -16,6 +16,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from kb.access import AccessStore, now_iso
+from kb.mesh import MeshState
 from kb.promotion_queue import build_pending_item, scan_candidate
 from kb.promotion_refs import ReferenceAssessment
 from kb.server import app
@@ -413,3 +414,46 @@ def test_access_snapshot_keeps_its_existing_shape(tmp_path: Any) -> None:
     for existing in ("ok", "bootstrap_keys", "principals", "tokens", "audit_events"):
         assert existing in payload, f"/api/access lost {existing}"
     assert isinstance(payload["audit_events"], list)
+
+
+def test_seat_home_is_not_empty_after_a_restart_wipes_the_mesh_projection(
+    tmp_path: Any,
+) -> None:
+    """A redeploy must not make a populated seat render as "nothing captured".
+
+    `document_count` used to come only from the in-memory mesh projection, which
+    is rebuilt per process and is empty immediately after a restart. That zero
+    fed `capture_done`, which flipped `empty` true, so a seat holding thousands
+    of notes showed the onboarding empty state on every deploy. This service
+    redeploys on every merge to main, so that was most of any given day.
+
+    The mesh here is deliberately left EMPTY, which is exactly the post-restart
+    state, so this test fails if the count ever goes back to the projection.
+    """
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    alice_token = admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"}).json()[
+        "token"
+    ]
+
+    class _Cognee:
+        async def document_counts_by_dataset(self) -> dict[str, int]:
+            return {"masumi-network": 10, "seat:alice": 42}
+
+    class _Citadel:
+        config = app.state.citadel.config
+        cognee = _Cognee()
+
+    original = app.state.citadel
+    app.state.citadel = _Citadel()
+    app.state.mesh = MeshState()  # a fresh process: projection holds nothing
+    try:
+        alice = TestClient(app, base_url="https://testserver")
+        payload = alice.get(
+            "/api/me/summary", headers={"Authorization": f"Bearer {alice_token}"}
+        ).json()
+    finally:
+        app.state.citadel = original
+
+    assert payload["document_count"] == 42, payload
+    assert payload["empty"] is False, "a populated seat rendered as empty"

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from uuid import NAMESPACE_URL, uuid5
 
 import pytest
+
+# The real cognee return type. Imported, never hand-rolled: a fake that invents a
+# third-party's shape can only prove that our parser parses the fake.
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
 
 from kb.config import CitadelConfig
 from kb.github_sync import GitHubAPIError
@@ -12,6 +17,7 @@ from kb.models import IngestResult
 from kb.repo_content_sync import (
     DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS,
     STATE_VERSION,
+    _cognee_data_ids,
     RepoContentFile,
     RepoContentGitHubClient,
     RepoContentSyncer,
@@ -40,13 +46,29 @@ class FakeLearningProcess:
     async def learn(self, data: str, **kwargs: Any) -> Any:
         self.calls.append({"data": data, **kwargs})
 
-        # A realistic cognee payload. The syncer now requires evidence of what
-        # cognee actually assigned before it will treat a file as done, so a
-        # fake that reports "accepted" with no data id models precisely the
-        # unverifiable claim that left 12 files permanently skipped.
-        self._seq = getattr(self, "_seq", 0) + 1
+        # The REAL cognee return type, imported from the installed package, not a
+        # dict invented here. The previous fake returned
+        # {"added": {"data_ingestion_info": [...]}}; cognee actually returns a
+        # PipelineRunInfo model wrapped as {"added": <model>}, so _cognee_data_ids
+        # extracted nothing in production while this fake made it look correct.
+        # Every direction of the test passed against a shape that does not exist.
+        # A fake may only specify a contract we own; for a third-party return
+        # value it has to be the third party's own type.
+        #
+        # The id is derived from the content, because cognee is content-addressed
+        # and returns the SAME data_id for a byte-identical document. That is the
+        # premise ADR-0016 relies on, and a per-call counter contradicted it.
         cognee_result = {
-            "added": {"data_ingestion_info": [{"data_id": f"data-{self._seq}"}]}
+            "added": PipelineRunCompleted(
+                pipeline_run_id=uuid5(NAMESPACE_URL, f"run:{data}"),
+                dataset_id=uuid5(NAMESPACE_URL, str(kwargs.get("dataset", "x"))),
+                dataset_name=str(kwargs.get("dataset", "x")),
+                payload=None,
+                data_ingestion_info=[
+                    {"data_id": str(uuid5(NAMESPACE_URL, f"data:{data}"))}
+                ],
+            ),
+            "background_cognify": True,
         }
 
         class Outcome:
@@ -729,3 +751,51 @@ async def test_a_state_entry_without_a_cognee_id_is_re_ingested(tmp_path: Path) 
     second = await syncer.run()
     assert second["files_ingested"] == 0
     assert second["files_skipped_by_reason"] == {"unchanged": 2}
+
+
+def test_cognee_data_ids_reads_the_real_cognee_return_type() -> None:
+    """Pin the extraction against cognee's ACTUAL type, not a fake of our own.
+
+    This is the test that was missing. `_cognee_data_ids` used to gate on
+    `isinstance(added, dict)`, and every fake in the suite returned a dict, so
+    the whole suite agreed with the bug. In production `cognee.add()` returns a
+    `PipelineRunInfo` model and the gate was always taken, so the helper returned
+    `[]` for every file and the sync could never converge.
+
+    Constructing the real type here means a cognee upgrade that changes the shape
+    fails HERE, loudly, instead of degrading into a silent livelock in prod.
+    """
+    data_id = "1b4196ac-5cb8-4e5f-abe2-a5ba8f42c2f2"
+    real = PipelineRunCompleted(
+        pipeline_run_id=uuid5(NAMESPACE_URL, "run"),
+        dataset_id=uuid5(NAMESPACE_URL, "ds"),
+        dataset_name="masumi-network",
+        payload=None,
+        data_ingestion_info=[{"data_id": data_id}],
+    )
+
+    def outcome(cognee_result: Any) -> Any:
+        ingest = IngestResult(True, "accepted", "masumi-network", (), cognee_result)
+
+        class Outcome:
+            all_ingests = (ingest,)
+
+        return Outcome()
+
+    # It must NOT be a dict. If this ever becomes one, the fallback below is what
+    # keeps working, but we want to know the contract changed.
+    assert not isinstance(real, dict)
+
+    # Every branch CogneePublicClient.remember can return (kb/cognee_client.py).
+    for extra in ({"background_cognify": True}, {"cognify": "suppressed"}, {"cognify": "deferred"}):
+        assert _cognee_data_ids(outcome({"added": real, **extra})) == [data_id]
+
+    # Forward compatibility: a future cognee returning a plain mapping still works.
+    assert _cognee_data_ids(
+        outcome({"added": {"data_ingestion_info": [{"data_id": "d-9"}]}})
+    ) == ["d-9"]
+
+    # Genuinely empty stays empty, so the guard still refuses to trust a
+    # claim it cannot check.
+    assert _cognee_data_ids(outcome({"added": {}})) == []
+    assert _cognee_data_ids(outcome(None)) == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5984,3 +5984,56 @@ def test_a_normal_search_is_still_audited_as_a_success() -> None:
 
     assert body.get("timed_out") in (None, False)
     assert audited and audited[-1]["success"] is True
+
+
+def test_api_mesh_reports_authoritative_corpus_totals_not_uptime_counters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/api/mesh must report the real corpus, not what this process happens to
+    have seen since it booted.
+
+    ADR-0018 added a `corpus` parameter to MeshState.snapshot for this, but this
+    endpoint, the one the dashboard actually reads, kept calling snapshot without
+    it. Production served `documents: 1, indexed_chunks: 1` against a real 17991
+    indexed docs, so a healthy vault rendered as empty on login. The parameter
+    existed and was simply never passed, which no test caught because every test
+    asserted on snapshot() directly rather than through the endpoint.
+    """
+    client = authed_client()
+
+    async def fake_corpus_health() -> dict[str, Any]:
+        return {"ok": True, "tracked_sources": 317, "indexed_docs": 17991}
+
+    monkeypatch.setattr(server_module, "_corpus_health", fake_corpus_health)
+
+    stats = client.get("/api/mesh").json()["stats"]
+
+    assert stats["documents"] == 317, stats
+    assert stats["indexed_chunks"] == 17991, stats
+    # The uptime figures are still reported, just no longer disguised as totals.
+    assert "since_restart" in stats
+    assert stats["since_restart"]["documents"] != 317
+
+
+def test_api_mesh_falls_back_to_uptime_counters_when_corpus_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A degraded corpus read must not blank the dashboard or 500.
+
+    `_corpus_health` is fail-soft and returns None totals on a transient graph
+    error. The endpoint has to survive that, because the alternative is that one
+    slow Kuzu read takes the whole dashboard down.
+    """
+    client = authed_client()
+
+    async def degraded_corpus_health() -> dict[str, Any]:
+        return {"ok": True, "tracked_sources": None, "indexed_docs": None, "degraded": "boom"}
+
+    monkeypatch.setattr(server_module, "_corpus_health", degraded_corpus_health)
+
+    response = client.get("/api/mesh")
+
+    assert response.status_code == 200
+    stats = response.json()["stats"]
+    assert stats["documents"] is not None
+    assert stats["indexed_chunks"] is not None


### PR DESCRIPTION
Three separate bugs, each shipped earlier today, each with the same shape: a fix that was written correctly and then never reached the code path that needed it. Found while chasing why one source repo was missing from the index.

## 1. Repo-content sync was livelocked

`cognee.add()` returns a `PipelineRunInfo` pydantic model, and `data_ingestion_info` is an attribute on it. `_cognee_data_ids` gated on `isinstance(added, dict)`, which is never true, so it returned `[]` for every file ever ingested.

That made the `unchanged` guard added in #178 permanently unsatisfiable. Every sync re-ingested everything; the second pass hit the process-lifetime dedupe in `Citadel.ingest`, came back `duplicate_in_process`, and that branch writes no state at all. No repo-content sync completed for over 12 hours.

The guard was right. The evidence check under it never fired, so the guard never let go.

- `_cognee_data_ids` reads the attribute, falling back to a mapping so a future cognee returning a plain dict still works.
- `Citadel.ingest` releases its dedupe key if the write fails, so one failed `remember()` no longer marks that content seen for the life of the process.
- `assert_cognee_dataset_api` now pins that `data_ingestion_info` exists, so a cognee bump fails at boot instead of degrading into a silent livelock.

## 2. `/api/mesh` reported uptime counters as corpus totals

ADR-0018 added a `corpus` parameter to `MeshState.snapshot` for exactly this. The endpoint the dashboard reads never passed it, so production served `documents: 1, indexed_chunks: 1` against a real 17991 indexed docs.

## 3. A populated seat rendered as "nothing captured yet"

`/api/me/summary` derived `document_count` from the in-memory mesh projection, which is empty right after a restart. That zero fed `capture_done` and flipped `empty` true, so the seat home showed its onboarding state over a full Node. `document_counts_by_dataset()` already existed for this and was already used a few lines below; the Node total never adopted it.

Read isolation is unchanged: the count is taken for the caller's own `seat_node_dataset(identity)`.

## Why the tests did not catch any of it

The fake for `cognee.add()` returned `{"added": {"data_ingestion_info": [...]}}`, a shape this repo invented and cognee never returns. The test asserted the parser parses the fake, and a revert-the-guard check passed for the same reason. Both directions ran against a shape that does not exist.

Fixed by building the real `PipelineRunCompleted`, imported from the installed package. The mesh and seat-home tests now go through the HTTP endpoints rather than asserting on the underlying function, which is what let an unwired parameter through.

## Verification

Each fix was checked in both directions. Reverting only the production line turns tests red, for the right reason:

- sync: `assert second["files_ingested"] == 0` fails `assert 2 == 0`, the livelock itself
- mesh: `assert stats["documents"] == 317` fails `assert 0 == 317`
- seat home: `assert payload["document_count"] == 42` fails `assert 0 == 42`

`1087 passed, 1 skipped`. `ruff check .` clean.

Production evidence gathered read-only: `/api/mesh/graph` returns 931 nodes and 9399 edges with `fallback: false`, and `/search` returns hits in ~530ms, so the corpus was intact throughout and every symptom here was a reporting defect.

## Not in this PR

`/api/mesh/graph` takes 21 seconds, which is a likely cause of the graph appearing not to load. That is a performance problem rather than a correctness one and wants its own change.