### PR TITLE
fix(access): a token expiry that cannot be parsed no longer means "never expires"

### DIFF
--- a/kb/access.py
+++ b/kb/access.py
@@ -226,9 +226,37 @@ def _parse_time(value: str | None) -> datetime | None:
     return parsed
 
 
+def validate_expires_at(value: str | None) -> str | None:
+    """Reject an expiry the expiry check would not be able to read.
+
+    Stored raw, an unparseable value is indistinguishable from no expiry at all,
+    so the token outlives its stated lifetime while the dashboard still labels it
+    "Expires". Refusing it at the door is the only place the caller can be told.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if _parse_time(text) is None:
+        raise ValueError(
+            f"expires_at is not an ISO 8601 timestamp: {value!r}"
+        )
+    return text
+
+
 def _is_expired(value: str | None) -> bool:
+    if not value:
+        # No expiry set. Permanent by design.
+        return False
     parsed = _parse_time(value)
-    return bool(parsed and parsed <= datetime.now(timezone.utc))
+    if parsed is None:
+        # An expiry was set and cannot be read. Previously this returned False
+        # and the token authenticated forever. Treat unreadable as expired:
+        # validate_expires_at stops new ones being written, and this covers
+        # anything already stored, including a value edited in by hand.
+        return True
+    return parsed <= datetime.now(timezone.utc)
 
 
 def _dedupe(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
@@ -453,6 +481,7 @@ class AccessStore:
             raise KeyError(principal_id)
         resolved_role = role or principal.role
         validate_role(resolved_role)
+        resolved_expires_at = validate_expires_at(expires_at)
         resolved_scopes = (
             validate_role_scopes(resolved_role, scopes)
             if scopes is not None
@@ -472,7 +501,7 @@ class AccessStore:
             scopes=resolved_scopes,
             team_id=team_id if team_id is not None else principal.team_id,
             created_at=now_iso(),
-            expires_at=expires_at,
+            expires_at=resolved_expires_at,
             default_dataset=_normalize_optional_str(default_dataset),
             default_session=_normalize_optional_str(default_session),
             allowed_datasets=_dedupe(allowed_datasets or ()),
@@ -494,6 +523,10 @@ class AccessStore:
         default_session: str | None = None,
         allowed_datasets: tuple[str, ...] | list[str] | None = None,
     ) -> TokenCreation:
+        # Before create_principal, not after: create_token validates this too,
+        # but by then the principal exists and raising would strand it with no
+        # token attached.
+        validate_expires_at(expires_at)
         principal = self.create_principal(
             name=name,
             kind=kind,

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -76,6 +76,92 @@ def test_future_expiry_still_authenticates(tmp_path: Path) -> None:
     assert rejection_events(access_store) == []
 
 
+def test_no_expiry_is_still_permanent(tmp_path: Path) -> None:
+    """Omitting the field means permanent, and must stay that way.
+
+    Tightening the unreadable-expiry path must not touch this case.
+    """
+    access_store = store(tmp_path)
+    created = access_store.create_principal_token(
+        name="permanent-bot",
+        kind="service_account",
+        role="reader",
+        expires_at=None,
+    )
+
+    assert access_store.authenticate_token(created.token) is not None
+    assert rejection_events(access_store) == []
+
+
+def test_an_unreadable_expiry_is_refused_at_mint(tmp_path: Path) -> None:
+    """The value was stored raw while role and scopes beside it were validated.
+
+    An expiry the expiry check cannot parse is indistinguishable from no expiry,
+    so the token lived forever while the dashboard labelled it "Expires".
+    """
+    access_store = store(tmp_path)
+
+    with pytest.raises(ValueError, match="not an ISO 8601 timestamp"):
+        access_store.create_principal_token(
+            name="never-expires-bot",
+            kind="service_account",
+            role="reader",
+            expires_at="next friday",
+        )
+
+
+def test_a_refused_expiry_leaves_no_orphan_principal(tmp_path: Path) -> None:
+    """create_principal_token builds the principal before the token.
+
+    Validating only inside create_token would strand a principal with no token
+    attached every time an expiry is rejected.
+    """
+    access_store = store(tmp_path)
+    before = len(access_store.snapshot()["principals"])
+
+    with pytest.raises(ValueError):
+        access_store.create_principal_token(
+            name="orphan-bot",
+            kind="service_account",
+            role="reader",
+            expires_at="whenever",
+        )
+
+    assert len(access_store.snapshot()["principals"]) == before
+
+
+def test_an_unreadable_expiry_already_in_the_store_is_treated_as_expired(
+    tmp_path: Path,
+) -> None:
+    """Covers what mint-time validation cannot: a value edited in by hand.
+
+    Before, an unparseable stored expiry made _is_expired return False and the
+    token authenticated forever.
+    """
+    import json
+
+    path = tmp_path / "access.json"
+    access_store = AccessStore(path)
+    created = access_store.create_principal_token(
+        name="hand-edited-bot",
+        kind="service_account",
+        role="reader",
+        expires_at=iso_offset(hours=1),
+    )
+    assert access_store.authenticate_token(created.token) is not None
+
+    raw = json.loads(path.read_text())
+    for token in raw["tokens"]:
+        token["expires_at"] = "sometime next quarter"
+    path.write_text(json.dumps(raw))
+
+    reopened = AccessStore(path)
+
+    assert reopened.authenticate_token(created.token) is None
+    events = rejection_events(reopened)
+    assert events[-1]["detail"]["reason"] == "expired"
+
+
 def test_revoked_token_is_rejected_with_audit_event(tmp_path: Path) -> None:
     access_store = store(tmp_path)
     created = access_store.create_principal_token(


### PR DESCRIPTION
Fixes #203

## What was wrong

`expires_at` was stored exactly as received. The `role` beside it goes through `validate_role`, the `scopes` through `validate_role_scopes` — and the value that decides how long a credential lives went through nothing.

`_is_expired` then read it back through `_parse_time`, which returns `None` for anything unparseable:

```python
def _is_expired(value: str | None) -> bool:
    parsed = _parse_time(value)
    return bool(parsed and parsed <= datetime.now(timezone.utc))   # None -> False
```

So an unreadable expiry was indistinguishable from no expiry, and the token authenticated forever. Meanwhile `kb/static/app.js:3418` renders the status as "Expires" whenever the field is merely truthy.

The net effect: `expires_at: "next friday"` mints a permanent credential, and the dashboard tells you it expires. Failing this direction is the wrong way round for a lifetime check.

To reach it you need admin rights (only admins mint tokens), so this is a footgun rather than a privilege-escalation path — but a silent one, and it undermines the control you would reach for first when rotating a credential.

## The fix

Two changes, because mint-time validation cannot reach a value that is already stored or hand-edited:

1. **`validate_expires_at`** rejects an unparseable timestamp at mint. `POST /api/access/tokens` already maps `ValueError` to 422, so the caller gets told. It also runs at the top of `create_principal_token`, not only inside `create_token` — the principal is built first, so raising later would strand it with no token attached.
2. **`_is_expired` distinguishes absent from unreadable.** Absent stays permanent, which is the documented meaning of omitting the field. Unreadable now counts as expired.

The live access store was checked before tightening: no existing token carries an expiry whose handling this changes, so no credential changes behaviour.

## Test gap this closes

The suite tested a past expiry and a future expiry — both well-formed. Nothing tested a malformed one, which is the only input that triggered the bug.

Reverting `kb/access.py` with the new tests in place fails three of them:

```
Failed: DID NOT RAISE ValueError            (mint accepts garbage)
Failed: DID NOT RAISE ValueError            (orphan-principal guard)
assert TokenSession(...) is None            (stored garbage still authenticates)
```

That third one is the bug itself: an unfixed store hands back a live `TokenSession` for a token whose expiry reads `"sometime next quarter"`.

294 tests pass across `test_access`, `test_access_client`, `test_cli_commands`, `test_server`.