### PR TITLE
fix: stop repo-content sync minting duplicate documents, and identify the existing ones

### DIFF
--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -12,7 +12,7 @@ import argparse
 import asyncio
 import base64
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from hashlib import sha256
 import json
 import logging
@@ -137,9 +137,18 @@ def format_repo_content_document(file: RepoContentFile) -> str:
     README was occupying 8 of 8 result slots under 8 document ids, and half the
     average result set was repeats of a single file.
 
-    ``Commit`` and ``Blob`` already pin the exact version this text came from,
-    and they are stable while the file is unchanged, which is the property that
+    ``Commit`` and ``Blob`` pin the exact version this text came from, and they
+    must be stable while the file is unchanged, which is the property that
     makes a document deduplicable. When the file changes they change with it.
+
+    That only holds if ``file.ref`` is the commit that last touched THIS file,
+    never the repo HEAD. HEAD moves when ANY file in the repo changes, so a
+    HEAD-valued ``Commit:`` line (and the same sha inside ``Source:``) re-wrote
+    the body of every unchanged file on every re-render, minted a new content
+    hash, and cognee's content-addressed ingestion dutifully created a new
+    document: one README blob (a4b30a45) ended up as three documents under
+    three commit values. The syncer resolves the per-file commit before
+    rendering; see the pin step in :meth:`RepoContentSyncer.run`.
     """
     return "\n".join(
         [
@@ -177,6 +186,31 @@ class RepoContentGitHubClient(GitHubOrgClient):
         commit_sha = data.get("sha")
         if not isinstance(commit_sha, str) or not commit_sha:
             raise GitHubAPIError(f"Could not resolve commit SHA for {full_name}@{ref}.")
+        return commit_sha
+
+    def fetch_last_commit_sha(self, full_name: str, path: str, *, ref: str) -> str:
+        """The commit that last touched ``path``, as of ``ref``.
+
+        This is what the document header must carry. The repo HEAD is a fact
+        about the whole repository; the last-touching commit is a fact about
+        the file, stable for exactly as long as the file's content is, and it
+        stays a working immutable permalink. Neither the recursive tree nor the
+        contents API carries commit information, so this is its own request —
+        paid only for files that are actually being ingested.
+        """
+        data = self._get_json(
+            f"/repos/{quote(full_name, safe='/')}/commits",
+            {"path": path, "sha": ref, "per_page": 1},
+        )
+        if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+            raise GitHubAPIError(
+                f"Could not resolve the last commit for {full_name}/{path}."
+            )
+        commit_sha = data[0].get("sha")
+        if not isinstance(commit_sha, str) or not commit_sha:
+            raise GitHubAPIError(
+                f"Could not resolve the last commit for {full_name}/{path}."
+            )
         return commit_sha
 
     def fetch_tree(self, full_name: str, *, ref: str) -> tuple[list[str], bool] | None:
@@ -653,10 +687,15 @@ class RepoContentSyncer:
                     # therefore treated as needing re-ingestion, which repairs
                     # the state on the next sync instead of requiring force.
                     #
-                    # Re-ingesting an unchanged file is now cheap and safe:
-                    # ADR-0016 removed the retrieval timestamp, so the rendered
-                    # document is byte-identical and cognee's content-addressed
-                    # ingestion resolves it to the same id rather than a copy.
+                    # Re-ingesting an unchanged file is cheap and safe only
+                    # because the rendered document is byte-identical, so
+                    # cognee's content-addressed ingestion resolves it to the
+                    # same id rather than a copy. That takes BOTH halves:
+                    # ADR-0016 removed the retrieval timestamp, and the pin
+                    # step below keeps the Commit/Source header off the moving
+                    # repo HEAD. With either half missing, every path that
+                    # re-renders (force, lost state, entries predating
+                    # cognee_data_ids) mints a duplicate document instead.
                     unchanged = (
                         not force
                         and previous.get("sha") == file.sha
@@ -710,6 +749,33 @@ class RepoContentSyncer:
                             ",".join(categories) or "unknown",
                         )
                         continue
+
+                    # Pin the header to the commit that last touched THIS
+                    # file. `ref` is the repo HEAD, which moves when ANY file
+                    # in the repo changes; rendering it into the body made an
+                    # unchanged file hash differently on every re-render and
+                    # duplicated the corpus (one blob under three commit
+                    # values). The last-touching commit is a function of the
+                    # file's own history, so the render is byte-stable across
+                    # syncs even when the state file did not survive — and it
+                    # stays an immutable permalink for citation. On failure,
+                    # record the error and retry next sync rather than ever
+                    # writing a document with a volatile ref.
+                    try:
+                        file_ref = self.client.fetch_last_commit_sha(
+                            full_name, path, ref=ref
+                        )
+                    except GitHubAPIError as exc:
+                        repo_result["errors"].append({"path": path, "error": str(exc)[:200]})
+                        continue
+                    file = replace(
+                        file,
+                        ref=file_ref,
+                        html_url=(
+                            f"https://github.com/{full_name}/blob/"
+                            f"{file_ref}/{quote(path, safe='/')}"
+                        ),
+                    )
 
                     document = format_repo_content_document(file)
                     if dry_run:

--- a/kb/service.py
+++ b/kb/service.py
@@ -334,10 +334,11 @@ class Citadel:
         """Find (and, when dry_run is False, delete) legacy garbage nodes (#15).
 
         Targets only the well-identified leak classes — COGNIFY_TEST_MARKER canaries,
-        the literal ``[DataItem]`` / session-scaffold blobs, and explicit
-        session-cache node types. The classifier is anchored so real content is
-        never matched; the default dry run returns every candidate id + preview so a
-        human verifies before any deletion.
+        the literal ``[DataItem]`` / session-scaffold blobs, explicit session-cache
+        node types, and pre-ADR-0016 repo-content fossils (machine-rendered headers
+        still carrying a ``Retrieved:`` timestamp line). The classifier is anchored
+        so real content is never matched; the default dry run returns every
+        candidate id + preview so a human verifies before any deletion.
         """
         nodes, _ = await self.cognee.graph_data()
         candidates: list[dict[str, Any]] = []
@@ -361,7 +362,12 @@ class Citadel:
         # The same garbage was also cognified into the chunk vector store, which the
         # graph scan can't see once the graph node is gone. Sweep it via search so
         # orphaned [DataItem]/marker chunks are caught and purged too (#15).
-        for probe in ("[DataItem]", "COGNIFY_TEST_MARKER", "Session ID Question Answer"):
+        for probe in (
+            "[DataItem]",
+            "COGNIFY_TEST_MARKER",
+            "Session ID Question Answer",
+            "Repository: Source: Commit: Blob: Retrieved:",
+        ):
             try:
                 hits = await self.search(probe, dataset=self.config.default_dataset, top_k=100)
             except Exception:  # noqa: BLE001 - sweep is best-effort
@@ -425,12 +431,59 @@ def _is_dataitem_garbage(text: str) -> bool:
     return has_answer
 
 
+_REPO_CONTENT_TITLE_RE = re.compile(r"^#\s+[^\s/]+/[^\s/]+/\S")
+_REPO_CONTENT_HEADER_FIELDS = ("Repository:", "Source:", "Commit:", "Blob:")
+
+
+def _is_repo_content_fossil(text: str) -> bool:
+    """True for a pre-ADR-0016 repo-content document only (d5d0fe3).
+
+    Until d5d0fe3 (ADR-0016) every repo-content sync stamped
+    ``Retrieved: {checked_at}`` into the rendered header, so an unchanged file
+    minted a NEW document each pass. Those pre-fix copies are never superseded
+    and keep occupying result slots.
+
+    A fossil is identified only by the FULL machine-rendered header: the text
+    must start with the ``# org/repo/path`` title line, the header block up to
+    the ``---`` separator may contain only blank lines, the ``Repository:`` /
+    ``Source:`` / ``Commit:`` / ``Blob:`` field lines in renderer order, and a
+    ``Retrieved:`` line — and that ``Retrieved:`` line must be present INSIDE
+    the header, before the separator. A bare "Retrieved:" in a body (after the
+    ``---``), a post-fix header without the line, or any line the renderer
+    never produced means the node is kept. No separator seen (e.g. a chunk cut
+    mid-header) also keeps the node — fail closed on deletion.
+    """
+    lines = [line.strip() for line in text.strip().splitlines()]
+    if not lines or not _REPO_CONTENT_TITLE_RE.match(lines[0]):
+        return False
+    fields = iter(_REPO_CONTENT_HEADER_FIELDS)
+    pending: str | None = next(fields)
+    retrieved_in_header = False
+    for line in lines[1:]:
+        if line == "---":
+            # End of header: qualify only with all four fields AND Retrieved.
+            return pending is None and retrieved_in_header
+        if not line:
+            continue
+        if pending is not None and line.startswith(pending):
+            pending = next(fields, None)
+        elif line.startswith("Retrieved:"):
+            retrieved_in_header = True
+        else:
+            # A line the renderer never emitted: this is not a rendered
+            # repo-content header, so never a fossil.
+            return False
+    return False
+
+
 def _legacy_garbage_kind(node_id: Any, properties: Any) -> str | None:
     """Classify a graph node as legacy garbage to purge, or None to keep (#15).
 
     Conservative + anchored: only an exact COGNIFY_TEST_MARKER id, the literal
-    [DataItem]/session-scaffold blob, or an explicit session-cache node type. Real
-    content is never classified — there is no substring-of-prose match.
+    [DataItem]/session-scaffold blob, an explicit session-cache node type, or a
+    pre-ADR-0016 repo-content fossil (full rendered header with a Retrieved:
+    line inside it). Real content is never classified — there is no
+    substring-of-prose match.
     """
     props = properties if isinstance(properties, dict) else {}
     for value in (props.get("text"), props.get("name"), props.get("title"), props.get("id"), node_id):
@@ -439,6 +492,8 @@ def _legacy_garbage_kind(node_id: Any, properties: Any) -> str | None:
     text = props.get("text")
     if isinstance(text, str) and _is_dataitem_garbage(text):
         return "dataitem"
+    if isinstance(text, str) and _is_repo_content_fossil(text):
+        return "repo_content_fossil"
     for key in ("type", "node_type", "category", "source"):
         value = props.get(key)
         if isinstance(value, str) and value.strip().lower() in _SESSION_CACHE_TYPES:

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -116,6 +116,14 @@ class FakeRepoContentClient(RepoContentGitHubClient):
         self.tree_fails = False
         self.tree_calls = 0
         self.probe_calls = 0
+        # The repo HEAD. Mutable so a test can push an unrelated commit —
+        # HEAD moves, the tracked files do not.
+        self.head = "commit123"
+        # Overrides for the commit that last touched a path. By default it is
+        # derived from the blob sha, mirroring the real coupling: it moves
+        # exactly when the file's content does, and not when HEAD does.
+        self.last_commits: dict[str, str] = {}
+        self.last_commit_calls = 0
 
     def fetch_tree(self, full_name: str, *, ref: str) -> tuple[list[str], bool] | None:
         self.tree_calls += 1
@@ -129,7 +137,15 @@ class FakeRepoContentClient(RepoContentGitHubClient):
         return "main"
 
     def fetch_commit_sha(self, full_name: str, *, ref: str) -> str:
-        return "commit123"
+        return self.head
+
+    def fetch_last_commit_sha(self, full_name: str, path: str, *, ref: str) -> str:
+        self.last_commit_calls += 1
+        key = f"{full_name}/{path}"
+        payload = self.files.get(key)
+        if payload is None:
+            raise GitHubAPIError(f"Could not resolve the last commit for {key}.")
+        return self.last_commits.get(key, f"touched-{payload['sha']}")
 
     def file_exists(self, full_name: str, path: str, *, ref: str) -> bool:
         self.probe_calls += 1
@@ -251,6 +267,192 @@ async def test_repo_content_syncer_ingests_changed_files(tmp_path: Path) -> None
 
     state = json.loads(Path(config.repo_content_sync_state_path).read_text(encoding="utf-8"))
     assert state["files"]["masumi-network/sokosumi-cli/README.md"]["sha"] == "abc"
+
+
+# --- header pinning: the body must not depend on the repo HEAD ---------------
+#
+# 2026-07-31: one README blob (a4b30a45) existed as THREE documents under three
+# commit values. `Commit:` and the sha inside `Source:` carried the repo HEAD,
+# which moves when ANY file in the repo changes, so every re-render of an
+# unchanged file minted a new content hash and cognee's content-addressed
+# ingestion created a copy. The header is now pinned to the commit that last
+# touched the file itself, so the render is a function of the file's own
+# history — byte-stable across syncs even when the state file did not survive
+# a deploy.
+
+
+def _pinning_config(tmp_path: Path) -> CitadelConfig:
+    return CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(tmp_path / "state.json"),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unchanged_file_renders_byte_identically_when_only_head_moves(
+    tmp_path: Path,
+) -> None:
+    """Two syncs of an unchanged file must produce the SAME BYTES, even when
+    the repo HEAD moved in between and the state file did not survive.
+
+    Lost state is the realistic worst case (deploys are ephemeral): the
+    `unchanged` guard has nothing to compare, so the file IS re-rendered and
+    re-ingested — and dedup then rests entirely on the render being
+    byte-identical. A HEAD-valued header made exactly this path mint a
+    duplicate document per unrelated push.
+    """
+    config = _pinning_config(tmp_path)
+    client = FakeRepoContentClient()
+    first_learning = FakeLearningProcess()
+    first_syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=client,
+        state_path=config.repo_content_sync_state_path,
+        learning=first_learning,  # type: ignore[arg-type]
+    )
+    first = await first_syncer.run()
+    assert first["files_ingested"] == 2
+
+    # An unrelated push moves HEAD; the tracked files themselves are untouched.
+    client.head = "commit456"
+    # The deploy was ephemeral: the checkpoint is gone.
+    Path(config.repo_content_sync_state_path).unlink()
+
+    second_learning = FakeLearningProcess()
+    second_syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=client,
+        state_path=config.repo_content_sync_state_path,
+        learning=second_learning,  # type: ignore[arg-type]
+    )
+    second = await second_syncer.run()
+
+    # With no state, both files really were re-rendered and re-ingested...
+    assert second["files_ingested"] == 2
+    first_docs = [call["data"] for call in first_learning.calls]
+    second_docs = [call["data"] for call in second_learning.calls]
+    # ...and every rendered document is byte-identical to the first sync's,
+    # so cognee resolves each to the SAME document instead of a copy.
+    assert second_docs == first_docs
+    for document in second_docs:
+        assert "commit123" not in document, "the repo HEAD leaked into the body"
+        assert "commit456" not in document, "the repo HEAD leaked into the body"
+
+
+@pytest.mark.asyncio
+async def test_a_file_whose_own_content_changed_renders_differently(
+    tmp_path: Path,
+) -> None:
+    """Pinning must not over-deduplicate: a real edit is a new document."""
+    config = _pinning_config(tmp_path)
+    client = FakeRepoContentClient()
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=client,
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+    await syncer.run()
+    old_readme_doc = learning.calls[0]["data"]
+
+    # The README itself is edited: new blob, new last-touching commit.
+    client.files["masumi-network/sokosumi-cli/README.md"] = {
+        "sha": "abc2",
+        "content": "# Sokosumi CLI\n\nHeadless mode docs, second edition.",
+    }
+    client.head = "commit789"
+    learning.calls.clear()
+    second = await syncer.run()
+
+    assert second["files_ingested"] == 1
+    assert second["files_skipped_by_reason"] == {"unchanged": 1}
+    new_readme_doc = learning.calls[0]["data"]
+    assert new_readme_doc != old_readme_doc
+    assert "second edition" in new_readme_doc
+    assert "Blob: abc2" in new_readme_doc
+
+
+@pytest.mark.asyncio
+async def test_the_pin_lookup_is_paid_only_for_ingested_files(tmp_path: Path) -> None:
+    """Unchanged files skip before the per-file commits call, so a steady-state
+    sync adds zero GitHub requests over the pre-pinning behaviour."""
+    config = _pinning_config(tmp_path)
+    client = FakeRepoContentClient()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=client,
+        state_path=config.repo_content_sync_state_path,
+        learning=FakeLearningProcess(),  # type: ignore[arg-type]
+    )
+    await syncer.run()
+    assert client.last_commit_calls == 2
+
+    second = await syncer.run()
+    assert second["files_skipped_by_reason"] == {"unchanged": 2}
+    assert client.last_commit_calls == 2, "an unchanged file must not pay the lookup"
+
+
+def test_fetch_last_commit_sha_asks_for_the_path_scoped_history() -> None:
+    """Pin the request shape and the parsing of GitHub's commits payload."""
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    class RecordingClient(RepoContentGitHubClient):
+        def _get_json(self, path: str, params: dict[str, Any]) -> Any:
+            requests.append((path, params))
+            return [{"sha": "feedface" * 5}]
+
+    client = RecordingClient(token=None)
+    sha = client.fetch_last_commit_sha("o/r", "docs/guide.md", ref="headsha")
+
+    assert sha == "feedface" * 5
+    assert requests == [
+        ("/repos/o/r/commits", {"path": "docs/guide.md", "sha": "headsha", "per_page": 1})
+    ]
+
+
+def test_fetch_last_commit_sha_refuses_an_empty_history() -> None:
+    """No commit means no immutable permalink; fail the file, never invent one."""
+
+    class EmptyHistoryClient(RepoContentGitHubClient):
+        def _get_json(self, path: str, params: dict[str, Any]) -> Any:
+            return []
+
+    with pytest.raises(GitHubAPIError):
+        EmptyHistoryClient(token=None).fetch_last_commit_sha("o/r", "README.md", ref="headsha")
+
+
+@pytest.mark.asyncio
+async def test_a_failed_pin_lookup_skips_the_file_instead_of_shipping_head(
+    tmp_path: Path,
+) -> None:
+    """A volatile ref must never reach the vault; the file retries next sync."""
+    config = _pinning_config(tmp_path)
+
+    class PinLookupDown(FakeRepoContentClient):
+        def fetch_last_commit_sha(self, full_name: str, path: str, *, ref: str) -> str:
+            raise GitHubAPIError("GitHub API returned 500")
+
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=PinLookupDown(),
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+    result = await syncer.run()
+
+    assert result["files_ingested"] == 0
+    assert learning.calls == []
+    assert len(result["repositories"][0]["errors"]) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -410,6 +410,122 @@ def test_legacy_garbage_kind_classifies_safely() -> None:
     assert _legacy_garbage_kind("r5", {"type": "TextSummary"}) is None
 
 
+_FOSSIL_DOC = "\n".join(
+    [
+        "# masumi-network/sokosumi/README.md",
+        "",
+        "Repository: masumi-network/sokosumi",
+        "Source: https://github.com/masumi-network/sokosumi/blob/main/README.md",
+        "Commit: 4f2a9c1db8e77a01c3d5f6a2b9e01234567890ab",
+        "Blob: 8c31b0e4f2a9c1db8e77a01c3d5f6a2b9e012345",
+        "Retrieved: 2026-07-28T14:03:11Z",
+        "",
+        "---",
+        "",
+        "# Sokosumi",
+        "",
+        "Sokosumi is a marketplace for AI agents on Masumi Network.",
+        "",
+        "---",
+        "",
+        "## Getting started",
+        "",
+        "Run `npm install` and configure your payment node.",
+    ]
+)
+
+_POST_FIX_DOC = "\n".join(
+    [
+        "# masumi-network/sokosumi/README.md",
+        "",
+        "Repository: masumi-network/sokosumi",
+        "Source: https://github.com/masumi-network/sokosumi/blob/main/README.md",
+        "Commit: 4f2a9c1db8e77a01c3d5f6a2b9e01234567890ab",
+        "Blob: 8c31b0e4f2a9c1db8e77a01c3d5f6a2b9e012345",
+        "",
+        "---",
+        "",
+        "# Sokosumi",
+        "",
+        "Sokosumi is a marketplace for AI agents on Masumi Network.",
+    ]
+)
+
+# Post-fix document whose BODY (after the --- separator) legitimately contains
+# the literal text "Retrieved: ..." — real documentation about retrieval.
+_BODY_RETRIEVED_DOC = "\n".join(
+    [
+        "# masumi-network/citadel/docs/adr/0016-drop-retrieval-timestamp.md",
+        "",
+        "Repository: masumi-network/citadel",
+        "Source: https://github.com/masumi-network/citadel/blob/main/docs/adr/0016.md",
+        "Commit: d5d0fe3b1656807547e77b5ee82eaf4c5a337c1f",
+        "Blob: c03a30b4f2a9c1db8e77a01c3d5f6a2b9e012345",
+        "",
+        "---",
+        "",
+        "Documents used to carry a header line of the form:",
+        "",
+        "Retrieved: 2026-07-28T14:03:11Z",
+        "",
+        "which minted a new copy on every sync pass.",
+    ]
+)
+
+
+def test_repo_content_fossil_is_matched() -> None:
+    # ADR-0016 / d5d0fe3: a pre-fix repo-content document — full rendered header
+    # with Retrieved: inside it — is classified under its OWN kind so a human
+    # can approve the class independently of marker/dataitem/session_cache.
+    from kb.service import _legacy_garbage_kind
+
+    assert _legacy_garbage_kind("f1", {"text": _FOSSIL_DOC}) == "repo_content_fossil"
+
+
+def test_repo_content_fossil_never_matches_real_content() -> None:
+    # SAFETY — this is deletion tooling; each of these is real knowledge that
+    # must survive the classifier.
+    from kb.service import _legacy_garbage_kind
+
+    # (a) Post-fix repo-content document: same header, no Retrieved: line.
+    assert _legacy_garbage_kind("k1", {"text": _POST_FIX_DOC}) is None
+    # (b) "Retrieved: ..." appearing in the BODY, after the --- separator.
+    assert _legacy_garbage_kind("k2", {"text": _BODY_RETRIEVED_DOC}) is None
+    # (c) A Retrieved: line with no repo-content header around it.
+    assert (
+        _legacy_garbage_kind(
+            "k3",
+            {"text": "Meeting notes\n\nRetrieved: 2026-07-28 from the archive\n\n---\n\nBody."},
+        )
+        is None
+    )
+    # (d) An ordinary Linear issue document.
+    assert (
+        _legacy_garbage_kind(
+            "k4",
+            {
+                "text": (
+                    "# MAS-142: Payment webhook retries\n\n"
+                    "Status: In Progress\nAssignee: sarthi\n\n---\n\n"
+                    "Webhook delivery fails on cold starts; add retry with backoff."
+                )
+            },
+        )
+        is None
+    )
+    # (e) A personal seat note.
+    assert (
+        _legacy_garbage_kind(
+            "k5",
+            {"text": "Note to self: the Kuzu writer lock serializes cognify; never fork it."},
+        )
+        is None
+    )
+    # A chunk cut mid-header (no --- separator reached) is kept — fail closed.
+    truncated = _FOSSIL_DOC.split("---")[0]
+    assert _legacy_garbage_kind("k6", {"text": truncated}) is None
+
+
 class _GraphGateway(FakeCognee):
     def __init__(self, graph_nodes: list[Any]) -> None:
         super().__init__()
@@ -444,6 +560,30 @@ async def test_cleanup_legacy_nodes_dry_run_then_delete() -> None:
     res = await kb.cleanup_legacy_nodes(dry_run=False)
     assert res["deleted"] == 2
     assert set(gw.deleted) == {"g1", "g2"}  # real1 is never deleted
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reports_fossils_under_their_own_kind() -> None:
+    # A repo-content fossil must surface under its OWN counts_by_kind key so a
+    # human reviewing the dry run can approve the class separately from the
+    # legacy marker/dataitem/session_cache classes.
+    nodes = [
+        ("g1", {"text": "COGNIFY_TEST_MARKER_" + "c" * 32}),
+        ("fossil1", {"text": _FOSSIL_DOC}),
+        ("keep1", {"text": _POST_FIX_DOC}),
+    ]
+    gw = _GraphGateway(nodes)
+    kb = Citadel(CitadelConfig(), cognee=gw)
+
+    dry = await kb.cleanup_legacy_nodes(dry_run=True)
+    assert dry["counts_by_kind"] == {"marker": 1, "repo_content_fossil": 1}
+    assert {c["id"] for c in dry["candidates"]} == {"g1", "fossil1"}
+    kinds = {c["id"]: c["kind"] for c in dry["candidates"]}
+    assert kinds["fossil1"] == "repo_content_fossil"
+
+    res = await kb.cleanup_legacy_nodes(dry_run=False)
+    assert res["deleted"] == 2
+    assert "keep1" not in gw.deleted  # the post-fix document survives
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Repo-content documents are duplicated in the vault. A single file can exist as many separate documents, and a search page can be filled by copies of one file. This fixes the mechanism that is still creating them, and makes the copies that already exist identifiable so they can be cleaned up.

## Measurements

Sampled live, 7 distinct queries / 63 result slots:

| measure | value |
|---|---|
| duplicate rate, by `(path, blob)` identity | 0.41 |
| queries with any duplicate slot | 7 of 7 |
| repo-content hits that are pre-`d5d0fe3` copies | 22 of 46 (48%) |

Worst single page: 10 slots, all `masumi-network/sokosumi/README.md`, 10 distinct document ids, every one `chunk_index 0`, backed by only **2 distinct blobs** across 4 commit values.

## Two generations of one defect

**Still active — the header carried the repo HEAD.** `Commit:` and the `Source:` URL were rendered from `fetch_commit_sha(repo, ref=branch)`, i.e. the repo HEAD rather than the commit that last touched the file. A push to any file changed the rendered body of every file in the repo, and since documents are content-addressed, each sync then minted a new document for files that had not changed.

The unchanged guard should have prevented this. It compares blob sha and content hash, both HEAD-independent, so the comparison was sound — but its third condition required a non-empty `cognee_data_ids`, and that list was empty for every file until 429cd90. The guard was never satisfiable and never fired.

Fixed by pinning `Commit:` and the `Source:` URL to the commit that last touched that file. Beyond keeping the permalink immutable, the deciding property is that this value is a pure function of the file's own history, so the render is byte-stable with **no local state** — which the `force`, repair, dry-run and state-loss paths all rely on. The lookup sits after the unchanged guard and the security scan, so it is paid only for files actually ingested: none in steady state, ~69 on a cold resync, against a 5000/hr limit. A failed lookup records a repo error and skips the file rather than writing a document with a volatile ref.

**Historical — the `Retrieved:` timestamp.** Documents rendered before `d5d0fe3` carry a `Retrieved:` line in the header block. That timestamp moved every pass, so each pass minted a copy; the observed timestamps sit 1h–1h45m apart, matching the evolve cadence. `d5d0fe3` stopped new copies but reclaimed nothing, because nothing in the system deletes or supersedes a document.

This adds a `repo_content_fossil` kind to the existing admin cleanup, counted under its own key so it can be reviewed and approved independently of the legacy classes. The classifier anchors on the exact renderer output, requires all four header fields in order, and stops scanning at the `---` separator, so a `Retrieved:` line in a document *body* cannot match. Any unrecognised header line fails closed and keeps the node. The chunk vector store is also swept, so copies whose graph node is already gone remain reachable.

Cleanup stays admin-only and dry-run by default. **Nothing is deleted by merging this.**

## Verification

Full suite: **1097 passed, 1 skipped** (1088 baseline + 9 new tests).

Both directions checked, per the repo's own rule:
- Reintroducing the HEAD ref turned `test_unchanged_file_renders_byte_identically_when_only_head_moves` red, with the diff showing only `Commit:` and `Source:` differing.
- Loosening the fossil classifier to a substring check turned the negative test red on the body-mention case, which is exactly what the anchor exists to prevent.

New tests cover: byte-identical re-render under a moved HEAD and lost state; changed content still rendering differently; zero steady-state lookup cost; request shape and parsing of the new client call; empty-history refusal; pin-failure fail-closed; fossil matched; and six shapes that must never match, including a post-fix document, a body containing the literal text, a Linear issue, a seat note, and a chunk cut mid-header.

## Known limits, deliberately not addressed here

- **Cleanup is partial.** Only a fossil's first chunk carries the header, so only that chunk is classifiable. Later chunks of multi-chunk fossils, and fossil-derived summary/entity artifacts, survive. The measured worst offenders were all `chunk_index 0`, so this fixes the measured problem, but it is not full reclamation.
- **Deletion is irreversible** — no tombstone or restore path. Mitigated in this class because every fossil header pins the exact GitHub blob, so the content stays fetchable by sha.
- **The vector delete is best-effort** and swallows failures with a warning; the search sweep is the net that catches orphans on a later run.
- Byte-stability depends on `CITADEL_LLM_ENRICHMENT_ENABLED` staying off for this connector, since enrichment prepends a nondeterministic `Summary:` upstream of ingest. Worth a config assertion later.
- Worth confirming separately whether prod mounts `/data`. If not, the sync checkpoint is lost each deploy and every file is re-ingested. With this change that is wasted work rather than duplicate documents.

Fixes #188
