### PR TITLE
fix(mcp): tools/list no longer fails open to the full tool surface

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -71,19 +71,41 @@ MCP_AGENT_INSTRUCTIONS = (
 def set_tools_list_session_resolver(
     resolver: Callable[[str], dict[str, Any] | None] | None,
 ) -> None:
-    """Register an in-process token→session lookup for tools/list role filtering."""
+    """Register an in-process token→session lookup for tools/list role filtering.
+
+    A resolver that returns None is answering authoritatively: this node does
+    not know the token (revoked, rotated, or never minted). A resolver that
+    cannot answer (store hiccup) must raise instead, so the caller can tell a
+    dead credential from a transient lookup failure (#171).
+    """
     global _tools_list_session_resolver
     _tools_list_session_resolver = resolver
 
 
-def _session_from_token_inprocess(token: str) -> dict[str, Any] | None:
-    """Resolve role/seat for tools/list without nested HTTP (avoids event-loop deadlock)."""
+class _UnknownToken:
+    """Sentinel: the access store authoritatively does not know this token."""
+
+
+_UNKNOWN_TOKEN = _UnknownToken()
+
+
+def _session_from_token_inprocess(
+    token: str,
+) -> dict[str, Any] | _UnknownToken | None:
+    """Resolve role/seat for tools/list without nested HTTP (avoids event-loop deadlock).
+
+    Returns the session dict, ``_UNKNOWN_TOKEN`` when the store definitively
+    does not know the token, or None when no in-process answer is available
+    (resolver errored, or kb.server is not importable) and the caller may try
+    the HTTP fallback.
+    """
     if _tools_list_session_resolver is not None:
         try:
-            return _tools_list_session_resolver(token)
-        except Exception as exc:  # noqa: BLE001 - fail open
+            session = _tools_list_session_resolver(token)
+        except Exception as exc:  # noqa: BLE001 - transient; caller may fall back
             logger.warning("tools/list in-process session resolver failed: %s", exc)
             return None
+        return session if session else _UNKNOWN_TOKEN
     # Late import: kb.server imports this module at load time.
     try:
         from kb.server import access_key_identity
@@ -95,7 +117,7 @@ def _session_from_token_inprocess(token: str) -> dict[str, Any] | None:
         logger.warning("tools/list access_key_identity failed: %s", exc)
         return None
     if not pair:
-        return None
+        return _UNKNOWN_TOKEN
     identity, _ = pair
     return {
         "ok": True,
@@ -105,7 +127,12 @@ def _session_from_token_inprocess(token: str) -> dict[str, Any] | None:
 
 
 class CitadelMcpError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        # HTTP status of the upstream Citadel response, when one arrived.
+        # Lets tools/list tell "the node rejected this token" (401) from
+        # "the node could not be asked" without parsing the message (#171).
+        self.status_code = status_code
 
 
 @dataclass(frozen=True)
@@ -431,18 +458,23 @@ def _transport_security() -> TransportSecuritySettings:
     return TransportSecuritySettings(enable_dns_rebinding_protection=False)
 
 
+def _request_from_context(ctx: Context | None) -> Any:
+    """The live HTTP request attached to the MCP context (None under stdio)."""
+    if ctx is None:
+        return None
+    try:
+        return ctx.request_context.request
+    except Exception:
+        return None
+
+
 def _bearer_from_context(ctx: Context | None) -> str | None:
     """Extract the caller's bearer token from the live HTTP request, if any.
 
     Returns None under stdio transport (no HTTP request is attached), which lets
     the server fall back to an env-configured client.
     """
-    if ctx is None:
-        return None
-    try:
-        request = ctx.request_context.request
-    except Exception:
-        return None
+    request = _request_from_context(ctx)
     if request is None:
         return None
     authorization = ""
@@ -625,7 +657,9 @@ def _filter_tools_for_session(
     never see the admin tools) and citadel_contribute for seat holders (Central
     is read-only from seat MCP). Returns the full list when the session is
     missing or carries an unknown role (fail open — call-time authz still
-    enforces). Tools absent from TOOL_POLICIES are never hidden by accident.
+    enforces); the tools/list handler decides when a failed resolution means
+    the reader floor instead (#171). Tools absent from TOOL_POLICIES are never
+    hidden by accident.
     """
     if not session:
         return all_tools
@@ -644,6 +678,18 @@ def _filter_tools_for_session(
                 continue
         visible.append(tool)
     return visible
+
+
+def _reader_floor(all_tools: list[Any]) -> list[Any]:
+    """The tool surface served when a hosted caller has no resolvable role (#171).
+
+    Reader-visible tools only: enough for a client to stay functional (search,
+    discovery, session) without advertising the write/admin surface to a caller
+    whose credential is missing or did not resolve. Deliberately not empty — a
+    blanked list breaks clients that register tools once (#100) — and server-side
+    authz still rejects the calls themselves.
+    """
+    return _filter_tools_for_session(all_tools, {"role": "reader", "seat_slug": None})
 
 
 def _validate_ingest_size(data: str) -> None:
@@ -762,7 +808,9 @@ class CitadelHttpClient:
             logger.warning(
                 "Citadel API call %s %s returned HTTP %s", method, path, exc.code
             )
-            raise CitadelMcpError(f"Citadel returned HTTP {exc.code}: {detail}") from exc
+            raise CitadelMcpError(
+                f"Citadel returned HTTP {exc.code}: {detail}", status_code=exc.code
+            ) from exc
         except URLError as exc:
             reason = redact_secrets(str(exc.reason), self.access_token)
             logger.error(
@@ -1455,9 +1503,15 @@ def create_mcp_server(
         A nested blocking ``GET /api/session`` self-deadlocks the hosted
         streamable-HTTP transport: it runs on the same loop that must serve it,
         so after the HTTP client's retries tools/list takes ~90s and clients
-        register zero tools. Server-side 403s remain the real enforcement; this
-        only stops 403 trial-and-error and fails OPEN on any resolution error so
-        a transient lookup never blanks the tool list. (#100)
+        register zero tools (#100). Server-side 403s remain the real
+        enforcement; this only stops 403 trial-and-error.
+
+        A hosted caller whose bearer is missing, unknown, or unresolvable gets
+        the READER floor, not the full list: failing open advertised the six
+        admin tools to any caller with a dead token (#171), while an empty list
+        would break clients that register tools once (#100). Stdio keeps the
+        full list — there is no per-request credential there, and the
+        env-configured client still authenticates every call.
         """
         all_tools = await mcp.list_tools()
         try:
@@ -1466,8 +1520,19 @@ def create_mcp_server(
             ctx = None
         token = _bearer_from_context(ctx)
         if not token:
-            return all_tools  # stdio / unauthenticated handshake — call-time authz still applies
+            if _request_from_context(ctx) is not None and fallback is None:
+                # Hosted node transport with no Authorization header: the
+                # caller cannot invoke a single tool (resolve_client refuses),
+                # so advertise the reader surface, not the admin one.
+                return _reader_floor(all_tools)
+            return all_tools  # stdio, or an env-authenticated bridge
         session = _session_from_token_inprocess(token)
+        if isinstance(session, _UnknownToken):
+            logger.warning(
+                "tools/list bearer token is not recognized by this node "
+                "(revoked or rotated?); serving reader-only tools"
+            )
+            return _reader_floor(all_tools)
         if session is None:
             try:
                 session = await asyncio.wait_for(
@@ -1480,9 +1545,19 @@ def create_mcp_server(
                     ),
                     timeout=_TOOLS_LIST_SESSION_WAIT,
                 )
-            except Exception as exc:  # noqa: BLE001 - fail open for availability
-                logger.warning("tools/list role filter could not resolve session: %s", exc)
-                return all_tools
+            except Exception as exc:  # noqa: BLE001 - degrade to the reader floor
+                if getattr(exc, "status_code", None) == 401:
+                    logger.warning(
+                        "tools/list bearer token is not recognized by this node "
+                        "(revoked or rotated?); serving reader-only tools"
+                    )
+                else:
+                    logger.warning(
+                        "tools/list could not resolve the caller's role (%s); "
+                        "serving reader-only tools",
+                        exc,
+                    )
+                return _reader_floor(all_tools)
         return _filter_tools_for_session(all_tools, session)
 
     return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -126,15 +126,19 @@ def test_tools_list_session_resolved_in_process_not_via_self_call(
     session = mcp_server._session_from_token_inprocess("ctdl_x")
     assert session == {"ok": True, "role": "reader", "seat_slug": "sarthi"}
 
-    # Fails open (no tool list blanking) when the store lookup errors or misses.
+    # A store ERROR returns None so the caller may try the HTTP fallback...
     def boom(token: str) -> Any:
         raise RuntimeError("store unavailable")
 
     monkeypatch.setattr(server_mod, "access_key_identity", boom)
     assert mcp_server._session_from_token_inprocess("ctdl_x") is None
 
+    # ...but a clean MISS is the store answering "this token does not exist",
+    # and must be distinguishable from the transient case (#171).
     monkeypatch.setattr(server_mod, "access_key_identity", lambda token: None)
-    assert mcp_server._session_from_token_inprocess("ctdl_x") is None
+    assert isinstance(
+        mcp_server._session_from_token_inprocess("ctdl_x"), mcp_server._UnknownToken
+    )
 
 
 def test_streamable_http_uses_json_response_not_sse() -> None:
@@ -843,15 +847,21 @@ def test_tools_list_protocol_handler_applies_role_filter(
         mcp_server.set_tools_list_session_resolver(None)
 
 
-def test_tools_list_uses_threaded_http_fallback_when_resolver_misses(
+def test_tools_list_uses_threaded_http_fallback_when_resolver_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # A resolver ERROR (store hiccup) is transient, so the node is asked over
+    # HTTP; a successful answer still filters normally.
     from mcp import types as mcp_types
 
     server = create_mcp_server(FakeHttpClient())
     monkeypatch.setattr(server, "get_context", lambda: object())
     monkeypatch.setattr(mcp_server, "_bearer_from_context", lambda ctx: "ctdl_tok")
-    mcp_server.set_tools_list_session_resolver(lambda _token: None)
+
+    def _boom(_token: str) -> Any:
+        raise RuntimeError("store unavailable")
+
+    mcp_server.set_tools_list_session_resolver(_boom)
 
     class _SessionClient:
         def __init__(self, **_: Any) -> None: ...
@@ -871,6 +881,106 @@ def test_tools_list_uses_threaded_http_fallback_when_resolver_misses(
         mcp_server.set_tools_list_session_resolver(None)
 
 
+def _assert_reader_floor(names: set[str]) -> None:
+    """#171: an unresolvable caller gets reader tools — never admin, never blank."""
+    assert not (_ADMIN_TOOLS & names)
+    assert "citadel_ingest" not in names
+    assert "citadel_contribute" not in names
+    assert "citadel_search" in names  # the floor must not blank the list (#100)
+    assert "citadel_session" in names
+
+
+def test_tools_list_unknown_token_gets_reader_floor_without_http_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #171: the resolver answering "no such token" is definitive. The old code
+    # collapsed it into the transient case, fell back to HTTP, failed, and
+    # served the full list — admin tools included — to a dead credential.
+    from mcp import types as mcp_types
+
+    server = create_mcp_server(FakeHttpClient())
+    monkeypatch.setattr(server, "get_context", lambda: object())
+    monkeypatch.setattr(mcp_server, "_bearer_from_context", lambda ctx: "ctdl_dead")
+    mcp_server.set_tools_list_session_resolver(lambda _token: None)
+
+    http_calls: list[str] = []
+
+    class _SessionClient:
+        def __init__(self, **_: Any) -> None: ...
+
+        def get(self, path: str, **_: Any) -> dict[str, Any]:
+            http_calls.append(path)
+            raise AssertionError("a definitive miss must not trigger the HTTP fallback")
+
+    monkeypatch.setattr(mcp_server, "CitadelHttpClient", _SessionClient)
+    try:
+        handler = server._mcp_server.request_handlers[mcp_types.ListToolsRequest]
+        result = asyncio.run(handler(mcp_types.ListToolsRequest(method="tools/list")))
+        _assert_reader_floor({t.name for t in result.root.tools})
+        assert http_calls == []
+    finally:
+        mcp_server.set_tools_list_session_resolver(None)
+
+
+@pytest.mark.parametrize("failure", ["node-rejected-token", "node-unreachable"])
+def test_tools_list_resolution_failure_gets_reader_floor_not_full_list(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    # #171: the production symptom. Resolution fails end to end (resolver errors,
+    # HTTP fallback 401s or cannot connect) — the old fail-open branch served all
+    # 22 tools, admin tools included. Now it degrades to the reader floor.
+    from mcp import types as mcp_types
+
+    if failure == "node-rejected-token":
+        fallback_error = mcp_server.CitadelMcpError("Citadel returned HTTP 401: nope")
+        fallback_error.status_code = 401
+    else:
+        fallback_error = mcp_server.CitadelMcpError(
+            "Could not reach Citadel at http://127.0.0.1:8000: down"
+        )
+
+    server = create_mcp_server(FakeHttpClient())
+    monkeypatch.setattr(server, "get_context", lambda: object())
+    monkeypatch.setattr(mcp_server, "_bearer_from_context", lambda ctx: "ctdl_tok")
+
+    def _boom(_token: str) -> Any:
+        raise RuntimeError("store unavailable")
+
+    mcp_server.set_tools_list_session_resolver(_boom)
+
+    class _SessionClient:
+        def __init__(self, **_: Any) -> None: ...
+
+        def get(self, path: str, **_: Any) -> dict[str, Any]:
+            raise fallback_error
+
+    monkeypatch.setattr(mcp_server, "CitadelHttpClient", _SessionClient)
+    try:
+        handler = server._mcp_server.request_handlers[mcp_types.ListToolsRequest]
+        result = asyncio.run(handler(mcp_types.ListToolsRequest(method="tools/list")))
+        _assert_reader_floor({t.name for t in result.root.tools})
+    finally:
+        mcp_server.set_tools_list_session_resolver(None)
+
+
+def test_tools_list_unauthenticated_hosted_caller_gets_reader_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #171: a hosted caller with no Authorization header cannot invoke a single
+    # tool (resolve_client refuses without a fallback client), so tools/list
+    # must not advertise the admin surface to it.
+    from mcp import types as mcp_types
+
+    server = create_mcp_server(None)  # hosted node shape: no env fallback client
+    monkeypatch.setattr(server, "get_context", lambda: object())
+    monkeypatch.setattr(mcp_server, "_bearer_from_context", lambda ctx: None)
+    monkeypatch.setattr(mcp_server, "_request_from_context", lambda ctx: object())
+
+    handler = server._mcp_server.request_handlers[mcp_types.ListToolsRequest]
+    result = asyncio.run(handler(mcp_types.ListToolsRequest(method="tools/list")))
+    _assert_reader_floor({t.name for t in result.root.tools})
+
+
 def test_tools_list_protocol_handler_fails_open_without_context() -> None:
     # No HTTP request context (stdio) → unfiltered, since call-time authz applies.
     from mcp import types as mcp_types
@@ -880,6 +990,123 @@ def test_tools_list_protocol_handler_fails_open_without_context() -> None:
     result = asyncio.run(handler(mcp_types.ListToolsRequest(method="tools/list")))
     names = {t.name for t in result.root.tools}
     assert _ADMIN_TOOLS <= names
+
+
+def test_hosted_transport_tools_list_filters_through_real_resolution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """#171 end to end: the hosted /mcp transport with kb.server's REAL resolver.
+
+    Covers the path production actually runs — bearer lifted from the live
+    streamable-HTTP request, kb.server's registered resolver consulting the real
+    access store — which the handler-level tests above replace with fakes. The
+    prior coverage asserted _filter_tools_for_session's contract directly and
+    stayed green while the hosted transport served the full list, admin tools
+    included, to dead tokens and anonymous callers.
+
+    Runs kb.server's real FastMCP server behind a PRIVATE streamable-HTTP
+    session manager: the module-global one can only ever `.run()` once, and
+    consuming it here would break the lifespan tests that run it later.
+    """
+    import httpx
+    from mcp.server.fastmcp.server import StreamableHTTPASGIApp
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    import kb.server as server_mod
+    from kb.access import AccessStore
+    from kb.config import CitadelConfig
+
+    # Point the HTTP fallback at a dead port: a definitive in-process miss must
+    # not need it, and a developer's live node on :8000 would fake a pass.
+    monkeypatch.setenv("CITADEL_MCP_SELF_BASE_URL", "http://127.0.0.1:9")
+
+    class _ConfigOnlyCitadel:
+        config = CitadelConfig(
+            tenant_id="test",
+            default_dataset="notes",
+            admin_key="an-admin-key-long-enough-for-the-gate00",
+            reader_keys=(),
+            writer_keys=(),
+        )
+
+    server_mod.app.state.citadel = _ConfigOnlyCitadel()
+    store = AccessStore(tmp_path / "access.json")
+    server_mod.app.state.access_store = store
+    seat_token = store.create_seat(name="Probe Seat", slug="probe").token
+    # Earlier tests null the resolver in their cleanup; restore the one
+    # kb.server registers at import so this exercises the real wiring.
+    server_mod.set_tools_list_session_resolver(server_mod._mcp_tools_list_session)
+
+    async def list_tool_names(
+        client: httpx.AsyncClient, authorization: str | None
+    ) -> set[str]:
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        if authorization:
+            headers["Authorization"] = authorization
+        init = await client.post(
+            "/mcp/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "probe", "version": "1"},
+                },
+            },
+        )
+        assert init.status_code == 200
+        sid = init.headers.get("mcp-session-id")
+        if sid:
+            headers["mcp-session-id"] = sid
+        await client.post(
+            "/mcp/",
+            headers=headers,
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        resp = await client.post(
+            "/mcp/",
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        assert resp.status_code == 200
+        return {tool["name"] for tool in resp.json()["result"]["tools"]}
+
+    manager = StreamableHTTPSessionManager(
+        app=server_mod.mcp_server._mcp_server,
+        json_response=True,
+        stateless=True,
+    )
+
+    async def scenario() -> dict[str, set[str]]:
+        async with manager.run():
+            transport = httpx.ASGITransport(app=StreamableHTTPASGIApp(manager))
+            async with httpx.AsyncClient(
+                transport=transport, base_url="https://testserver"
+            ) as client:
+                return {
+                    "seat": await list_tool_names(client, f"Bearer {seat_token}"),
+                    "unknown": await list_tool_names(client, "Bearer ctdl_rotated_away"),
+                    "anonymous": await list_tool_names(client, None),
+                }
+
+    results = asyncio.run(scenario())
+
+    # The #33 benefit, through the real resolution path: a writer seat sees its
+    # writer tools but never the admin surface or contribute.
+    assert not (_ADMIN_TOOLS & results["seat"])
+    assert "citadel_contribute" not in results["seat"]
+    assert "citadel_ingest" in results["seat"]
+
+    # #171: a dead token and an anonymous caller get the reader floor,
+    # not the full list.
+    _assert_reader_floor(results["unknown"])
+    _assert_reader_floor(results["anonymous"])
 
 
 def test_remote_http_base_url_is_rejected_without_escape_hatch(


### PR DESCRIPTION
## Problem

On the hosted streamable-HTTP transport, `tools/list` served the complete 22-tool list, the six admin tools and `citadel_contribute` included, whenever the caller's role could not be resolved. That covers an unknown or rotated bearer token, a transient store error, an unreachable HTTP fallback, and a request with no `Authorization` header at all. Reproduced end to end against the real transport before the fix:

```
valid writer seat token: 13 tools, admin visible: none, contribute: False
unknown token:           22 tools, admin visible: all six, contribute: True
no token:                22 tools, admin visible: all six, contribute: True
```

Call-time authz was and is enforced server-side, so this was list-surface exposure, not invocation access (the "not a security issue" framing in #171). But it erased the #33 benefit exactly for the callers most likely to probe, and it matches the primary ask in the #171 follow-up comment: stop the failure path from serving the full list.

## Fix (`kb/mcp_server.py`)

- Unresolvable hosted callers now get the reader floor: the reader-visible subset (search, discovery, session, and the other reader tools). Never blank, because a blanked list breaks clients that register tools once (#100). Never the write or admin surface.
- The in-process resolver answers authoritatively. A clean miss means the access store does not know the token: distinct log line ("not recognized by this node (revoked or rotated?)"), no HTTP fallback, reader floor. A resolver error stays transient and still tries the short threaded fallback.
- The fallback distinguishes a node 401 (token rejected, logged as such) from "node could not be asked" via a `status_code` carried on `CitadelMcpError`, instead of string parsing.
- A hosted request with no bearer and no env fallback client gets the reader floor too; such a caller cannot invoke a single tool (`resolve_client` refuses), so there is nothing to advertise beyond the reader surface.
- Stdio is unchanged: no per-request credential exists there and the env-configured client authenticates every call.

## Why the existing tests stayed green while this was live

- `test_tools_list_filters_by_role_and_seat` calls `_filter_tools_for_session` directly with hand-built sessions, and its last two asserts (`session=None`, unknown role) assert the fail-open outcome as correct.
- `test_tools_list_protocol_handler_applies_role_filter` monkeypatches `_bearer_from_context` and registers a fake resolver, so the real resolution path (registered kb.server resolver, HTTP fallback, fail-open branch) was never exercised.

Exactly as predicted in #171. The new `test_hosted_transport_tools_list_filters_through_real_resolution` closes that gap: real streamable-HTTP round trip, kb.server's real registered resolver, a real minted seat token from a real `AccessStore`, plus a dead token and an anonymous caller.

## Verification

Red then green with the tests kept and only the source fix reverted:

```
FAILED test_tools_list_session_resolved_in_process_not_via_self_call
FAILED test_tools_list_unknown_token_gets_reader_floor_without_http_fallback
FAILED test_tools_list_resolution_failure_gets_reader_floor_not_full_list[node-rejected-token]
FAILED test_tools_list_resolution_failure_gets_reader_floor_not_full_list[node-unreachable]
FAILED test_tools_list_unauthenticated_hosted_caller_gets_reader_floor
FAILED test_hosted_transport_tools_list_filters_through_real_resolution
6 failed, 5 passed
```

With the fix: the file's 58 tests pass, and the full suite is green (1230 passed, 1 skipped).

Fixes #171
