### PR TITLE
fix(mcp): offload resource-handler self-calls off the event loop

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -1315,30 +1315,56 @@ def create_mcp_server(
 
         return await _call_async("citadel_promotion_reject", reject)
 
+    # Resource reads execute on the event loop that also serves the node's HTTP
+    # API, so a handler that performs a sync self-call parks the loop on the very
+    # request it is waiting for — the same hazard documented for tools/list below
+    # (#100). Every handler must therefore be async and offload its HTTP call via
+    # _call_async, exactly like the tools above.
+
     @mcp.resource("citadel://session")
-    def session_resource() -> str:
+    async def session_resource() -> str:
         """Current Citadel role, actor, and capabilities."""
-        return json.dumps(resolve_client(mcp.get_context()).get("/api/session"), indent=2, default=str)
+        ctx = mcp.get_context()
+        payload = await _call_async(
+            "citadel://session",
+            lambda: resolve_client(ctx).get("/api/session"),
+        )
+        return json.dumps(payload, indent=2, default=str)
 
     @mcp.resource("citadel://discovery")
-    def discovery_resource() -> str:
+    async def discovery_resource() -> str:
         """Safe public Citadel agent discovery metadata."""
-        return json.dumps(public_manifest(), indent=2, default=str)
+        payload = await _call_async("citadel://discovery", public_manifest)
+        return json.dumps(payload, indent=2, default=str)
 
     @mcp.resource("citadel://sources")
-    def sources_resource() -> str:
+    async def sources_resource() -> str:
         """Configured source-learning status."""
-        return json.dumps(resolve_client(mcp.get_context()).get("/api/learning-agent"), indent=2, default=str)
+        ctx = mcp.get_context()
+        payload = await _call_async(
+            "citadel://sources",
+            lambda: resolve_client(ctx).get("/api/learning-agent"),
+        )
+        return json.dumps(payload, indent=2, default=str)
 
     @mcp.resource("citadel://indexes")
-    def indexes_resource() -> str:
+    async def indexes_resource() -> str:
         """Current Citadel index status."""
-        return json.dumps(resolve_client(mcp.get_context()).get("/api/indexes"), indent=2, default=str)
+        ctx = mcp.get_context()
+        payload = await _call_async(
+            "citadel://indexes",
+            lambda: resolve_client(ctx).get("/api/indexes"),
+        )
+        return json.dumps(payload, indent=2, default=str)
 
     @mcp.resource("citadel://events/recent")
-    def recent_events_resource() -> str:
+    async def recent_events_resource() -> str:
         """Recent mesh events."""
-        mesh = resolve_client(mcp.get_context()).get("/api/mesh")
+        ctx = mcp.get_context()
+        mesh = await _call_async(
+            "citadel://events/recent",
+            lambda: resolve_client(ctx).get("/api/mesh"),
+        )
         return json.dumps({"events": mesh.get("events", [])}, indent=2, default=str)
 
     @mcp.prompt()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ import asyncio
 from io import BytesIO
 import inspect
 import json
+import threading
 from typing import Any
 from urllib.error import HTTPError
 
@@ -251,7 +252,7 @@ def test_discovery_resource_reads_public_manifest_only() -> None:
     resource = asyncio.run(server._resource_manager.get_resource("citadel://discovery"))
 
     assert resource is not None
-    assert json.loads(resource.fn()) == {
+    assert json.loads(asyncio.run(resource.fn())) == {
         "ok": True,
         "path": "/.well-known/citadel.json",
         "public": True,
@@ -293,11 +294,78 @@ def test_authed_resource_uses_caller_token_on_hosted_transport(
     monkeypatch.setattr(mcp_server, "CitadelHttpClient", StubClient)
 
     resource = asyncio.run(server._resource_manager.get_resource("citadel://indexes"))
-    payload = json.loads(resource.fn())
+    payload = json.loads(asyncio.run(resource.fn()))
 
     assert captured["token"] == "ctdl_resourcetoken"
     assert captured["path"] == "/api/indexes"
     assert payload == {"ok": True, "path": "/api/indexes"}
+
+
+MCP_RESOURCE_URIS = [
+    "citadel://session",
+    "citadel://discovery",
+    "citadel://sources",
+    "citadel://indexes",
+    "citadel://events/recent",
+]
+
+
+@pytest.mark.parametrize("uri", MCP_RESOURCE_URIS)
+def test_resource_handlers_are_coroutine_functions(uri: str) -> None:
+    """Resource reads run on the server's event loop. A sync handler makes its
+    HTTP self-call on the loop that has to serve that very call — the hazard
+    documented for tools/list (#100) — so every handler must be async and
+    offload via _call_async exactly like the tools.
+    """
+    server = create_mcp_server(FakeHttpClient())
+
+    resource = asyncio.run(server._resource_manager.get_resource(uri))
+
+    assert resource is not None
+    assert inspect.iscoroutinefunction(resource.fn), (
+        f"{uri} handler is sync; it must be async and offload its HTTP call "
+        "so the event loop stays free (#100)"
+    )
+
+
+def test_resource_read_leaves_the_event_loop_free() -> None:
+    """Drive a resource read whose HTTP client refuses to return until a
+    loop-side task has run. Only a handler that offloads the call off the loop
+    can pass: a handler that blocks the loop starves the concurrent task, the
+    client times out unsignalled, and the assertion goes red. A payload-only
+    test would pass either way; this one cannot.
+    """
+    loop_progressed = threading.Event()
+
+    class BlockingHttpClient(FakeHttpClient):
+        def get(self, path: str, **kwargs: Any) -> dict[str, Any]:
+            # Runs in a worker thread when the handler offloads correctly, and
+            # on the event loop when it does not. Waits for proof that the loop
+            # kept moving while this call was in flight.
+            return {"loop_made_progress": loop_progressed.wait(timeout=5.0)}
+
+    server = create_mcp_server(BlockingHttpClient())
+
+    async def scenario() -> dict[str, Any]:
+        resource = await server._resource_manager.get_resource("citadel://indexes")
+        assert resource is not None
+
+        async def make_progress() -> None:
+            # Must get loop time WHILE the resource read is blocked in the
+            # HTTP client, or the client above returns False.
+            await asyncio.sleep(0.05)
+            loop_progressed.set()
+
+        raw, _ = await asyncio.gather(resource.read(), make_progress())
+        return json.loads(raw)
+
+    payload = asyncio.run(scenario())
+
+    assert payload["loop_made_progress"] is True, (
+        "the event loop made no progress while the resource read was in "
+        "flight — the handler ran its HTTP call on the loop instead of "
+        "offloading it (#100)"
+    )
 
 
 def test_search_clamps_top_k_and_tracks_tool_name() -> None:


### PR DESCRIPTION
The five MCP resource handlers ran their client call directly on the event loop. This moves them onto the same async idiom every tool in the file already uses.

Refs #100

## What was wrong

`session_resource`, `discovery_resource`, `sources_resource`, `indexes_resource` and `recent_events_resource` were plain `sync def` and called `resolve_client(...).get(...)` inline. That performs a blocking `urlopen` against `_self_base_url()`, i.e. the node's own address. A resource read is served by the same event loop that would have to produce that response, so the call waited on something it was itself preventing.

The tools never had this problem: they are `async def` and `await _call_async(...)`, which offloads to `asyncio.to_thread`. The comment above `tools/list` documents this exact hazard from #100 — the tools were converted at the time, the resource handlers were not.

`retryable = method == "GET"` also applies here, so the shared retry policy repeated the call rather than surfacing it.

## Change

All five handlers become `async def`: resolve the context on the loop, then `await _call_async(...)` around the client call. `discovery_resource` offloads its manifest build the same way. The pattern is copied from the existing tools rather than invented.

A sweep of the rest of the file found no other handler making a blocking self-call: all 23 tools already await `_call_async`, `_role_filtered_list_tools` already threads its HTTP fallback and its in-process path is a local store lookup, the three prompt handlers are pure string formatting, and `main()`'s blocking calls run in a stdio client process rather than the serving loop.

## Verification

Full suite **1108 passed, 1 skipped**; `ruff check` clean on both files.

Two tests added. The first asserts all five handlers are coroutine functions, parametrized over the URIs. The second is the one that matters: it drives `citadel://indexes` through `resource.read()` with a client stub that blocks on a `threading.Event`, and passes **only if a concurrent loop task made progress** while the read was in flight. A payload-only test would pass against either implementation; this one cannot.

Checked in both directions, per the repo's usual rule. Reverting `indexes_resource` to its original sync form failed both tests for the right reasons — the coroutine assertion failed for that URI alone while the other four stayed green, and the loop-progress test reported no progress after starving the concurrent task for its full timeout, with the run duration confirming the loop was genuinely parked. Handler restored, suite green.

Two pre-existing resource tests were updated to `await` the now-coroutine functions; nothing they asserted was removed.

## Judgement call, not changed here

Retrying a self-call is never useful. The `retryable` policy was written so external clients could ride out a remote node hiccup; on the loopback path there is no network to hiccup, so a failure means this process is already unhealthy and a retry adds load exactly then. With the handlers offloaded the retry no longer affects the loop, only worker-thread occupancy, so the shared retry code is left alone rather than changed underneath the external clients that legitimately depend on it. Constructing the internal client with retries disabled is a reasonable follow-up.
