### PR TITLE
test: stop the suite authenticating to a real Node

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,39 @@ def _isolate_claude_home(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _no_credentials_for_a_real_node(monkeypatch):
+    """Stop the suite authenticating to whatever Node the developer is pointed at.
+
+    `citadel setup --root` does not only write the local config: it calls
+    sync_local_capture_roots_to_server, which resolves the seat from the token in
+    the environment and merges the local roots into that seat on the Node. A test
+    that passes --root without also passing --node-url therefore registers its own
+    tmp_path against a live seat. One did, and 47 of the 50 approved capture roots
+    on the seat were pytest temp directories, one per run of the suite.
+
+    That is worse than clutter. The server merge is a union, so the list only
+    grows, and capture_roots_sync refuses locally once it would exceed
+    MAX_APPROVED_CAPTURE_ROOTS (50) — a state its own comment describes as a loop
+    that cannot end on its own, because the rejected write never lands and so the
+    "unchanged" short-circuit never fires.
+
+    Clearing the token is enough: _sync_local_capture_roots_once returns
+    "skipped" on an empty token before it resolves a base URL, so no request is
+    made at all. A test that wants a token still sets one with monkeypatch, which
+    runs after this fixture and wins.
+    """
+    for name in (
+        "CITADEL_MCP_ACCESS_TOKEN",
+        "CITADEL_WRITER_KEYS",
+        "CITADEL_ADMIN_KEY",
+        "CITADEL_ADMIN_TOKEN",
+        "CITADEL_ACCESS_KEYS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _reset_auth_throttle():
     """Empty the failed-auth buckets around every test (M4).
 

--- a/tests/test_suite_isolation.py
+++ b/tests/test_suite_isolation.py
@@ -1,0 +1,62 @@
+"""The suite must not be able to authenticate to a real Node.
+
+Three autouse fixtures in conftest already exist because the suite mutated
+something real: the developer's ~/.claude config, a module-global throttle, and
+app.state. This is the fourth, and the damage it prevents is the least visible,
+because a capture root synced to a live seat leaves no trace in the test output.
+"""
+
+from __future__ import annotations
+
+import os
+
+from kb.capture import capture_token
+from kb.capture_config import MAX_APPROVED_CAPTURE_ROOTS
+from kb.capture_roots_sync import _sync_local_capture_roots_once
+
+
+def test_no_seat_token_is_visible_to_a_test() -> None:
+    """capture_token reads the environment directly, so this is the real check.
+
+    Reduced to a bool on a separate line on purpose. This test fails precisely
+    when a real credential is present, and pytest's assertion introspection walks
+    the expression tree and reports every sub-expression it evaluated: both
+    `assert capture_token() == ""` and `assert bool(capture_token()) is False`
+    print the token they just caught, into CI logs, for a public repository.
+    Only a name already bound to a bool keeps the value out of the report.
+    """
+    leaked = bool(capture_token())
+
+    assert leaked is False, (
+        "a seat token is visible to the suite; _no_credentials_for_a_real_node "
+        "should have cleared CITADEL_MCP_ACCESS_TOKEN / CITADEL_WRITER_KEYS"
+    )
+
+
+def test_no_admin_credential_is_visible_to_a_test() -> None:
+    for name in ("CITADEL_ADMIN_KEY", "CITADEL_ADMIN_TOKEN", "CITADEL_ACCESS_KEYS"):
+        present = bool(os.getenv(name))
+
+        assert present is False, f"{name} is visible to the suite"
+
+
+def test_capture_root_sync_skips_instead_of_calling_a_node(tmp_path) -> None:
+    """The specific path that put 47 pytest temp dirs on a production seat.
+
+    A root is configured, so the "no local roots" short-circuit does not apply;
+    the sync must stop at the missing token instead, before any request.
+    """
+    from kb.capture_config import CaptureConfig, CaptureRoot
+
+    config = CaptureConfig(roots=[CaptureRoot(path=str(tmp_path), tags=("personal",))])
+
+    result = _sync_local_capture_roots_once(config)
+
+    assert result.status == "skipped"
+    assert "no seat token" in result.detail
+    assert result.seat_slug is None
+
+
+def test_the_ceiling_this_protects_is_still_where_we_think() -> None:
+    """If this constant moves, the headroom argument in conftest moves with it."""
+    assert MAX_APPROVED_CAPTURE_ROOTS == 50


### PR DESCRIPTION
Fixes #204

## What I found

Checking why a seat showed no captures, I looked at its approved capture roots. Of 50, **47 were pytest temp directories** — one per run of the suite, every one named after the same test.

```
/private/var/folders/.../pytest-of-<user>/pytest-511/test_capture_json_dry_run_is_c0
/private/var/folders/.../pytest-of-<user>/pytest-512/test_capture_json_dry_run_is_c0
... 45 more, spanning 47 distinct pytest runs
```

## Why the suite can do that

`citadel setup --root` does not only write the local config. It calls `sync_local_capture_roots_to_server`, which resolves the seat from whatever token is in the environment and merges the local roots into that seat on the Node.

`tests/test_headless.py:95` passes `--root` without `--node-url`, so it falls through to the real configured node with the developer's real token. The test immediately below it (`:107`) *does* pass `--node-url https://node.example`, which is what makes the omission easy to miss in review.

## Why it is more than clutter

`kb/capture_roots_sync.py:83` merges as a **union**, so the server list only ever grows. `:92` then refuses locally once the merge would exceed `MAX_APPROVED_CAPTURE_ROOTS` (50). The existing comment there describes the consequence precisely:

> the write never lands: merged stays different from the server list, so the "unchanged" short-circuit above never fires and every subsequent sync re-sends the same rejected request. That is the 422 loop, and it cannot end on its own.

The seat is at **50 of 50**. One more new root reaches that state, and 94% of the capacity was spent by a test.

## The fix

At the class, not the one test — a fourth autouse fixture in `conftest.py`, beside the three already there for the same reason (real `~/.claude` config, a module-global throttle, `app.state`).

Clearing the credentials is sufficient and precise: `_sync_local_capture_roots_once` returns `"skipped"` on an empty token *before* it resolves a base URL, so no request is made at all. Tests that want a token still set one with `monkeypatch`, which runs after the fixture and wins. That is why `test_capture_json_real_post_shape` and friends are unaffected.

## A trap in the new tests

These tests fail exactly when a real credential is present, so their failure output is the one place a token must never appear — and this repository is public.

pytest's assertion introspection reports every sub-expression it evaluated. Both of these print the token they just caught:

```python
assert capture_token() == ""                 # prints the token
assert bool(capture_token()) is False        # prints `where True = bool('ctdl_...')`
```

Only a name already bound to a bool keeps the value out of the report:

```python
leaked = bool(capture_token())
assert leaked is False, "a seat token is visible to the suite; ..."
```

Verified rather than assumed: with the fixture removed and a real token exported, 3 tests fail and the token appears **0 times** in the full failure output.

## Checks

- full suite: **1229 passed, 1 skipped**
- fixture removed + real token exported: 3 fail (the guard bites), 0 secret occurrences
- fixture restored, same shell, token still exported: 4 pass

## Not included

The 47 stale roots already on the seat are server-side state; this PR stops new ones being created but does not remove them. Worth doing separately, since it also restores the headroom.