### PR TITLE
fix(search): convert epoch hit timestamps to ISO

### DIFF
--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -7,6 +7,7 @@ Keeps a stable hit schema agents can filter on without a second fetch.
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any
 
@@ -557,6 +558,43 @@ def _first_str(*values: Any) -> str | None:
     return None
 
 
+# Epoch windows for _first_timestamp. A number is read in whichever unit puts
+# it inside [2001-09-09, 2096-10-02]; the two windows are three orders of
+# magnitude apart, so no value is valid in both and a unit can never be
+# guessed wrong by decades.
+_EPOCH_SECONDS_MIN = 1_000_000_000  # 2001-09-09T01:46:40+00:00
+_EPOCH_SECONDS_MAX = 4_000_000_000  # 2096-10-02T07:06:40+00:00
+_EPOCH_MILLIS_MIN = _EPOCH_SECONDS_MIN * 1000
+_EPOCH_MILLIS_MAX = _EPOCH_SECONDS_MAX * 1000
+
+
+def _first_timestamp(*values: Any) -> str | None:
+    """First usable timestamp as an ISO-8601 UTC string.
+
+    Strings pass through like ``_first_str``. Numbers are epoch seconds or
+    epoch millis (cognee DataPoint ``updated_at``/``created_at`` are millis),
+    disambiguated by the windows above. Anything outside both windows — 0,
+    negatives, small counters, far-future junk — yields None rather than a
+    date: a missing date is recoverable, a wrong one gets trusted. ``bool``
+    is an ``int`` subclass and is never a timestamp.
+    """
+    for value in values:
+        if isinstance(value, str):
+            if value.strip():
+                return value.strip()
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        if _EPOCH_SECONDS_MIN <= value <= _EPOCH_SECONDS_MAX:
+            seconds = float(value)
+        elif _EPOCH_MILLIS_MIN <= value <= _EPOCH_MILLIS_MAX:
+            seconds = value / 1000.0
+        else:
+            continue
+        return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat(timespec="seconds")
+    return None
+
+
 def _hit_chunk_index(hit: dict[str, Any]) -> Any:
     """The hit's own chunk_index (CHUNKS payloads carry one), else None."""
     if "chunk_index" in hit:
@@ -666,7 +704,7 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
         "repo": repo,
         "path": path,
         "doc_type": doc_type,
-        "updated_at": _first_str(
+        "updated_at": _first_timestamp(
             item.get("updated_at"),
             envelope.get("created_at"),
             metadata.get("updated_at"),

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -403,3 +403,86 @@ def test_a_trace_still_cannot_dress_itself_as_documentation() -> None:
 
     assert infer_doc_type(trace) == "session-trace"
     assert infer_trust_tier(trace) == "reference-only"
+
+
+# --- updated_at: cognee epoch timestamps must survive normalization ----------
+#
+# Production hits carry ``updated_at``/``created_at`` as epoch-millis ints
+# (cognee DataPoint), the ``_citadel`` envelope has NO ``created_at``, and
+# ``metadata`` holds only ``index_fields`` — so every source the field reads
+# from was dead and the schema shipped a freshness field that was always null.
+
+
+def test_updated_at_epoch_millis_becomes_iso() -> None:
+    hit = normalize_search_hit({"updated_at": 1785361521790, "text": "note"})
+    assert hit["updated_at"] == "2026-07-29T21:45:21+00:00"
+
+
+def test_updated_at_epoch_seconds_becomes_iso() -> None:
+    hit = normalize_search_hit({"updated_at": 1782742208, "text": "note"})
+    assert hit["updated_at"] == "2026-06-29T14:10:08+00:00"
+
+
+def test_updated_at_iso_string_passes_through() -> None:
+    hit = normalize_search_hit({"updated_at": "2026-07-29T21:45:21+00:00", "text": "note"})
+    assert hit["updated_at"] == "2026-07-29T21:45:21+00:00"
+
+
+def test_updated_at_nonsense_yields_none_not_a_wrong_date() -> None:
+    # 0/negative must not become 1970; a huge value must not become year 56000;
+    # values between the seconds and millis windows have no sane reading in
+    # either unit; True is an int subclass and must not be read as a timestamp.
+    for junk in (0, -5, 1_782_742_208_187_000, 100_000_000_000, 4_999_999_999, True):
+        hit = normalize_search_hit({"updated_at": junk, "text": "note"})
+        assert hit["updated_at"] is None, junk
+
+
+def test_updated_at_survives_the_real_production_hit_shape() -> None:
+    """Exact shape captured from the live node on 2026-08-03 (values synthetic).
+
+    The load-bearing facts: top-level ``updated_at`` is epoch millis, the
+    ``_citadel`` envelope carries NO ``created_at`` key, and ``metadata`` holds
+    only ``index_fields``. A fixture that invents ``created_at`` in the
+    envelope would pass against a shape production does not have.
+    """
+    hit = {
+        "id": "0c9d5df0-0000-4000-8000-000000000001",
+        "created_at": 1782742208187,
+        "updated_at": 1782742208187,
+        "version": 1,
+        "type": "DocumentChunk",
+        "text": "synthetic chunk body",
+        "chunk_index": 0,
+        "document_id": "0c9d5df0-0000-4000-8000-000000000002",
+        "document_name": "text_0123456789abcdef0123456789abcdef",
+        "belongs_to_set": None,
+        "feedback_weight": 0,
+        "importance_weight": None,
+        "ontology_valid": False,
+        "source_chunk_id": None,
+        "source_content_hash": None,
+        "source_node_set": None,
+        "source_pipeline": None,
+        "source_task": None,
+        "source_user": None,
+        "topological_rank": 0,
+        "metadata": {"index_fields": ["text"]},
+        "_citadel": {
+            "content_hint": "unclassified",
+            "content_sha256": "0" * 64,
+            "dataset": "seat:synthetic",
+            "doc_type": "other",
+            "document_endpoint": "/api/documents/0c9d5df0-0000-4000-8000-000000000002",
+            "provenance": {},
+            "rank": 1,
+            "relevance": None,
+            "result_id": "0c9d5df0-0000-4000-8000-000000000001",
+            "retrieval": "chunks",
+            "trust": "unattested",
+            "trust_tier": "unattested",
+        },
+    }
+    assert "created_at" not in hit["_citadel"]
+    normalized = normalize_search_hit(hit)
+    assert normalized["updated_at"] == "2026-06-29T14:10:08+00:00"
+    assert isinstance(normalized["updated_at"], str)


### PR DESCRIPTION
Fixes #209

## What

`normalize_search_hit` returned `updated_at: null` on every production hit. The field went through `_first_str`, which only accepts strings, while the node delivers cognee DataPoint timestamps as epoch-millis ints. The two fallbacks were dead as well: the `_citadel` envelope carries no `created_at` key and hit `metadata` holds only `index_fields` (both verified 0/9 against the live node on 2026-08-03).

This adds `_first_timestamp` and routes `updated_at` through it. Strings still pass through unchanged. Ints and floats are read as epoch seconds or epoch millis and emitted as one ISO-8601 UTC string (`isoformat(timespec="seconds")`, matching the `now_iso()` idiom elsewhere in `kb/`).

## Millis vs seconds disambiguation

A number is read in whichever unit puts it inside the window 2001-09-09 to 2096-10-02 (`1e9..4e9` as seconds, `1e12..4e12` as millis). The two windows are three orders of magnitude apart, so no value is valid in both units and a unit can never be guessed wrong by decades. Values outside both windows yield `None` rather than a date: 0 and negatives do not become 1970, huge values do not become a far-future year, and `bool` is rejected explicitly as an `int` subclass. A missing date is recoverable; a wrong one gets trusted.

## Tests

Red first (revert of `kb/search_format.py` only), then green:

- epoch millis int produces the exact ISO string
- epoch seconds int produces the exact ISO string
- an ISO string input passes through unchanged
- 0 / negative / between-windows / far-future / `True` all yield `None`
- a fixture with the exact live hit shape captured on 2026-08-03 (top-level epoch-millis `updated_at`, `_citadel` envelope without `created_at`, `metadata` with only `index_fields`; values synthetic) yields a real date, with an explicit assertion that the fixture's envelope has no `created_at`, so the test cannot pass against a shape production does not have

Full suite: 1235 passed, 1 skipped.

## Verified against production

`citadel search --json` run from the branch code against the live node: 9/9 hits went from `updated_at: null` to values like `2026-07-29T21:45:21+00:00`, with `title` and `trust_tier` unchanged. Raw HTTP `/search` and MCP `citadel_search` are pass-through surfaces and are untouched.