### PR TITLE
fix(sync): refuse corrupt state files instead of flattening to empty

### DIFF
--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -37,6 +37,7 @@ from kb.repository_update import (
 from kb.retry import run_with_retries
 from kb.security_scan import SecurityScanEntry, redact_secrets, scan_text_entries
 from kb.service import Citadel
+from kb.state_io import StateFileError, load_state_file
 
 __all__ = [
     "GitHubAPIError",
@@ -269,9 +270,16 @@ class GitHubOrgSyncer:
         return cls(Citadel.from_env())
 
     async def status(self) -> dict[str, Any]:
-        state = self._load_state()
+        # A corrupt state file must show as a red source, not a 500 (#148).
+        state_error: str | None = None
+        try:
+            state = self._load_state()
+        except StateFileError as exc:
+            state = {}
+            state_error = str(exc)
         return {
-            "ok": True,
+            "ok": state_error is None,
+            "state_error": state_error,
             "org": self.org,
             "source_url": SOURCE_URL_TEMPLATE.format(org=self.org),
             "dataset": self.config.github_sync_dataset,
@@ -579,26 +587,12 @@ class GitHubOrgSyncer:
         return result
 
     def _load_state(self) -> dict[str, Any]:
-        if not self.state_path.exists():
-            return {
-                "version": STATE_VERSION,
-                "org": self.org,
-                "repos": {},
-                "commits": {},
-                "seen_event_ids": [],
-            }
-        try:
-            with self.state_path.open("r", encoding="utf-8") as file:
-                data = json.load(file)
-        except (OSError, json.JSONDecodeError):
-            return {
-                "version": STATE_VERSION,
-                "org": self.org,
-                "repos": {},
-                "commits": {},
-                "seen_event_ids": [],
-            }
-        if not isinstance(data, dict):
+        # Absent file = genuine first run. A file that exists but cannot be
+        # parsed raises StateFileError instead of flattening to this default:
+        # an empty state would mark every repo changed and every event new,
+        # then ingest and post a false "everything changed" digest (#148).
+        data = load_state_file(self.state_path)
+        if data is None:
             return {
                 "version": STATE_VERSION,
                 "org": self.org,

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -22,6 +22,7 @@ from kb.access import CENTRAL_DATASET, SEAT_DATASET_PREFIX, AccessStore, seat_da
 from kb.cognee_client import _suppress_inline_cognify
 from kb.learning import LearningProcess
 from kb.service import Citadel
+from kb.state_io import StateFileError, load_state_file, save_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -270,24 +271,32 @@ class LinearSyncer:
         return LinearClient(api_key=api_key)
 
     def _load_state(self) -> dict[str, Any]:
-        if not self.state_path.exists():
+        # Absent file = genuine first run. A corrupt file raises instead of
+        # flattening to empty: an empty state reports "you have no assigned
+        # issues" with a green source status (#148).
+        payload = load_state_file(self.state_path)
+        if payload is None:
             return {"version": STATE_VERSION, "issues": [], "mirrors": {}}
-        try:
-            payload = json.loads(self.state_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return {"version": STATE_VERSION, "issues": [], "mirrors": {}}
-        return payload if isinstance(payload, dict) else {"version": STATE_VERSION, "issues": [], "mirrors": {}}
+        return payload
 
     def _save_state(self, payload: dict[str, Any]) -> None:
-        self.state_path.parent.mkdir(parents=True, exist_ok=True)
-        self.state_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        # Atomic (temp file + rename) so a restart mid-write cannot leave the
+        # truncated file _load_state would refuse (#148).
+        save_state_file(self.state_path, payload)
 
     async def status(self) -> dict[str, Any]:
-        state = self._load_state()
+        # A corrupt state file must show as a red source, not a 500 (#148).
+        state_error: str | None = None
+        try:
+            state = self._load_state()
+        except StateFileError as exc:
+            state = {}
+            state_error = str(exc)
         issues = state.get("issues") if isinstance(state.get("issues"), list) else []
         mirrors = state.get("mirrors") if isinstance(state.get("mirrors"), dict) else {}
         mirror_count = sum(len(v) for v in mirrors.values() if isinstance(v, list))
         return {
+            "state_error": state_error,
             "enabled": bool(self.config.linear_api_key),
             "dataset": self.config.linear_sync_dataset,
             "last_synced_at": state.get("last_synced_at"),
@@ -354,6 +363,7 @@ class LinearSyncer:
         # the id is matched instead. Explicit config map entries always win.
         user_map = dict(self.config.linear_user_map)
         auto_mapped = 0
+        auto_map_error: str | None = None
         if self.access_store:
             email_to_slug = {
                 email: dataset.removeprefix(SEAT_DATASET_PREFIX)
@@ -363,6 +373,10 @@ class LinearSyncer:
                 members = await asyncio.to_thread(self._client().fetch_users)
             except LinearAPIError as exc:
                 members = []
+                # Carry the failure into the payload and persisted state so a
+                # 0 auto-map count is not misread as "the key cannot read
+                # member emails" when the fetch itself failed (#148).
+                auto_map_error = str(exc)
                 logger.warning(
                     "Linear member fetch failed; mirrors fall back to assignee email/config map: %s",
                     exc,
@@ -470,6 +484,7 @@ class LinearSyncer:
             "last_synced_at": utc_now(),
             "last_error": None,  # clear any prior failure on a successful sync
             "last_attempt_at": utc_now(),
+            "auto_map_error": auto_map_error,
             "issues": [asdict(issue) for issue in issues],
             "mirrors": mirrors,
         }
@@ -481,9 +496,11 @@ class LinearSyncer:
             "issue_count": len(issues),
             "mirrored_count": mirrored,
             # Diagnostics for #46: how many assignees were auto-mapped to seats by
-            # email. 0 with issues present usually means the Linear key cannot read
-            # member emails — set CITADEL_LINEAR_USER_MAP explicitly in that case.
+            # email. Only read 0 as "the Linear key cannot read member emails —
+            # set CITADEL_LINEAR_USER_MAP" when auto_map_error is None; a failed
+            # member fetch also leaves this at 0 (#148).
             "auto_mapped_assignees": auto_mapped,
+            "auto_map_error": auto_map_error,
             "central_ingested": central_outcome.ingest.accepted,
             "mirrors": mirrors,
             "last_synced_at": payload["last_synced_at"],

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -24,6 +24,7 @@ from kb.github_sync import GitHubAPIError, GitHubOrgClient, utc_now
 from kb.learning import LearningProcess
 from kb.security_scan import SecurityScanEntry, scan_text_entries
 from kb.service import Citadel
+from kb.state_io import StateFileError, load_state_file, save_state_file
 
 __all__ = [
     "DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS",
@@ -506,13 +507,11 @@ class RepoContentSyncer:
         self.state_path = Path(state_path or self.config.repo_content_sync_state_path)
 
     def _load_state(self) -> dict[str, Any]:
-        if not self.state_path.exists():
-            return {"version": STATE_VERSION, "files": {}}
-        try:
-            data = json.loads(self.state_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return {"version": STATE_VERSION, "files": {}}
-        if not isinstance(data, dict):
+        # Absent file = genuine first run. A corrupt file raises instead of
+        # flattening to empty: an empty state makes nothing "unchanged", so the
+        # entire allowlist re-ingests while reporting ok: True (#148).
+        data = load_state_file(self.state_path)
+        if data is None:
             return {"version": STATE_VERSION, "files": {}}
         files = data.get("files")
         if not isinstance(files, dict):
@@ -520,8 +519,9 @@ class RepoContentSyncer:
         return {"version": STATE_VERSION, "files": files, **{k: v for k, v in data.items() if k != "files"}}
 
     def _save_state(self, state: dict[str, Any]) -> None:
-        self.state_path.parent.mkdir(parents=True, exist_ok=True)
-        self.state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        # Atomic (temp file + rename) so a restart mid-write cannot leave the
+        # truncated file _load_state would refuse (#148).
+        save_state_file(self.state_path, state)
 
     def _resolved_repos(self) -> list[str]:
         repos = self.config.repo_content_sync_repos or DEFAULT_REPO_CONTENT_REPOS
@@ -546,10 +546,17 @@ class RepoContentSyncer:
         return resolved
 
     async def status(self) -> dict[str, Any]:
-        state = self._load_state()
+        # A corrupt state file must show as a red source, not a 500 (#148).
+        state_error: str | None = None
+        try:
+            state = self._load_state()
+        except StateFileError as exc:
+            state = {}
+            state_error = str(exc)
         files = state.get("files") if isinstance(state.get("files"), dict) else {}
         return {
-            "ok": True,
+            "ok": state_error is None,
+            "state_error": state_error,
             "authenticated": bool(getattr(self.client, "token", None)),
             "source_type": "github_repo_content",
             "org": self.org,

--- a/kb/server.py
+++ b/kb/server.py
@@ -4457,12 +4457,18 @@ async def sources(request: Request, type: str | None = None) -> Any:
     if type in {None, "github"}:
         github_status = await get_github_syncer().status()
         github_error, github_error_at = _last_source_error("github")
+        # A corrupt state file outranks the audit trail: the source is not
+        # "ready", it is refusing to run until an operator intervenes (#148).
+        if github_status.get("state_error"):
+            github_error = redact_secrets(str(github_status["state_error"])[:300])
         sources_payload.append(
             {
                 "id": "github-org",
                 "source_type": "github",
                 "name": github_status.get("org"),
-                "status": "tracked" if github_status.get("last_checked_at") else "ready",
+                "status": "error"
+                if github_status.get("state_error")
+                else ("tracked" if github_status.get("last_checked_at") else "ready"),
                 "url": github_status.get("source_url"),
                 "last_checked_at": github_status.get("last_checked_at"),
                 "documents": github_status.get("tracked_repositories", 0),
@@ -4477,12 +4483,16 @@ async def sources(request: Request, type: str | None = None) -> Any:
     if type in {None, "github_repo_content"}:
         repo_content_status = await get_repo_content_syncer().status()
         repo_content_error, repo_content_error_at = _last_source_error("github_repo_content")
+        if repo_content_status.get("state_error"):
+            repo_content_error = redact_secrets(str(repo_content_status["state_error"])[:300])
         sources_payload.append(
             {
                 "id": "github-repo-content",
                 "source_type": "github_repo_content",
                 "name": repo_content_status.get("org"),
-                "status": "tracked" if repo_content_status.get("last_checked_at") else "ready",
+                "status": "error"
+                if repo_content_status.get("state_error")
+                else ("tracked" if repo_content_status.get("last_checked_at") else "ready"),
                 "last_checked_at": repo_content_status.get("last_checked_at"),
                 "documents": repo_content_status.get("tracked_files", 0),
                 "open_conflicts": 0,
@@ -4499,12 +4509,16 @@ async def sources(request: Request, type: str | None = None) -> Any:
         if linear_status.get("last_error"):
             linear_error = redact_secrets(str(linear_status["last_error"])[:300])
             linear_error_at = linear_status.get("last_synced_at") or linear_error_at
+        if linear_status.get("state_error"):
+            linear_error = redact_secrets(str(linear_status["state_error"])[:300])
         sources_payload.append(
             {
                 "id": "linear-workspace",
                 "source_type": "linear",
                 "name": "Linear workspace",
-                "status": "tracked" if linear_status.get("last_synced_at") else "ready",
+                "status": "error"
+                if linear_status.get("state_error")
+                else ("tracked" if linear_status.get("last_synced_at") else "ready"),
                 "last_checked_at": linear_status.get("last_synced_at"),
                 "documents": linear_status.get("issue_count", 0),
                 "open_conflicts": 0,

--- a/kb/state_io.py
+++ b/kb/state_io.py
@@ -1,0 +1,67 @@
+"""Durable sync-state files: strict load, atomic save (#148).
+
+A syncer state file has exactly two legitimate states: absent (a genuine
+first run) or a parseable JSON object. Anything else is corruption — most
+likely a restart that interrupted a non-atomic write — and must never be
+flattened to an empty state, because empty is indistinguishable from "first
+run": the next pass would treat every tracked item as new and emit a false
+"everything changed" digest, then save over the corrupt file and destroy
+the evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class StateFileError(RuntimeError):
+    """A sync state file exists but cannot be read as a JSON object.
+
+    Raised instead of returning an empty state so corruption fails the run
+    loudly. Recovery is an operator decision: restore the file from a backup,
+    or delete it to explicitly start over from a first run.
+    """
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(
+            f"Sync state file {path} exists but is unreadable ({reason}). "
+            "Refusing to treat corruption as a first run — restore the file "
+            "or delete it to explicitly start over."
+        )
+        self.path = path
+        self.reason = reason
+
+
+def load_state_file(path: Path) -> dict[str, Any] | None:
+    """Return the parsed state object, or None when the file has never existed.
+
+    Raises :class:`StateFileError` when the file exists but cannot be read or
+    is not a JSON object. Callers map None to their first-run default.
+    """
+    if not path.exists():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise StateFileError(path, exc.__class__.__name__) from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise StateFileError(path, "invalid JSON") from exc
+    if not isinstance(data, dict):
+        raise StateFileError(path, f"expected a JSON object, got {type(data).__name__}")
+    return data
+
+
+def save_state_file(path: Path, payload: dict[str, Any]) -> None:
+    """Write the state atomically (temp file + rename, the kb/access.py pattern).
+
+    A restart mid-save leaves the previous file intact instead of a truncated
+    one, so :func:`load_state_file` never has corruption to refuse.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_suffix(f"{path.suffix}.tmp")
+    temp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    temp_path.replace(path)

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -495,3 +495,26 @@ def test_every_dashboard_page_is_reachable_from_the_ui() -> None:
         "Add a nav entry or a data-page-target button, or list it as "
         "intentionally unreachable with a reason."
     )
+
+
+def test_a_corrupt_sync_state_file_shows_red_instead_of_500(tmp_path: Any) -> None:
+    """#148: a state file that fails to parse must surface as an error'd
+    source. Before this, status() flattened corruption to an empty state, so
+    the source showed "ready" with zero documents — indistinguishable from a
+    node that had never synced."""
+    from kb.config import CitadelConfig
+    from kb.github_sync import GitHubOrgSyncer
+    from kb.service import Citadel
+
+    client = authed_client()
+    state_path = tmp_path / "github_state.json"
+    state_path.write_text('{"version": 1, "repos"', encoding="utf-8")
+    config = CitadelConfig(github_sync_state_path=str(state_path))
+    app.state.github_syncer = GitHubOrgSyncer(Citadel(config), org="masumi-network")
+
+    response = client.get("/api/sources?type=github")
+
+    assert response.status_code == 200
+    source = response.json()["sources"][0]
+    assert source["status"] == "error"
+    assert "github_state.json" in source["last_error"]

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -481,3 +481,43 @@ def test_a_real_failure_is_still_logged_as_an_error(monkeypatch, caplog) -> None
 
     assert caught.value.status == 500
     assert [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+# --- #148: corrupt state must fail loudly, not flatten to "first run" --------
+
+
+@pytest.mark.asyncio
+async def test_corrupt_state_raises_instead_of_everything_changed(tmp_path: Any) -> None:
+    """#148: a restart mid-write truncates the state file; the next run must
+    refuse it. Flattening to empty made every repo "changed" and every event
+    "new", ingested a false digest, and then saved over the evidence."""
+    from kb.state_io import StateFileError
+
+    config = CitadelConfig(github_sync_state_path=str(tmp_path / "github_state.json"))
+    citadel = FakeCitadel(config)
+    syncer = GitHubOrgSyncer(citadel, client=FakeGitHubClient(), org="masumi-network")
+    await syncer.run()  # seed a real state file
+    corrupt = '{"version": 1, "org": "masumi-network", "repos"'
+    Path(config.github_sync_state_path).write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(StateFileError):
+        await syncer.run()
+
+    # No digest was fabricated from the corrupt state, and the file was left
+    # untouched as evidence.
+    assert len(citadel.ingest_calls) == 1
+    assert Path(config.github_sync_state_path).read_text(encoding="utf-8") == corrupt
+
+
+@pytest.mark.asyncio
+async def test_status_reports_corrupt_state_instead_of_raising(tmp_path: Any) -> None:
+    """status() must catch the corruption so /api/sources shows red, not 500."""
+    config = CitadelConfig(github_sync_state_path=str(tmp_path / "github_state.json"))
+    syncer = GitHubOrgSyncer(FakeCitadel(config), client=FakeGitHubClient(), org="masumi-network")
+    Path(config.github_sync_state_path).write_text("not json", encoding="utf-8")
+
+    status = await syncer.status()
+
+    assert status["ok"] is False
+    assert "github_state.json" in status["state_error"]
+    assert status["tracked_repositories"] == 0

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -7,6 +7,7 @@ import pytest
 from kb.access import AccessStore, seat_dataset
 from kb.config import CitadelConfig
 from kb.linear_sync import (
+    LinearAPIError,
     LinearClient,
     LinearIssue,
     LinearSyncer,
@@ -384,3 +385,82 @@ def test_linear_sync_status_disabled(tmp_path: Any) -> None:
 
     status = asyncio.run(_status())
     assert status["enabled"] is False
+
+
+# --- #148: corrupt state must fail loudly, not report "no issues" ------------
+
+
+@pytest.mark.asyncio
+async def test_corrupt_state_goes_red_in_status_and_raises_on_reads(tmp_path: Any) -> None:
+    """#148: flattening corruption to empty told the user they had no assigned
+    issues while /api/sources stayed green. Reads must raise; status must
+    carry the error instead of 500ing."""
+    from kb.state_io import StateFileError
+
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+    )
+    from pathlib import Path
+
+    Path(config.linear_sync_state_path).write_text('{"issues": [', encoding="utf-8")
+    syncer = LinearSyncer(Citadel(config), client=FakeLinearClient([]))
+
+    status = await syncer.status()
+    assert "linear_state.json" in status["state_error"]
+    assert status["issue_count"] == 0
+
+    with pytest.raises(StateFileError):
+        syncer.issues_for_scope(scope="org", seat_dataset_name=None)
+
+
+@pytest.mark.asyncio
+async def test_member_fetch_failure_is_carried_not_a_neutral_zero(
+    tmp_path: Any,
+    sample_issues: list[dict[str, Any]],
+    monkeypatch: Any,
+) -> None:
+    """#148 (adjacent): a failed fetch_users left auto_mapped_assignees at 0,
+    and the docs read that 0 as "the key cannot read member emails" — a wrong
+    diagnosis. The error must ride in the payload and the persisted state."""
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+        access_store_path=str(tmp_path / "access.json"),
+    )
+    citadel = Citadel(config)
+    store = AccessStore(config.access_store_path)
+    store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
+
+    async def fake_learn(self: Any, data: str, **kwargs: Any) -> Any:
+        class FakeResult:
+            accepted = True
+
+        class Outcome:
+            ingest = FakeResult()
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
+
+    class MemberFetchFails(FakeLinearClient):
+        def fetch_users(self, *, max_users: int = 250) -> list[dict[str, Any]]:
+            raise LinearAPIError("Linear API request failed with HTTP 403")
+
+    syncer = LinearSyncer(
+        citadel,
+        client=MemberFetchFails(sample_issues),
+        access_store=store,
+    )
+    result = await syncer.run(force=True)
+
+    assert result["ok"] is True
+    assert result["auto_mapped_assignees"] == 0
+    assert "403" in result["auto_map_error"]
+
+    import json as _json
+    from pathlib import Path
+
+    state = _json.loads(Path(config.linear_sync_state_path).read_text(encoding="utf-8"))
+    assert "403" in state["auto_map_error"]

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -1001,3 +1001,63 @@ def test_cognee_data_ids_reads_the_real_cognee_return_type() -> None:
     # claim it cannot check.
     assert _cognee_data_ids(outcome({"added": {}})) == []
     assert _cognee_data_ids(outcome(None)) == []
+
+
+# --- #148: corrupt state must fail loudly, not re-ingest the whole allowlist -
+
+
+@pytest.mark.asyncio
+async def test_corrupt_state_raises_instead_of_full_reingest(tmp_path: Path) -> None:
+    """#148: flattening corruption to empty made nothing "unchanged", so the
+    entire allowlist re-ingested while reporting ok: True. The run must refuse
+    the corrupt file and leave it as evidence."""
+    from kb.state_io import StateFileError
+
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_state_path=str(tmp_path / "repo_content_sync_state.json"),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+    )
+    learning = FakeLearningProcess()
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+    first = await syncer.run()
+    assert first["files_ingested"] == 2
+    corrupt = '{"version": 1, "files": {"masumi-network/sokosumi-cli/READ'
+    Path(config.repo_content_sync_state_path).write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(StateFileError):
+        await syncer.run()
+
+    assert len(learning.calls) == 2  # the seeding run only; nothing re-ingested
+    assert Path(config.repo_content_sync_state_path).read_text(encoding="utf-8") == corrupt
+
+
+@pytest.mark.asyncio
+async def test_status_reports_corrupt_state_instead_of_raising(tmp_path: Path) -> None:
+    """status() must catch the corruption so /api/sources shows red, not 500."""
+    config = CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_state_path=str(tmp_path / "state.json"),
+        repo_content_sync_repos=("sokosumi-cli",),
+    )
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+    )
+    Path(config.repo_content_sync_state_path).write_text("[1, 2", encoding="utf-8")
+
+    status = await syncer.status()
+
+    assert status["ok"] is False
+    assert "state.json" in status["state_error"]
+    assert status["tracked_files"] == 0

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -1,0 +1,70 @@
+"""Strict sync-state loading (#148).
+
+A state file has exactly two legitimate states: absent (first run) or a
+parseable JSON object. Anything else is corruption — most likely a restart
+that interrupted a non-atomic write — and must raise instead of flattening
+to an empty state, because empty is indistinguishable from "first run" and
+the next pass would emit a false "everything changed" digest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kb.state_io import StateFileError, load_state_file, save_state_file
+
+
+def test_missing_file_is_first_run(tmp_path: Path) -> None:
+    assert load_state_file(tmp_path / "never_written.json") is None
+
+
+def test_truncated_json_raises_instead_of_flattening(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    # A restart mid-write truncates the file; the tail of the object is gone.
+    path.write_text('{"version": 1, "repos": {"masumi-network/agen', encoding="utf-8")
+
+    with pytest.raises(StateFileError) as excinfo:
+        load_state_file(path)
+
+    # The message must carry enough for an operator to act on it.
+    assert str(path) in str(excinfo.value)
+
+
+def test_non_object_json_raises(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(StateFileError):
+        load_state_file(path)
+
+
+def test_save_then_load_round_trips_and_leaves_no_temp_file(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "state.json"
+    payload: dict[str, Any] = {"version": 1, "files": {"a.md": {"sha": "abc"}}}
+
+    save_state_file(path, payload)
+
+    assert load_state_file(path) == payload
+    assert [p.name for p in path.parent.iterdir()] == ["state.json"]
+
+
+def test_interrupted_save_leaves_previous_state_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The write is temp-file + rename, so dying mid-save cannot truncate."""
+    path = tmp_path / "state.json"
+    save_state_file(path, {"version": 1, "repos": {"a": 1}})
+
+    def die(self: Path, target: Path) -> None:
+        raise OSError("killed before rename")
+
+    monkeypatch.setattr(Path, "replace", die)
+    with pytest.raises(OSError):
+        save_state_file(path, {"version": 1, "repos": {}})
+    monkeypatch.undo()
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {"version": 1, "repos": {"a": 1}}


### PR DESCRIPTION
Fixes #148.

## The bug

Each syncer's `_load_state` caught `(OSError, json.JSONDecodeError)` and returned an empty state. All three already guard the legitimate first-run case with `state_path.exists()` before the try, so the handler only ever fired on genuine corruption, and empty is indistinguishable from "nothing has ever been synced". A restart mid-write (the saves were non-atomic `write_text`) therefore produced a false "everything changed" pass: every repo changed, every event new, a fabricated digest ingested and posted, and the corrupt file then overwritten by `_save_state`, destroying the evidence.

## The fix

**`kb/state_io.py`** owns the rule now:

- `load_state_file(path)`: absent file returns `None` (first run, stays silent); a file that exists but is unreadable, unparseable, or not a JSON object raises `StateFileError` with the path and a recovery hint (restore the file, or delete it to explicitly start over).
- `save_state_file(path, payload)`: atomic temp-file + rename (the `kb/access.py` pattern), so a restart mid-write can no longer produce a truncated file in the first place.

**The three syncers** (`kb/github_sync.py`, `kb/repo_content_sync.py`, `kb/linear_sync.py`) load through it:

- `run()` on a corrupt file raises, so the evolve stage logs `FAILED with StateFileError` and the pass exits non-zero instead of reporting a clean success. The corrupt file is left untouched as evidence.
- `status()` catches `StateFileError` and returns `ok: false` + `state_error`, and `/api/sources` maps that to `status: "error"` with `last_error` set. Red, not a 500 (pinned by a server test).
- `linear_sync` and `repo_content_sync` `_save_state` are now atomic (`github_sync` already was).

**Adjacent, from the same issue:** a failed Linear member fetch left `auto_mapped_assignees` at a neutral 0, and the comment next to it instructed the operator to misread that 0 as "the Linear key cannot read member emails". Raising would be wrong there (the sync is otherwise fine), so the failure now rides in the run payload and the persisted state as `auto_map_error`, and the comment states when the 0 is diagnostic.

## Census of the shape (bare except around a JSON state read, flattened to empty)

Ten sites in `kb/`. Fixed here: the three syncer `_load_state`s above. Left alone deliberately, with reasons:

| Site | Why it stays |
| --- | --- |
| `kb/source_search.py` `_load_state` | Read-only consumer of the GitHub state for search/digest sections; raising would 500 `/api/search` for every source. The file's owner now goes red. |
| `kb/promotion_refs.py` `load_tracked_org_repos` | Read-only consumer; already logs a warning. |
| `kb/mesh.py` `_read_state_json` | Best-effort startup rehydrate, documented as such and logged. |
| `kb/conflicts.py` `ConflictStore._load` | Same owner-shaped flattening (corrupt file silently drops all conflict records, next save overwrites). Its save is already atomic; raising would 500 `/api/conflicts` with no red path. Follow-up candidate. |
| `kb/skills.py` catalog refresh | Corrupt state reports every skill "added" once, then rewrites; low stakes. Follow-up candidate. |
| `kb/contact_store.py` `_load` | Deliberate and loudly logged ("a corrupt file must not take the public endpoint down"), but `append()` still rewrites over a corrupt file. Follow-up candidate. |
| `kb/backup_mirror.py` `_load_latest_manifest` | Corrupt manifest degrades to a full re-mirror: extra work, never wrong data, and its writes are atomic. |

(`kb/obsidian_sync.py` `_load` already raises on corruption and saves atomically: the behavior the three syncers now match.)

## Tests

Seven failing-first tests pin the bug (corrupt file raises + evidence preserved + nothing ingested, status carries `state_error`, `/api/sources` shows `error` not 500, `auto_map_error` carried) plus five for `kb/state_io.py` including an interrupted-save test proving the previous state survives a crash before rename. Reverting only the source files reproduces all seven failures (`Failed: DID NOT RAISE StateFileError`, `KeyError: 'state_error'`, `assert 'ready' == 'error'`).

Full suite: 1242 passed, 1 skipped.