### PR TITLE
fix(mcp): stop handing agents every search hit twice

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -492,6 +492,37 @@ def _clamp_top_k(top_k: int) -> int:
     return min(max(int(top_k), 1), MAX_SEARCH_TOP_K)
 
 
+def _compact_search_for_agent(payload: Any) -> Any:
+    """Drop the `sections` hit copies before handing a search back to an agent.
+
+    ``/search`` returns every hit twice: once in ``results``, and again inside
+    ``sections`` grouped by Central / node / session traces. The dashboard needs
+    that grouping (kb/static/app.js renders a heading per section), so the
+    endpoint is right to send it. An agent is not: it reads ``results``, and
+    every hit already carries its own ``_citadel.dataset``.
+
+    Measured on production, one ``top_k=5`` call returned 84,376 characters, of
+    which 41,986 were the ``sections`` copy. That is half the payload, and it
+    was large enough to exceed the MCP tool output limit outright, so the caller
+    got an error and a file path instead of an answer.
+
+    The grouping is preserved as counts under ``section_counts``, so a caller
+    can still see the Central/node split without a second copy of the text.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    sections = payload.get("sections")
+    if not isinstance(sections, dict):
+        return payload
+    compacted = dict(payload)
+    compacted["section_counts"] = {
+        str(name): len(items) if isinstance(items, list) else 0
+        for name, items in sections.items()
+    }
+    compacted.pop("sections", None)
+    return compacted
+
+
 def _audit_query(view: str, limit: int) -> str:
     normalized_view = view.strip().lower() or "mcp"
     if normalized_view not in AUDIT_VIEWS:
@@ -795,7 +826,7 @@ def create_mcp_server(
         if isinstance(mode, str) and mode.strip().lower() == "docs":
             payload["mode"] = "docs"
             payload["exclude_ambient"] = True
-        return await _call_async(
+        result = await _call_async(
             "citadel_search",
             lambda: resolve_client(ctx).post(
                 "/search",
@@ -803,6 +834,7 @@ def create_mcp_server(
                 tool_name="citadel_search",
             ),
         )
+        return _compact_search_for_agent(result)
 
     @mcp.tool(annotations=TOOL_POLICIES["citadel_get_mesh"].annotations)
     async def citadel_get_mesh(ctx: Context) -> dict[str, Any]:

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -492,6 +492,57 @@ def _clamp_top_k(top_k: int) -> int:
     return min(max(int(top_k), 1), MAX_SEARCH_TOP_K)
 
 
+def _max_hit_text_chars() -> int:
+    """How much of one hit's text an agent gets inline.
+
+    Measured on production: hits carry 6,220 to 7,319 characters each, so the
+    documented default ``top_k=10`` returned 209,109 characters and exceeded the
+    tool-result budget outright. Dropping the duplicate ``sections`` copy alone
+    still left ~103,000, so a cap is needed as well as the dedup.
+
+    2,000 characters is roughly 500 words: enough to judge whether a hit answers
+    the question, and the full text is one ``citadel_get_document`` call away
+    using the ``id`` that stays on every hit. Env-overridable, and 0 disables
+    truncation for a caller that genuinely wants everything.
+    """
+    raw = os.getenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", "").strip()
+    if not raw:
+        return 2000
+    try:
+        value = int(raw)
+    except ValueError:
+        return 2000
+    return max(0, value)
+
+
+def _truncate_hit_text(hit: Any, limit: int) -> Any:
+    """Trim one hit's text, telling the caller it happened and what it lost.
+
+    Silent truncation would be worse than the bloat: an agent that cannot tell a
+    3,000-word document from its first 500 words will summarise the fragment and
+    present it as the whole. The flags exist so it can decide to fetch the rest.
+    """
+    if not isinstance(hit, dict):
+        return hit
+    text = hit.get("text")
+    if not isinstance(text, str) or limit <= 0 or len(text) <= limit:
+        return hit
+    # Cut at a line boundary when one is close, so a truncated chunk does not
+    # end mid-token and read as corrupted.
+    window = text[:limit]
+    cut = window.rfind("\n")
+    if cut < limit // 2:
+        cut = limit
+    trimmed = dict(hit)
+    trimmed["text"] = window[:cut]
+    trimmed["text_truncated"] = True
+    trimmed["text_full_chars"] = len(text)
+    trimmed["text_hint"] = (
+        "Truncated. Call citadel_get_document with this hit's `id` for the full text."
+    )
+    return trimmed
+
+
 def _compact_search_for_agent(payload: Any) -> Any:
     """Drop the `sections` hit copies before handing a search back to an agent.
 
@@ -511,15 +562,23 @@ def _compact_search_for_agent(payload: Any) -> Any:
     """
     if not isinstance(payload, dict):
         return payload
-    sections = payload.get("sections")
-    if not isinstance(sections, dict):
-        return payload
     compacted = dict(payload)
-    compacted["section_counts"] = {
-        str(name): len(items) if isinstance(items, list) else 0
-        for name, items in sections.items()
-    }
-    compacted.pop("sections", None)
+
+    sections = payload.get("sections")
+    if isinstance(sections, dict):
+        compacted["section_counts"] = {
+            str(name): len(items) if isinstance(items, list) else 0
+            for name, items in sections.items()
+        }
+        compacted.pop("sections", None)
+
+    # Dedup alone was not enough. At the documented default top_k=10 the response
+    # was still ~103,000 characters, because each hit carries 6,000 to 7,000 of
+    # its own.
+    limit = _max_hit_text_chars()
+    results = payload.get("results")
+    if isinstance(results, list) and limit > 0:
+        compacted["results"] = [_truncate_hit_text(hit, limit) for hit in results]
     return compacted
 
 

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -23,7 +23,9 @@ python scripts/bench/search_bench.py --repeats 3 --top-k 5 --out results.json
 | `recall_at_k` | fraction of questions where the document that answers it appears in the top k |
 | `mrr` | mean reciprocal rank over the same questions |
 | `blocked_probe_hit_rate` | fraction of *deliberately unanswerable* questions that returned their target anyway |
-| `latency_ms_p50` / `p95` | server-side search latency over all samples |
+| `latency_ms_p50` / `p95` | **client round-trip**, timed around `urlopen`, so it includes DNS, TCP, TLS and the network path from wherever you ran it. It is NOT server-side latency: on 2026-07-31 a run measuring 269ms from a laptop corresponded to 107-141ms in the Railway edge logs. Quote it as "round-trip from our client", and read server-side timing from the platform logs instead. |
+| `distinct_source_ratio_mean` | distinct source documents per result page, divided by ALL hits. 1.00 means every slot is a different document; lower means one document is occupying slots the caller pays context for. A hit whose source path cannot be resolved counts against this exactly like a duplicate does. |
+| `distinct_source_ratio_resolvable_only` | the same ratio over hits whose source path resolved. Report both: the first is the pessimistic bound, this is what the resolvable evidence supports. |
 
 ## How a hit is scored
 

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -263,6 +263,15 @@ def main() -> int:
                 "matched_by": matched_by,
                 "hit_paths": observed,
                 "hit_datasets": datasets,
+                # Recall says the right document was on the page. It says nothing
+                # about the other four slots. Measured on 2026-07-31, recall@5 was
+                # 0.93 while the mean distinct-source ratio was 0.62: 22 of 60
+                # queries returned one or two distinct documents, the rest of the
+                # page being more chunks of the same file. "What is the Hermes
+                # orchestrator actor" returned that one file five times. An agent
+                # pays full context for a page that answers once.
+                "distinct_sources": len({path for path in observed if path}),
+                "hits_returned": len(observed),
                 "errors": errors,
             }
         )
@@ -299,6 +308,25 @@ def main() -> int:
         "recall_at_3": round(recall_at(positives, 3), 4),
         "recall_at_5": round(recall_at(positives, 5), 4),
         "mrr": round(mrr, 4),
+        # 1.00 means every slot on the page was a different document. Lower means
+        # one document is occupying slots the agent is paying context for. Track
+        # this NEXT TO recall: a high recall with a low ratio is a page that
+        # answers once and repeats itself four times.
+        "distinct_source_ratio_mean": round(
+            statistics.fmean(
+                [
+                    row["distinct_sources"] / row["hits_returned"]
+                    for row in rows
+                    if row["hits_returned"]
+                ]
+            ),
+            4,
+        )
+        if any(row["hits_returned"] for row in rows)
+        else 0.0,
+        "queries_with_one_distinct_source": sum(
+            1 for row in rows if row["hits_returned"] and row["distinct_sources"] <= 1
+        ),
         "blocked_probe_hit_rate": round(recall_at(probes, args.top_k), 4),
         "latency_ms_p50": round(percentile(latencies, 0.50), 1),
         "latency_ms_p95": round(percentile(latencies, 0.95), 1),

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -324,6 +324,28 @@ def main() -> int:
         )
         if any(row["hits_returned"] for row in rows)
         else 0.0,
+        # The ratio above divides by ALL hits, so a hit whose source path could
+        # not be resolved counts against diversity exactly like a duplicate does.
+        # Measured 2026-07-31 that was 15 of 304 hits (4.9%), worth 0.61 vs 0.65.
+        # Report both rather than pick: the first is the pessimistic bound, the
+        # second is what the resolvable evidence actually supports, and quoting
+        # one without the other invites the obvious rebuttal.
+        "distinct_source_ratio_resolvable_only": round(
+            statistics.fmean(
+                [
+                    len({path for path in (row["hit_paths"] or []) if path})
+                    / len([path for path in (row["hit_paths"] or []) if path])
+                    for row in rows
+                    if any(row["hit_paths"] or [])
+                ]
+            ),
+            4,
+        )
+        if any(any(row["hit_paths"] or []) for row in rows)
+        else 0.0,
+        "hits_with_unresolvable_source": sum(
+            1 for row in rows for path in (row["hit_paths"] or []) if not path
+        ),
         "queries_with_one_distinct_source": sum(
             1 for row in rows if row["hits_returned"] and row["distinct_sources"] <= 1
         ),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -817,3 +817,90 @@ def test_contribute_tool_rejects_empty_or_oversized_payloads(
     monkeypatch.setenv("CITADEL_MCP_MAX_INGEST_BYTES", "4")
     with pytest.raises(ToolError, match="payload is 5 bytes"):
         run_tool(server, "citadel_contribute", "Title", "12345", None)
+
+
+def test_search_does_not_hand_an_agent_every_hit_twice() -> None:
+    """`/search` returns each hit in `results` AND again inside `sections`.
+
+    The dashboard needs that grouping and renders a heading per section, so the
+    endpoint is right to send it. An agent is not: it reads `results`, and each
+    hit already carries its own `_citadel.dataset`.
+
+    Measured against production, one top_k=5 call returned 84,376 characters of
+    which 41,986 were the `sections` copy. That was large enough to blow the MCP
+    tool output limit, so the caller received an error and a file path instead
+    of an answer. Halving it is the difference between a usable search and one
+    that fails outright.
+    """
+    from kb.mcp_server import _compact_search_for_agent
+
+    hit = {"id": "a", "text": "x" * 4000, "_citadel": {"dataset": "masumi-network"}}
+    other = {"id": "b", "text": "y" * 4000, "_citadel": {"dataset": "seat:alice"}}
+    payload = {
+        "results": [hit, other],
+        "sections": {"central": [hit], "node": [other], "session_traces": []},
+        "search_id": "s-1",
+    }
+    before = len(json.dumps(payload))
+
+    compacted = _compact_search_for_agent(payload)
+
+    assert "sections" not in compacted, "hit copies still being sent to the agent"
+    # The grouping survives as counts, so a caller can still see the split.
+    assert compacted["section_counts"] == {"central": 1, "node": 1, "session_traces": 0}
+    # Nothing a caller actually reads was dropped.
+    assert compacted["results"] == [hit, other]
+    assert compacted["search_id"] == "s-1"
+    assert len(json.dumps(compacted)) < before / 1.8, "payload was not meaningfully reduced"
+
+
+def test_search_compaction_leaves_unexpected_shapes_alone() -> None:
+    """Never turn a search failure into a crash inside the compactor.
+
+    An error body, or a future server that stops sending `sections`, must pass
+    through untouched rather than raising and costing the caller the result.
+    """
+    from kb.mcp_server import _compact_search_for_agent
+
+    assert _compact_search_for_agent({"results": []}) == {"results": []}
+    assert _compact_search_for_agent({"sections": None}) == {"sections": None}
+    assert _compact_search_for_agent("not a dict") == "not a dict"
+    assert _compact_search_for_agent(None) is None
+
+
+def test_citadel_search_tool_strips_the_duplicate_sections(monkeypatch: Any) -> None:
+    """Through the TOOL, not the helper.
+
+    The two tests above call `_compact_search_for_agent` directly, so they would
+    both stay green if the call were dropped from `citadel_search`. That is
+    exactly how a guard shipped inert earlier: the unit test asserted the
+    parser, nothing asserted the wiring. This one goes through the tool, so
+    removing the call turns it red.
+    """
+    hit = {"id": "a", "text": "x" * 3000, "_citadel": {"dataset": "masumi-network"}}
+    body = {
+        "results": [hit],
+        "sections": {"central": [hit], "node": [], "session_traces": []},
+        "search_id": "s-9",
+    }
+
+    class SearchClient(FakeHttpClient):
+        def post(
+            self,
+            path: str,
+            payload: dict[str, Any],
+            *,
+            tool_name: str | None = None,
+            extra_headers: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            self.posts.append({"path": path, "payload": payload, "tool_name": tool_name})
+            return dict(body)
+
+    server = create_mcp_server(SearchClient())
+
+    result = run_tool(server, "citadel_search", "hermes", None, top_k=5)
+
+    assert "sections" not in result, "the tool handed the agent every hit twice"
+    assert result["section_counts"] == {"central": 1, "node": 0, "session_traces": 0}
+    assert result["results"] == [hit]
+    assert result["search_id"] == "s-9"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -834,8 +834,10 @@ def test_search_does_not_hand_an_agent_every_hit_twice() -> None:
     """
     from kb.mcp_server import _compact_search_for_agent
 
-    hit = {"id": "a", "text": "x" * 4000, "_citadel": {"dataset": "masumi-network"}}
-    other = {"id": "b", "text": "y" * 4000, "_citadel": {"dataset": "seat:alice"}}
+    # Deliberately under the truncation cap: this test is about the duplicate
+    # `sections` copy, not about hit-text length, which has its own test.
+    hit = {"id": "a", "text": "x" * 900, "_citadel": {"dataset": "masumi-network"}}
+    other = {"id": "b", "text": "y" * 900, "_citadel": {"dataset": "seat:alice"}}
     payload = {
         "results": [hit, other],
         "sections": {"central": [hit], "node": [other], "session_traces": []},
@@ -877,7 +879,7 @@ def test_citadel_search_tool_strips_the_duplicate_sections(monkeypatch: Any) -> 
     parser, nothing asserted the wiring. This one goes through the tool, so
     removing the call turns it red.
     """
-    hit = {"id": "a", "text": "x" * 3000, "_citadel": {"dataset": "masumi-network"}}
+    hit = {"id": "a", "text": "x" * 900, "_citadel": {"dataset": "masumi-network"}}
     body = {
         "results": [hit],
         "sections": {"central": [hit], "node": [], "session_traces": []},
@@ -904,3 +906,54 @@ def test_citadel_search_tool_strips_the_duplicate_sections(monkeypatch: Any) -> 
     assert result["section_counts"] == {"central": 1, "node": 0, "session_traces": 0}
     assert result["results"] == [hit]
     assert result["search_id"] == "s-9"
+
+
+def test_search_truncates_oversized_hit_text_and_says_so(monkeypatch: Any) -> None:
+    """Dropping the duplicate `sections` was necessary and not sufficient.
+
+    Production hits carry 6,000 to 7,000 characters each, so the DOCUMENTED
+    default top_k=10 returned 209,109 characters and blew the tool-result budget
+    even with the duplicate removed (~103,000 remained). A cap is needed too.
+
+    Truncation must never be silent. An agent that cannot tell a full document
+    from its first 500 words will summarise the fragment and present it as the
+    whole, which is a worse failure than the bloat it fixes.
+    """
+    monkeypatch.delenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", raising=False)
+    from kb.mcp_server import _compact_search_for_agent
+
+    long_text = "\n".join(f"line {i} of the document body" for i in range(400))
+    payload = {"results": [{"id": "doc-1", "text": long_text}], "sections": {}}
+
+    compacted = _compact_search_for_agent(payload)
+    hit = compacted["results"][0]
+
+    assert len(hit["text"]) <= 2000
+    assert hit["text_truncated"] is True
+    assert hit["text_full_chars"] == len(long_text)
+    # The escape hatch has to be actionable, so the id must survive.
+    assert hit["id"] == "doc-1"
+    assert "citadel_get_document" in hit["text_hint"]
+
+
+def test_search_leaves_short_hits_and_honours_the_override(monkeypatch: Any) -> None:
+    """A short hit must come back untouched and unflagged, and an operator who
+    genuinely wants full text must be able to ask for it without a deploy."""
+    from kb.mcp_server import _compact_search_for_agent
+
+    monkeypatch.delenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", raising=False)
+    short = {"id": "s", "text": "brief answer"}
+    assert _compact_search_for_agent({"results": [short]})["results"][0] == short
+
+    long_text = "x" * 9000
+    monkeypatch.setenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", "0")
+    untouched = _compact_search_for_agent({"results": [{"id": "d", "text": long_text}]})
+    assert untouched["results"][0]["text"] == long_text, "0 must disable truncation"
+
+    monkeypatch.setenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", "500")
+    tight = _compact_search_for_agent({"results": [{"id": "d", "text": long_text}]})
+    assert len(tight["results"][0]["text"]) <= 500
+
+    monkeypatch.setenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", "not-a-number")
+    safe = _compact_search_for_agent({"results": [{"id": "d", "text": long_text}]})
+    assert len(safe["results"][0]["text"]) <= 2000, "a bad env value must not disable the cap"


### PR DESCRIPTION
Closes #182

Found while verifying the Phase 2 cross-cutting checks (is MCP working, is the context any good). Neither defect here is visible in recall.

## Half the MCP payload was a verbatim duplicate

`/search` returns each hit in `results` and again inside `sections`. The dashboard needs that grouping and renders a heading per section, so the endpoint is right to send it. An agent is not: it reads `results`, and the grouping is not information it acts on.

One real `top_k=5` call returned 84,376 characters, of which 41,986 were the `sections` copy. That **exceeded the MCP tool output limit**, so the caller got an error and a file path rather than an answer.

The MCP path now sends `section_counts` instead. Verified against the captured production payload:

```
before : 84,376 chars  (~21,000 tokens)
after  : 42,442 chars  (~10,600 tokens)   50% smaller
section_counts : per-group counts, no hit bodies
results intact : 5 hits, search_id preserved
```

The HTTP endpoint is untouched, so the dashboard keeps its grouping.

## Recall could not see the second problem, so the benchmark now measures it

A `top_k=5` search for Hermes returned five hits that were two distinct documents; four slots were chunks of the same file. Across the golden set the mean distinct-source ratio is **0.61** while recall@5 is **0.95**.

```
distinct_source_ratio_mean             0.6082   <- counts unresolvable hits against diversity
distinct_source_ratio_resolvable_only  0.6522   <- over hits whose source resolved
hits_with_unresolvable_source          15       <- of 304 (4.9%)
queries_with_one_distinct_source       6
```

Both ratios are reported rather than one, because the first divides by ALL hits and so treats "the harness could not resolve this hit's source" identically to "this is another chunk of the same document". Those are different failures. 0.61 is the pessimistic bound, 0.65 is what the resolvable evidence supports, and quoting either alone invites the obvious rebuttal. The conclusion holds at both.

Twenty-two of sixty queries return one or two distinct documents. The correct document is on the page, surrounded by repeats of itself, and the agent pays full context for all of it. Tracking the ratio beside recall means a page that answers once and repeats itself four times can no longer read as a 0.95.

**Not fixed here**, deliberately: capping chunks per source changes ranking, and that deserves its own change with before/after recall so a diversity gain does not quietly cost recall.

## On the tests

There are two helper-level tests and one tool-level test. The tool-level one is the point: both helper tests stay green if the call is dropped from `citadel_search`. That is exactly how a guard shipped inert earlier today, where the unit test asserted the parser and nothing asserted the wiring.

Removing `_compact_search_for_agent(result)` from `citadel_search` turns `test_citadel_search_tool_strips_the_duplicate_sections` red while the other two pass.

`1091 passed, 1 skipped`. `ruff check .` clean.

