### PR TITLE
fix: org digest LLM model id, and discovery manifest host

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -457,6 +457,23 @@ def _bearer_from_context(ctx: Context | None) -> str | None:
 
 
 def _public_url_headers_from_context(ctx: Context | None) -> dict[str, str]:
+    """Validated X-Forwarded-Host/Proto lifted from the caller's live request.
+
+    The node renders ``/.well-known/citadel.json`` URLs from the request's
+    host, so a loopback self-call must carry the ORIGINAL caller's host or the
+    manifest advertises the self-address instead of a reachable base_url. Two
+    gates decide what gets forwarded:
+
+    - Shape (always): host must be a bare ``host[:port]`` (PUBLIC_HOST_RE) and
+      proto must be http/https. This blocks header injection, not spoofing.
+    - Pin (opt-in): when ``CITADEL_MCP_PUBLIC_HOSTS`` names the hosts this node
+      is served as (comma-separated, case-insensitive, exact match including
+      any port), a host outside the list is dropped and the manifest falls
+      back to the node's default rendering. Set it when the node is directly
+      exposed or behind a proxy that appends rather than replaces forwarded
+      headers; edges that overwrite ``X-Forwarded-Host`` (Railway's does) make
+      the pin redundant.
+    """
     if ctx is None:
         return {}
     try:
@@ -477,6 +494,13 @@ def _public_url_headers_from_context(ctx: Context | None) -> dict[str, str]:
     host = host.split(",", 1)[0].strip()
     proto = proto.split(",", 1)[0].strip().lower()
     if host and PUBLIC_HOST_RE.fullmatch(host) and proto in {"http", "https"}:
+        pinned = {
+            entry.strip().lower()
+            for entry in os.getenv("CITADEL_MCP_PUBLIC_HOSTS", "").split(",")
+            if entry.strip()
+        }
+        if pinned and host.lower() not in pinned:
+            return {}
         return {"X-Forwarded-Host": host, "X-Forwarded-Proto": proto}
     return {}
 
@@ -664,8 +688,15 @@ class CitadelHttpClient:
     ) -> dict[str, Any]:
         return self._request("GET", path, tool_name=tool_name, extra_headers=extra_headers)
 
-    def get_public(self, path: str) -> dict[str, Any]:
-        return self._request("GET", path, require_token=False)
+    def get_public(
+        self,
+        path: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "GET", path, require_token=False, extra_headers=extra_headers
+        )
 
     def post(
         self,
@@ -804,10 +835,14 @@ def create_mcp_server(
         base_url = getattr(fallback, "base_url", None) if fallback is not None else None
         return CitadelHttpClient(base_url=base_url or _self_base_url(), access_token="")
 
-    def public_manifest() -> dict[str, Any]:
+    def public_manifest(extra_headers: dict[str, str] | None = None) -> dict[str, Any]:
         if fallback is not None and hasattr(fallback, "get_public"):
-            return fallback.get_public("/.well-known/citadel.json")
-        return resolve_public_client().get_public("/.well-known/citadel.json")
+            return fallback.get_public(
+                "/.well-known/citadel.json", extra_headers=extra_headers
+            )
+        return resolve_public_client().get_public(
+            "/.well-known/citadel.json", extra_headers=extra_headers
+        )
 
     @mcp.tool(annotations=TOOL_POLICIES["citadel_discovery"].annotations)
     async def citadel_discovery(ctx: Context) -> dict[str, Any]:
@@ -1334,7 +1369,18 @@ def create_mcp_server(
     @mcp.resource("citadel://discovery")
     async def discovery_resource() -> str:
         """Safe public Citadel agent discovery metadata."""
-        payload = await _call_async("citadel://discovery", public_manifest)
+        # The node renders the manifest's base_url from the request's host, and
+        # this handler reaches it through a loopback self-call. Without the
+        # caller's forwarded host the manifest advertised the self-address
+        # (http://127.0.0.1:$PORT), which a discovering agent cannot reach.
+        # Forward the caller's validated proto/host exactly like the
+        # citadel_discovery tool does. No credential is attached: the manifest
+        # must stay readable without a token.
+        ctx = mcp.get_context()
+        forwarded = _public_url_headers_from_context(ctx)
+        payload = await _call_async(
+            "citadel://discovery", lambda: public_manifest(extra_headers=forwarded)
+        )
         return json.dumps(payload, indent=2, default=str)
 
     @mcp.resource("citadel://sources")

--- a/kb/organization_digest.py
+++ b/kb/organization_digest.py
@@ -4,11 +4,24 @@ import json
 import logging
 import os
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
 
 from kb.config import CitadelConfig
-from kb.llm_enrichment import default_llm_model, openrouter_api_key, openrouter_chat
+from kb.llm_enrichment import default_llm_model, openrouter_api_key, openrouter_endpoint
+from kb.retry import run_with_retries
+from kb.secure_http import open_secure
+from kb.security_scan import redact_secrets
 
 logger = logging.getLogger(__name__)
+
+# litellm's provider-routing form ("openrouter/<vendor>/<model>") that cognee
+# requires in LLM_MODEL. OpenRouter's own API rejects it as a model id.
+LITELLM_OPENROUTER_PREFIX = "openrouter/"
+
+_OPERATION = "organization_digest.llm_agent_read"
+_MODEL_LOG_CHARS = 160
+_ERROR_BODY_LOG_CHARS = 500
 
 
 def _github_result(result: dict[str, Any]) -> dict[str, Any]:
@@ -146,15 +159,136 @@ def deterministic_agent_read(packet: dict[str, Any]) -> list[str]:
     return lines[:3]
 
 
-def llm_agent_read(packet: dict[str, Any]) -> list[str] | None:
-    if not openrouter_api_key():
-        return None
-    model = (
+def resolve_openrouter_model() -> tuple[str, str]:
+    """Resolve the digest model id as ``(configured, sent)``.
+
+    ``configured`` is the raw value of CITADEL_ORG_DIGEST_LLM_MODEL,
+    LLM_MODEL, or the enrichment default, in that order. ``sent`` is the id
+    actually sent to OpenRouter: cognee needs LLM_MODEL in litellm form
+    ("openrouter/<vendor>/<model>"), which OpenRouter's own API rejects, so
+    that prefix is stripped here instead of asking operators to keep two
+    variables in sync. A native id whose vendor happens to be "openrouter"
+    (no second slash, e.g. "openrouter/auto") is left untouched.
+    """
+    configured = (
         os.getenv("CITADEL_ORG_DIGEST_LLM_MODEL")
         or os.getenv("LLM_MODEL")
         or default_llm_model()
+    ).strip()
+    sent = configured
+    if sent.lower().startswith(LITELLM_OPENROUTER_PREFIX):
+        remainder = sent[len(LITELLM_OPENROUTER_PREFIX) :]
+        if "/" in remainder:
+            sent = remainder
+    return configured, sent
+
+
+def _redacted_line(value: Any, *, length: int) -> str:
+    """One log-safe line: whitespace collapsed, secrets redacted, then cut.
+
+    Redaction runs on the full text before truncation so the cut can never
+    split a credential out of the redaction patterns' reach.
+    """
+    collapsed = " ".join(str(value or "").split())
+    return redact_secrets(collapsed)[:length]
+
+
+def _http_error_body(exc: HTTPError) -> str:
+    """Best-effort read of the error response body; never raises."""
+    try:
+        raw = exc.read()
+    except Exception:  # pragma: no cover - a closed/absent fp must not mask the 4xx
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw or "")
+
+
+def _openrouter_chat_diagnosable(
+    messages: list[dict[str, str]],
+    *,
+    model: str,
+    configured_model: str,
+    max_tokens: int,
+    timeout: int,
+) -> str | None:
+    """One OpenRouter chat completion whose failures are diagnosable.
+
+    Unlike :func:`kb.llm_enrichment.openrouter_chat`, an HTTP failure here
+    logs the resolved model id and the redacted response body. Production
+    logged only "HTTP Error 400: Bad Request" once per evolve pass, which
+    cannot distinguish a rejected model id from a context-length rejection.
+    """
+    api_key = openrouter_api_key()
+    if not api_key:
+        return None
+    payload = {
+        "model": model,
+        "temperature": 0.2,
+        "max_tokens": max_tokens,
+        "messages": messages,
+    }
+    request = Request(
+        f"{openrouter_endpoint()}/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "citadel-llm",
+        },
+        method="POST",
     )
-    message = openrouter_chat(
+
+    def fetch() -> dict[str, Any]:
+        with open_secure(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8") or "{}")
+
+    try:
+        body = run_with_retries(fetch, operation=_OPERATION)
+    except HTTPError as exc:
+        logger.warning(
+            "%s LLM call failed with HTTP %s for model %s (configured %s); response body: %s",
+            _OPERATION,
+            exc.code,
+            _redacted_line(model, length=_MODEL_LOG_CHARS),
+            _redacted_line(configured_model, length=_MODEL_LOG_CHARS),
+            _redacted_line(_http_error_body(exc), length=_ERROR_BODY_LOG_CHARS) or "<empty>",
+        )
+        return None
+    except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "%s LLM call failed with %s for model %s: %s",
+            _OPERATION,
+            exc.__class__.__name__,
+            _redacted_line(model, length=_MODEL_LOG_CHARS),
+            _redacted_line(str(exc), length=_ERROR_BODY_LOG_CHARS),
+        )
+        return None
+
+    if not isinstance(body, dict):
+        return None
+    choices = body.get("choices") or []
+    if not choices:
+        return None
+    content = (choices[0].get("message") or {}).get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return content
+
+
+def llm_agent_read(packet: dict[str, Any]) -> list[str] | None:
+    if not openrouter_api_key():
+        return None
+    configured, model = resolve_openrouter_model()
+    if model != configured:
+        logger.info(
+            "%s using OpenRouter model %s (stripped litellm provider prefix from %s)",
+            _OPERATION,
+            _redacted_line(model, length=_MODEL_LOG_CHARS),
+            _redacted_line(configured, length=_MODEL_LOG_CHARS),
+        )
+    message = _openrouter_chat_diagnosable(
         [
             {
                 "role": "system",
@@ -171,7 +305,7 @@ def llm_agent_read(packet: dict[str, Any]) -> list[str] | None:
             },
         ],
         model=model,
-        operation="organization_digest.llm_agent_read",
+        configured_model=configured,
         max_tokens=420,
         timeout=30,
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,7 +28,7 @@ class FakeHttpClient:
     def __init__(self) -> None:
         self.gets: list[dict[str, Any]] = []
         self.posts: list[dict[str, Any]] = []
-        self.public_gets: list[str] = []
+        self.public_gets: list[dict[str, Any]] = []
 
     def get(
         self,
@@ -51,8 +51,15 @@ class FakeHttpClient:
             "extra_headers": extra_headers or {},
         }
 
-    def get_public(self, path: str) -> dict[str, Any]:
-        self.public_gets.append(path)
+    # Mirrors CitadelHttpClient.get_public exactly: keyword-only extra_headers.
+    # The real client owns this shape; keep the fake in lockstep with it.
+    def get_public(
+        self,
+        path: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        self.public_gets.append({"path": path, "extra_headers": extra_headers or {}})
         return {"ok": True, "path": path, "public": True}
 
     def post(
@@ -258,8 +265,104 @@ def test_discovery_resource_reads_public_manifest_only() -> None:
         "path": "/.well-known/citadel.json",
         "public": True,
     }
-    assert client.public_gets == ["/.well-known/citadel.json"]
+    assert client.public_gets == [
+        {"path": "/.well-known/citadel.json", "extra_headers": {}}
+    ]
     assert client.gets == []
+
+
+def test_discovery_resource_forwards_validated_caller_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The manifest's base_url is rendered from the request's host, so the
+    resource must forward the caller's validated proto/host on its loopback
+    self-call, exactly like the citadel_discovery tool. Without this the
+    resource advertised http://127.0.0.1:$PORT, an address the discovering
+    agent cannot reach, while the tool returned the public URL.
+
+    The fetch must also stay tokenless: a bearer on the MCP request must not
+    leak into the public manifest call (client.gets stays empty).
+    """
+    from types import SimpleNamespace
+
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    fake_ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(
+                headers={
+                    "authorization": "Bearer ctdl_resourcetoken",
+                    "x-forwarded-host": "citadel-archive-production.up.railway.app",
+                    "x-forwarded-proto": "https",
+                },
+                url="http://127.0.0.1:8080/mcp",
+            )
+        )
+    )
+    monkeypatch.setattr(server, "get_context", lambda: fake_ctx)
+
+    resource = asyncio.run(server._resource_manager.get_resource("citadel://discovery"))
+    payload = json.loads(asyncio.run(resource.fn()))
+
+    assert payload["ok"] is True
+    assert client.public_gets == [
+        {
+            "path": "/.well-known/citadel.json",
+            "extra_headers": {
+                "X-Forwarded-Host": "citadel-archive-production.up.railway.app",
+                "X-Forwarded-Proto": "https",
+            },
+        }
+    ]
+    assert client.gets == []
+
+
+def test_public_host_pin_drops_unlisted_forwarded_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With CITADEL_MCP_PUBLIC_HOSTS set, a well-formed but unlisted forwarded
+    host must be dropped (manifest falls back to the node's default rendering)
+    while a listed host still passes. Shape validation alone accepts ANY
+    plausible hostname, so the pin is the only app-level origin check."""
+
+    def ctx_for(host: str) -> Any:
+        class FakeRequest:
+            headers = {"x-forwarded-proto": "https", "x-forwarded-host": host}
+            url = "http://127.0.0.1:8000/mcp"
+
+        class FakeRequestContext:
+            request = FakeRequest()
+
+        class FakeContext:
+            request_context = FakeRequestContext()
+
+        return FakeContext()
+
+    monkeypatch.setenv(
+        "CITADEL_MCP_PUBLIC_HOSTS",
+        "citadel-archive-production.up.railway.app, Citadel.Example.COM",
+    )
+
+    assert mcp_server._public_url_headers_from_context(ctx_for("attacker.example")) == {}
+    assert mcp_server._public_url_headers_from_context(
+        ctx_for("citadel-archive-production.up.railway.app")
+    ) == {
+        "X-Forwarded-Host": "citadel-archive-production.up.railway.app",
+        "X-Forwarded-Proto": "https",
+    }
+    # Case-insensitive on both sides of the comparison.
+    assert mcp_server._public_url_headers_from_context(ctx_for("citadel.example.com")) == {
+        "X-Forwarded-Host": "citadel.example.com",
+        "X-Forwarded-Proto": "https",
+    }
+
+    # Unset pin restores the shape-check-only behavior for the same host.
+    monkeypatch.delenv("CITADEL_MCP_PUBLIC_HOSTS")
+    assert mcp_server._public_url_headers_from_context(ctx_for("attacker.example")) == {
+        "X-Forwarded-Host": "attacker.example",
+        "X-Forwarded-Proto": "https",
+    }
 
 
 def test_authed_resource_uses_caller_token_on_hosted_transport(

--- a/tests/test_organization_digest.py
+++ b/tests/test_organization_digest.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
+import io
+import json
+import logging
 import threading
 from typing import Any
+from urllib.error import HTTPError
 
 import pytest
 
 from kb.config import CitadelConfig
 from kb.google_chat import GoogleChatDelivery
 from kb.learning_agent import LearningAgent
-from kb.organization_digest import build_organization_digest, has_meaningful_source_changes
+from kb.llm_enrichment import DEFAULT_LLM_MODEL
+from kb.organization_digest import (
+    build_organization_digest,
+    has_meaningful_source_changes,
+    llm_agent_read,
+    resolve_openrouter_model,
+)
 
 
 class FakeRepoContentSyncer:
@@ -370,3 +380,215 @@ async def test_learning_agent_posts_gateways_concurrently(monkeypatch: Any) -> N
     assert sorted(started) == ["alpha", "bravo"]
     assert result["notifications"]["gateways"]["alpha"]["sent"] is True
     assert result["notifications"]["gateways"]["bravo"]["sent"] is True
+
+
+# --- OpenRouter model resolution + diagnosable failure logging -----------------
+
+
+def _clear_llm_env(monkeypatch: Any) -> None:
+    for name in (
+        "CITADEL_ORG_DIGEST_LLM_MODEL",
+        "LLM_MODEL",
+        "CITADEL_LLM_MODEL",
+        "LLM_ENDPOINT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _digest_packet() -> dict[str, Any]:
+    return {
+        "kind": "organization_update_digest_source_packet",
+        "summary": {"org": "masumi-network"},
+    }
+
+
+class _FakeCompletionResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeCompletionResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_resolve_model_strips_litellm_prefix_from_llm_model(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_MODEL", "openrouter/deepseek/deepseek-v4-flash")
+
+    assert resolve_openrouter_model() == (
+        "openrouter/deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash",
+    )
+
+
+def test_resolve_model_keeps_bare_openrouter_id(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_MODEL", "deepseek/deepseek-v4-flash")
+
+    assert resolve_openrouter_model() == (
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash",
+    )
+
+
+def test_resolve_model_org_digest_override_wins_in_either_form(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_MODEL", "openrouter/vendor/from-llm-model")
+
+    monkeypatch.setenv("CITADEL_ORG_DIGEST_LLM_MODEL", "openrouter/qwen/qwen3-coder")
+    assert resolve_openrouter_model() == ("openrouter/qwen/qwen3-coder", "qwen/qwen3-coder")
+
+    monkeypatch.setenv("CITADEL_ORG_DIGEST_LLM_MODEL", "qwen/qwen3-coder")
+    assert resolve_openrouter_model() == ("qwen/qwen3-coder", "qwen/qwen3-coder")
+
+
+def test_resolve_model_keeps_native_openrouter_vendor_id(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("LLM_MODEL", "openrouter/auto")
+
+    assert resolve_openrouter_model() == ("openrouter/auto", "openrouter/auto")
+
+
+def test_resolve_model_default_and_citadel_llm_model_fallbacks(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    assert resolve_openrouter_model() == (DEFAULT_LLM_MODEL, DEFAULT_LLM_MODEL)
+
+    monkeypatch.setenv("CITADEL_LLM_MODEL", "openrouter/z-ai/glm-5")
+    assert resolve_openrouter_model() == ("openrouter/z-ai/glm-5", "z-ai/glm-5")
+
+
+def test_llm_agent_read_sends_stripped_model_to_openrouter(
+    monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unit-test-openrouter-key")
+    monkeypatch.setenv("LLM_MODEL", "openrouter/deepseek/deepseek-v4-flash")
+    seen: list[dict[str, Any]] = []
+
+    def fake_open_secure(request: Any, *, timeout: float) -> _FakeCompletionResponse:
+        seen.append(
+            {
+                "url": request.full_url,
+                "payload": json.loads(request.data.decode("utf-8")),
+                "timeout": timeout,
+            }
+        )
+        return _FakeCompletionResponse(
+            {"choices": [{"message": {"content": "- one\n- two\n- three"}}]}
+        )
+
+    monkeypatch.setattr("kb.organization_digest.open_secure", fake_open_secure)
+
+    with caplog.at_level(logging.INFO, logger="kb.organization_digest"):
+        lines = llm_agent_read(_digest_packet())
+
+    assert lines == ["one", "two", "three"]
+    assert len(seen) == 1
+    assert seen[0]["payload"]["model"] == "deepseek/deepseek-v4-flash"
+    assert seen[0]["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert "stripped litellm provider prefix" in caplog.text
+
+
+def test_llm_agent_read_sends_bare_model_unchanged(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unit-test-openrouter-key")
+    monkeypatch.setenv("LLM_MODEL", "deepseek/deepseek-v4-flash")
+    seen: list[dict[str, Any]] = []
+
+    def fake_open_secure(request: Any, *, timeout: float) -> _FakeCompletionResponse:
+        seen.append(json.loads(request.data.decode("utf-8")))
+        return _FakeCompletionResponse(
+            {"choices": [{"message": {"content": "- one\n- two\n- three"}}]}
+        )
+
+    monkeypatch.setattr("kb.organization_digest.open_secure", fake_open_secure)
+
+    assert llm_agent_read(_digest_packet()) == ["one", "two", "three"]
+    assert seen[0]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_llm_agent_read_logs_model_and_response_body_on_http_400(
+    monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unit-test-openrouter-key")
+    monkeypatch.setenv("LLM_MODEL", "openrouter/deepseek/deepseek-v4-flash")
+    calls: list[str] = []
+
+    def fake_open_secure(request: Any, *, timeout: float) -> Any:
+        calls.append(request.full_url)
+        raise HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            None,
+            io.BytesIO(
+                b'{"error":{"message":'
+                b'"deepseek/deepseek-v4-flash is not a valid model ID","code":400}}'
+            ),
+        )
+
+    monkeypatch.setattr("kb.organization_digest.open_secure", fake_open_secure)
+
+    with caplog.at_level(logging.WARNING, logger="kb.organization_digest"):
+        assert llm_agent_read(_digest_packet()) is None
+
+    # One attempt only: a 400 is not transient, so no retries.
+    assert calls == ["https://openrouter.ai/api/v1/chat/completions"]
+    assert "HTTP 400" in caplog.text
+    # Resolved and configured ids are both recorded, distinguishably.
+    assert (
+        "for model deepseek/deepseek-v4-flash "
+        "(configured openrouter/deepseek/deepseek-v4-flash)"
+    ) in caplog.text
+    # The response body reaches the log, so the next occurrence is diagnosable.
+    assert "is not a valid model ID" in caplog.text
+
+
+def test_llm_agent_read_redacts_credentials_in_logged_error_body(
+    monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unit-test-openrouter-key")
+    monkeypatch.setenv("LLM_MODEL", "openrouter/deepseek/deepseek-v4-flash")
+    # Synthesized fixture: matches the ctdl_ token shape, never a real value.
+    leaked = "ctdl_unit_test_fake_token_1234567890"
+    body = json.dumps(
+        {"error": {"message": f"upstream rejected token {leaked}", "code": 400}}
+    ).encode("utf-8")
+
+    def fake_open_secure(request: Any, *, timeout: float) -> Any:
+        raise HTTPError(request.full_url, 400, "Bad Request", None, io.BytesIO(body))
+
+    monkeypatch.setattr("kb.organization_digest.open_secure", fake_open_secure)
+
+    with caplog.at_level(logging.WARNING, logger="kb.organization_digest"):
+        assert llm_agent_read(_digest_packet()) is None
+
+    assert leaked not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_digest_falls_back_deterministically_when_llm_call_400s(monkeypatch: Any) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unit-test-openrouter-key")
+    monkeypatch.setenv("LLM_MODEL", "openrouter/deepseek/deepseek-v4-flash")
+
+    def fake_open_secure(request: Any, *, timeout: float) -> Any:
+        raise HTTPError(request.full_url, 400, "Bad Request", None, io.BytesIO(b"{}"))
+
+    monkeypatch.setattr("kb.organization_digest.open_secure", fake_open_secure)
+
+    digest = build_organization_digest(
+        _learning_result(),
+        CitadelConfig(organization_digest_llm_enabled=True),
+        include_preview=True,
+    )
+
+    assert digest["agent_read_source"] == "deterministic_fallback"
+    assert "Agent read" in digest["preview"]


### PR DESCRIPTION
Two independent fixes, both for components that were failing while every status surface stayed green. Deployed together so one evolve pass verifies both.

Refs #100

## 1. Org digest LLM call returned 400 on every pass

The digest's LLM read failed with `HTTP Error 400` once per evolve pass, for at least 20 hours. It falls back to the deterministic path, evolve reports success, and no counter surfaces it — so the digest has been running without its LLM component and nothing indicated that.

The model id is resolved `CITADEL_ORG_DIGEST_LLM_MODEL` → `LLM_MODEL` → `CITADEL_LLM_MODEL` and passed verbatim to the OpenRouter API. `LLM_MODEL` carries the litellm `openrouter/` prefix because cognee requires that form, and that is not a valid id on OpenRouter's own API. This normalises the prefix at the call site so either form works, leaving `LLM_MODEL` untouched for cognee. **No operator environment change is required.**

The failure also logged neither the resolved model id nor the response body, which is why the cause could only ever be inferred. Both are now logged on failure, with credential-shaped values redacted, so the next occurrence diagnoses itself rather than needing another investigation.

## 2. citadel://discovery advertised a loopback base_url

Reading the resource returned `service.base_url: http://127.0.0.1:8080`, while the `citadel_discovery` **tool** returned the real public URL for the same manifest. Discovery is the first surface an onboarding agent reads, so the resource variant handed out an address no client can reach.

The manifest is rendered server-side from the request's host. The tool path forwards the caller's proto and host; the resource path fetched from the loopback base with no forwarded headers, so the server described itself as loopback. The resource path now gets the same treatment, stays async so it still offloads off the event loop, and stays reachable without a credential.

## Verification

Full suite **1124 passed, 1 skipped**; `ruff` clean on all four files. Both changes verified in both directions — deliberately reintroduced, confirmed the right test went red, reverted.

The parametrized loop-freedom test added earlier still covers all five resource URIs and still passes, so the async offload was not weakened by the discovery change.

## Honest limits

Neither fix is fully provable by unit test, and both define their own live check:

- The digest 400's **causality** stays inferred until the first post-deploy evolve pass. The response body was never logged, so a context-length 400 was never excluded. The new WARNING carries the status and redacted body, so that pass settles it either way — the fix is correct regardless, but the diagnosis is what the log now proves.
- The discovery defect **cannot** be caught by a unit test with a fake client: a fake returns whatever it is told, and the bug lived in which headers a real request carries. Verifying it needs one round trip through the hosted endpoint checking that `base_url` is the public host.

Forwarded-header validation was reviewed as part of this: production is protected at the edge rather than by the application, and an opt-in host pin is available. Setting `CITADEL_PUBLIC_BASE_URL` would make this independent of forwarded headers entirely and is worth batching into the next configuration change.
