### PR TITLE
fix(access): stop discarding the role when a seat is selected

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -964,6 +964,13 @@ class CreateSeatBody(BaseModel):
 
 class IssueSeatTokenBody(BaseModel):
     token_name: str | None = Field(default=None, max_length=120)
+    # Declared only to be rejected. Pydantic silently drops fields the model
+    # does not declare, so without this a caller who POSTs {"role": "admin"}
+    # gets a 200 and a writer token — they believe they hold an admin
+    # credential and every admin call 403s. A seat token always carries the
+    # seat's own role, so any supplied value, matching or not, is an error the
+    # endpoint must say out loud (see issue_access_seat_token).
+    role: str | None = None
 
 
 class CapturePolicyBody(BaseModel):
@@ -3575,6 +3582,20 @@ async def issue_access_seat_token(
 ) -> dict[str, Any]:
     """Mint a fresh token for an EXISTING seat (e.g. to re-link a lost token)."""
     actor = require_access(request, "admin", "access:manage")
+    if body.role is not None:
+        # Reject rather than ignore: a silently dropped role hands the caller a
+        # credential different from the one they asked for. A seat token always
+        # carries the seat's role; admin in particular is forbidden because an
+        # admin token bypasses the seat's dataset allowlist and dissolves its
+        # private-memory boundary (AccessStore.create_seat enforces the same).
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Seat tokens derive their role from the seat; 'role' cannot be "
+                "set here. Mint admin tokens without a seat via POST "
+                "/api/access/tokens."
+            ),
+        )
     try:
         normalized = validate_seat_slug(slug)
     except ValueError as exc:

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -3600,6 +3600,10 @@ function renderTokenSeatOptions(seats = []) {
 
 // When a seat is chosen the seat defines scope, so hide+disable the free-text
 // dataset inputs (disabled inputs are excluded from FormData) and show a hint.
+// The role select is disabled too, but stays visible with its own hint: the
+// seat endpoint always mints the seat's writer token and discards any chosen
+// role, so an enabled selector would promise a role the server never grants
+// (an operator once picked admin here and walked away holding a writer token).
 function applyTokenSeatScopeToggle() {
   const select = document.getElementById("accessSeat");
   if (!select) return;
@@ -3609,11 +3613,40 @@ function applyTokenSeatScopeToggle() {
   const datasetInput = document.getElementById("accessDefaultDataset");
   const allowedInput = document.getElementById("accessAllowedDatasets");
   const hint = document.getElementById("accessSeatScopeHint");
+  const roleSelect = document.getElementById("accessRole");
+  const roleHint = document.getElementById("accessRoleSeatHint");
   if (datasetField) datasetField.hidden = hasSeat;
   if (allowedField) allowedField.hidden = hasSeat;
   if (datasetInput) datasetInput.disabled = hasSeat;
   if (allowedInput) allowedInput.disabled = hasSeat;
   if (hint) hint.hidden = !hasSeat;
+  if (roleSelect) roleSelect.disabled = hasSeat;
+  if (roleHint) roleHint.hidden = !hasSeat;
+}
+
+// Describe the credential that was actually minted, read from the server
+// response (api_token + principal), never from the form. The seat endpoint
+// derives role and datasets from the seat and discards any requested role, so
+// echoing the form here would repeat the exact mismatch this line exists to
+// expose: a token requested as admin that authenticates as writer.
+function mintedTokenSummary(response) {
+  const apiToken = (response && response.api_token) || {};
+  const principal = (response && response.principal) || {};
+  const role = apiToken.role || principal.role || "unknown";
+  const seatSlug = principal.seat_slug || null;
+  const allowed = Array.isArray(apiToken.allowed_datasets)
+    ? apiToken.allowed_datasets.filter(Boolean)
+    : [];
+  let datasets;
+  if (role === "admin") {
+    datasets = "every dataset (admin bypasses the allowlist)";
+  } else if (allowed.length) {
+    datasets = allowed.join(", ");
+  } else {
+    datasets = "all non-seat datasets (no allowlist on this token)";
+  }
+  const seat = seatSlug ? `seat ${seatSlug}` : "no seat (service account)";
+  return `Role: ${role} · ${seat} · Datasets: ${datasets}`;
 }
 
 function renderAuditAccessEvents(events = []) {
@@ -4281,6 +4314,7 @@ document.getElementById("accessTokenForm").addEventListener("submit", async (eve
     newAccessToken.hidden = false;
     newAccessToken.innerHTML = `
       <strong>Token created</strong>
+      <p>${escapeHtml(mintedTokenSummary(response))}</p>
       <p>Copy this now. Citadel stores only the hash and will not show it again.</p>
       <code>${escapeHtml(response.token)}</code>
     `;

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -1089,6 +1089,9 @@
                       <option value="writer">Read write</option>
                       <option value="admin">Admin</option>
                     </select>
+                    <p id="accessRoleSeatHint" class="hint" hidden>
+                      Seat tokens are always writer. A seat is a private-memory boundary, and an admin token would bypass its dataset allowlist and dissolve it. Mint admin tokens with no seat.
+                    </p>
                   </div>
                 </div>
                 <div class="field-grid">

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4468,6 +4468,99 @@ def test_admin_scope_override_is_audited(tmp_path: Any) -> None:
     assert search_events[-1]["detail"]["scope_override"] is True
 
 
+# --------------------------------------------------------------------------
+# Token minting must hand over the credential that was asked for, or say no.
+# An operator picked role=admin with a seat selected, got a 200, and held a
+# writer token: every admin call 403'd while the UI had claimed admin. Three
+# guards below: the form disables the ignored control, the server rejects an
+# explicit role instead of dropping it, and the success panel describes what
+# was actually minted from the server response.
+# --------------------------------------------------------------------------
+
+
+def test_seat_token_endpoint_rejects_an_explicit_role(tmp_path: Any) -> None:
+    """POST /api/access/seats/{slug}/tokens 422s when 'role' is supplied.
+
+    Pydantic silently drops undeclared fields, so before this the endpoint
+    accepted {"role": "admin"} and returned a writer token: a credential
+    different from the one requested, discovered only when admin calls 403.
+    A matching role is rejected too; the field is never honoured, so accepting
+    it sometimes would teach callers it works.
+    """
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    client = authed_client()
+    created = client.post("/api/access/seats", json={"name": "Sarthi", "slug": "sarthi"})
+    assert created.status_code == 200
+
+    for role in ("admin", "writer"):
+        denied = client.post(
+            "/api/access/seats/sarthi/tokens",
+            json={"token_name": "re-link", "role": role},
+        )
+        assert denied.status_code == 422, role
+        detail = denied.json()["detail"]
+        assert "role" in detail
+        assert "/api/access/tokens" in detail
+
+    # Without the field the endpoint still mints, scoped by the seat.
+    minted = client.post("/api/access/seats/sarthi/tokens", json={"token_name": "re-link"})
+    assert minted.status_code == 200
+    payload = minted.json()
+    assert payload["api_token"]["role"] == "writer"
+    assert payload["principal"]["seat_slug"] == "sarthi"
+    assert "seat:sarthi" in payload["api_token"]["allowed_datasets"]
+
+
+def test_token_form_disables_role_when_a_seat_is_chosen() -> None:
+    """Choosing a seat disables the role select and shows the why.
+
+    The seat branch of the form posts only token_name, so the role selector is
+    decoration there. It used to stay enabled, which is how an operator chose
+    admin and believed it. The toggle must treat role exactly like the dataset
+    fields it already disables, plus a visible hint carrying the reason.
+    """
+    app_js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    page = authed_client().get("/app").text
+
+    toggle = re.search(r"function applyTokenSeatScopeToggle\(\) \{(.*?)\n\}", app_js, re.S)
+    assert toggle, "applyTokenSeatScopeToggle moved"
+    body = toggle.group(1)
+    assert 'getElementById("accessRole")' in body
+    assert 'getElementById("accessRoleSeatHint")' in body
+    assert "roleSelect.disabled = hasSeat" in body
+    assert "roleHint.hidden = !hasSeat" in body
+
+    # The hint the toggle reveals exists in the markup and states the rule.
+    assert 'id="accessRoleSeatHint"' in page
+    assert "Seat tokens are always writer" in page
+    assert "private-memory boundary" in page
+
+
+def test_minted_token_summary_reads_the_server_response_not_the_form() -> None:
+    """The success panel describes the minted credential from the response.
+
+    Role and scope come from api_token/principal in the server's reply, never
+    from the submitted form values, so a token minted differently from what
+    the form claimed is visible the moment it is created. The summary is
+    escaped like the token itself before entering innerHTML.
+    """
+    app_js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    fn = re.search(r"function mintedTokenSummary\(response\) \{(.*?)\n\}", app_js, re.S)
+    assert fn, "mintedTokenSummary moved"
+    body = fn.group(1)
+    assert "api_token" in body
+    assert "principal" in body
+    assert "seat_slug" in body
+    assert "allowed_datasets" in body
+    # Never the requested values.
+    assert "formData" not in body
+    assert "FormData" not in body
+
+    # The panel renders it, escaped, alongside the one-time token.
+    assert "escapeHtml(mintedTokenSummary(response))" in app_js
+
+
 class GateCognee:
     """Minimal Cognee stub so a real Citadel gate runs through the server stack."""
 


### PR DESCRIPTION
Selecting a role and a seat together silently produced a token with a different role than the one requested. Found while minting an admin credential: the operator chose admin with a seat, got a token, and it authenticated as `writer` with every admin endpoint returning 403.

Refs #100

## Why it happens

The form offers role and seat as independent choices, but no endpoint accepts both:

| endpoint | role? | seat? |
|---|---|---|
| `POST /api/access/tokens` | yes | no — creates a new principal |
| `POST /api/access/seats/{slug}/tokens` | **no** — body is `{token_name}` only | yes |

`kb/static/app.js` branches on the seat field: when one is selected it posts only `{token_name}` to the seat endpoint, so the chosen role is discarded on the client and never reaches the server. `applyTokenSeatScopeToggle` already hides and disables the two **dataset** fields in that case, but never touched the role selector — so role stayed visible, enabled, and ignored.

## The rule being enforced is correct

`AccessStore.create_seat` refuses the admin role deliberately: an admin token bypasses the dataset allowlist (`can_bypass_dataset_allowlist`) and would dissolve the seat's private-memory boundary. Seats must not be admin-capable. Only the presentation was broken, so this changes nothing about the constraint.

## Three layers

**Form.** `applyTokenSeatScopeToggle` now also disables the role selector when a seat is chosen and reveals a hint explaining that seat tokens are always writer, and why. Same hidden/disabled/hint mechanics and the same `.hint` class as the existing scope hint — no visual redesign.

**Success panel.** A new summary reports what was *actually* minted — role, seat or "no seat", and the datasets it can reach — built strictly from the server's `api_token` and `principal`, never from the form. Dataset wording follows the real enforcement in `enforce_dataset_allowlist`, so an admin token reads "every dataset (admin bypasses the allowlist)" rather than an empty list.

**Server.** `IssueSeatTokenBody` now declares `role` solely so the endpoint can reject it with a 422 naming the rule and pointing at `POST /api/access/tokens` for admin minting. Pydantic silently drops undeclared fields, so leaving it invisible *is* the silent-mismatch failure mode; declaring it to reject it turns a wrong-credential 200 into an explanatory 422. Any supplied role is rejected, matching or not — accepting it sometimes would teach callers it works. `extra="forbid"` was considered and rejected: it emits a generic message without the why, and would break clients sending harmless extras.

## Verification

Full suite **1127 passed, 1 skipped**.

Three tests added: the seat endpoint 422s on an explicit role (admin and writer) while the no-role path still mints a writer scoped to its seat; the form disables the role control when a seat is chosen; the summary reads the server response rather than the form.

Checked in both directions. Disarming the server guard made the rejection test fail with `assert 200 == 422` — the old silent writer-token mint. Deleting the two role-toggle lines failed the form test on the missing `roleSelect.disabled`. Swapping the summary for a `formData.get("role")` echo failed the summary test. All three reverted, suite green.

## Note

The Next.js app needs no equivalent fix and no export: `web/src/pages/app/admin.tsx` is an explicit not-yet-ported placeholder, and the exported `kb/webui/` contains no token form.
