### PR TITLE
fix(search): provenance, honest relevance, working filters, and reachable documents

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from time import monotonic, perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
+from uuid import NAMESPACE_OID, UUID, uuid5
 
 logger = logging.getLogger(__name__)
 
@@ -902,9 +903,12 @@ class CogneePublicClient:
         ``graph_data`` yields so the assembly logic in ``get_document`` is
         unchanged. Falls back to the full ``graph_data()`` read when the engine
         lacks these primitives or the targeted read raises — a shape surprise
-        degrades to correct-but-slow, never a spurious 404. A genuinely missing
-        node returns an empty graph (``get_node`` -> None, ``get_connections``
-        -> []) so ``get_document`` still resolves it to None without a fallback.
+        degrades to correct-but-slow, never a spurious 404. A node missing from
+        the graph returns an empty targeted result (``get_node`` -> None,
+        ``get_connections`` -> []) WITHOUT triggering that fallback: a full
+        graph read cannot contain a node the graph lacks. Ids the graph cannot
+        resolve are instead retried against the durable chunk store by
+        ``get_document`` (``_document_from_chunk_store``).
         """
         try:
             engine = await self._graph_engine()
@@ -954,29 +958,53 @@ class CogneePublicClient:
         properties. Document nodes (e.g. TextDocument) carry no text themselves
         — it lives on linked DocumentChunk nodes — so a textless match is
         assembled from its ``is_part_of`` chunk neighbors, ordered by
-        ``chunk_index``; ``None`` when the node is missing or no text is found
-        either way (textless entities keep resolving to None/404).
+        ``chunk_index``. A CHUNK id (what every CHUNKS search hit carries) is
+        resolved through its ``is_part_of`` parent document so drill-down
+        returns the WHOLE document, not just the ~2K fragment search already
+        showed. When the graph cannot resolve the id at all, fall back to the
+        durable chunk store search reads from (``_document_from_chunk_store``)
+        — the graph and chunk stores can diverge, and a hit that search can
+        retrieve must stay reachable through drill-down. ``None`` only when no
+        text exists in either store (textless entities keep resolving to
+        None/404).
+        """
+        doc_id = str(document_id)
+        document = await self._document_from_graph(doc_id, follow_parent=True)
+        if document is not None:
+            return document
+        return await self._document_from_chunk_store(doc_id)
+
+    @staticmethod
+    def _extract_text(props: dict[str, Any]) -> tuple[str | None, str | None]:
+        """First non-empty text field under the keys cognee nodes/chunks use."""
+        for key in ("text", "chunk", "content", "raw_content"):
+            value = props.get(key)
+            if isinstance(value, str) and value.strip():
+                return value, key
+        return None, None
+
+    async def _document_from_graph(
+        self, doc_id: str, *, follow_parent: bool
+    ) -> dict[str, Any] | None:
+        """Resolve ``doc_id`` against the graph store (targeted read).
+
+        ``follow_parent=True`` (the drill-down entrypoint) additionally chases a
+        text-bearing chunk's ``is_part_of`` parent document and returns the
+        parent's FULL assembled body; the recursive parent call passes
+        ``follow_parent=False`` so resolution is bounded at one hop.
         """
         try:
-            nodes, edges = await self._document_graph(str(document_id))
+            nodes, edges = await self._document_graph(doc_id)
         except Exception as exc:  # noqa: BLE001
             if self._is_no_data_error(exc):
                 return None
             raise
-
-        def _extract_text(props: dict[str, Any]) -> tuple[str | None, str | None]:
-            for key in ("text", "chunk", "content", "raw_content"):
-                value = props.get(key)
-                if isinstance(value, str) and value.strip():
-                    return value, key
-            return None, None
 
         # One pass over nodes: props by str id for O(1) neighbor lookup
         # (setdefault keeps first-encounter semantics on duplicate ids).
         props_by_id: dict[str, dict[str, Any]] = {}
         for node_id, properties in nodes:
             props_by_id.setdefault(str(node_id), dict(properties or {}))
-        doc_id = str(document_id)
         props = props_by_id.get(doc_id)
         if props is None:
             return None
@@ -1002,8 +1030,36 @@ class CogneePublicClient:
                 continue
             seen.add(neighbor_id)
             part_neighbor_ids.append(neighbor_id)
-        text, text_key = _extract_text(props)
+        text, text_key = self._extract_text(props)
         if text is not None:
+            if follow_parent:
+                # A text-bearing node with a TEXTLESS ``is_part_of`` neighbor is
+                # a DocumentChunk next to its parent document (chunks carry the
+                # text; TextDocument nodes carry none). Search hands out CHUNK
+                # ids, so resolving the id to just this chunk's text re-serves
+                # the same fragment the search snippet already showed. Resolve
+                # the PARENT instead so drill-down returns the whole document;
+                # the chunk's own text stays the fallback when the parent
+                # cannot be assembled (never worse than before).
+                parent_id = next(
+                    (
+                        neighbor_id
+                        for neighbor_id in part_neighbor_ids
+                        if (neighbor := props_by_id.get(neighbor_id)) is not None
+                        and self._extract_text(neighbor)[0] is None
+                    ),
+                    None,
+                )
+                if parent_id is not None:
+                    parent = await self._document_from_graph(
+                        parent_id, follow_parent=False
+                    )
+                    if parent is not None and parent.get("body"):
+                        owner_ids = list(parent.get("dataset_node_ids") or [parent_id])
+                        if doc_id not in owner_ids:
+                            owner_ids.append(doc_id)
+                        parent["dataset_node_ids"] = owner_ids
+                        return parent
             return {
                 "id": doc_id,
                 "source_type": "cognee",
@@ -1025,7 +1081,7 @@ class CogneePublicClient:
             neighbor_props = props_by_id.get(neighbor_id)
             if neighbor_props is None:
                 continue
-            neighbor_text, _ = _extract_text(neighbor_props)
+            neighbor_text, _ = self._extract_text(neighbor_props)
             if neighbor_text is None:
                 continue
             index = neighbor_props.get("chunk_index")
@@ -1046,6 +1102,147 @@ class CogneePublicClient:
             "metadata": dict(props),
             "dataset_node_ids": [doc_id],
         }
+
+    # Search hits come from the durable chunk vector collection (cognee's
+    # ChunksRetriever reads ONLY "DocumentChunk_text"), while drill-down
+    # resolves through the graph store. The two stores can diverge — an
+    # interrupted cognify, or a graph emptied/rebuilt by a past incident while
+    # the chunk store survived — leaving chunks that search retrieves but the
+    # graph cannot resolve (the measured drill-down 404s). The chunk store is
+    # therefore the fallback source of truth for document text.
+    _CHUNK_VECTOR_COLLECTION = "DocumentChunk_text"
+    # cognee's TextChunker assigns chunk ids deterministically:
+    # uuid5(NAMESPACE_OID, f"{document_id}-{chunk_index}") — so a document's
+    # chunks are recoverable with ONE batched retrieve over probe indexes
+    # 0..N-1. 512 covers ~1 MB of text at the node's observed ~2K chunk size.
+    # Known gap: a single paragraph larger than the chunk size gets a
+    # content-derived id (TextChunker's oversized-paragraph branch), which an
+    # index probe cannot enumerate; such a chunk is included only when it is
+    # the requested id itself.
+    _CHUNK_SIBLING_PROBE_LIMIT = 512
+
+    async def _vector_engine(self) -> Any:
+        """Return cognee's vector engine (seam for chunk-store reads and tests)."""
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.infrastructure.databases.vector import get_vector_engine
+
+        return get_vector_engine()
+
+    @staticmethod
+    def _retrieved_payload(row: Any) -> dict[str, Any] | None:
+        """Payload dict of one vector-store ``retrieve`` row (ScoredResult)."""
+        payload = getattr(row, "payload", None)
+        return payload if isinstance(payload, dict) else None
+
+    async def _document_from_chunk_store(self, doc_id: str) -> dict[str, Any] | None:
+        """Assemble a document from the durable chunk store when the graph can't.
+
+        Accepts either a chunk id (resolved to its parent via the payload's
+        ``document_id``) or a document id (siblings probed directly). Best
+        effort by design: any failure degrades to ``None`` — exactly the 404
+        the caller would have served anyway — never an error. Returns the same
+        shape as the graph assembly; ``dataset_node_ids`` carries the parent
+        document id, which is the relational ``Data.id`` the read-scope map
+        keys on (ADR-0009), so the drill-down isolation gate is unchanged.
+        """
+        try:
+            requested = UUID(doc_id)
+        except (TypeError, ValueError):
+            # Synthetic ids (chunk:<sha256>, ghsync:*) have no chunk-store row.
+            return None
+        try:
+            engine = await self._vector_engine()
+            retrieve = getattr(engine, "retrieve", None)
+            if not callable(retrieve):
+                return None
+            seed_rows = await retrieve(self._CHUNK_VECTOR_COLLECTION, [requested])
+            seed_payload = (
+                self._retrieved_payload(seed_rows[0]) if seed_rows else None
+            )
+            document_id: str | None
+            if seed_payload is not None:
+                # Chunk hit: the parent document id rides in the payload.
+                parent_raw = seed_payload.get("document_id")
+                if not parent_raw and isinstance(
+                    seed_payload.get("is_part_of"), dict
+                ):
+                    parent_raw = seed_payload["is_part_of"].get("id")
+                document_id = str(parent_raw) if parent_raw else None
+            else:
+                # Not a chunk id — probe it as a document id.
+                document_id = doc_id
+            payloads: dict[str, dict[str, Any]] = {}
+            if seed_payload is not None:
+                payloads[str(requested)] = seed_payload
+            if document_id is not None:
+                try:
+                    document_id = str(UUID(document_id))
+                except (TypeError, ValueError):
+                    document_id = None
+            if document_id is not None:
+                sibling_ids = [
+                    uuid5(NAMESPACE_OID, f"{document_id}-{index}")
+                    for index in range(self._CHUNK_SIBLING_PROBE_LIMIT)
+                ]
+                for row in await retrieve(
+                    self._CHUNK_VECTOR_COLLECTION, sibling_ids
+                ):
+                    payload = self._retrieved_payload(row)
+                    if payload is None:
+                        continue
+                    row_id = str(getattr(row, "id", "") or payload.get("id") or "")
+                    if row_id:
+                        payloads.setdefault(row_id, payload)
+            chunks: list[tuple[tuple[int, float], dict[str, Any]]] = []
+            for payload in payloads.values():
+                text, _ = self._extract_text(payload)
+                if text is None:
+                    continue
+                index = payload.get("chunk_index")
+                if isinstance(index, (int, float)):
+                    sort_key = (0, float(index))
+                else:
+                    sort_key = (1, float(len(chunks)))
+                chunks.append((sort_key, payload))
+            if not chunks:
+                return None
+            chunks.sort(key=lambda item: item[0])
+            title = next(
+                (
+                    payload.get("document_name")
+                    for _, payload in chunks
+                    if payload.get("document_name")
+                ),
+                None,
+            )
+            metadata: dict[str, Any] = {"assembled_from": "chunk_store"}
+            if document_id is not None:
+                metadata["document_id"] = document_id
+            if title is not None:
+                metadata["document_name"] = title
+            owner_ids = [document_id] if document_id is not None else []
+            if doc_id not in owner_ids:
+                owner_ids.append(doc_id)
+            return {
+                "id": document_id or doc_id,
+                "source_type": "cognee",
+                "title": title,
+                "body": "\n\n".join(
+                    self._extract_text(payload)[0] or "" for _, payload in chunks
+                ),
+                "chunk_count": len(chunks),
+                "metadata": metadata,
+                "dataset_node_ids": owner_ids,
+            }
+        except Exception:  # noqa: BLE001 - fallback is best-effort; None == 404
+            logger.warning(
+                "chunk-store drill-down fallback failed; document stays unresolved",
+                exc_info=True,
+            )
+            return None
 
     async def cognify(self, *, datasets: list[str], force: bool = False) -> Any:
         """Cognify already-added data in ``datasets``.

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -213,6 +213,9 @@ class CogneeGateway(Protocol):
     async def get_document(self, document_id: str) -> dict[str, Any] | None:
         ...
 
+    async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
+        ...
+
     async def graph_data(self) -> tuple[list[Any], list[Any]]:
         ...
 
@@ -974,6 +977,121 @@ class CogneePublicClient:
             return document
         return await self._document_from_chunk_store(doc_id)
 
+    async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
+        """Owner node ids for the ADR-0009 drill-down visibility rule — WITHOUT
+        assembling the document body.
+
+        /search resolves its drill-down hint once per unique hit id per page,
+        and the hint needs only ``dataset_node_ids``. Answering that through
+        ``get_document`` paid for the full body assembly per id — for a
+        graph-missing id that is the ``_CHUNK_SIBLING_PROBE_LIMIT``-id vector
+        retrieve returning up to ~1 MB of chunk payloads, all discarded. This
+        read is bounded instead: ONE targeted graph read, and (only when the
+        graph lacks the id) at most two single-id vector retrieves. The full
+        assembly stays on /api/documents, one document per explicit click.
+
+        Returns the same owner ids ``get_document`` carries in
+        ``dataset_node_ids`` (a chunk id resolves through its ``is_part_of``
+        parent document, whose node id is the relational Data.id the read-scope
+        map keys on), or ``None`` when the id would not resolve. Corner cases
+        this cheap read cannot see (a transient second graph read failing, a
+        chunk row whose text vanished while siblings survived) return ``None``
+        — the hint then under-promises (a 200 it did not advertise), never an
+        ADR-0009 404 it promised was a document.
+        """
+        doc_id = str(document_id)
+        try:
+            nodes, edges = await self._document_graph(doc_id)
+        except Exception as exc:  # noqa: BLE001
+            if not self._is_no_data_error(exc):
+                raise
+            nodes, edges = [], []
+        props, props_by_id, part_neighbor_ids = self._graph_projection(
+            doc_id, nodes, edges
+        )
+        if props is not None:
+            text, _ = self._extract_text(props)
+            if text is not None:
+                # Chunk id: its datasets live on the textless parent document
+                # (the id get_document's parent-follow resolves through).
+                parent_id = self._textless_neighbor_id(props_by_id, part_neighbor_ids)
+                if parent_id is not None:
+                    return [parent_id, doc_id]
+                return [doc_id, *part_neighbor_ids]
+            # Textless document node: drillable only when a text-bearing chunk
+            # neighbor exists (textless entities must stay a 404).
+            for neighbor_id in part_neighbor_ids:
+                neighbor = props_by_id.get(neighbor_id)
+                if neighbor is not None and self._extract_text(neighbor)[0] is not None:
+                    return [doc_id]
+            # No text anywhere in the graph: get_document falls through to the
+            # chunk store, and so does this.
+        return await self._owner_ids_from_chunk_store(doc_id)
+
+    async def _owner_ids_from_chunk_store(self, doc_id: str) -> list[str] | None:
+        """Owner ids from the durable chunk store via SEED lookups only.
+
+        At most two single-id retrieves (string ids — see
+        ``_document_from_chunk_store`` for why UUID objects break LanceDB):
+        the requested id itself, then — when that misses — the deterministic
+        chunk-0 probe ``uuid5(NAMESPACE_OID, f"{doc_id}-0")``, since
+        TextChunker numbers chunks sequentially from zero. Never the sibling
+        probe. Best effort like the full fallback: any failure returns ``None``
+        (the hint denies, fail-closed).
+        """
+        try:
+            requested = str(UUID(doc_id))
+        except (TypeError, ValueError):
+            # Synthetic ids (chunk:<sha256>, ghsync:*) have no chunk-store row.
+            return None
+        try:
+            engine = await self._vector_engine()
+            retrieve = getattr(engine, "retrieve", None)
+            if not callable(retrieve):
+                return None
+            seed_rows = await retrieve(self._CHUNK_VECTOR_COLLECTION, [requested])
+            seed_payload = (
+                self._retrieved_payload(seed_rows[0]) if seed_rows else None
+            )
+            if seed_payload is not None:
+                # Chunk hit: the parent document id rides in the payload —
+                # exactly the owner attribution the full assembly reports.
+                if self._extract_text(seed_payload)[0] is None:
+                    return None
+                parent_raw = seed_payload.get("document_id")
+                if not parent_raw and isinstance(
+                    seed_payload.get("is_part_of"), dict
+                ):
+                    parent_raw = seed_payload["is_part_of"].get("id")
+                try:
+                    parent_id = str(UUID(str(parent_raw))) if parent_raw else None
+                except (TypeError, ValueError):
+                    parent_id = None
+                owner_ids = [parent_id] if parent_id is not None else []
+                if doc_id not in owner_ids:
+                    owner_ids.append(doc_id)
+                return owner_ids
+            # Not a chunk id — probe it as a document id through its chunk 0.
+            probe_rows = await retrieve(
+                self._CHUNK_VECTOR_COLLECTION,
+                [str(uuid5(NAMESPACE_OID, f"{requested}-0"))],
+            )
+            probe_payload = (
+                self._retrieved_payload(probe_rows[0]) if probe_rows else None
+            )
+            if probe_payload is None or self._extract_text(probe_payload)[0] is None:
+                return None
+            owner_ids = [requested]
+            if doc_id not in owner_ids:
+                owner_ids.append(doc_id)
+            return owner_ids
+        except Exception:  # noqa: BLE001 - best-effort; None == deny, fail-closed
+            logger.warning(
+                "chunk-store owner-id lookup failed; drill-down hint denies",
+                exc_info=True,
+            )
+            return None
+
     @staticmethod
     def _extract_text(props: dict[str, Any]) -> tuple[str | None, str | None]:
         """First non-empty text field under the keys cognee nodes/chunks use."""
@@ -982,6 +1100,59 @@ class CogneePublicClient:
             if isinstance(value, str) and value.strip():
                 return value, key
         return None, None
+
+    @staticmethod
+    def _graph_projection(
+        doc_id: str, nodes: list[Any], edges: list[Any]
+    ) -> tuple[dict[str, Any] | None, dict[str, dict[str, Any]], list[str]]:
+        """(requested props, props by id, ``is_part_of`` neighbor ids) of one read.
+
+        One pass over nodes: props by str id for O(1) neighbor lookup
+        (setdefault keeps first-encounter semantics on duplicate ids).
+        ``is_part_of`` neighbors (either direction) are collected once and used
+        twice: assembling a textless document's body from its chunks, and
+        dataset attribution for read-scope checks — a chunk id has no
+        relational Data row of its own, so its datasets live on the linked
+        document's node id. ``dataset_node_ids`` plumbs those candidate ids
+        to the caller (kb/server.py drill-down isolation, ADR-0009) so the
+        graph is never re-walked. Duplicate edges to one neighbor count once.
+        Shared by ``_document_from_graph`` and ``resolve_document_owner_ids``
+        so the hint's owner attribution can never drift from the endpoint's.
+        """
+        props_by_id: dict[str, dict[str, Any]] = {}
+        for node_id, properties in nodes:
+            props_by_id.setdefault(str(node_id), dict(properties or {}))
+        part_neighbor_ids: list[str] = []
+        seen: set[str] = set()
+        for source_id, target_id, relationship, _edge_props in edges:
+            if str(relationship) != "is_part_of":
+                continue
+            if str(source_id) == doc_id:
+                neighbor_id = str(target_id)
+            elif str(target_id) == doc_id:
+                neighbor_id = str(source_id)
+            else:
+                continue
+            if neighbor_id in seen:
+                continue
+            seen.add(neighbor_id)
+            part_neighbor_ids.append(neighbor_id)
+        return props_by_id.get(doc_id), props_by_id, part_neighbor_ids
+
+    @classmethod
+    def _textless_neighbor_id(
+        cls, props_by_id: dict[str, dict[str, Any]], part_neighbor_ids: list[str]
+    ) -> str | None:
+        """First textless ``is_part_of`` neighbor: a chunk's parent document."""
+        return next(
+            (
+                neighbor_id
+                for neighbor_id in part_neighbor_ids
+                if (neighbor := props_by_id.get(neighbor_id)) is not None
+                and cls._extract_text(neighbor)[0] is None
+            ),
+            None,
+        )
 
     async def _document_from_graph(
         self, doc_id: str, *, follow_parent: bool
@@ -1000,36 +1171,11 @@ class CogneePublicClient:
                 return None
             raise
 
-        # One pass over nodes: props by str id for O(1) neighbor lookup
-        # (setdefault keeps first-encounter semantics on duplicate ids).
-        props_by_id: dict[str, dict[str, Any]] = {}
-        for node_id, properties in nodes:
-            props_by_id.setdefault(str(node_id), dict(properties or {}))
-        props = props_by_id.get(doc_id)
+        props, props_by_id, part_neighbor_ids = self._graph_projection(
+            doc_id, nodes, edges
+        )
         if props is None:
             return None
-        # ``is_part_of`` neighbors (either direction), collected once and used
-        # twice: assembling a textless document's body from its chunks, and
-        # dataset attribution for read-scope checks — a chunk id has no
-        # relational Data row of its own, so its datasets live on the linked
-        # document's node id. ``dataset_node_ids`` plumbs those candidate ids
-        # to the caller (kb/server.py drill-down isolation, ADR-0009) so the
-        # graph is never re-walked. Duplicate edges to one neighbor count once.
-        part_neighbor_ids: list[str] = []
-        seen: set[str] = set()
-        for source_id, target_id, relationship, _edge_props in edges:
-            if str(relationship) != "is_part_of":
-                continue
-            if str(source_id) == doc_id:
-                neighbor_id = str(target_id)
-            elif str(target_id) == doc_id:
-                neighbor_id = str(source_id)
-            else:
-                continue
-            if neighbor_id in seen:
-                continue
-            seen.add(neighbor_id)
-            part_neighbor_ids.append(neighbor_id)
         text, text_key = self._extract_text(props)
         if text is not None:
             if follow_parent:
@@ -1041,15 +1187,7 @@ class CogneePublicClient:
                 # the PARENT instead so drill-down returns the whole document;
                 # the chunk's own text stays the fallback when the parent
                 # cannot be assembled (never worse than before).
-                parent_id = next(
-                    (
-                        neighbor_id
-                        for neighbor_id in part_neighbor_ids
-                        if (neighbor := props_by_id.get(neighbor_id)) is not None
-                        and self._extract_text(neighbor)[0] is None
-                    ),
-                    None,
-                )
+                parent_id = self._textless_neighbor_id(props_by_id, part_neighbor_ids)
                 if parent_id is not None:
                     parent = await self._document_from_graph(
                         parent_id, follow_parent=False
@@ -1149,7 +1287,13 @@ class CogneePublicClient:
         keys on (ADR-0009), so the drill-down isolation gate is unchanged.
         """
         try:
-            requested = UUID(doc_id)
+            # STRING ids, never uuid.UUID objects — cognee's own retrieve()
+            # callers pass strings (hybrid/chunks.py), and LanceDBAdapter
+            # renders the filter with an f-string, so a UUID object becomes
+            # `id IN (UUID('…'),)` and the whole query errors out ("Error
+            # optimizing sql filter"). pgvector tolerated the objects, which is
+            # how the difference stayed invisible on the production node.
+            requested = str(UUID(doc_id))
         except (TypeError, ValueError):
             # Synthetic ids (chunk:<sha256>, ghsync:*) have no chunk-store row.
             return None
@@ -1176,7 +1320,7 @@ class CogneePublicClient:
                 document_id = doc_id
             payloads: dict[str, dict[str, Any]] = {}
             if seed_payload is not None:
-                payloads[str(requested)] = seed_payload
+                payloads[requested] = seed_payload
             if document_id is not None:
                 try:
                     document_id = str(UUID(document_id))
@@ -1184,7 +1328,7 @@ class CogneePublicClient:
                     document_id = None
             if document_id is not None:
                 sibling_ids = [
-                    uuid5(NAMESPACE_OID, f"{document_id}-{index}")
+                    str(uuid5(NAMESPACE_OID, f"{document_id}-{index}"))
                     for index in range(self._CHUNK_SIBLING_PROBE_LIMIT)
                 ]
                 for row in await retrieve(

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -7,6 +7,7 @@ Keeps a stable hit schema agents can filter on without a second fetch.
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 from typing import Any
 
 SPEC_QUERY_RE = re.compile(
@@ -39,6 +40,87 @@ REPO_CONTENT_HEADER_RE = re.compile(
     r"Blob:\s*\S+",
     re.IGNORECASE,
 )
+# Same structural header, but as a PARSER: named groups recover the repo, the
+# per-file commit, the blob and the source URL that cognee's chunk payloads
+# never carry as keys. ``\A`` anchors at the very start of the chunk, because a
+# document that merely QUOTES another document's header mid-body must not be
+# credited with that document's identity — a benchmark once scored quoting
+# documents as if they were the quoted ones on exactly this confusion.
+REPO_CONTENT_HEADER_PARSE_RE = re.compile(
+    r"\A\s*#\s+(?P<header_path>\S+)[ \t]*\n\s*\n"
+    r"Repository:[ \t]*(?P<repo>\S+)[ \t]*\n"
+    r"Source:[ \t]*(?P<source_url>https?://\S+)[ \t]*\n"
+    r"Commit:[ \t]*(?P<commit>\S+)[ \t]*\n"
+    r"Blob:[ \t]*(?P<blob>\S+)[ \t]*(?:\n|\Z)",
+    re.IGNORECASE,
+)
+# The title line format_issue_note writes: "# Linear SOK-123: title". The
+# workspace digest ("# Linear workspace sync") deliberately does not match —
+# it aggregates 120 issues and identifies none of them.
+LINEAR_HEADER_PARSE_RE = re.compile(
+    r"\A\s*#\s+Linear[ \t]+(?P<issue>[A-Z][A-Z0-9]*-\d+):[ \t]*(?P<title>[^\n]+?)[ \t]*(?:\n|\Z)"
+)
+# One "- **Key:** value" bullet from the block right under the Linear title.
+LINEAR_HEADER_FIELD_RE = re.compile(r"^-\s+\*\*(?P<key>[A-Za-z ]+):\*\*[ \t]*(?P<value>.+?)[ \t]*$")
+
+
+def parse_content_header(text: Any) -> dict[str, str]:
+    """Provenance from the structural header a syncer wrote at the START of a chunk.
+
+    cognee stores no per-document metadata (hits expose empty ``provenance`` and
+    ``text_<md5>`` document names), but the repo-content and Linear syncers each
+    render a machine-readable header as the first lines of the documents they
+    ingest. Parsing it back is the only provenance available.
+
+    Only a header at position zero is credited (leading whitespace aside). The
+    values are still body text and therefore author-controlled — callers must
+    label them as content-derived, never as attested trust.
+    """
+    if not isinstance(text, str) or not text:
+        return {}
+    match = REPO_CONTENT_HEADER_PARSE_RE.match(text)
+    if match:
+        repo = match.group("repo")
+        header_path = match.group("header_path")
+        parsed: dict[str, str] = {
+            "kind": "repo-content",
+            "repo": repo,
+            "source_url": match.group("source_url"),
+            "commit": match.group("commit"),
+            "blob": match.group("blob"),
+            "title": header_path,
+        }
+        # The title line is "org/repo/path"; strip the repo prefix to get the
+        # in-repo path. If the two lines disagree the path claim is dropped
+        # rather than guessed.
+        if header_path.lower().startswith(repo.lower() + "/"):
+            parsed["path"] = header_path[len(repo) + 1 :]
+        return parsed
+    match = LINEAR_HEADER_PARSE_RE.match(text)
+    if match:
+        parsed = {
+            "kind": "linear-issue",
+            "issue": match.group("issue"),
+            "title": match.group("title"),
+        }
+        # Consume only the contiguous bullet block right under the title. The
+        # issue DESCRIPTION follows a blank line, so a "- **URL:**" line quoted
+        # inside a description is never credited.
+        rest = text[match.end() :].splitlines()
+        index = 0
+        while index < len(rest) and not rest[index].strip():
+            index += 1
+        while index < len(rest):
+            field = LINEAR_HEADER_FIELD_RE.match(rest[index])
+            if not field:
+                break
+            if field.group("key").strip().lower() == "url":
+                parsed["source_url"] = field.group("value")
+            index += 1
+        return parsed
+    return {}
+
+
 # Cardano policy IDs are 56 hex chars; asset names / units are often longer hex.
 HEX_ASSET_RE = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{56,})(?![0-9a-fA-F])")
 TOKEN_ASSET_QUERY_RE = re.compile(
@@ -106,6 +188,132 @@ def is_docs_mode_query(query: str, *, mode: str | None = None) -> bool:
     return is_token_asset_query(query)
 
 
+# --- lexical relevance ------------------------------------------------------
+#
+# The retriever returns chunk payload dicts with NO score: cognee's CHUNKS
+# retriever hands back ``found_chunk.payload`` only, and the vector engine's
+# ScoredResult.score (a raw cosine distance) is dropped inside cognee before
+# the client boundary ever sees it. Surfacing the real distance is a
+# cognee-client change; until then the only relevance signal this layer can
+# offer HONESTLY is observable lexical overlap between the query and the hit.
+# It is labelled as exactly that — never presented as a retriever score.
+
+_QUERY_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_./-]*")
+_QUERY_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "with", "this", "that", "these", "those", "from",
+        "what", "how", "where", "when", "which", "who", "whose", "why", "are",
+        "was", "were", "does", "did", "doing", "not", "you", "your", "has",
+        "have", "had", "can", "could", "should", "would", "will", "shall",
+        "may", "might", "must", "about", "into", "onto", "over", "under",
+        "between", "our", "their", "they", "them", "its", "his", "her",
+        "also", "but", "nor", "either", "any", "all", "some", "than", "then",
+        "there", "here", "been", "being", "because", "just", "only", "very",
+        "much", "more", "most", "such", "each", "per", "via", "own", "off",
+        "out", "too", "get", "got", "let", "see", "say", "said", "tell", "show",
+        "find", "use", "used", "using", "one", "two", "way", "make", "made",
+        "need", "want", "know", "like", "work", "works", "please",
+    }
+)
+MAX_QUERY_TERMS = 12
+NO_LEXICAL_MATCH_WARNING = (
+    "No result contains any query term. The retriever always returns the "
+    "nearest chunks it stores, even when nothing in the vault is genuinely "
+    "close, so these hits may be unrelated to the query — verify their content "
+    "before relying on them."
+)
+
+
+def query_terms(query: str) -> list[str]:
+    """Distinct informative query tokens, lowercased, order preserved."""
+    seen: set[str] = set()
+    terms: list[str] = []
+    for raw in _QUERY_TOKEN_RE.findall((query or "").lower()):
+        token = raw.strip("_./-")
+        if len(token) < 3 or token in _QUERY_STOPWORDS or token in seen:
+            continue
+        seen.add(token)
+        terms.append(token)
+        if len(terms) >= MAX_QUERY_TERMS:
+            break
+    return terms
+
+
+@lru_cache(maxsize=1024)
+def _term_pattern(term: str) -> re.Pattern[str]:
+    # Token boundaries, not substring: "cli" must not match "client".
+    return re.compile(r"(?<![a-z0-9])" + re.escape(term) + r"(?![a-z0-9])")
+
+
+def text_term_matches(text: str, terms: list[str]) -> list[str]:
+    """Which of ``terms`` occur (token-bounded) in ``text``."""
+    if not text or not terms:
+        return []
+    lowered = text.lower()
+    return [term for term in terms if _term_pattern(term).search(lowered)]
+
+
+def best_match_window(
+    text: str, terms: list[str], *, width: int = 400
+) -> tuple[int, str] | None:
+    """(offset, window) around the densest cluster of query terms.
+
+    Returns None when no term occurs. Exists because truncating a long document
+    at its HEAD hides exactly the part that matched the query — the head of a
+    repo file is its provenance header and imports, and the answer usually
+    lives thousands of characters in.
+    """
+    if not text or not terms:
+        return None
+    lowered = text.lower()
+    positions: list[tuple[int, str]] = []
+    for term in terms:
+        for count, match in enumerate(_term_pattern(term).finditer(lowered)):
+            positions.append((match.start(), term))
+            if count >= 7:
+                break
+    if not positions:
+        return None
+    positions.sort()
+    best_start = positions[0][0]
+    best_count = 0
+    for index, (pos, _term) in enumerate(positions):
+        distinct: set[str] = set()
+        for later_pos, later_term in positions[index:]:
+            if later_pos > pos + width:
+                break
+            distinct.add(later_term)
+        if len(distinct) > best_count:
+            best_count = len(distinct)
+            best_start = pos
+    start = max(0, best_start - max(40, width // 8))
+    return start, text[start : start + width]
+
+
+def lexical_relevance_summary(
+    query: str,
+    coverages: list[float],
+    *,
+    scores_available: bool = False,
+) -> dict[str, Any]:
+    """Response-level honesty block about how relevant the page CAN be known to be.
+
+    ``no_lexical_match`` is the explicit no-confident-match marker: true when
+    the page is non-empty yet no hit contains a single query term. It is
+    phrased as low confidence, not as proof of irrelevance — a semantic match
+    through synonyms would also score zero coverage.
+    """
+    terms = query_terms(query)
+    max_coverage = max(coverages, default=0.0)
+    return {
+        "basis": "lexical-term-overlap",
+        "retriever_scores_available": bool(scores_available),
+        "query_terms": terms,
+        "max_term_coverage": round(float(max_coverage), 3),
+        "no_lexical_match": bool(terms) and bool(coverages) and max_coverage <= 0.0,
+    }
+
+
 def _hit_text(item: dict[str, Any]) -> str:
     parts = [
         item.get("title"),
@@ -129,6 +337,14 @@ def _hit_text(item: dict[str, Any]) -> str:
         ]
     )
     return " ".join(str(p) for p in parts if p)
+
+
+def hit_term_coverage(item: dict[str, Any], terms: list[str]) -> tuple[float, list[str]]:
+    """(fraction of query terms present, the matched terms) for one hit."""
+    if not terms:
+        return 0.0, []
+    matched = text_term_matches(_hit_text(item), terms)
+    return len(matched) / len(terms), matched
 
 
 def infer_doc_type(item: dict[str, Any]) -> str:
@@ -305,7 +521,18 @@ def apply_query_ranking(
         return list(results)
     dict_hits = [item for item in results if isinstance(item, dict)]
     other = [item for item in results if not isinstance(item, dict)]
-    dict_hits.sort(key=lambda item: query_rank_score(item, query, mode=mode), reverse=True)
+    # Class boost first, then lexical term coverage as the tie-breaker. Without
+    # the second key a page of same-class hits (ten repo-content chunks, all
+    # `canonical-docs`) sorted into exactly its input order and mode=docs was
+    # indistinguishable from not passing it. Coverage can only reorder WITHIN a
+    # class — it never lifts an issue above documentation.
+    terms = query_terms(query)
+
+    def rank_key(item: dict[str, Any]) -> tuple[float, float]:
+        coverage, _matched = hit_term_coverage(item, terms)
+        return query_rank_score(item, query, mode=mode), coverage
+
+    dict_hits.sort(key=rank_key, reverse=True)
     return dict_hits + other
 
 
@@ -316,8 +543,19 @@ def _first_str(*values: Any) -> str | None:
     return None
 
 
-def normalize_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
-    """Stable agent hit schema for CLI --json output."""
+SNIPPET_CHARS = 500
+
+
+def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None) -> dict[str, Any]:
+    """Stable agent hit schema for CLI --json output.
+
+    With ``query`` given, each hit also carries ``term_coverage`` /
+    ``matched_terms`` (observable lexical overlap — see
+    ``lexical_relevance_summary`` for why there is no retriever score), and the
+    snippet of a LONG text is a window around the densest query-term cluster
+    instead of the head: the head of a repo-content chunk is its provenance
+    header, which is exactly where the answer is not.
+    """
     if not isinstance(item, dict):
         text = str(item)
         return {
@@ -329,7 +567,7 @@ def normalize_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
             "doc_type": DOC_TYPE_OTHER,
             "updated_at": None,
             "score": None,
-            "snippet": text[:500],
+            "snippet": text[:SNIPPET_CHARS],
             "content_hint": HINT_UNCLASSIFIED,
             "trust_tier": TRUST_UNATTESTED,
             "rank": index + 1,
@@ -339,25 +577,44 @@ def normalize_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
     provenance = envelope.get("provenance") if isinstance(envelope.get("provenance"), dict) else {}
     metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
 
-    path = _first_str(item.get("path"), provenance.get("path"), metadata.get("path"))
+    raw_text = _first_str(
+        item.get("text"),
+        item.get("content"),
+        item.get("summary"),
+        item.get("chunk"),
+    )
+    # Parse the structural header BEFORE the snippet collapses whitespace: it
+    # is the only provenance a bare chunk carries, and identity filters below
+    # (repo=/path=) depend on it when the server envelope is absent.
+    header = parse_content_header(raw_text)
+
+    path = _first_str(
+        item.get("path"), provenance.get("path"), metadata.get("path"), header.get("path")
+    )
     url = _first_str(
         item.get("url"),
         item.get("source_url"),
         provenance.get("source_url"),
         item.get("source"),
+        header.get("source_url"),
     )
-    title = _first_str(item.get("title"), provenance.get("title"), metadata.get("title"))
-    text = _first_str(
-        item.get("text"),
-        item.get("content"),
-        item.get("summary"),
-        item.get("chunk"),
-        title,
-    ) or ""
+    title = _first_str(
+        item.get("title"),
+        provenance.get("title"),
+        metadata.get("title"),
+        header.get("title"),
+    )
+    text = raw_text or title or ""
     if not title:
         title = text.split("\n", 1)[0][:120] if text else (path or url or "untitled")
 
-    repo = _first_str(item.get("repo"), metadata.get("repo"), metadata.get("full_name"))
+    repo = _first_str(
+        item.get("repo"),
+        provenance.get("repo"),
+        metadata.get("repo"),
+        metadata.get("full_name"),
+        header.get("repo"),
+    )
     if not repo and isinstance(url, str) and "github.com/" in url:
         match = re.search(r"github\.com/([^/]+/[^/]+)", url)
         if match:
@@ -372,7 +629,15 @@ def normalize_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
     if not isinstance(score, (int, float)) or isinstance(score, bool):
         score = None
 
-    return {
+    terms = query_terms(query) if query else []
+    snippet_source = text
+    if terms and len(text) > SNIPPET_CHARS:
+        window = best_match_window(text, terms, width=SNIPPET_CHARS)
+        if window and window[0] > 0:
+            snippet_source = "…" + window[1]
+    snippet = " ".join(snippet_source.split())[:SNIPPET_CHARS]
+
+    normalized: dict[str, Any] = {
         "id": item.get("id") or envelope.get("result_id"),
         "title": title,
         "url": url,
@@ -385,15 +650,20 @@ def normalize_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
             metadata.get("updated_at"),
         ),
         "score": score,
-        "snippet": " ".join(text.split())[:500],
+        "snippet": snippet,
         # Alias kept for older agent parsers that read ``text``.
-        "text": " ".join(text.split())[:500],
+        "text": snippet,
         "content_hint": infer_content_hint(item, doc_type),
         "trust_tier": trust_tier,
         "rank": envelope.get("rank") or (index + 1),
         "dataset": envelope.get("dataset"),
         "_citadel": envelope or None,
     }
+    if terms:
+        coverage, matched = hit_term_coverage(item, terms)
+        normalized["term_coverage"] = round(coverage, 3)
+        normalized["matched_terms"] = matched
+    return normalized
 
 
 def _hit_envelope(hit: dict[str, Any]) -> dict[str, Any]:
@@ -417,33 +687,72 @@ def _hit_trust_tier(hit: dict[str, Any]) -> str:
     ).lower()
 
 
-def _hit_blob(hit: dict[str, Any], *extra_keys: str) -> str:
-    """Lowercased haystack for substring filters (shaped hits + server envelopes)."""
+_GITHUB_REPO_URL_RE = re.compile(r"github\.com/([^/\s]+/[^/\s]+)")
+
+
+def _hit_raw_text(hit: dict[str, Any]) -> str | None:
+    return _first_str(hit.get("text"), hit.get("content"), hit.get("chunk"), hit.get("body"))
+
+
+def _hit_repo_identity(hit: dict[str, Any]) -> str | None:
+    """Which repository this hit IS from — never which repositories it mentions.
+
+    Sources, in order: explicit repo keys, the server-parsed provenance, a
+    github.com source URL, and finally the structural header at the start of
+    the chunk. Body prose is deliberately not consulted: repo="sokosumi-cli"
+    used to match a sokosumi-docs file because its install instructions
+    contained that string. Neither is the envelope dataset — Central is
+    literally named after the org, so repo=<org> would match every hit in it.
+    """
     provenance = _hit_provenance(hit)
     metadata = hit.get("metadata") if isinstance(hit.get("metadata"), dict) else {}
-    parts: list[Any] = [
+    identity = _first_str(
         hit.get("repo"),
-        hit.get("path"),
-        hit.get("url"),
-        hit.get("source"),
-        hit.get("snippet"),
-        hit.get("text"),
-        hit.get("content"),
-        hit.get("title"),
-        provenance.get("path"),
-        provenance.get("source_url"),
-        provenance.get("title"),
+        provenance.get("repo"),
         metadata.get("repo"),
-        metadata.get("path"),
         metadata.get("full_name"),
-        # NOT envelope["dataset"]: Central is literally named after the org, so
-        # repo="masumi-network" matched every hit in it, and a seat dataset
-        # matched its own slug. Scoping filters must not be satisfied by the
-        # name of the dataset a hit happens to live in.
-    ]
-    for key in extra_keys:
-        parts.append(hit.get(key))
-    return " ".join(str(part).lower() for part in parts if part)
+    )
+    if identity:
+        return identity
+    url = _first_str(hit.get("url"), hit.get("source_url"), provenance.get("source_url"))
+    if url:
+        match = _GITHUB_REPO_URL_RE.search(url)
+        if match:
+            return match.group(1)
+    header = parse_content_header(_hit_raw_text(hit))
+    return header.get("repo")
+
+
+def repo_filter_matches(identity: str | None, wanted: str) -> bool:
+    """Repo IDENTITY match: exact, name-only, or org-only — never substring.
+
+    Fail-closed: a hit that cannot state which repo it is from does not satisfy
+    a repo filter, whatever its body text happens to contain.
+    """
+    if not identity:
+        return False
+    identity = identity.strip().strip("/").lower()
+    needle = (wanted or "").strip().strip("/").lower()
+    if not needle:
+        return True
+    return (
+        identity == needle
+        or identity.endswith("/" + needle)
+        or identity.startswith(needle + "/")
+    )
+
+
+def _hit_path_identity(hit: dict[str, Any]) -> str | None:
+    """The path this hit IS — from path keys or the parsed start-of-chunk header."""
+    provenance = _hit_provenance(hit)
+    metadata = hit.get("metadata") if isinstance(hit.get("metadata"), dict) else {}
+    path = _first_str(hit.get("path"), provenance.get("path"), metadata.get("path"))
+    if path:
+        return path
+    header = parse_content_header(_hit_raw_text(hit))
+    # The header title line is "org/repo/path", a superset of the path — fine
+    # for substring path filters, still an identity claim rather than body text.
+    return header.get("path") or header.get("title")
 
 
 def compact_search_filters(
@@ -497,14 +806,18 @@ def filter_hits(
         wanted = {t.strip().lower() for t in types if t.strip()}
         filtered = [h for h in filtered if _hit_doc_type(h) in wanted]
     if repo:
-        needle = repo.lower()
-        filtered = [h for h in filtered if needle in _hit_blob(h)]
+        # Identity, not substring: matching the whole hit blob credited any hit
+        # whose BODY mentioned the repo name (install lines, cross-references).
+        filtered = [h for h in filtered if repo_filter_matches(_hit_repo_identity(h), repo)]
     if path:
-        # Treat as substring; callers may pass glob-ish **/MIP-003/** which still
-        # matches as plain text on path/snippet for agent convenience.
+        # Substring over the hit's own path identity only; callers may pass
+        # glob-ish **/MIP-003/** which still matches as plain text. Matching the
+        # whole blob made path= another body-text filter.
         needle = path.replace("**/", "").replace("/**", "").replace("*", "").lower()
         if needle:
-            filtered = [h for h in filtered if needle in _hit_blob(h)]
+            filtered = [
+                h for h in filtered if needle in (_hit_path_identity(h) or "").lower()
+            ]
     if canonical_only:
         # Content-shaped, NOT a trust filter: it keeps hits whose text reads like
         # documentation. It cannot vouch for any of them — the tier that could
@@ -554,7 +867,9 @@ def shape_search_payload(
         ordered = apply_query_ranking(raw_results, query, mode=mode)
     else:
         ordered = list(raw_results)
-    hits = [normalize_search_hit(item, index=i) for i, item in enumerate(ordered)]
+    hits = [normalize_search_hit(item, index=i, query=query) for i, item in enumerate(ordered)]
+    filters_active = bool(types or repo or path or canonical_only or exclude_ambient)
+    before_filters = len(hits)
     hits = filter_hits(
         hits,
         types=types,
@@ -563,6 +878,15 @@ def shape_search_payload(
         canonical_only=canonical_only,
         exclude_ambient=exclude_ambient,
     )
+    relevance = lexical_relevance_summary(
+        query,
+        [
+            float(h["term_coverage"])
+            for h in hits
+            if isinstance(h.get("term_coverage"), (int, float))
+        ],
+        scores_available=any(h.get("score") is not None for h in hits),
+    )
     warnings: list[str] = []
     if payload.get("note"):
         warnings.append(str(payload["note"]))
@@ -570,6 +894,8 @@ def shape_search_payload(
     truncated = timed_out or bool(payload.get("truncated"))
     if timed_out:
         warnings.append("search timed out; results may be incomplete")
+    if relevance["no_lexical_match"]:
+        warnings.append(NO_LEXICAL_MATCH_WARNING)
     authority = token_asset_authority_warning(query)
     if authority:
         warnings.append(authority)
@@ -584,9 +910,15 @@ def shape_search_payload(
         "truncated": truncated,
         "spec_mode": bool(apply_spec_ranking) and not docs_mode,
         "docs_mode": docs_mode,
+        "relevance": relevance,
         "warnings": warnings,
         "ok": True,
     }
+    if filters_active:
+        # Filters run on the returned page, so they can only shrink it. Say how
+        # much they did, so a short page reads as "filters excluded candidates",
+        # not "the vault holds nothing else".
+        out["filter_stats"] = {"before": before_filters, "after": len(hits)}
     if timed_out:
         out["code"] = CODE_TIMEOUT
     elif payload.get("code"):

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -64,7 +64,7 @@ LINEAR_HEADER_PARSE_RE = re.compile(
 LINEAR_HEADER_FIELD_RE = re.compile(r"^-\s+\*\*(?P<key>[A-Za-z ]+):\*\*[ \t]*(?P<value>.+?)[ \t]*$")
 
 
-def parse_content_header(text: Any) -> dict[str, str]:
+def parse_content_header(text: Any, *, chunk_index: Any = None) -> dict[str, str]:
     """Provenance from the structural header a syncer wrote at the START of a chunk.
 
     cognee stores no per-document metadata (hits expose empty ``provenance`` and
@@ -72,10 +72,24 @@ def parse_content_header(text: Any) -> dict[str, str]:
     render a machine-readable header as the first lines of the documents they
     ingest. Parsing it back is the only provenance available.
 
-    Only a header at position zero is credited (leading whitespace aside). The
-    values are still body text and therefore author-controlled — callers must
-    label them as content-derived, never as attested trust.
+    Only a header at position zero is credited (leading whitespace aside), and
+    only for the document's FIRST chunk: every chunk starts at position zero of
+    its own payload, so "the start" of chunk 1+ is still mid-document,
+    author-controlled text — a contributor to any synced repo could open a
+    later chunk with a forged header and gain another document's identity (and
+    membership in repo=/path= filtered results). Pass the hit's ``chunk_index``
+    when the payload carries one; a numeric index other than 0 refuses to
+    parse, while absent/None keeps crediting (whole-document payloads and
+    pre-chunk sources carry no index). The values are still body text and
+    therefore author-controlled — callers must label them as content-derived,
+    never as attested trust.
     """
+    if (
+        isinstance(chunk_index, (int, float))
+        and not isinstance(chunk_index, bool)
+        and chunk_index != 0
+    ):
+        return {}
     if not isinstance(text, str) or not text:
         return {}
     match = REPO_CONTENT_HEADER_PARSE_RE.match(text)
@@ -543,6 +557,14 @@ def _first_str(*values: Any) -> str | None:
     return None
 
 
+def _hit_chunk_index(hit: dict[str, Any]) -> Any:
+    """The hit's own chunk_index (CHUNKS payloads carry one), else None."""
+    if "chunk_index" in hit:
+        return hit.get("chunk_index")
+    metadata = hit.get("metadata") if isinstance(hit.get("metadata"), dict) else {}
+    return metadata.get("chunk_index")
+
+
 SNIPPET_CHARS = 500
 
 
@@ -586,7 +608,7 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
     # Parse the structural header BEFORE the snippet collapses whitespace: it
     # is the only provenance a bare chunk carries, and identity filters below
     # (repo=/path=) depend on it when the server envelope is absent.
-    header = parse_content_header(raw_text)
+    header = parse_content_header(raw_text, chunk_index=_hit_chunk_index(item))
 
     path = _first_str(
         item.get("path"), provenance.get("path"), metadata.get("path"), header.get("path")
@@ -719,7 +741,7 @@ def _hit_repo_identity(hit: dict[str, Any]) -> str | None:
         match = _GITHUB_REPO_URL_RE.search(url)
         if match:
             return match.group(1)
-    header = parse_content_header(_hit_raw_text(hit))
+    header = parse_content_header(_hit_raw_text(hit), chunk_index=_hit_chunk_index(hit))
     return header.get("repo")
 
 
@@ -749,7 +771,7 @@ def _hit_path_identity(hit: dict[str, Any]) -> str | None:
     path = _first_str(hit.get("path"), provenance.get("path"), metadata.get("path"))
     if path:
         return path
-    header = parse_content_header(_hit_raw_text(hit))
+    header = parse_content_header(_hit_raw_text(hit), chunk_index=_hit_chunk_index(hit))
     # The header title line is "org/repo/path", a superset of the path — fine
     # for substring path filters, still an identity claim rather than body text.
     return header.get("path") or header.get("title")

--- a/kb/server.py
+++ b/kb/server.py
@@ -2520,8 +2520,10 @@ def result_provenance(result: dict[str, Any]) -> dict[str, str]:
     write a structural header as the first lines of every document they ingest.
     ``parse_content_header`` recovers repo/path/source_url/commit/blob (and the
     Linear issue id) from a header at the START of the chunk only — a header
-    quoted mid-body is never credited. Header-derived values are body text and
-    therefore author-controlled, so they are marked ``basis: content-header``
+    quoted mid-body is never credited — and only on the document's FIRST chunk
+    (``chunk_index`` 0 or absent), because chunk 1+ starts are author-controlled
+    body text. Header-derived values are body text and therefore
+    author-controlled even then, so they are marked ``basis: content-header``
     and must never feed ``trust_tier``.
     """
     metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else {}
@@ -2555,7 +2557,10 @@ def result_provenance(result: dict[str, Any]) -> dict[str, str]:
             result.get("content"),
             result.get("chunk"),
             result.get("body"),
-        )
+        ),
+        # Chunk 1+ starts are author-controlled mid-document text: a header
+        # there is forgeable, so only the document's first chunk is credited.
+        chunk_index=result.get("chunk_index", metadata.get("chunk_index")),
     )
     if header:
         header_used = False
@@ -2606,11 +2611,20 @@ def _result_retriever_score(result: dict[str, Any]) -> float | None:
     cognee 1.2.2's CHUNKS retriever returns chunk payload dicts without one —
     the vector engine's ScoredResult carries a cosine distance, but the
     retriever hands back ``found_chunk.payload`` only, so the distance is
-    dropped upstream of this repo's client boundary. Today this is therefore
-    always None. It is checked anyway so that the moment the client boundary
-    starts merging the distance into the payload, hits surface it here without
-    another change. Never invented: absent stays absent.
+    dropped upstream of this repo's client boundary. For cognee hits this is
+    therefore always None. It is checked anyway so that the moment the client
+    boundary starts merging the distance into the payload, hits surface it here
+    without another change. Never invented: absent stays absent.
+
+    The one live producer of a ``score`` today is the github digest fallback
+    (``search_github_sync_state``), whose value is a token-overlap COUNT — an
+    unbounded integer in a different unit. Passing it through here would
+    surface it as ``retriever_score`` and flip ``retriever_scores_available``
+    on exactly the pages whose only signal is lexical, so that path is
+    excluded rather than mislabelled.
     """
+    if result.get("source") == "github_sync_state":
+        return None
     for key in ("score", "distance", "similarity"):
         value = result.get(key)
         if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -6221,7 +6235,6 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
                 },
             )
             raise HTTPException(status_code=500, detail=str(exc)) from exc
-    latency_ms = (time.perf_counter() - started) * 1000.0
     if timed_out:
         await mesh_state.record_error(
             citadel.config, operation="search", error="search budget exceeded"
@@ -6267,16 +6280,24 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     # Honest drill-down hint (ADR-0009): the document_drilldown_available flag
     # (and the document_endpoint URL) must be TRUE only when /api/documents would
     # actually return 200 for THIS caller. Bypass callers reach any resolvable id,
-    # so they skip the check. For a scoped caller we resolve each id through the
-    # SAME steps /api/documents takes — get_document to recover its
+    # so they skip the check. For a scoped caller we resolve each id to the SAME
+    # owner ids the /api/documents cognee branch would gate on —
+    # resolve_document_owner_ids, the seed-only read that recovers
     # ``dataset_node_ids`` (a CHUNKS hit's datasets live on its is_part_of parent
     # document, NOT the chunk node itself, so a raw-id map lookup would always
-    # miss), then the SAME visibility rule over the SAME once-fetched
-    # node_dataset_map — so the hint can never drift from the endpoint it points
-    # at. Resolved once per UNIQUE drillable id on the final page; the shared
-    # map is fetched once and reused across ids.
+    # miss) WITHOUT assembling the document body get_document would build and
+    # this boolean would discard — then the SAME visibility rule over the SAME
+    # once-fetched node_dataset_map, so the hint can never drift from the
+    # endpoint it points at. Resolved once per UNIQUE drillable id on the final
+    # page; the shared map is fetched once and reused across ids.
+    drilldown_ms: float | None = None
     if not bypass_drilldown:
+        drilldown_started = time.perf_counter()
         drilldown_map = await load_node_dataset_map(warn_unavailable=False)
+        # This pass runs OUTSIDE _search_within_budget and the _SearchSlot, so
+        # nothing else bounds it: give it its own deadline. On expiry the
+        # remaining ids deny — the safe under-promise, never a hung request.
+        drilldown_deadline = drilldown_started + citadel.config.search_timeout_seconds
 
         async def _resolve_drilldown(result_id: str) -> bool:
             if result_id.startswith(f"{GITHUB_DOC_ID_PREFIX}:"):
@@ -6285,17 +6306,18 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
                 # get_document); the endpoint returns 200 for any reader with a
                 # resolvable id.
                 return True
-            # Native cognee id: resolve exactly as the /api/documents cognee branch
-            # does. A missing document (None), a cold/empty map, or an id whose owner
-            # nodes are all hidden each deny (fail-closed) so the flag never promises
-            # a 404 — textless entities and foreign-seat docs/chunks fall out here.
+            # Native cognee id: an unresolvable id (None), a cold/empty map, or
+            # an id whose owner nodes are all hidden each deny (fail-closed) so
+            # the flag never promises a 404 — textless entities and foreign-seat
+            # docs/chunks fall out here.
             try:
-                document = await get_citadel().get_document(result_id)
+                owner_node_ids = await get_citadel().resolve_document_owner_ids(
+                    result_id
+                )
             except Exception:  # noqa: BLE001 - any failure fails closed, like a 404
                 return False
-            if document is None:
+            if owner_node_ids is None:
                 return False
-            owner_node_ids = document.get("dataset_node_ids") or [result_id]
             return node_ids_visible_in_map(actor, owner_node_ids, drilldown_map)
 
         drilldown_hint: dict[str, bool] = {}
@@ -6310,12 +6332,27 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
                 # non-drillable, nothing to resolve.
                 continue
             if result_id not in drilldown_hint:
-                drilldown_hint[result_id] = await _resolve_drilldown(result_id)
+                remaining = drilldown_deadline - time.perf_counter()
+                if remaining <= 0:
+                    drilldown_hint[result_id] = False
+                else:
+                    try:
+                        drilldown_hint[result_id] = await asyncio.wait_for(
+                            _resolve_drilldown(result_id), timeout=remaining
+                        )
+                    except asyncio.TimeoutError:
+                        drilldown_hint[result_id] = False
             if drilldown_hint[result_id]:
                 envelope["document_endpoint"] = document_endpoint
                 retrieval = envelope.get("retrieval")
                 if isinstance(retrieval, dict):
                     retrieval["document_drilldown_available"] = True
+        drilldown_ms = (time.perf_counter() - drilldown_started) * 1000.0
+
+    # Measured AFTER the drill-down pass: taking it at the _SearchSlot exit made
+    # the audit row and search telemetry under-report exactly the per-hit cost
+    # the pass adds. drilldown_ms below breaks out the pass's own share.
+    latency_ms = (time.perf_counter() - started) * 1000.0
 
     for search_dataset in search_datasets:
         await mesh_state.record_search(
@@ -6343,6 +6380,8 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         "latency_ms": round(latency_ms, 1),
         "timed_out": timed_out,
     }
+    if drilldown_ms is not None:
+        audit_detail["drilldown_ms"] = round(drilldown_ms, 1)
     if filters_active:
         audit_detail["candidates_fetched"] = candidates_fetched
         audit_detail["candidates_matched"] = candidates_matched
@@ -6428,14 +6467,28 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         payload["timed_out"] = True
         payload["truncated"] = True
         payload["code"] = CODE_TIMEOUT
-    elif not normalized and body.dataset is None and not filters_active:
+    elif not normalized and body.dataset is None and (
+        not filters_active or candidates_fetched == 0
+    ):
+        # With filters active this fires only when retrieval itself came back
+        # empty — an empty page whose candidates the filters excluded gets the
+        # filter warning below instead, not dataset advice.
         payload["note"] = (
             "No results in the default dataset. Pass an explicit \"dataset\" to search a "
             "specific source; see known_datasets."
         )
         payload["known_datasets"] = known_datasets(citadel.config)
     warnings: list[str] = []
-    if filters_active and candidates_matched < body.top_k and not timed_out:
+    if (
+        filters_active
+        and candidates_matched < body.top_k
+        # Only when the filters actually excluded candidates: with
+        # candidates_matched == candidates_fetched (including 0 fetched) the
+        # page is short because retrieval found nothing else, and saying the
+        # opposite would be literally false.
+        and candidates_matched < candidates_fetched
+        and not timed_out
+    ):
         warnings.append(
             f"Filters matched {candidates_matched} of {candidates_fetched} fetched "
             "candidates; the page is short because post-retrieval filters excluded "

--- a/kb/server.py
+++ b/kb/server.py
@@ -83,14 +83,20 @@ from kb.search_format import (
     CODE_TIMEOUT,
     DOC_TYPE_CANONICAL,
     DOC_TYPE_TRACE,
+    NO_LEXICAL_MATCH_WARNING,
     apply_query_ranking,
+    best_match_window,
     compact_search_filters,
     filter_hits,
+    hit_term_coverage,
     infer_content_hint,
     infer_doc_type,
     infer_trust_tier,
     is_docs_mode_query,
     is_spec_mode_query,
+    lexical_relevance_summary,
+    parse_content_header,
+    query_terms,
     token_asset_authority_warning,
 )
 from kb.security_scan import (
@@ -2246,6 +2252,18 @@ async def capture_search_feedback(
             session_id=session_id,
             filters=filters,
         )
+        # search_id_for hashes query + result_count + datasets only, so the
+        # same query with and without mode=docs (or any filter) produced the
+        # SAME search_id and telemetry could not tell the two calls apart.
+        # Suffix a digest of the filters: still deterministic (identical calls
+        # still share an id, so explicit follow-up feedback keeps linking), but
+        # differently-filtered calls no longer collide.
+        base_search_id = telemetry.get("search_id")
+        if filters and isinstance(base_search_id, str):
+            filters_digest = hashlib.sha256(
+                json.dumps(filters, sort_keys=True, default=str).encode("utf-8")
+            ).hexdigest()[:8]
+            telemetry["search_id"] = f"{base_search_id}.f{filters_digest}"
         # ADR-0009 (presence for all, content per caller): the row lands on the
         # caller's own Node when they have one, so query text and hit ids stay
         # private to them. A row that has to land on a shared dataset — a
@@ -2495,6 +2513,17 @@ def first_string(*values: Any) -> str | None:
 
 
 def result_provenance(result: dict[str, Any]) -> dict[str, str]:
+    """Provenance for one hit: explicit keys first, then the parsed content header.
+
+    cognee's chunk payloads carry none of the explicit keys (117/117 production
+    hits shipped ``provenance == {}``), but the repo-content and Linear syncers
+    write a structural header as the first lines of every document they ingest.
+    ``parse_content_header`` recovers repo/path/source_url/commit/blob (and the
+    Linear issue id) from a header at the START of the chunk only — a header
+    quoted mid-body is never credited. Header-derived values are body text and
+    therefore author-controlled, so they are marked ``basis: content-header``
+    and must never feed ``trust_tier``.
+    """
     metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else {}
     provenance = {
         "source": first_string(
@@ -2520,6 +2549,25 @@ def result_provenance(result: dict[str, Any]) -> dict[str, str]:
         "title": first_string(result.get("title"), metadata.get("title")),
         "session_id": first_string(result.get("session_id"), metadata.get("session_id")),
     }
+    header = parse_content_header(
+        first_string(
+            result.get("text"),
+            result.get("content"),
+            result.get("chunk"),
+            result.get("body"),
+        )
+    )
+    if header:
+        header_used = False
+        for key in ("repo", "path", "source_url", "commit", "blob", "issue", "title"):
+            value = header.get(key)
+            if value and not provenance.get(key):
+                provenance[key] = value
+                header_used = True
+        if header_used:
+            if not provenance.get("source"):
+                provenance["source"] = header.get("kind")
+            provenance["basis"] = "content-header"
     return {key: value for key, value in provenance.items() if value}
 
 
@@ -2552,12 +2600,31 @@ def with_result_id(result: dict[str, Any]) -> dict[str, Any]:
     return {"id": f"chunk:{derived}", **result}
 
 
+def _result_retriever_score(result: dict[str, Any]) -> float | None:
+    """A numeric relevance value the retriever itself attached, if any.
+
+    cognee 1.2.2's CHUNKS retriever returns chunk payload dicts without one —
+    the vector engine's ScoredResult carries a cosine distance, but the
+    retriever hands back ``found_chunk.payload`` only, so the distance is
+    dropped upstream of this repo's client boundary. Today this is therefore
+    always None. It is checked anyway so that the moment the client boundary
+    starts merging the distance into the payload, hits surface it here without
+    another change. Never invented: absent stays absent.
+    """
+    for key in ("score", "distance", "similarity"):
+        value = result.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
 def with_result_metadata(
     result: Any,
     index: int,
     dataset: str,
     *,
     drilldown_predicate: Callable[[str], bool] | None = None,
+    query: str | None = None,
 ) -> Any:
     """Attach a reserved Citadel provenance envelope to dict search results.
 
@@ -2568,6 +2635,13 @@ def with_result_metadata(
     that follows the hint never lands on an ADR-0009 404. Without a predicate
     the flag falls back to "any id with a backing endpoint" (non-caller-scoped
     callers/tests). Synthetic ``chunk:<hash>`` ids stay non-drillable either way.
+
+    ``query`` (when supplied) adds ``_citadel.relevance``: the retriever's own
+    score when the payload carries one (it does not today — see
+    ``_result_retriever_score``), observable lexical term coverage, and a
+    ``match_context`` window around the densest query-term cluster so that a
+    caller which truncates ``text`` at the head still shows the part of a long
+    document that actually matched.
     """
     if not isinstance(result, dict):
         return result
@@ -2600,6 +2674,27 @@ def with_result_metadata(
     }
     if drilldown_available:
         metadata["document_endpoint"] = document_endpoint
+    if query is not None:
+        terms = query_terms(query)
+        coverage, matched = hit_term_coverage({**normalized, "_citadel": metadata}, terms)
+        relevance: dict[str, Any] = {
+            "term_coverage": round(coverage, 3),
+            "matched_terms": matched,
+        }
+        retriever_score = _result_retriever_score(normalized)
+        if retriever_score is not None:
+            relevance["retriever_score"] = retriever_score
+        full_text = first_string(
+            normalized.get("text"),
+            normalized.get("content"),
+            normalized.get("chunk"),
+            normalized.get("body"),
+        )
+        if full_text and terms:
+            window = best_match_window(full_text, terms)
+            if window and window[0] > 0:
+                relevance["match_context"] = {"offset": window[0], "text": window[1]}
+        metadata["relevance"] = relevance
     # Classify BEFORE deciding trust, because the two questions have different
     # authorities and conflating them is what broke `mode="docs"`.
     #
@@ -6089,6 +6184,14 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     mesh_state = get_mesh()
     search_datasets = resolve_search_datasets(actor, body.dataset, citadel.config)
     search_sessions = resolve_search_sessions(actor, body.session_id, search_datasets)
+    filter_kw = body.filter_kwargs()
+    filters_active = any(filter_kw.values())
+    # Filters run AFTER retrieval, so on a fixed candidate page they can only
+    # shrink it: top_k=10 with a repo filter used to return 4 hits. Over-fetch
+    # candidates when filters are active and trim back to top_k after
+    # filtering; 100 is SearchBody's own top_k ceiling, so a filtered call can
+    # never fetch more than an unfiltered one is allowed to ask for.
+    fetch_k = min(max(body.top_k * 3, body.top_k + 10), 100) if filters_active else body.top_k
     limit = citadel.config.search_max_concurrency
     timed_out = False
     started = time.perf_counter()
@@ -6101,7 +6204,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
                 query=body.query,
                 datasets=search_datasets,
                 sessions=search_sessions,
-                top_k=body.top_k,
+                top_k=fetch_k,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
             await mesh_state.record_error(citadel.config, operation="search", error=str(exc))
@@ -6124,13 +6227,125 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             citadel.config, operation="search", error="search budget exceeded"
         )
 
+    # Shaping order: envelope -> rank -> filter -> trim -> drilldown. The
+    # drill-down hints are resolved LAST, over the final page only, because
+    # each scoped resolution costs a get_document call and over-fetching for
+    # filters would otherwise triple that cost for hits the caller never sees.
+    bypass_drilldown = can_bypass_dataset_allowlist(actor)
+    normalized = [
+        with_result_metadata(
+            result,
+            index,
+            dataset,
+            # Scoped callers: deny drill-down for now and patch the survivors
+            # up after the trim. The safe failure direction — a missed patch
+            # under-promises (a 200 the hint did not advertise), never an
+            # ADR-0009 404 the hint promised was a document.
+            drilldown_predicate=None if bypass_drilldown else (lambda _result_id: False),
+            query=body.query,
+        )
+        for index, (dataset, result) in enumerate(merged)
+    ]
+    cleaned_mode = body.cleaned_mode()
+    docs_mode = is_docs_mode_query(body.query, mode=cleaned_mode)
+    if docs_mode or is_spec_mode_query(body.query):
+        normalized = apply_query_ranking(normalized, body.query, mode=cleaned_mode)
+    candidates_fetched = len(normalized)
+    if filters_active:
+        dict_hits = [item for item in normalized if isinstance(item, dict)]
+        other = [item for item in normalized if not isinstance(item, dict)]
+        normalized = filter_hits(dict_hits, **filter_kw) + other
+    candidates_matched = len(normalized)
+    if len(normalized) > body.top_k:
+        normalized = normalized[: body.top_k]
+    # Refresh rank numbers after re-order / filter / trim so agents see
+    # consistent ordering.
+    for index, item in enumerate(normalized):
+        if isinstance(item, dict) and isinstance(item.get("_citadel"), dict):
+            item["_citadel"]["rank"] = index + 1
+
+    # Honest drill-down hint (ADR-0009): the document_drilldown_available flag
+    # (and the document_endpoint URL) must be TRUE only when /api/documents would
+    # actually return 200 for THIS caller. Bypass callers reach any resolvable id,
+    # so they skip the check. For a scoped caller we resolve each id through the
+    # SAME steps /api/documents takes — get_document to recover its
+    # ``dataset_node_ids`` (a CHUNKS hit's datasets live on its is_part_of parent
+    # document, NOT the chunk node itself, so a raw-id map lookup would always
+    # miss), then the SAME visibility rule over the SAME once-fetched
+    # node_dataset_map — so the hint can never drift from the endpoint it points
+    # at. Resolved once per UNIQUE drillable id on the final page; the shared
+    # map is fetched once and reused across ids.
+    if not bypass_drilldown:
+        drilldown_map = await load_node_dataset_map(warn_unavailable=False)
+
+        async def _resolve_drilldown(result_id: str) -> bool:
+            if result_id.startswith(f"{GITHUB_DOC_ID_PREFIX}:"):
+                # github drill-down has no ADR-0009 scope gate and resolves via a
+                # different endpoint branch (github_section_document, not
+                # get_document); the endpoint returns 200 for any reader with a
+                # resolvable id.
+                return True
+            # Native cognee id: resolve exactly as the /api/documents cognee branch
+            # does. A missing document (None), a cold/empty map, or an id whose owner
+            # nodes are all hidden each deny (fail-closed) so the flag never promises
+            # a 404 — textless entities and foreign-seat docs/chunks fall out here.
+            try:
+                document = await get_citadel().get_document(result_id)
+            except Exception:  # noqa: BLE001 - any failure fails closed, like a 404
+                return False
+            if document is None:
+                return False
+            owner_node_ids = document.get("dataset_node_ids") or [result_id]
+            return node_ids_visible_in_map(actor, owner_node_ids, drilldown_map)
+
+        drilldown_hint: dict[str, bool] = {}
+        for item in normalized:
+            if not isinstance(item, dict) or not isinstance(item.get("_citadel"), dict):
+                continue
+            envelope = item["_citadel"]
+            result_id = str(envelope.get("result_id") or "")
+            document_endpoint = document_endpoint_for_result(result_id)
+            if not document_endpoint:
+                # Synthetic chunk:<hash> id with no backing store — honestly
+                # non-drillable, nothing to resolve.
+                continue
+            if result_id not in drilldown_hint:
+                drilldown_hint[result_id] = await _resolve_drilldown(result_id)
+            if drilldown_hint[result_id]:
+                envelope["document_endpoint"] = document_endpoint
+                retrieval = envelope.get("retrieval")
+                if isinstance(retrieval, dict):
+                    retrieval["document_drilldown_available"] = True
+
     for search_dataset in search_datasets:
         await mesh_state.record_search(
             citadel.config,
             query=body.query,
             dataset=search_dataset,
-            result_count=sum(1 for ds, _ in merged if ds == search_dataset),
+            # Counted from the page the caller actually receives, not from the
+            # over-fetched candidate pool.
+            result_count=sum(
+                1
+                for item in normalized
+                if isinstance(item, dict)
+                and isinstance(item.get("_citadel"), dict)
+                and item["_citadel"].get("dataset") == search_dataset
+            ),
         )
+    audit_detail: dict[str, Any] = {
+        "operation": "search",
+        "query_sha256": hashlib.sha256(body.query.encode("utf-8")).hexdigest(),
+        "query_length": len(body.query),
+        "result_count": len(normalized),
+        "top_k": body.top_k,
+        "datasets": search_datasets,
+        "scope_override": scope_override_active(actor, search_datasets),
+        "latency_ms": round(latency_ms, 1),
+        "timed_out": timed_out,
+    }
+    if filters_active:
+        audit_detail["candidates_fetched"] = candidates_fetched
+        audit_detail["candidates_matched"] = candidates_matched
     record_mcp_audit(
         request,
         actor=actor,
@@ -6141,88 +6356,8 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         # unquantified. The detail dict already carried timed_out; nothing read it.
         success=not timed_out,
         dataset=search_datasets[0],
-        detail={
-            "operation": "search",
-            "query_sha256": hashlib.sha256(body.query.encode("utf-8")).hexdigest(),
-            "query_length": len(body.query),
-            "result_count": len(merged),
-            "top_k": body.top_k,
-            "datasets": search_datasets,
-            "scope_override": scope_override_active(actor, search_datasets),
-            "latency_ms": round(latency_ms, 1),
-            "timed_out": timed_out,
-        },
+        detail=audit_detail,
     )
-    # Honest drill-down hint (ADR-0009): the document_drilldown_available flag
-    # (and the document_endpoint URL) must be TRUE only when /api/documents would
-    # actually return 200 for THIS caller. Bypass callers reach any resolvable id,
-    # so they skip the check. For a scoped caller we resolve each id through the
-    # SAME steps /api/documents takes — get_document to recover its
-    # ``dataset_node_ids`` (a CHUNKS hit's datasets live on its is_part_of parent
-    # document, NOT the chunk node itself, so a raw-id map lookup would always
-    # miss), then the SAME visibility rule over the SAME once-fetched
-    # node_dataset_map — so the hint can never drift from the endpoint it points
-    # at. Resolved once per UNIQUE drillable id (results are already deduped and
-    # top_k-bounded); the shared map is fetched once and reused across ids.
-    bypass_drilldown = can_bypass_dataset_allowlist(actor)
-    drilldown_map = (
-        None if bypass_drilldown else await load_node_dataset_map(warn_unavailable=False)
-    )
-
-    async def _resolve_drilldown(result_id: str) -> bool:
-        if result_id.startswith(f"{GITHUB_DOC_ID_PREFIX}:"):
-            # github drill-down has no ADR-0009 scope gate and resolves via a
-            # different endpoint branch (github_section_document, not
-            # get_document); the endpoint returns 200 for any reader with a
-            # resolvable id.
-            return True
-        # Native cognee id: resolve exactly as the /api/documents cognee branch
-        # does. A missing document (None), a cold/empty map, or an id whose owner
-        # nodes are all hidden each deny (fail-closed) so the flag never promises
-        # a 404 — textless entities and foreign-seat docs/chunks fall out here.
-        try:
-            document = await get_citadel().get_document(result_id)
-        except Exception:  # noqa: BLE001 - any failure fails closed, like a 404
-            return False
-        if document is None:
-            return False
-        owner_node_ids = document.get("dataset_node_ids") or [result_id]
-        return node_ids_visible_in_map(actor, owner_node_ids, drilldown_map)
-
-    drilldown_hint: dict[str, bool] = {}
-    if not bypass_drilldown:
-        for _dataset, result in merged:
-            if not isinstance(result, dict):
-                continue
-            result_id = str(with_result_id(result)["id"])
-            if result_id in drilldown_hint or not document_endpoint_for_result(result_id):
-                # Already resolved, or a synthetic chunk:<hash> id with no backing
-                # store — with_result_metadata marks those non-drillable anyway.
-                continue
-            drilldown_hint[result_id] = await _resolve_drilldown(result_id)
-
-    def _drilldown_available(result_id: str) -> bool:
-        # Bypass callers reach any resolvable id; scoped callers get the honest
-        # per-endpoint decision precomputed above (default-deny for safety).
-        return True if bypass_drilldown else drilldown_hint.get(result_id, False)
-
-    normalized = [
-        with_result_metadata(
-            result, index, dataset, drilldown_predicate=_drilldown_available
-        )
-        for index, (dataset, result) in enumerate(merged)
-    ]
-    if is_docs_mode_query(body.query, mode=body.cleaned_mode()) or is_spec_mode_query(body.query):
-        normalized = apply_query_ranking(normalized, body.query, mode=body.cleaned_mode())
-    filter_kw = body.filter_kwargs()
-    if any(filter_kw.values()):
-        dict_hits = [item for item in normalized if isinstance(item, dict)]
-        other = [item for item in normalized if not isinstance(item, dict)]
-        normalized = filter_hits(dict_hits, **filter_kw) + other
-    # Refresh rank numbers after re-order / filter so agents see consistent ordering.
-    for index, item in enumerate(normalized):
-        if isinstance(item, dict) and isinstance(item.get("_citadel"), dict):
-            item["_citadel"]["rank"] = index + 1
     primary_dataset = search_datasets[0]
     node_dataset = (
         actor.default_dataset if is_seat_dataset(actor.default_dataset) else None
@@ -6242,6 +6377,26 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         session_id=body.session_id,
         filters=body.telemetry_filters(),
     )
+    # Response-level relevance honesty (see lexical_relevance_summary): the
+    # retriever exposes no score at this boundary, so the page reports the one
+    # signal it CAN attest — lexical term overlap — and flags a page in which
+    # no hit contains a single query term as not confidently matched.
+    coverages: list[float] = []
+    retriever_scores_seen = False
+    for item in normalized:
+        if not isinstance(item, dict) or not isinstance(item.get("_citadel"), dict):
+            continue
+        hit_relevance = item["_citadel"].get("relevance")
+        if not isinstance(hit_relevance, dict):
+            continue
+        coverage = hit_relevance.get("term_coverage")
+        if isinstance(coverage, (int, float)) and not isinstance(coverage, bool):
+            coverages.append(float(coverage))
+        if hit_relevance.get("retriever_score") is not None:
+            retriever_scores_seen = True
+    relevance_summary = lexical_relevance_summary(
+        body.query, coverages, scores_available=retriever_scores_seen
+    )
     payload: dict[str, Any] = {
         "results": normalized,
         "dataset": primary_dataset,
@@ -6250,7 +6405,19 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             central_dataset=central_dataset(citadel.config),
             node_dataset=node_dataset,
         ),
+        "docs_mode": docs_mode,
+        "spec_mode": is_spec_mode_query(body.query) and not docs_mode,
+        "relevance": relevance_summary,
     }
+    if cleaned_mode:
+        payload["mode"] = cleaned_mode
+    if filters_active:
+        payload["filtering"] = {
+            "applied": {key: value for key, value in filter_kw.items() if value},
+            "candidates_fetched": candidates_fetched,
+            "candidates_matched": candidates_matched,
+            "returned": len(normalized),
+        }
     if len(search_datasets) > 1:
         payload["datasets"] = search_datasets
     if timed_out:
@@ -6261,17 +6428,26 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         payload["timed_out"] = True
         payload["truncated"] = True
         payload["code"] = CODE_TIMEOUT
-    elif not normalized and body.dataset is None:
+    elif not normalized and body.dataset is None and not filters_active:
         payload["note"] = (
             "No results in the default dataset. Pass an explicit \"dataset\" to search a "
             "specific source; see known_datasets."
         )
         payload["known_datasets"] = known_datasets(citadel.config)
+    warnings: list[str] = []
+    if filters_active and candidates_matched < body.top_k and not timed_out:
+        warnings.append(
+            f"Filters matched {candidates_matched} of {candidates_fetched} fetched "
+            "candidates; the page is short because post-retrieval filters excluded "
+            "the rest, not because the search found nothing else."
+        )
+    if relevance_summary["no_lexical_match"]:
+        warnings.append(NO_LEXICAL_MATCH_WARNING)
     authority = token_asset_authority_warning(body.query)
     if authority:
-        payload.setdefault("warnings", [])
-        if isinstance(payload["warnings"], list):
-            payload["warnings"].append(authority)
+        warnings.append(authority)
+    if warnings:
+        payload["warnings"] = warnings
     if telemetry:
         payload["search_id"] = telemetry.get("search_id")
         payload["feedback"] = {

--- a/kb/service.py
+++ b/kb/service.py
@@ -231,6 +231,14 @@ class Citadel:
         """Resolve a cognee search-hit id to its document/chunk (#28)."""
         return await self.cognee.get_document(document_id)
 
+    async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
+        """Owner node ids for the drill-down visibility rule, body not assembled.
+
+        The cheap read /search's per-hit hint uses; /api/documents keeps the
+        full ``get_document`` assembly. ``None`` means the id would not resolve.
+        """
+        return await self.cognee.resolve_document_owner_ids(document_id)
+
     async def _graph_counts(self) -> dict[str, int]:
         nodes, edges = await self.cognee.graph_data()
         return {"nodes": len(nodes), "edges": len(edges)}

--- a/tests/test_get_document_drilldown.py
+++ b/tests/test_get_document_drilldown.py
@@ -182,7 +182,14 @@ class _ChunkStore:
     PGVectorAdapter.retrieve / LanceDBAdapter.retrieve: return only rows whose
     id was requested, [] when the collection is unknown, rows shaped as
     ScoredResult. This fake refuses to invent rows: content must be seeded by
-    id, exactly like the store it mirrors.
+    id, exactly like the store it mirrors. It also REJECTS non-string ids the
+    way LanceDB effectively does: LanceDBAdapter interpolates the ids into a
+    SQL filter (f"id IN {tuple(ids)}"), so a uuid.UUID object renders as
+    UUID('…') and the query errors out — measured against a real lancedb
+    table as RuntimeError "lance error: Invalid user input: Error optimizing
+    sql filter". A fake that str()-normalized its lookups was looser than the
+    real adapter and hid exactly that class of bug (pgvector tolerated the
+    objects, so only lancedb nodes lost the fallback, silently).
     """
 
     def __init__(self, rows: dict[str, dict[str, Any]]) -> None:
@@ -190,14 +197,19 @@ class _ChunkStore:
         self.calls: list[tuple[str, list[str]]] = []
 
     async def retrieve(self, collection_name: str, data_point_ids: list[Any]) -> list[Any]:
-        self.calls.append((collection_name, [str(i) for i in data_point_ids]))
+        for row_id in data_point_ids:
+            if not isinstance(row_id, str):
+                raise RuntimeError(
+                    "lance error: Invalid user input: Error optimizing sql filter"
+                )
+        self.calls.append((collection_name, list(data_point_ids)))
         if collection_name != "DocumentChunk_text":
             return []
         out = []
         for row_id in data_point_ids:
-            payload = self._rows.get(str(row_id))
+            payload = self._rows.get(row_id)
             if payload is not None:
-                out.append(_ScoredResult(UUID(str(row_id)), payload))
+                out.append(_ScoredResult(UUID(row_id), payload))
         return out
 
 
@@ -381,3 +393,109 @@ async def test_healthy_graph_never_consults_chunk_store(real_graph: Any) -> None
 
     assert document is not None
     assert store.calls == []
+
+
+async def test_chunk_store_reads_pass_string_ids(real_graph: Any) -> None:
+    """The fallback must send str ids, never uuid.UUID objects.
+
+    The fake's retrieve raises on non-str exactly like the real LanceDB
+    adapter, so this resolving at all proves the client's convention matches
+    cognee's own retrieve() callers (hybrid/chunks.py passes strings).
+    """
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    document = await client.get_document(ORPHAN_CHUNK_IDS[0])
+
+    assert document is not None
+    assert store.calls
+    assert all(isinstance(i, str) for _, ids in store.calls for i in ids)
+
+
+# --------------------------------------------------------------------------
+# Owner-id resolution for the /search drill-down hint: the SAME owner ids
+# get_document attributes, with NONE of the body assembly.
+# --------------------------------------------------------------------------
+
+
+async def test_owner_ids_for_graph_chunk_need_no_vector_reads(real_graph: Any) -> None:
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    owner_ids = await client.resolve_document_owner_ids(CHUNK_IDS[1])
+
+    assert owner_ids is not None
+    # Parent document id first (the relational Data.id the read-scope map keys
+    # on), requested chunk id kept.
+    assert owner_ids[0] == DOC_ID
+    assert CHUNK_IDS[1] in owner_ids
+    assert store.calls == []
+
+
+async def test_owner_ids_for_graph_missing_chunk_use_the_seed_lookup_only(
+    real_graph: Any,
+) -> None:
+    """/search's per-hit cost bound: never the sibling probe.
+
+    get_document's chunk-store fallback retrieves _CHUNK_SIBLING_PROBE_LIMIT
+    ids and assembles the whole body; the hint needs only the parent id, which
+    the SEED payload already carries. One retrieve, one id.
+    """
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    owner_ids = await client.resolve_document_owner_ids(ORPHAN_CHUNK_IDS[2])
+
+    assert owner_ids is not None
+    assert owner_ids[0] == ORPHAN_DOC_ID
+    assert ORPHAN_CHUNK_IDS[2] in owner_ids
+    assert len(store.calls) == 1
+    assert all(len(ids) == 1 for _, ids in store.calls)
+
+
+async def test_owner_ids_for_graph_missing_document_probe_chunk_zero_only(
+    real_graph: Any,
+) -> None:
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    owner_ids = await client.resolve_document_owner_ids(ORPHAN_DOC_ID)
+
+    assert owner_ids == [ORPHAN_DOC_ID]
+    # Seed miss + the deterministic chunk-0 probe: two single-id retrieves.
+    assert len(store.calls) == 2
+    assert all(len(ids) == 1 for _, ids in store.calls)
+
+
+async def test_owner_ids_match_get_document_attribution(real_graph: Any) -> None:
+    """Visibility parity: the hint gates on the ids the endpoint gates on.
+
+    Any drift re-opens the promised-404 class ADR-0009 forbids.
+    """
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _orphan_store())
+
+    for requested in (CHUNK_IDS[1], DOC_ID, ORPHAN_CHUNK_IDS[2], ORPHAN_DOC_ID):
+        document = await client.get_document(requested)
+        owner_ids = await client.resolve_document_owner_ids(requested)
+        assert document is not None and owner_ids is not None, requested
+        assert set(owner_ids) == set(document["dataset_node_ids"]), requested
+
+
+async def test_owner_ids_unresolvable_ids_return_none(real_graph: Any) -> None:
+    """Textless entity, ghost id, synthetic id: None, exactly like get_document."""
+    client = _client_over(real_graph)
+    store = _empty_store()
+    _install_chunk_store(client, store)
+
+    assert await client.resolve_document_owner_ids(ENTITY_ID) is None
+    ghost = str(uuid5(NAMESPACE_OID, "ghost-node"))
+    assert await client.resolve_document_owner_ids(ghost) is None
+    assert await client.resolve_document_owner_ids("chunk:deadbeef") is None
+    # The synthetic id never touched the vector engine; the UUID ids paid at
+    # most the two seed lookups each.
+    assert all(len(ids) == 1 for _, ids in store.calls)

--- a/tests/test_get_document_drilldown.py
+++ b/tests/test_get_document_drilldown.py
@@ -1,0 +1,383 @@
+"""Drill-down resolution tests for CogneePublicClient.get_document.
+
+Measured defect (2026-08-02, prod node): a hit id that search retrieved from
+the durable chunk store returned document_drilldown_available=false and
+/api/documents 404'd, while a control id resolved fine — an answer can be
+retrievable in search and unreachable through drill-down. Two code paths are
+under test here:
+
+1. GRAPH: a CHUNKS search hit id IS a DocumentChunk id. get_document used to
+   return only that chunk's own text (the same fragment search already
+   showed); it must resolve the ``is_part_of`` parent and return the whole
+   document.
+2. CHUNK-STORE FALLBACK: search reads the "DocumentChunk_text" vector
+   collection; drill-down used to read ONLY the graph. When the graph cannot
+   resolve an id that the chunk store holds, get_document must assemble the
+   document from the chunk store instead of returning None (HTTP 404).
+
+Fixture honesty ("a fake cannot specify a shape you don't own"): the graph
+tests run against the REAL cognee LadybugAdapter (the kuzu provider prod
+uses) over a throwaway on-disk database, written through cognee's real batch
+writers (add_nodes/add_edges) — the same get_node/get_connections shapes,
+undirected-match direction loss included, that production serves. The vector
+store cannot be exercised for real without an embedding engine, so its seam
+is a mirror of the REAL retrieve() contract verified against cognee 1.2.2
+(PGVectorAdapter.retrieve / LanceDBAdapter.retrieve): ScoredResult rows with
+``id``/``payload`` attributes, only requested ids returned, [] for an
+unknown collection. What only a live node can prove: that the measured id
+53915a09-610b-5ad2-9c61-d66f7f5986ad now resolves — post-deploy, GET
+/api/documents/<that id> must return 200 with the full README body and
+metadata.assembled_from == "chunk_store".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import NAMESPACE_OID, UUID, uuid5
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from kb.cognee_client import CogneePublicClient  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+DOC_ID = str(uuid5(NAMESPACE_OID, "drilldown-doc"))
+CHUNK_IDS = [str(uuid5(NAMESPACE_OID, f"{DOC_ID}-{index}")) for index in range(3)]
+ENTITY_ID = str(uuid5(NAMESPACE_OID, "drilldown-entity"))
+# In the chunk store but never written to the graph (the measured 404 class).
+ORPHAN_DOC_ID = str(uuid5(NAMESPACE_OID, "orphan-doc"))
+ORPHAN_CHUNK_IDS = [
+    str(uuid5(NAMESPACE_OID, f"{ORPHAN_DOC_ID}-{index}")) for index in range(4)
+]
+FULL_BODY = "part zero\n\npart one\n\npart two"
+
+
+class _DataPoint:
+    """Duck-typed stand-in accepted by LadybugAdapter.add_nodes (model_dump)."""
+
+    def __init__(self, dump: dict[str, Any]) -> None:
+        self._dump = dump
+
+    def model_dump(self) -> dict[str, Any]:
+        return dict(self._dump)
+
+
+@pytest.fixture(scope="module")
+def real_graph(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    """A REAL LadybugAdapter over a temp kuzu db, holding the cognify topology.
+
+    Written through cognee's own batch writers so the on-disk shape (and the
+    get_node/get_connections read shapes) are exactly what production serves:
+    a textless TextDocument node, text-bearing DocumentChunk nodes, edges in
+    the real chunk --is_part_of--> document direction plus a reversed
+    document --is_part_of--> chunk edge (the adapter's undirected match makes
+    direction unobservable, so the assembly must not care), and a textless
+    Entity reachable from a chunk via ``contains``.
+    """
+    ladybug = pytest.importorskip(
+        "cognee.infrastructure.databases.graph.ladybug.adapter"
+    )
+    import asyncio
+
+    adapter = ladybug.LadybugAdapter(
+        db_path=str(tmp_path_factory.mktemp("kuzu") / "graph.kuzu"),
+        kuzu_buffer_pool_size=1 << 28,
+        kuzu_max_db_size=1 << 30,
+    )
+
+    async def _seed() -> None:
+        await adapter.add_nodes(
+            [
+                _DataPoint(
+                    {
+                        "id": DOC_ID,
+                        "name": "README.md",
+                        "type": "TextDocument",
+                        "mime_type": "text/plain",
+                    }
+                ),
+                _DataPoint(
+                    {
+                        "id": CHUNK_IDS[0],
+                        "name": "DocumentChunk",
+                        "type": "DocumentChunk",
+                        "text": "part zero",
+                        "chunk_index": 0,
+                        "document_id": DOC_ID,
+                    }
+                ),
+                _DataPoint(
+                    {
+                        "id": CHUNK_IDS[1],
+                        "name": "DocumentChunk",
+                        "type": "DocumentChunk",
+                        "text": "part one",
+                        "chunk_index": 1,
+                        "document_id": DOC_ID,
+                    }
+                ),
+                _DataPoint(
+                    {
+                        "id": CHUNK_IDS[2],
+                        "name": "DocumentChunk",
+                        "type": "DocumentChunk",
+                        "text": "part two",
+                        "chunk_index": 2,
+                        "document_id": DOC_ID,
+                    }
+                ),
+                _DataPoint(
+                    {
+                        "id": ENTITY_ID,
+                        "name": "SomeEntity",
+                        "type": "Entity",
+                        "description": "textless entity",
+                    }
+                ),
+            ]
+        )
+        await adapter.add_edges(
+            [
+                # Real cognify direction: chunk --is_part_of--> document.
+                (CHUNK_IDS[0], DOC_ID, "is_part_of", {}),
+                (CHUNK_IDS[1], DOC_ID, "is_part_of", {}),
+                # Deliberately REVERSED endpoint order for one chunk: the
+                # traversal must be direction-agnostic.
+                (DOC_ID, CHUNK_IDS[2], "is_part_of", {}),
+                (CHUNK_IDS[0], ENTITY_ID, "contains", {}),
+            ]
+        )
+
+    asyncio.run(_seed())
+    yield adapter
+    asyncio.run(adapter.close())
+
+
+def _client_over(graph_engine: Any) -> CogneePublicClient:
+    client = CogneePublicClient()
+
+    async def _engine() -> Any:
+        return graph_engine
+
+    client._graph_engine = _engine  # type: ignore[method-assign]
+    return client
+
+
+class _ScoredResult:
+    """Mirror of cognee's vector ScoredResult rows (id + payload + score)."""
+
+    def __init__(self, row_id: UUID, payload: dict[str, Any]) -> None:
+        self.id = row_id
+        self.payload = payload
+        self.score = 0
+
+
+class _ChunkStore:
+    """Mirror of the REAL vector retrieve() contract (cognee 1.2.2).
+
+    PGVectorAdapter.retrieve / LanceDBAdapter.retrieve: return only rows whose
+    id was requested, [] when the collection is unknown, rows shaped as
+    ScoredResult. This fake refuses to invent rows: content must be seeded by
+    id, exactly like the store it mirrors.
+    """
+
+    def __init__(self, rows: dict[str, dict[str, Any]]) -> None:
+        self._rows = {str(k): dict(v) for k, v in rows.items()}
+        self.calls: list[tuple[str, list[str]]] = []
+
+    async def retrieve(self, collection_name: str, data_point_ids: list[Any]) -> list[Any]:
+        self.calls.append((collection_name, [str(i) for i in data_point_ids]))
+        if collection_name != "DocumentChunk_text":
+            return []
+        out = []
+        for row_id in data_point_ids:
+            payload = self._rows.get(str(row_id))
+            if payload is not None:
+                out.append(_ScoredResult(UUID(str(row_id)), payload))
+        return out
+
+
+def _install_chunk_store(
+    client: CogneePublicClient, store: _ChunkStore
+) -> None:
+    async def _engine() -> _ChunkStore:
+        return store
+
+    client._vector_engine = _engine  # type: ignore[method-assign]
+
+
+def _orphan_store() -> _ChunkStore:
+    texts = ["orphan zero", "orphan one", "orphan two", "orphan three"]
+    return _ChunkStore(
+        {
+            chunk_id: {
+                "id": chunk_id,
+                "text": texts[index],
+                "chunk_index": index,
+                "document_id": ORPHAN_DOC_ID,
+                "document_name": "sokosumi-cli-readme.md",
+            }
+            for index, chunk_id in enumerate(ORPHAN_CHUNK_IDS)
+        }
+    )
+
+
+def _empty_store() -> _ChunkStore:
+    return _ChunkStore({})
+
+
+# --------------------------------------------------------------------------
+# Graph path, REAL adapter: chunk-id hits must resolve the whole document.
+# --------------------------------------------------------------------------
+
+
+async def test_chunk_id_resolves_full_parent_document(real_graph: Any) -> None:
+    """A CHUNKS hit id (a DocumentChunk id) must return the WHOLE document.
+
+    This is the fragment defect: the pre-fix code returned only the chunk's
+    own text ("part one"), i.e. drill-down re-served the search snippet and
+    the remaining lines of the document stayed unreachable.
+    """
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    document = await client.get_document(CHUNK_IDS[1])
+
+    assert document is not None
+    assert document["body"] == FULL_BODY  # not just "part one"
+    assert document["chunk_count"] == 3
+    # Scope attribution must carry the parent document id (the map key) and
+    # keep the requested chunk id.
+    assert DOC_ID in document["dataset_node_ids"]
+    assert CHUNK_IDS[1] in document["dataset_node_ids"]
+
+
+async def test_document_id_assembles_chunks_both_edge_directions(
+    real_graph: Any,
+) -> None:
+    """Textless document node assembles ALL chunks, one edge written reversed."""
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    document = await client.get_document(DOC_ID)
+
+    assert document is not None
+    assert document["body"] == FULL_BODY  # includes the reversed-edge chunk
+    assert document["chunk_count"] == 3
+    assert document["dataset_node_ids"] == [DOC_ID]
+
+
+async def test_textless_entity_still_resolves_none(real_graph: Any) -> None:
+    """Entities adjacent to text chunks via ``contains`` stay a 404.
+
+    Guards against the parent-follow/fallback fabricating a document for a
+    textless entity. The chunk store legitimately has no row for it either.
+    """
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    assert await client.get_document(ENTITY_ID) is None
+
+
+# --------------------------------------------------------------------------
+# Chunk-store fallback: graph-missing ids must resolve from the durable
+# store search reads (the measured 404).
+# --------------------------------------------------------------------------
+
+
+async def test_graph_missing_chunk_id_resolves_from_chunk_store(
+    real_graph: Any,
+) -> None:
+    """The measured defect: searchable chunk, no graph node, drill-down 404'd.
+
+    The requested id exists ONLY in the chunk store. get_document must
+    assemble the full document from the store (all four sibling chunks,
+    ordered), not return None.
+    """
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    document = await client.get_document(ORPHAN_CHUNK_IDS[2])
+
+    assert document is not None
+    assert document["body"] == "orphan zero\n\norphan one\n\norphan two\n\norphan three"
+    assert document["chunk_count"] == 4
+    assert document["metadata"]["assembled_from"] == "chunk_store"
+    # ADR-0009 scope attribution: the parent document id is the relational
+    # Data.id the node_dataset_map keys on; it must lead dataset_node_ids.
+    assert document["dataset_node_ids"][0] == ORPHAN_DOC_ID
+    assert ORPHAN_CHUNK_IDS[2] in document["dataset_node_ids"]
+    # The fallback read the SAME collection search reads.
+    assert store.calls and all(
+        collection == "DocumentChunk_text" for collection, _ in store.calls
+    )
+
+
+async def test_graph_missing_document_id_resolves_from_chunk_store(
+    real_graph: Any,
+) -> None:
+    """A document id with no graph node resolves via deterministic sibling ids."""
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _orphan_store())
+
+    document = await client.get_document(ORPHAN_DOC_ID)
+
+    assert document is not None
+    assert document["id"] == ORPHAN_DOC_ID
+    assert document["chunk_count"] == 4
+    assert document["body"].startswith("orphan zero")
+    assert document["dataset_node_ids"][0] == ORPHAN_DOC_ID
+
+
+async def test_id_absent_everywhere_resolves_none(real_graph: Any) -> None:
+    """No graph node, no chunk-store row: the 404 stays honest."""
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    ghost = str(uuid5(NAMESPACE_OID, "ghost-node"))
+    assert await client.get_document(ghost) is None
+
+
+async def test_chunk_store_failure_degrades_to_none(real_graph: Any) -> None:
+    """A broken vector engine must degrade to the pre-fix 404, never raise."""
+    client = _client_over(real_graph)
+
+    class _Exploding:
+        async def retrieve(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            raise RuntimeError("vector store down")
+
+    async def _engine() -> Any:
+        return _Exploding()
+
+    client._vector_engine = _engine  # type: ignore[method-assign]
+
+    ghost = str(uuid5(NAMESPACE_OID, "ghost-node"))
+    assert await client.get_document(ghost) is None
+
+
+async def test_non_uuid_id_skips_chunk_store(real_graph: Any) -> None:
+    """Synthetic ids (chunk:<sha>, ghsync:*) never touch the vector engine."""
+    client = _client_over(real_graph)
+    store = _empty_store()
+    _install_chunk_store(client, store)
+
+    assert await client.get_document("chunk:deadbeef") is None
+    assert store.calls == []
+
+
+async def test_healthy_graph_never_consults_chunk_store(real_graph: Any) -> None:
+    """Ids the graph resolves must not pay for vector reads (drill-down hint
+    resolution calls get_document once per unique hit id per search)."""
+    client = _client_over(real_graph)
+    store = _orphan_store()
+    _install_chunk_store(client, store)
+
+    document = await client.get_document(DOC_ID)
+
+    assert document is not None
+    assert store.calls == []

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -1,0 +1,416 @@
+"""Search response shaping: the four defects measured against production 2026-08-02.
+
+Across 15 result pages / 117 slots, every hit shipped with an empty
+``_citadel.provenance``, no relevance signal of any kind, no honest empty/low
+confidence path, and a ``mode=docs`` call that was byte-identical to the plain
+call down to its ``search_id``. Each test here fails on the pre-fix code.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from kb.config import CitadelConfig
+from kb.conflicts import KnowledgeConflictStore
+from kb.mesh import MeshState
+from kb.search_format import (
+    apply_query_ranking,
+    filter_hits,
+    normalize_search_hit,
+    parse_content_header,
+)
+from kb.server import app, result_provenance, with_result_metadata
+
+
+def repo_doc_text(repo: str, path: str, body: str) -> str:
+    """Exactly the shape format_repo_content_document writes."""
+    return (
+        f"# {repo}/{path}\n"
+        "\n"
+        f"Repository: {repo}\n"
+        f"Source: https://github.com/{repo}/blob/f401d38/{path}\n"
+        "Commit: f401d3896820ff35a82cf707818e308b67f5bce2\n"
+        "Blob: a4b30a4548af239f695ba3cba1935b545e96d675\n"
+        "\n"
+        "---\n"
+        "\n"
+        f"{body}\n"
+    )
+
+
+LINEAR_NOTE_TEXT = (
+    "# Linear SOK-623: coworker init UX\n"
+    "\n"
+    "- **State:** In Review (started)\n"
+    "- **Team:** Sokosumi\n"
+    "- **Priority:** 2\n"
+    "- **Updated:** 2026-07-30\n"
+    "- **URL:** https://linear.app/masumi/issue/SOK-623/coworker-init-ux\n"
+    "\n"
+    "The description block. It may even quote - **URL:** https://evil.example\n"
+    "and that quote must never be credited as the issue's URL.\n"
+)
+
+
+class PageCitadel:
+    """Returns a fixed candidate page and records the top_k it was asked for."""
+
+    config = CitadelConfig(
+        tenant_id="test",
+        default_dataset="notes",
+        admin_key="test-admin",
+        reader_keys=("test-reader",),
+        writer_keys=("test-writer",),
+    )
+
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self.results = list(results)
+        self.requested_top_k: list[int] = []
+
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.requested_top_k.append(kwargs["top_k"])
+        return self.results[: kwargs["top_k"]]
+
+    async def get_document(self, document_id: str) -> dict[str, Any] | None:
+        return None
+
+
+def shaped_client(citadel: Any) -> TestClient:
+    app.state.citadel = citadel
+    app.state.mesh = MeshState()
+    app.state.conflict_store = KnowledgeConflictStore(
+        Path(tempfile.mkdtemp()) / "conflicts.json"
+    )
+    client = TestClient(app, base_url="https://testserver")
+    response = client.post("/admin/session", json={"access_key": "test-admin"})
+    assert response.status_code == 200
+    return client
+
+
+# --- defect 1: provenance was empty on 117 of 117 hits ----------------------
+
+
+def test_repo_content_header_populates_provenance() -> None:
+    """The header the syncer writes is parsed back into the envelope."""
+    text = repo_doc_text("masumi-network/sokosumi-docs", "docs/install.md", "# Install\n\nRun it.")
+
+    provenance = result_provenance({"id": "c1", "text": text})
+
+    assert provenance["repo"] == "masumi-network/sokosumi-docs"
+    assert provenance["path"] == "docs/install.md"
+    assert provenance["source_url"] == (
+        "https://github.com/masumi-network/sokosumi-docs/blob/f401d38/docs/install.md"
+    )
+    assert provenance["commit"] == "f401d3896820ff35a82cf707818e308b67f5bce2"
+    assert provenance["blob"] == "a4b30a4548af239f695ba3cba1935b545e96d675"
+    # Header values are body text, so they are labelled as such — they must
+    # never be mistaken for attested metadata.
+    assert provenance["basis"] == "content-header"
+
+    envelope = with_result_metadata({"id": "c1", "text": text}, 0, "masumi-network")["_citadel"]
+    assert envelope["provenance"]["repo"] == "masumi-network/sokosumi-docs"
+
+
+def test_linear_header_populates_issue_id_and_url() -> None:
+    provenance = result_provenance({"id": "c2", "text": LINEAR_NOTE_TEXT})
+
+    assert provenance["issue"] == "SOK-623"
+    assert provenance["title"] == "coworker init UX"
+    assert provenance["source_url"] == (
+        "https://linear.app/masumi/issue/SOK-623/coworker-init-ux"
+    )
+    # The URL quoted inside the description was not credited.
+    assert "evil.example" not in provenance["source_url"]
+
+
+def test_a_header_quoted_mid_body_is_not_credited() -> None:
+    """The confusion that once made a benchmark score quoting documents."""
+    quoting = "A note that quotes:\n\n" + repo_doc_text(
+        "masumi-network/sokosumi", "README.md", "body"
+    )
+
+    assert parse_content_header(quoting) == {}
+    provenance = result_provenance({"id": "c3", "text": quoting})
+    assert "repo" not in provenance
+    assert "commit" not in provenance
+
+
+def test_untitled_chunks_keep_empty_provenance() -> None:
+    """No header, no keys: the envelope stays honestly empty."""
+    assert result_provenance({"id": "c4", "text": "free-floating personal note"}) == {}
+
+
+# --- defect 2: no relevance signal on any hit -------------------------------
+
+
+def test_hits_carry_lexical_relevance_and_no_invented_score() -> None:
+    text = repo_doc_text("masumi-network/widget", "docs/retry.md", "Kupo retry policy notes.")
+
+    envelope = with_result_metadata(
+        {"id": "c5", "text": text}, 0, "masumi-network", query="kupo retry policy"
+    )["_citadel"]
+
+    relevance = envelope["relevance"]
+    assert relevance["term_coverage"] == 1.0
+    assert set(relevance["matched_terms"]) == {"kupo", "retry", "policy"}
+    # cognee's CHUNKS payload carries no score, and none may be invented.
+    assert "retriever_score" not in relevance
+
+
+def test_retriever_score_is_passed_through_when_the_payload_has_one() -> None:
+    """The moment the client boundary surfaces the distance, hits carry it."""
+    envelope = with_result_metadata(
+        {"id": "c6", "text": "kupo retry", "score": 0.42},
+        0,
+        "notes",
+        query="kupo",
+    )["_citadel"]
+
+    assert envelope["relevance"]["retriever_score"] == 0.42
+
+
+# --- defect 3: absent content returned confident nonsense -------------------
+
+
+def test_absent_content_query_is_flagged_not_confident() -> None:
+    citadel = PageCitadel(
+        [
+            {"id": "n1", "text": "notes about the dashboard layout"},
+            {"id": "n2", "text": "linear board grooming session"},
+            {"id": "n3", "text": "weekly planning discussion"},
+        ]
+    )
+    client = shaped_client(citadel)
+
+    response = client.post("/search", json={"query": "quantum zebra teleportation"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["results"]) == 3
+    relevance = body["relevance"]
+    assert relevance["retriever_scores_available"] is False
+    assert relevance["max_term_coverage"] == 0.0
+    assert relevance["no_lexical_match"] is True
+    assert any("No result contains any query term" in w for w in body["warnings"])
+    for hit in body["results"]:
+        assert hit["_citadel"]["relevance"]["term_coverage"] == 0.0
+
+
+def test_matching_content_is_not_flagged() -> None:
+    """The marker must be earnable in both directions, not another inert guard."""
+    citadel = PageCitadel(
+        [{"id": "n1", "text": "the kupo retry policy is exponential backoff"}]
+    )
+    client = shaped_client(citadel)
+
+    response = client.post("/search", json={"query": "kupo retry policy"})
+
+    body = response.json()
+    assert body["relevance"]["no_lexical_match"] is False
+    assert body["relevance"]["max_term_coverage"] == 1.0
+    assert not any(
+        "No result contains any query term" in w for w in body.get("warnings", [])
+    )
+
+
+# --- defect 4: mode=docs was a no-op and filters matched body text ----------
+
+
+def test_docs_mode_gets_its_own_search_id() -> None:
+    """Same query, same hits, same count — the ids must still differ.
+
+    Measured: the plain call and the mode=docs call returned the same page AND
+    the same search_id, so telemetry could not tell them apart.
+    """
+    results = [
+        {"id": "d1", "text": repo_doc_text("masumi-network/a", "docs/one.md", "guide one")},
+        {"id": "d2", "text": repo_doc_text("masumi-network/b", "docs/two.md", "guide two")},
+    ]
+    plain = shaped_client(PageCitadel(results)).post(
+        "/search", json={"query": "sokosumi install guide"}
+    )
+    docs = shaped_client(PageCitadel(results)).post(
+        "/search", json={"query": "sokosumi install guide", "mode": "docs"}
+    )
+
+    assert plain.status_code == 200 and docs.status_code == 200
+    assert plain.json()["search_id"] != docs.json()["search_id"]
+    assert docs.json()["docs_mode"] is True
+    assert docs.json()["mode"] == "docs"
+    assert plain.json()["docs_mode"] is False
+    assert "mode" not in plain.json()
+
+
+def test_search_id_stays_deterministic_for_identical_calls() -> None:
+    """Distinguishing filtered calls must not break follow-up feedback linking."""
+    results = [{"id": "d1", "text": repo_doc_text("masumi-network/a", "docs/one.md", "guide")}]
+    first = shaped_client(PageCitadel(results)).post(
+        "/search", json={"query": "sokosumi install guide", "mode": "docs"}
+    )
+    second = shaped_client(PageCitadel(results)).post(
+        "/search", json={"query": "sokosumi install guide", "mode": "docs"}
+    )
+
+    assert first.json()["search_id"] == second.json()["search_id"]
+
+
+def test_docs_mode_ranks_within_a_class_by_term_coverage() -> None:
+    """Ten same-class hits used to keep their input order whatever the query."""
+    miss = {
+        "id": "m",
+        "text": repo_doc_text("masumi-network/a", "docs/misc.md", "unrelated prose"),
+    }
+    match = {
+        "id": "h",
+        "text": repo_doc_text(
+            "masumi-network/b", "docs/retry.md", "kupo indexer retry policy"
+        ),
+    }
+
+    ranked = apply_query_ranking([miss, match], "kupo retry policy", mode="docs")
+
+    assert ranked[0] is match, [r.get("id") for r in ranked]
+
+
+def test_repo_filter_is_identity_not_body_substring() -> None:
+    """repo="sokosumi-cli" returned a sokosumi-DOCS file that mentioned the CLI."""
+    docs_file = normalize_search_hit(
+        {
+            "id": "docs",
+            "text": repo_doc_text(
+                "masumi-network/sokosumi-docs",
+                "docs/install.md",
+                "Install the CLI:\n\n    npm install -g sokosumi-cli\n",
+            ),
+        }
+    )
+    cli_file = normalize_search_hit(
+        {
+            "id": "cli",
+            "text": repo_doc_text("masumi-network/sokosumi-cli", "README.md", "The CLI."),
+        }
+    )
+
+    kept = filter_hits([docs_file, cli_file], repo="sokosumi-cli")
+
+    assert [h["id"] for h in kept] == ["cli"]
+    # Identity still matches the org prefix and the exact full name.
+    assert len(filter_hits([docs_file, cli_file], repo="masumi-network")) == 2
+    assert [
+        h["id"]
+        for h in filter_hits([docs_file, cli_file], repo="masumi-network/sokosumi-docs")
+    ] == ["docs"]
+
+
+def test_repo_filter_fails_closed_without_identity() -> None:
+    """A hit that cannot say which repo it is from never satisfies repo=."""
+    anonymous = normalize_search_hit(
+        {"id": "anon", "text": "prose that merely mentions sokosumi-cli"}
+    )
+
+    assert filter_hits([anonymous], repo="sokosumi-cli") == []
+
+
+def test_filtered_search_over_fetches_and_fills_the_page() -> None:
+    """top_k=5 with a filter used to return whatever survived from 5 candidates."""
+    noise = [{"id": f"n{i}", "text": f"digest chatter number {i}"} for i in range(8)]
+    matching = [
+        {
+            "id": f"w{i}",
+            "text": repo_doc_text("masumi-network/widget", f"docs/page{i}.md", f"widget {i}"),
+        }
+        for i in range(7)
+    ]
+    citadel = PageCitadel(noise + matching)
+    client = shaped_client(citadel)
+
+    response = client.post(
+        "/search",
+        json={"query": "widget docs", "top_k": 5, "repo": "masumi-network/widget"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Over-fetched: the retriever was asked for more than top_k candidates.
+    assert citadel.requested_top_k == [15]
+    # And the page is FULL, not the 0 of 5 the old order of operations left.
+    assert len(body["results"]) == 5
+    assert all(
+        hit["_citadel"]["provenance"]["repo"] == "masumi-network/widget"
+        for hit in body["results"]
+    )
+    assert body["filtering"]["candidates_fetched"] == 15
+    assert body["filtering"]["candidates_matched"] == 7
+    assert body["filtering"]["returned"] == 5
+    assert body["filtering"]["applied"]["repo"] == "masumi-network/widget"
+
+
+def test_short_filtered_page_is_documented_honestly() -> None:
+    citadel = PageCitadel(
+        [{"id": f"n{i}", "text": f"digest chatter number {i}"} for i in range(9)]
+        + [
+            {
+                "id": "w0",
+                "text": repo_doc_text("masumi-network/widget", "docs/only.md", "widget"),
+            }
+        ]
+    )
+    client = shaped_client(citadel)
+
+    response = client.post(
+        "/search",
+        json={"query": "widget docs", "top_k": 5, "repo": "masumi-network/widget"},
+    )
+
+    body = response.json()
+    assert len(body["results"]) == 1
+    assert body["filtering"]["candidates_matched"] == 1
+    assert any(
+        "post-retrieval filters excluded" in warning for warning in body["warnings"]
+    )
+
+
+# --- head-of-document truncation hides the match ----------------------------
+
+
+def test_match_context_survives_head_truncation() -> None:
+    """The envelope carries a window around the match, far past any head cut.
+
+    MCP trims ``text`` to its first ~2,000 characters. For a 6,000-character
+    document whose answer sits at the end, the head shows the provenance header
+    and imports — exactly where the answer is not. ``_citadel.relevance.
+    match_context`` is computed from the FULL text before any trim.
+    """
+    filler = "\n".join(f"unrelated line {i} about nothing in particular" for i in range(120))
+    text = repo_doc_text(
+        "masumi-network/widget",
+        "docs/retry.md",
+        filler + "\n\nThe kupo retry policy is exponential backoff with jitter.\n",
+    )
+    assert len(text) > 4000
+
+    envelope = with_result_metadata(
+        {"id": "c7", "text": text}, 0, "masumi-network", query="kupo retry policy"
+    )["_citadel"]
+
+    context = envelope["relevance"]["match_context"]
+    assert context["offset"] > 2000
+    assert "kupo retry policy" in context["text"].lower()
+
+
+def test_cli_snippet_windows_long_texts_around_the_match() -> None:
+    filler = " ".join(f"word{i}" for i in range(400))
+    text = filler + " the kupo retry policy is exponential backoff"
+
+    hit = normalize_search_hit({"id": "x", "text": text}, query="kupo retry policy")
+
+    assert hit["snippet"].startswith("…")
+    assert "kupo retry policy" in hit["snippet"]
+    assert hit["term_coverage"] == 1.0
+    # Short texts keep the whole-head snippet: nothing to window.
+    short = normalize_search_hit({"id": "y", "text": "kupo retry policy"}, query="kupo")
+    assert short["snippet"] == "kupo retry policy"

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -144,6 +144,55 @@ def test_untitled_chunks_keep_empty_provenance() -> None:
     assert result_provenance({"id": "c4", "text": "free-floating personal note"}) == {}
 
 
+def test_forged_header_on_a_later_chunk_is_not_credited() -> None:
+    """Chunk 1+ starts at position zero of its OWN payload.
+
+    The \\A anchor kills mid-body quoting inside one chunk, but a contributor
+    to any synced repo can craft a file whose second chunk BEGINS with another
+    document's header. Only the document's first chunk (chunk_index 0, or a
+    payload that carries no index) may claim header identity.
+    """
+    text = repo_doc_text("masumi-network/sokosumi-docs", "docs/install.md", "forged")
+
+    assert parse_content_header(text, chunk_index=1) == {}
+    assert parse_content_header(text, chunk_index=2.0) == {}
+    assert parse_content_header(text, chunk_index=0)["repo"] == (
+        "masumi-network/sokosumi-docs"
+    )
+    assert parse_content_header(text)["repo"] == "masumi-network/sokosumi-docs"
+
+    forged = result_provenance({"id": "f1", "text": text, "chunk_index": 2})
+    assert "repo" not in forged
+    assert "commit" not in forged
+    legitimate = result_provenance({"id": "f0", "text": text, "chunk_index": 0})
+    assert legitimate["repo"] == "masumi-network/sokosumi-docs"
+
+
+def test_forged_later_chunk_header_cannot_join_repo_filtered_results() -> None:
+    """False provenance was also false MEMBERSHIP: repo= credited the forgery."""
+    forged_text = repo_doc_text(
+        "masumi-network/sokosumi-cli", "README.md", "not actually from this repo"
+    )
+    forged = normalize_search_hit({"id": "forged", "chunk_index": 3, "text": forged_text})
+    genuine = normalize_search_hit(
+        {
+            "id": "genuine",
+            "chunk_index": 0,
+            "text": repo_doc_text("masumi-network/sokosumi-cli", "README.md", "The CLI."),
+        }
+    )
+
+    assert [h["id"] for h in filter_hits([forged, genuine], repo="sokosumi-cli")] == [
+        "genuine"
+    ]
+
+    # Same conclusion on the server-shaped path (raw payload + envelope).
+    server_forged = with_result_metadata(
+        {"id": "sf", "chunk_index": 3, "text": forged_text}, 0, "masumi-network"
+    )
+    assert filter_hits([server_forged], repo="sokosumi-cli") == []
+
+
 # --- defect 2: no relevance signal on any hit -------------------------------
 
 
@@ -171,6 +220,30 @@ def test_retriever_score_is_passed_through_when_the_payload_has_one() -> None:
     )["_citadel"]
 
     assert envelope["relevance"]["retriever_score"] == 0.42
+
+
+def test_github_digest_fallback_score_is_not_a_retriever_score() -> None:
+    """search_github_sync_state attaches a token-overlap COUNT under ``score``.
+
+    That integer is a different unit entirely; passing it through surfaced an
+    unbounded count as ``retriever_score`` and flipped
+    ``retriever_scores_available`` true on the one search path that has no
+    retriever at all — contradicting the pass-through's own contract.
+    """
+    envelope = with_result_metadata(
+        {
+            "id": "ghsync:abc123",
+            "source": "github_sync_state",
+            "title": "GitHub source digest",
+            "content": "sokosumi repository digest content",
+            "score": 7,
+        },
+        0,
+        "github-sync",
+        query="sokosumi digest",
+    )["_citadel"]
+
+    assert "retriever_score" not in envelope["relevance"]
 
 
 # --- defect 3: absent content returned confident nonsense -------------------
@@ -347,6 +420,58 @@ def test_filtered_search_over_fetches_and_fills_the_page() -> None:
     assert body["filtering"]["candidates_matched"] == 7
     assert body["filtering"]["returned"] == 5
     assert body["filtering"]["applied"]["repo"] == "masumi-network/widget"
+
+
+def test_empty_retrieval_with_filters_gets_dataset_help_not_filter_blame() -> None:
+    """candidates_fetched == 0: nothing was excluded by filters.
+
+    The old gate fired on matched < top_k alone, so an empty retrieval under a
+    filter claimed "post-retrieval filters excluded the rest" (literally false)
+    AND suppressed the known_datasets help — exactly when the caller needed it.
+    """
+    client = shaped_client(PageCitadel([]))
+
+    response = client.post(
+        "/search",
+        json={"query": "widget docs", "top_k": 5, "repo": "masumi-network/widget"},
+    )
+
+    body = response.json()
+    assert body["results"] == []
+    assert body["filtering"]["candidates_fetched"] == 0
+    assert not any(
+        "post-retrieval filters excluded" in warning
+        for warning in body.get("warnings", [])
+    )
+    assert "note" in body
+    assert body["known_datasets"]
+
+
+def test_short_page_where_filters_excluded_nothing_is_not_blamed_on_filters() -> None:
+    """matched == fetched < top_k: retrieval found nothing else, say so."""
+    citadel = PageCitadel(
+        [
+            {
+                "id": "w0",
+                "text": repo_doc_text("masumi-network/widget", "docs/only.md", "widget"),
+            }
+        ]
+    )
+    client = shaped_client(citadel)
+
+    response = client.post(
+        "/search",
+        json={"query": "widget docs", "top_k": 5, "repo": "masumi-network/widget"},
+    )
+
+    body = response.json()
+    assert len(body["results"]) == 1
+    assert body["filtering"]["candidates_fetched"] == 1
+    assert body["filtering"]["candidates_matched"] == 1
+    assert not any(
+        "post-retrieval filters excluded" in warning
+        for warning in body.get("warnings", [])
+    )
 
 
 def test_short_filtered_page_is_documented_honestly() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3126,6 +3126,14 @@ class DrilldownIsolationCitadel(FakeCitadel):
     async def get_document(self, document_id: str) -> dict[str, Any] | None:
         return self.cognee_documents.get(document_id)
 
+    async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
+        # Mirrors the real service contract: the owner ids get_document would
+        # carry in dataset_node_ids, None when the id would not resolve.
+        document = self.cognee_documents.get(document_id)
+        if document is None:
+            return None
+        return list(document.get("dataset_node_ids") or [document_id])
+
 
 def test_document_drilldown_enforces_read_scope_without_existence_oracle(
     tmp_path: Any,
@@ -3365,6 +3373,131 @@ def test_search_drilldown_hint_fails_closed_on_cold_map(tmp_path: Any) -> None:
         "entity-x": True,
     }
     assert admin_central == 200
+
+
+class DrilldownCountingCitadel(DrilldownSearchCitadel):
+    """Counts which resolution surface /search actually pays for per hit."""
+
+    def __init__(self) -> None:
+        self.get_document_calls: list[str] = []
+        self.owner_id_calls: list[str] = []
+
+    async def get_document(self, document_id: str) -> dict[str, Any] | None:
+        self.get_document_calls.append(document_id)
+        return await super().get_document(document_id)
+
+    async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
+        self.owner_id_calls.append(document_id)
+        return await super().resolve_document_owner_ids(document_id)
+
+
+def test_search_hint_never_assembles_document_bodies(tmp_path: Any) -> None:
+    # The hint needs one boolean per unique id, so /search must resolve owner
+    # ids through the seed-only read — never get_document, whose chunk-store
+    # fallback probes 512 sibling ids and assembles up to ~1MB of body per
+    # graph-missing hit, all discarded. This is the regression test whose
+    # absence let that cost ship: it fails the moment /search touches
+    # get_document again.
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    citadel = DrilldownCountingCitadel()
+    app.state.citadel = citadel
+    app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
+    api = TestClient(app, base_url="https://testserver")
+    try:
+        body = api.post(
+            "/search",
+            json={"query": "x"},
+            headers={
+                "Authorization": f"Bearer {bob_token}",
+                "x-citadel-mcp-tool": "citadel_search",
+            },
+        ).json()
+    finally:
+        app.state.knowledge_mesh = None
+
+    # The hint itself stays correct...
+    assert _search_hint(body) == {
+        "doc-c": True,
+        "doc-a": False,
+        "chunk-b": True,
+        "entity-x": False,
+    }
+    # ...but no document body was assembled to compute it: one owner-id
+    # resolution per unique cognee id, zero get_document calls.
+    assert citadel.get_document_calls == []
+    assert sorted(citadel.owner_id_calls) == [
+        "chunk-b",
+        "doc-a",
+        "doc-c",
+        "entity-x",
+    ]
+    # The audit row exposes the pass's cost instead of stopping the clock
+    # before it (the pre-fix latency_ms was measured before the drill-down
+    # pass, under-reporting exactly what it added).
+    events = app.state.access_store.snapshot()["audit_events"]
+    search_events = [
+        event for event in events if event["detail"].get("operation") == "search"
+    ]
+    assert search_events
+    assert isinstance(search_events[-1]["detail"].get("drilldown_ms"), (int, float))
+    assert search_events[-1]["detail"]["latency_ms"] >= (
+        search_events[-1]["detail"]["drilldown_ms"]
+    )
+
+
+def test_search_hint_pass_denies_once_its_deadline_expires(tmp_path: Any) -> None:
+    # The pass runs outside _search_within_budget and the _SearchSlot, so it
+    # carries its own deadline: a hung owner-id read is cancelled at the
+    # budget, the id denies (the safe under-promise), and the remaining ids
+    # deny without being attempted — the request never hangs on the hint.
+    class _HungResolverCitadel(DrilldownCountingCitadel):
+        config = CitadelConfig(
+            tenant_id="test",
+            default_dataset="notes",
+            admin_key="test-admin",
+            reader_keys=("test-reader",),
+            writer_keys=("test-writer",),
+            search_timeout_seconds=0.2,
+        )
+
+        async def resolve_document_owner_ids(
+            self, document_id: str
+        ) -> list[str] | None:
+            self.owner_id_calls.append(document_id)
+            await asyncio.sleep(30)  # cancelled by the pass deadline
+            return None
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    citadel = _HungResolverCitadel()
+    app.state.citadel = citadel
+    app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
+    api = TestClient(app, base_url="https://testserver")
+    try:
+        body = api.post(
+            "/search",
+            json={"query": "x"},
+            headers={"Authorization": f"Bearer {bob_token}"},
+        ).json()
+    finally:
+        app.state.knowledge_mesh = None
+
+    assert _search_hint(body) == {
+        "doc-c": False,
+        "doc-a": False,
+        "chunk-b": False,
+        "entity-x": False,
+    }
+    # At most the first id was ever attempted; the rest were denied at the
+    # already-expired deadline without a call.
+    assert len(citadel.owner_id_calls) <= 1
 
 
 class KnowledgeCitadel(FakeCitadel):


### PR DESCRIPTION
Two changes that must ship together. Measured across 15 result pages and 117 slots against production.

Refs #104, #106, #125, #186

## What was measured

```
_citadel.provenance == {}   on 117 of 117 hits
no relevance signal          on 117 of 117 hits
mode=docs                    same hits, same order, same search_id
repo="sokosumi-cli"          returned a sokosumi-DOCS file
filtered top_k=10            returned 4 hits (page shrank instead of refilling)
document_drilldown_available false on the majority; one answer-bearing doc 404'd
```

## Provenance

Parsed from the structural header the sync already writes, so the information stops being thrown away. Hits carry `repo`, `path`, `source_url`, `commit`, `blob`, with `basis: content-header`.

Parsing is anchored at the **start** of a chunk. A header quoted mid-body stays body text rather than being credited as identity — that exact confusion previously let a benchmark score documents that merely quoted another document's header, and it would now corrupt the `repo=` filter too.

## Relevance, reported rather than invented

cognee drops its score before this layer, so there is no retriever score to surface yet. Rather than synthesise one, the envelope exposes lexical `term_coverage` and `matched_terms`, an explicit `retriever_scores_available: false`, a dormant pass-through ready for the day the score is plumbed through `cognee_client`, and a `no_lexical_match` warning when a query matches nothing.

A fabricated confidence number would be worse than none. **Surfacing cognee's cosine distance at the `kb/cognee_client.py` boundary is the cheapest follow-up in this area** — the pass-through then lights up with no further change here.

## Filters

They now match the parsed identity instead of raw body text, so `repo=` means the repo. They over-fetch 3x (capped at 100) and trim, so filtering refills the page instead of shrinking it. `mode=docs` both applies a ranking tiebreak and produces a distinct `search_id`, so telemetry can tell the two calls apart — previously it could not.

Truncated hits carry `match_context`, so the matching passage survives MCP trimming. Previously a truncated hit always showed the head of the document, which is where the answer usually is not: one measured case had the decisive line at 217 of 263, with the snippet stopping at ~2,000 of 9,749 characters.

## Drill-down

**The 404 was not a traversal bug.** It is data divergence: the chunk exists in the `DocumentChunk_text` vector store while its node is absent from the graph, so a graph-only lookup correctly finds nothing.

A chunk id now resolves its `is_part_of` parent and returns the parent's assembled body, which is what a caller following a search hit actually wants. An id the graph cannot resolve falls back to the chunk store, probing deterministic uuid5 siblings to reassemble the document, tagged `assembled_from="chunk_store"` so a caller can tell how it was built. Genuinely textless or absent ids still 404, and the ADR-0009 read-scope gate is unchanged — this widens what can be assembled, never who may see it.

The underlying divergence remains and needs a re-cognify or graph backfill. This stops it silently costing readers the document.

## Why these ship together

Deploying the drill-down fix without the shaping fix would make every graph-missing hit pay a sibling probe **before** trimming. The shaping change resolves drill-down post-trim, which caps that cost.

## Verification

Full suite **1153 passed, 1 skipped**; ruff clean.

Drill-down tests run against the real `LadybugAdapter` over a temporary kuzu database written through cognee's own writers, not a hand-rolled fake. Stashing the fix reproduces both measured failures (3 failed, 6 passed).

Both directions on both tracks: eight targeted sabotages, each reddening exactly the expected tests, each reverted.

## Live checks this needs after deploy

Unit tests cannot prove these; a fake returns whatever it is told.

- A repo-content query returns provenance with `basis: content-header` (baseline 0/117).
- The same query with and without `mode=docs` yields **different** `search_id`s.
- `repo="sokosumi-cli"` no longer returns the sokosumi-docs false positive, and the page refills.
- A fabricated query returns `relevance.no_lexical_match: true`.
- `get_document` on `53915a09-610b-5ad2-9c61-d66f7f5986ad` returns the ~9,749-char README with `assembled_from="chunk_store"`; the control `8cb0c09b-…` returns its 5,795-char body without the marker.
- Watch scoped-search latency: up to two extra vector retrieves per graph-missing unique id, bounded by the post-trim resolution.

## What this does not fix

`duplicate_blob_rate` does not move here. Retriever score stays absent until the `cognee_client` boundary is addressed. Provenance stays empty for headerless tail chunks. The graph/vector divergence itself still needs a backfill.
