### PR TITLE
fix(ui): give the graph page a way in

### DIFF
--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -78,6 +78,10 @@
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
               <span class="nav-label">Search</span>
             </button>
+            <button class="nav-link" data-page-target="knowledge" aria-label="Graph" type="button">
+              <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="5" r="2.5"/><circle cx="5" cy="18" r="2.5"/><circle cx="19" cy="18" r="2.5"/><line x1="10.4" y1="7" x2="6.6" y2="15.6"/><line x1="13.6" y1="7" x2="17.4" y2="15.6"/><line x1="7.5" y1="18" x2="16.5" y2="18"/></svg>
+              <span class="nav-label">Graph</span>
+            </button>
             <button class="nav-link" data-page-target="review" aria-label="Review" data-min-role="writer" type="button">
               <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3 8-8"/><path d="M20 12v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h9"/></svg>
               <span class="nav-label">Review</span>
@@ -1518,6 +1522,6 @@ args = [
     <div id="toastStack" class="toast-stack" role="status" aria-live="polite"></div>
 
     <script src="/static/vendor/force-graph.min.js"></script>
-    <script src="/static/app.js?v=light-1"></script>
+    <script src="/static/app.js?v=graph-nav-1"></script>
   </body>
 </html>

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -457,3 +457,41 @@ def test_seat_home_is_not_empty_after_a_restart_wipes_the_mesh_projection(
 
     assert payload["document_count"] == 42, payload
     assert payload["empty"] is False, "a populated seat rendered as empty"
+
+
+def test_every_dashboard_page_is_reachable_from_the_ui() -> None:
+    """A page with no way in is invisible, however healthy its data is.
+
+    The Knowledge/graph page shipped complete: canvas, depth control, legend,
+    metrics strip, node inspector. It had no `data-page-target` anywhere, so the
+    only way to reach it was to type the URL hash by hand, and the graph looked
+    to users like a feature that did not exist. Meanwhile /api/mesh/graph was
+    returning 932 nodes and 5952 edges in ~300ms.
+
+    `locked` and `overview` are deliberately unreachable: `locked` is the
+    fallback setPage() routes to when a caller lacks the role, and a comment at
+    app.js initialPage() records that `overview` was intentionally dropped from
+    the nav.
+    """
+    from pathlib import Path
+    import re
+
+    html = Path("kb/static/index.html").read_text(encoding="utf-8")
+    pages = set(re.findall(r'data-page="([a-z-]+)"', html))
+    targets = set(re.findall(r'data-page-target="([a-z-]+)"', html))
+    intentionally_unreachable = {"locked", "overview"}
+    # Genuinely unreachable, same defect as the graph page: built, complete, and
+    # with no nav entry, no setPage() call and no hash link anywhere. Listed
+    # rather than silently subtracted so this test still fails on a NEW orphan.
+    # Not fixed here because each needs a role decision (settings and audit are
+    # plausibly admin-only) and guessing at that is a security call, not a UI
+    # one. Tracked separately.
+    known_unreachable = {"audit", "feedback", "settings"}
+
+    orphaned = pages - targets - intentionally_unreachable - known_unreachable
+
+    assert not orphaned, (
+        f"pages with no way to reach them from the UI: {sorted(orphaned)}. "
+        "Add a nav entry or a data-page-target button, or list it as "
+        "intentionally unreachable with a reason."
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1266,13 +1266,24 @@ def test_ui_shell_is_served_after_login() -> None:
 STATIC_DIR = Path(server_module.__file__).resolve().parent / "static"
 
 
-def test_app_nav_has_four_primary_entries() -> None:
-    """Home, Search, Review, Admin. Nothing else is a primary nav entry.
+def test_app_nav_has_five_primary_entries() -> None:
+    """Home, Search, Graph, Review, Admin. Nothing else is a primary nav entry.
 
     Seven entries were the problem the redesign exists to fix: two of them
     nobody could tell apart, and the promotion queue that people actually needed
-    was buried inside an admin-only Overview. Explore and Activity are still
-    reachable by route; they are just not resident in the sidebar.
+    was buried inside an admin-only Overview.
+
+    This asserted four for exactly that reason, on the stated premise that the
+    non-resident pages were "still reachable by route". For the Knowledge page
+    that premise was false: it had no nav entry, no setPage() call and no hash
+    link anywhere, so the graph was reachable only by typing the URL fragment
+    and to every user it simply did not exist, while /api/mesh/graph was serving
+    932 nodes in ~300ms. Graph is now resident, at the owner's request.
+
+    Five is still a cap, not an invitation. The lesson of the seven-entry
+    version stands: anything added here has to earn residency, and a page that
+    cannot must at least be reachable from somewhere, which
+    test_every_dashboard_page_is_reachable_from_the_ui now enforces.
     """
     client = authed_client()
 
@@ -1282,7 +1293,7 @@ def test_app_nav_has_four_primary_entries() -> None:
     assert nav, "the /app shell no longer renders a <nav class=\"side-nav\">"
     labels = re.findall(r'<span class="nav-label">([^<]+)</span>', nav.group(0))
 
-    assert labels == ["Home", "Search", "Review", "Admin"], labels
+    assert labels == ["Home", "Search", "Graph", "Review", "Admin"], labels
     assert 'class="nav-link" data-page-target="overview"' not in page
     assert 'class="nav-link" data-page-target="ingest"' not in page
     # Review is writer-gated; Admin stays admin-gated.


### PR DESCRIPTION
Closes #181

The Knowledge page shipped complete: force-graph canvas, depth control, Fit and Pause, legend, metrics strip, and a node inspector. It had **no nav entry, no `setPage()` call and no hash link anywhere**, so the only way to reach it was typing the URL fragment by hand. To anyone using the app the graph did not exist.

Nothing was wrong with the data. Measured against production:

```
/api/mesh/graph?limit=1000 -> 3577ms (330ms warm)
  nodes returned      : 932   (total 18469, truncated)
  edges returned      : 5952
  edges the UI keeps  : 5952  (100%)
  nodes with >=1 edge : 921 / 932
```

Every edge survives the endpoint filter at `app.js:524` and 921 of 932 nodes are connected. The page was unreachable, not broken.

## Changes

- **Graph entry in the side nav**, reader role, between Search and Review.
- **Cache-buster bumped.** `app.js` had been pinned at `?v=light-1` across every deploy, so a browser holding the old bundle kept showing stale state after fixes had already shipped. That is a good part of why the dashboard looked broken for longer than it was.
- **A test that every page has some way in.** It immediately found three more pages in the same state as the graph: `audit`, `feedback` and `settings`, all with zero references anywhere.

## The four-entry nav decision

`test_app_nav_has_four_primary_entries` asserted exactly four entries, from a redesign that cut seven to four because too many entries was the original problem. That is a real decision and I did not want to delete it quietly.

Its stated premise was that non-resident pages are "still reachable by route". For the Knowledge page that premise was false. The test is updated to five and its docstring now records why, keeps the cap framing, and points at the new reachability test as the backstop.

## The three other orphaned pages

`audit`, `feedback` and `settings` are listed explicitly in the new test rather than subtracted silently, so it still fails on a **new** orphan. They are not fixed here because each needs a role decision (settings and audit are plausibly admin-only) and guessing at that is a security call rather than a UI one.

## Verification

`1088 passed, 1 skipped`. `ruff check .` clean.

Removing the nav entry turns the new test red with `pages with no way to reach them from the UI: ['knowledge']`.