### PR TITLE
fix(promote): require admin to run a live promotion, not just a preview

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -5064,7 +5064,17 @@ async def promotion_status(request: Request) -> Any:
 
 @app.post("/api/promote/run")
 async def run_promotion(body: PromoteRunBody, request: Request) -> Any:
+    # A seat previewing its own promotable candidates is the intended flow and
+    # stays at writer (can_run_promotion below also refuses another seat's
+    # dataset). But dry_run comes from the request body, and with it false this
+    # same call writes durably into the shared Central dataset under a
+    # synthetic admin identity, with no further approval on the auto-promote
+    # path. A caller may not grant itself that by flipping a flag, so the write
+    # half now requires what GET /api/promote already requires. The scheduled
+    # promotion path is unaffected.
     actor = require_access(request, "writer", "kb:ingest")
+    if not body.dry_run:
+        actor = require_access(request, "admin", "sources:sync")
     if not is_seat_dataset(body.dataset):
         raise HTTPException(
             status_code=400,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4731,6 +4731,32 @@ def test_seat_writer_can_run_own_promotion(tmp_path: Any) -> None:
     assert response.json()["dataset"] == "seat:alice"
 
 
+def test_seat_writer_cannot_run_a_live_promotion(tmp_path: Any) -> None:
+    """dry_run is caller-supplied, and with it false this endpoint writes
+    durably into shared Central under a synthetic admin identity with no
+    further approval on the auto-promote path. A writer may preview its own
+    candidates; it may not grant itself the write by flipping the flag."""
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    created = admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"})
+    token = created.json()["token"]
+    seat_client = TestClient(app, base_url="https://testserver")
+
+    preview = seat_client.post(
+        "/api/promote/run",
+        json={"dataset": "seat:alice", "dry_run": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    live = seat_client.post(
+        "/api/promote/run",
+        json={"dataset": "seat:alice", "dry_run": False},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert preview.status_code == 200
+    assert live.status_code == 403
+
+
 def test_seat_writer_cannot_run_other_seat_promotion(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()


### PR DESCRIPTION
`GET /api/promote` reports the promotion configuration and requires `admin` + `sources:sync`. `POST /api/promote/run` performs the promotion and required only `writer` + `kb:ingest` — so reading the configuration was harder than running the job.

## What stays

The preview half is deliberate and unchanged. A seat asking which of its own notes are promotable is the intended flow, and `can_run_promotion` already refuses another seat's dataset. Two existing tests cover exactly that, and both still pass.

## What changes

`dry_run` arrives in the request body. With it false, the same call performs a durable write into the shared Central dataset, under a synthetic admin identity, and the auto-promote branch takes it without further approval. A caller should not be able to grant itself that by changing a field it controls.

The write half now requires what the sibling `GET` already requires. Scheduled promotion is unaffected.

## Verification

Full suite **1186 passed, 1 skipped**; ruff clean.

The added test drives both halves with one seat token: preview returns 200, live run returns 403.

Checked in both directions. Removing the gate turns that test red — the live run returns 200 — while `test_seat_writer_can_run_own_promotion` and `test_seat_writer_cannot_run_other_seat_promotion` both stay green. So it discriminates the write from the feature rather than merely restating the route.

## Note for review

This is the narrow change. A first attempt required `admin` for the whole endpoint and broke the seat preview flow, which the existing test caught — worth knowing if anyone is tempted to simplify it later. Deeper hardening of the promotion decision path is tracked separately.
