### PR TITLE
fix(contact): let an admin actually read the partner enquiries

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -3133,7 +3133,13 @@ async def list_contact_enquiries(request: Request, limit: int = 50) -> dict[str,
     Once the gateway is set up this stays useful as the durable record behind a
     Chat message that someone scrolls past.
     """
-    require_access(request, "admin", "access:read")
+    # access:manage, not access:read. The latter is defined nowhere: it is in no
+    # role's DEFAULT_SCOPES, and validate_role_scopes raises on any scope outside
+    # the role defaults, so a token carrying it cannot be minted either. The gate
+    # therefore refused every possible caller, including the account owner, and
+    # the enquiry queue that ADR-0013 added so partner messages would survive an
+    # unconfigured Chat gateway was itself unreadable.
+    require_access(request, "admin", "access:manage")
     store = get_contact_store()
     return {
         "enquiries": store.recent(min(max(1, limit), 200)),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5995,6 +5995,25 @@ def test_contact_enquiries_endpoint_is_admin_only(monkeypatch, tmp_path) -> None
     assert client.get("/api/contact/enquiries").status_code in {401, 403}
 
 
+def test_an_admin_can_actually_read_the_enquiries(monkeypatch, tmp_path) -> None:
+    """The half the admin-only test above cannot see.
+
+    Asserting that a stranger is refused says nothing about whether anyone is
+    admitted, so that test passed just as happily while the gate demanded a scope
+    no credential could hold and the queue was readable by nobody. This one fails
+    if the endpoint is walled off from its own owner.
+    """
+    store = _contact_store_at(monkeypatch, tmp_path)
+    client = authed_client()
+    client.post("/contact", json=_enquiry())
+    assert len(store.recent()) == 1
+
+    response = client.get("/api/contact/enquiries")
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+
+
 def test_contact_is_never_written_to_the_vault(monkeypatch, tmp_path) -> None:
     """The part of ADR-0013 that did NOT change.
 


### PR DESCRIPTION
Fixes #202

## What was wrong

`GET /api/contact/enquiries` gated on a scope named `access:read`. That string appears exactly once in the entire tree: in the gate itself.

- it is in no role's `DEFAULT_SCOPES` (`kb/access.py`)
- `validate_role_scopes` **raises** on any scope outside the role defaults, so a token carrying it cannot be minted either
- `effective_scopes` falls back to `default_scopes(role)` for env credentials, which also lacks it

So there is no credential — token, env key, or session — that can pass this gate.

## Verified against production

```
GET /api/sources            -> 200   (same admin token, control)
GET /api/contact/enquiries  -> 403   {"detail":"Scope required: access:read."}
```

## Why it matters

ADR-0013 added the enquiry queue specifically so partner messages would survive an unconfigured Chat gateway. The messages were being stored correctly. Nobody could read them.

## The fix

One word: `access:read` -> `access:manage`. That is the existing scope in the same family, admin already holds it, and "manage" implies read. No scope model change, no new grant.

## Why the existing test didn't catch it

`test_contact_enquiries_endpoint_is_admin_only` asserts an unauthenticated caller gets 401/403. That stayed true the whole time the endpoint was refusing *everyone* — the test passes just as happily when the feature is completely unreachable.

The new test submits an enquiry and reads it back as an admin. Reverting only the gate line (leaving the test in place) fails it with `assert 403 == 200`; restoring the fix passes. 37 contact/access/scope/role tests pass.