### PR TITLE
fix(digest): stop the org digest minting a new document every sync

### DIFF
--- a/kb/repository_update.py
+++ b/kb/repository_update.py
@@ -335,13 +335,8 @@ def compose_repository_update(
         commits=new_commits,
         pull_requests=recent_pull_requests,
     )
-    window_started_at_iso = window_started_at.isoformat(timespec="seconds").replace(
-        "+00:00", "Z"
-    )
     digest = format_digest(
         org=org,
-        checked_at=checked_at,
-        window_started_at=window_started_at_iso,
         repos=repos,
         changed_repos=changed_repos,
         events=new_events,
@@ -369,8 +364,6 @@ def compose_repository_update(
 def format_digest(
     *,
     org: str,
-    checked_at: str,
-    window_started_at: str | None = None,
     repos: list[GitHubRepo],
     changed_repos: list[GitHubRepo],
     events: list[GitHubEvent],
@@ -380,6 +373,20 @@ def format_digest(
     active_repositories: list[dict[str, Any]] | None = None,
     max_commits_per_repo: int | None = None,
 ) -> str:
+    """Render one Repository Daily Update as a vault document body.
+
+    Deliberately carries NO wall-clock fields (ADR-0016: a document rendered
+    from unchanged source content must be byte-identical to the last render).
+    It used to open with ``Checked at: {utc_now}`` and the derived ``Window
+    started at:`` line, so a digest whose reported activity had not changed was
+    still textually distinct on every sync. That defeated content-hash dedup at
+    ingest and the text-keyed dedup at query time, and each pass stored another
+    copy: one measured result page held five byte-identical digests apart from
+    their ``Checked at:`` line. The activity itself already carries its own
+    timestamps (event, commit, and PR lines), which change exactly when the
+    digest's content changes; the run's wall-clock time lives in the sync state
+    (``last_checked_at`` / ``last_digest_at``), not in the indexed body.
+    """
     open_pull_requests = open_pull_requests or []
     merged_pull_requests = merged_pull_requests or []
     active_repositories = active_repositories or []
@@ -387,8 +394,6 @@ def format_digest(
     lines = [
         f"# {org} GitHub daily update",
         "",
-        f"Checked at: {checked_at}",
-        *( [f"Window started at: {window_started_at}"] if window_started_at else [] ),
         f"Source: {source_url}",
         f"Repositories scanned: {len(repos)}",
         f"Changed repositories since last check: {len(changed_repos)}",

--- a/kb/service.py
+++ b/kb/service.py
@@ -335,10 +335,14 @@ class Citadel:
 
         Targets only the well-identified leak classes — COGNIFY_TEST_MARKER canaries,
         the literal ``[DataItem]`` / session-scaffold blobs, explicit session-cache
-        node types, and pre-ADR-0016 repo-content fossils (machine-rendered headers
-        still carrying a ``Retrieved:`` timestamp line). The classifier is anchored
-        so real content is never matched; the default dry run returns every
-        candidate id + preview so a human verifies before any deletion.
+        node types, pre-ADR-0016 repo-content fossils (machine-rendered headers
+        still carrying a ``Retrieved:`` timestamp line), and pre-fix GitHub digest
+        fossils (machine-rendered digest headers still carrying a ``Checked at:``
+        timestamp line). Each class is counted under its own ``counts_by_kind``
+        key so a human can approve one class independently of the others. The
+        classifier is anchored so real content is never matched; the default dry
+        run returns every candidate id + preview so a human verifies before any
+        deletion.
         """
         nodes, _ = await self.cognee.graph_data()
         candidates: list[dict[str, Any]] = []
@@ -367,6 +371,7 @@ class Citadel:
             "COGNIFY_TEST_MARKER",
             "Session ID Question Answer",
             "Repository: Source: Commit: Blob: Retrieved:",
+            "GitHub daily update Checked at: Repositories scanned:",
         ):
             try:
                 hits = await self.search(probe, dataset=self.config.default_dataset, top_k=100)
@@ -476,14 +481,85 @@ def _is_repo_content_fossil(text: str) -> bool:
     return False
 
 
+_DIGEST_TITLE_SUFFIX = " GitHub daily update"
+# Every header field the digest renderer has ever emitted between the title
+# line and the first section heading, in renderer order. Optional entries cover
+# older render vintages: the earliest digests had neither ``Window started
+# at:`` nor the last three counter lines.
+_GITHUB_DIGEST_HEADER_FIELDS: tuple[tuple[str, bool], ...] = (
+    ("Checked at:", True),
+    ("Window started at:", False),
+    ("Source:", True),
+    ("Repositories scanned:", True),
+    ("Changed repositories since last check:", True),
+    ("New public organization events:", True),
+    ("New commits observed:", False),
+    ("Open pull requests active in window:", False),
+    ("Merged pull requests in window:", False),
+)
+_DIGEST_HEADER_TERMINATOR = "## Changed repositories"
+
+
+def _is_github_digest_fossil(text: str) -> bool:
+    """True for a pre-fix GitHub org digest only.
+
+    Until the digest renderer was brought under ADR-0016, every GitHub sync
+    stamped ``Checked at: {utc_now}`` (and later a derived ``Window started
+    at:`` line) into the digest body, so a digest whose reported activity had
+    not changed still minted a NEW document each pass — the same defect class
+    d5d0fe3 fixed for repo content via its ``Retrieved:`` line. Those pre-fix
+    copies are never superseded and keep occupying result slots.
+
+    A fossil is identified only by the FULL machine-rendered header: the text
+    must start with the ``# {org} GitHub daily update`` title line, every
+    non-blank line before the ``## Changed repositories`` section heading must
+    match the renderer's header fields in renderer order, every required field
+    (``Checked at:`` above all) must be present, and the section heading itself
+    must be reached. A ``Checked at:`` in prose, a post-fix header (which has
+    no ``Checked at:``), an unknown or out-of-order line, or a chunk cut before
+    the section heading all keep the node — fail closed on deletion.
+    """
+    lines = [line.strip() for line in text.strip().splitlines()]
+    if not lines:
+        return False
+    title = lines[0]
+    if (
+        not title.startswith("# ")
+        or not title.endswith(_DIGEST_TITLE_SUFFIX)
+        or not title[2 : -len(_DIGEST_TITLE_SUFFIX)].strip()
+    ):
+        return False
+    index = 0
+    for line in lines[1:]:
+        if line == _DIGEST_HEADER_TERMINATOR:
+            # End of header: qualify only when every required field was seen.
+            return all(not required for _, required in _GITHUB_DIGEST_HEADER_FIELDS[index:])
+        if not line:
+            continue
+        while index < len(_GITHUB_DIGEST_HEADER_FIELDS) and not line.startswith(
+            _GITHUB_DIGEST_HEADER_FIELDS[index][0]
+        ):
+            if _GITHUB_DIGEST_HEADER_FIELDS[index][1]:
+                # A required renderer field is missing or out of order: this is
+                # not a pre-fix rendered digest header, so never a fossil.
+                return False
+            index += 1
+        if index >= len(_GITHUB_DIGEST_HEADER_FIELDS):
+            # A line the renderer never emitted in this position: keep the node.
+            return False
+        index += 1
+    return False
+
+
 def _legacy_garbage_kind(node_id: Any, properties: Any) -> str | None:
     """Classify a graph node as legacy garbage to purge, or None to keep (#15).
 
     Conservative + anchored: only an exact COGNIFY_TEST_MARKER id, the literal
-    [DataItem]/session-scaffold blob, an explicit session-cache node type, or a
+    [DataItem]/session-scaffold blob, an explicit session-cache node type, a
     pre-ADR-0016 repo-content fossil (full rendered header with a Retrieved:
-    line inside it). Real content is never classified — there is no
-    substring-of-prose match.
+    line inside it), or a pre-fix GitHub digest fossil (full rendered digest
+    header with a Checked at: line inside it). Real content is never
+    classified — there is no substring-of-prose match.
     """
     props = properties if isinstance(properties, dict) else {}
     for value in (props.get("text"), props.get("name"), props.get("title"), props.get("id"), node_id):
@@ -494,6 +570,8 @@ def _legacy_garbage_kind(node_id: Any, properties: Any) -> str | None:
         return "dataitem"
     if isinstance(text, str) and _is_repo_content_fossil(text):
         return "repo_content_fossil"
+    if isinstance(text, str) and _is_github_digest_fossil(text):
+        return "github_digest_fossil"
     for key in ("type", "node_type", "category", "source"):
         value = props.get(key)
         if isinstance(value, str) and value.strip().lower() in _SESSION_CACHE_TYPES:

--- a/tests/test_repository_update.py
+++ b/tests/test_repository_update.py
@@ -122,8 +122,27 @@ def test_new_activity_is_meaningful_and_formatted_into_the_digest() -> None:
     assert "# masumi-network GitHub daily update" in update.digest
     assert "teach the archive about commits" in update.digest
     assert "masumi-network/agent#42" in update.digest
-    assert f"Checked at: {CHECKED_AT}" in update.digest
-    assert "Window started at: 2026-06-08T09:00:00Z" in update.digest
+
+
+def test_digest_is_stable_when_the_window_content_is_unchanged() -> None:
+    """Two syncs over identical activity must produce byte-identical digests.
+
+    ``Checked at: {utc_now}`` (and the wall-clock-derived ``Window started
+    at:``) used to make every sync's digest textually distinct even when the
+    reported activity had not changed, which defeated content-hash dedup at
+    ingest and text-keyed dedup at query time — the exact defect ADR-0016
+    fixed for repo content, in this second render path. Measured before the
+    fix: one result page held five byte-identical digests apart from their
+    ``Checked at:`` line.
+    """
+    first = compose()
+    second = compose(checked_at="2026-06-09T11:00:00Z")
+
+    assert first.digest == second.digest
+    assert "Checked at:" not in first.digest, "a per-sync timestamp reintroduces duplicates"
+    assert (
+        "Window started at:" not in first.digest
+    ), "a wall-clock-derived window bound reintroduces duplicates"
 
 
 def test_force_treats_all_activity_as_new() -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -526,6 +526,160 @@ def test_repo_content_fossil_never_matches_real_content() -> None:
     assert _legacy_garbage_kind("k6", {"text": truncated}) is None
 
 
+# Pre-fix GitHub org digest, current render vintage: full machine-rendered
+# header with Checked at: and Window started at: before the first section.
+_DIGEST_FOSSIL_DOC = "\n".join(
+    [
+        "# masumi-network GitHub daily update",
+        "",
+        "Checked at: 2026-07-19T05:44:02Z",
+        "Window started at: 2026-07-18T05:44:02Z",
+        "Source: https://github.com/orgs/masumi-network/repositories",
+        "Repositories scanned: 42",
+        "Changed repositories since last check: 3",
+        "New public organization events: 7",
+        "New commits observed: 12",
+        "Open pull requests active in window: 2",
+        "Merged pull requests in window: 1",
+        "",
+        "## Changed repositories",
+        "- masumi-network/sokosumi (TypeScript): pushed 2026-07-19T04:12:00Z, "
+        "updated 2026-07-19T04:12:00Z, open issues 4, stars 12, forks 3. "
+        "Marketplace for AI agents. https://github.com/masumi-network/sokosumi",
+        "",
+        "## Open pull requests worth attention",
+        "- masumi-network/sokosumi#88 by sarthib7: Ship the composer. "
+        "Updated 2026-07-19T03:00:00Z. https://github.com/masumi-network/sokosumi/pull/88",
+    ]
+)
+
+# Oldest render vintage: no Window started at:, only the first three counter
+# lines existed. These are the earliest copies in the vault.
+_DIGEST_FOSSIL_OLDEST_DOC = "\n".join(
+    [
+        "# masumi-network GitHub daily update",
+        "",
+        "Checked at: 2026-06-12T05:00:00Z",
+        "Source: https://github.com/orgs/masumi-network/repositories",
+        "Repositories scanned: 30",
+        "Changed repositories since last check: 1",
+        "New public organization events: 2",
+        "",
+        "## Changed repositories",
+        "- masumi-network/agent (Python): pushed 2026-06-12T04:00:00Z.",
+    ]
+)
+
+# Post-fix digest: same renderer, no wall-clock lines. Cleanup must keep it.
+_DIGEST_POST_FIX_DOC = "\n".join(
+    [
+        "# masumi-network GitHub daily update",
+        "",
+        "Source: https://github.com/orgs/masumi-network/repositories",
+        "Repositories scanned: 42",
+        "Changed repositories since last check: 3",
+        "New public organization events: 7",
+        "New commits observed: 12",
+        "Open pull requests active in window: 2",
+        "Merged pull requests in window: 1",
+        "",
+        "## Changed repositories",
+        "- masumi-network/sokosumi (TypeScript): pushed 2026-08-02T04:12:00Z.",
+    ]
+)
+
+
+def test_github_digest_fossil_never_matches_real_content() -> None:
+    # SAFETY FIRST — this is deletion tooling; each of these is real knowledge
+    # that must survive the classifier. Written before the classifier existed.
+    from kb.service import _legacy_garbage_kind
+
+    # (a) An ordinary Linear issue document.
+    assert (
+        _legacy_garbage_kind(
+            "d1",
+            {
+                "text": (
+                    "# MAS-201: Digest cron misses the window\n\n"
+                    "Status: Todo\nAssignee: sarthi\n\n---\n\n"
+                    "The daily update sometimes runs twice; investigate the scheduler."
+                )
+            },
+        )
+        is None
+    )
+    # (b) A personal seat note.
+    assert (
+        _legacy_garbage_kind(
+            "d2",
+            {"text": "Note to self: the GitHub daily update lands around 05:44 UTC."},
+        )
+        is None
+    )
+    # (c) Repo-content documents: the pre-ADR-0016 fossil keeps its OWN kind
+    # (never the digest kind), and the post-fix repo document is kept.
+    assert _legacy_garbage_kind("d3", {"text": _FOSSIL_DOC}) == "repo_content_fossil"
+    assert _legacy_garbage_kind("d4", {"text": _POST_FIX_DOC}) is None
+    # (d) A document whose BODY merely mentions "Checked at:" — prose about the
+    # digest, not a rendered digest header.
+    assert (
+        _legacy_garbage_kind(
+            "d5",
+            {
+                "text": (
+                    "# Ops runbook: reading the sync dashboard\n\n"
+                    "Every sync stamps a Checked at: timestamp into its state file.\n"
+                    "Compare it against last_digest_at before blaming the cron.\n\n"
+                    "## Changed repositories\n\n"
+                    "This section of the dashboard lists fingerprint changes."
+                )
+            },
+        )
+        is None
+    )
+    # (e) A post-fix digest: rendered header WITHOUT the wall-clock lines.
+    assert _legacy_garbage_kind("d6", {"text": _DIGEST_POST_FIX_DOC}) is None
+    # (f) A chunk cut mid-header (## Changed repositories never reached).
+    truncated_digest = _DIGEST_FOSSIL_DOC.split("## Changed repositories")[0]
+    assert _legacy_garbage_kind("d7", {"text": truncated_digest}) is None
+    # (g) A line the renderer never emitted inside the header block.
+    tampered = _DIGEST_FOSSIL_DOC.replace(
+        "Source: https://github.com/orgs/masumi-network/repositories",
+        "Source: https://github.com/orgs/masumi-network/repositories\n"
+        "Reviewed by: sarthi",
+    )
+    assert _legacy_garbage_kind("d8", {"text": tampered}) is None
+    # (h) Header fields out of renderer order.
+    reordered = _DIGEST_FOSSIL_DOC.replace(
+        "Checked at: 2026-07-19T05:44:02Z\nWindow started at: 2026-07-18T05:44:02Z\n"
+        "Source: https://github.com/orgs/masumi-network/repositories",
+        "Source: https://github.com/orgs/masumi-network/repositories\n"
+        "Checked at: 2026-07-19T05:44:02Z\nWindow started at: 2026-07-18T05:44:02Z",
+    )
+    assert _legacy_garbage_kind("d9", {"text": reordered}) is None
+    # (i) A title that is not the digest title.
+    retitled = _DIGEST_FOSSIL_DOC.replace(
+        "# masumi-network GitHub daily update", "# masumi-network GitHub weekly report"
+    )
+    assert _legacy_garbage_kind("d10", {"text": retitled}) is None
+
+
+def test_github_digest_fossil_is_matched() -> None:
+    # A pre-fix GitHub org digest — full rendered header carrying the moving
+    # Checked at: line — is classified under its OWN kind so a human can
+    # approve this class independently of repo_content_fossil and the rest.
+    from kb.service import _legacy_garbage_kind
+
+    assert _legacy_garbage_kind("g1", {"text": _DIGEST_FOSSIL_DOC}) == "github_digest_fossil"
+    assert (
+        _legacy_garbage_kind("g2", {"text": _DIGEST_FOSSIL_OLDEST_DOC})
+        == "github_digest_fossil"
+    )
+    # The middle vintage rendered Checked at: without a Window started at: line.
+    no_window = _DIGEST_FOSSIL_DOC.replace("Window started at: 2026-07-18T05:44:02Z\n", "")
+    assert _legacy_garbage_kind("g3", {"text": no_window}) == "github_digest_fossil"
+
+
 class _GraphGateway(FakeCognee):
     def __init__(self, graph_nodes: list[Any]) -> None:
         super().__init__()
@@ -584,6 +738,37 @@ async def test_cleanup_reports_fossils_under_their_own_kind() -> None:
     res = await kb.cleanup_legacy_nodes(dry_run=False)
     assert res["deleted"] == 2
     assert "keep1" not in gw.deleted  # the post-fix document survives
+
+
+@pytest.mark.asyncio
+async def test_cleanup_counts_digest_fossils_under_their_own_key() -> None:
+    # Pre-fix GitHub digests are a separate accumulation from repo-content
+    # fossils (different render shape, different sync). They must surface under
+    # their OWN counts_by_kind key so a human can approve the digest class
+    # separately from repo_content_fossil.
+    nodes = [
+        ("digest1", {"text": _DIGEST_FOSSIL_DOC}),
+        ("digest2", {"text": _DIGEST_FOSSIL_OLDEST_DOC}),
+        ("repofossil1", {"text": _FOSSIL_DOC}),
+        ("keepdigest", {"text": _DIGEST_POST_FIX_DOC}),
+        ("keepnote", {"text": "A genuine project decision."}),
+    ]
+    gw = _GraphGateway(nodes)
+    kb = Citadel(CitadelConfig(), cognee=gw)
+
+    dry = await kb.cleanup_legacy_nodes(dry_run=True)
+    assert dry["counts_by_kind"] == {"github_digest_fossil": 2, "repo_content_fossil": 1}
+    kinds = {c["id"]: c["kind"] for c in dry["candidates"]}
+    assert kinds == {
+        "digest1": "github_digest_fossil",
+        "digest2": "github_digest_fossil",
+        "repofossil1": "repo_content_fossil",
+    }
+
+    res = await kb.cleanup_legacy_nodes(dry_run=False)
+    assert res["deleted"] == 3
+    assert "keepdigest" not in gw.deleted  # the post-fix digest survives
+    assert "keepnote" not in gw.deleted
 
 
 @pytest.mark.asyncio

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -526,6 +526,22 @@ def test_repo_content_fossil_never_matches_real_content() -> None:
     assert _legacy_garbage_kind("k6", {"text": truncated}) is None
 
 
+# Body lines the renderer builds by joining several f-string fragments
+# (kb/repository_update.py:415-416 does the same). Assembled with explicit
+# concatenation here rather than adjacent string literals inside the list
+# below, so neither a reader nor a scanner has to decide whether a comma was
+# forgotten. These lines sit AFTER the section heading, so they are realism
+# only — the classifier never reads past the heading.
+_DIGEST_REPO_LINE = (
+    "- masumi-network/sokosumi (TypeScript): pushed 2026-07-19T04:12:00Z, "
+    + "updated 2026-07-19T04:12:00Z, open issues 4, stars 12, forks 3. "
+    + "Marketplace for AI agents. https://github.com/masumi-network/sokosumi"
+)
+_DIGEST_PR_LINE = (
+    "- masumi-network/sokosumi#88 by sarthib7: Ship the composer. "
+    + "Updated 2026-07-19T03:00:00Z. https://github.com/masumi-network/sokosumi/pull/88"
+)
+
 # Pre-fix GitHub org digest, current render vintage: full machine-rendered
 # header with Checked at: and Window started at: before the first section.
 _DIGEST_FOSSIL_DOC = "\n".join(
@@ -543,13 +559,10 @@ _DIGEST_FOSSIL_DOC = "\n".join(
         "Merged pull requests in window: 1",
         "",
         "## Changed repositories",
-        "- masumi-network/sokosumi (TypeScript): pushed 2026-07-19T04:12:00Z, "
-        "updated 2026-07-19T04:12:00Z, open issues 4, stars 12, forks 3. "
-        "Marketplace for AI agents. https://github.com/masumi-network/sokosumi",
+        _DIGEST_REPO_LINE,
         "",
         "## Open pull requests worth attention",
-        "- masumi-network/sokosumi#88 by sarthib7: Ship the composer. "
-        "Updated 2026-07-19T03:00:00Z. https://github.com/masumi-network/sokosumi/pull/88",
+        _DIGEST_PR_LINE,
     ]
 )
 


### PR DESCRIPTION
The GitHub org digest duplicates itself on every sync. This is the same defect class ADR-0016 fixed for repo content, in a code path that was never fixed.

Refs #148, #149, #151

## Measured

On one digest result page, **6 of 10 slots were duplicates** — five byte-identical apart from a single line, three more identical to each other. A query naming 2026-08-01 returned three 2026-07-19 digests differing only in that line.

Documents are content-addressed, so a moving field in the body mints a new document every sync for content that has not changed.

## Two moving fields, not one

`Checked at:` was the obvious one. `Window started at:` was derived from it (checked_at minus a fixed 24h), so it moved identically every run. Removing only the first would have left the defect fully intact — worth knowing, because that is exactly how this class survives a fix.

Every remaining field was audited rather than assumed: the six counter lines derive from the digest's own reported content, the "showing up to N" line is config-driven, per-item timestamps (event created, commit authored, PR updated, repo pushed) change exactly when the digest changes, and every ordering is deterministic. Two syncs over identical activity now render byte-identical bodies.

The run timestamp already lives in sync state (`last_checked_at` / `last_digest_at`), which is untouched.

A second renderer, `format_organization_digest_text` in `kb/organization_digest.py`, also carries a timestamp — but it is **never ingested**, only posted to notification gateways, so its timestamp is harmless and it is left alone.

## Reclaiming what already accumulated

New `github_digest_fossil` cleanup kind, mirroring `repo_content_fossil`. Anchored on the full machine-rendered header: the title line, then every non-blank line before the `## Changed repositories` heading must match the renderer's fields in renderer order, `Checked at:` must be present, and the terminator must be reached. It covers all three render vintages found in git history.

Anything else fails closed and is kept: prose that merely mentions "Checked at:", post-fix digests, chunks cut mid-header, unknown or out-of-order header lines, repo-content documents. Counted under its own `counts_by_kind` key so it can be reviewed separately.

## Diagnosed here, deliberately not fixed

Two findings worth recording, because both are load-bearing and neither is addressed by this change:

**`last_digest_at` proves composition, not retrievability.** `github_sync.py` stamps it whenever the sync decided to ingest, *without* checking `ingest_result.accepted` — so a rejected or duplicate-rejected ingest still advances the timestamp. And an accepted ingest is only `add()` plus a scheduled background cognify whose failures never reach the sync's status. `last_digest_at = 2026-08-02` therefore means "composed and add() returned", nothing more.

**The duplication is what makes the digest look stale.** `kb/service.py` falls back to `search_github_sync_state` — which reads the genuinely newest digest — *only* when recall returns empty for the github dataset. The accumulated fossils guarantee recall is never empty for digest-shaped queries, so the one reader that would surface today's digest is unreachable, and stale copies fill the page instead. Cleaning up the fossils plus byte-stable rendering makes that fallback reachable again when the index lags.

## Verification

Full suite **1131 passed, 1 skipped**; ruff clean.

Negative tests were written **first** and are adversarial — including prose that mentions "Checked at:" *and* carries a `## Changed repositories` heading. Positive tests cover all three historical vintages.

Both directions: deliberately re-adding a live `Checked at:` line failed the byte-stability test on `assert first.digest == second.digest`; loosening the classifier to a bare substring match reddened the negative test by classifying the ops-runbook prose fixture. Both reverted.

Honest caveat: the classifier fixtures are renderer-shape reconstructions verified against the renderer source at three git vintages, not live vault bytes. That duplication actually stops in production cannot be proven by any fake.

## Live checks after deploy

- Cleanup dry run: every `github_digest_fossil` preview must start with `# masumi-network GitHub daily update`. **One non-digest preview means do not approve the class.** Note approval currently deletes all listed kinds at once.
- Two syncs over a quiet day: the second ingest is rejected as a duplicate and no new document id appears for digest-shaped queries.
- Once an evolve pass completes, a current-date query should surface the newest digest.

`duplicate_blob_rate` does **not** move when this deploys. The renderer fix only stops new fossils; the rate drops when cleanup is approved and run, and not to zero, since headerless LLM-chunked tails survive by design.
