### PR TITLE
fix(promotion): run the classifier off the event loop and record real write outcomes

### DIFF
--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from hashlib import sha256
 import logging
 from pathlib import Path
 from typing import Any
@@ -203,6 +204,21 @@ def _coerce_classification(parsed: Any) -> Classification | None:
     )
 
 
+def _central_write_key(text: str) -> str:
+    """sha256 of the raw text: exactly the key ``Citadel.ingest`` dedupes on.
+
+    NOT :func:`candidate_hash`, which strips and lowercases first. A key
+    coarser than the guard it models suppresses writes that guard would have
+    accepted: a case-variant of already-promoted content hashes differently
+    at ingest but identically after normalization, so the normalized key
+    changed a promotion decision. Promotion submits the candidate text
+    verbatim, so this key and the ingest key agree byte for byte (with LLM
+    enrichment enabled a full-tier write is chunked and ingest keys the
+    chunks; the skip then still stops re-delivery of identical source text).
+    """
+    return sha256(text.encode("utf-8")).hexdigest()
+
+
 class PromotionEnumerationError(RuntimeError):
     """Every seed query for a seat failed, so its content could not be read.
 
@@ -238,12 +254,14 @@ class PromotionEngine:
         self.learning = learning
         self.access_store = access_store
         self.config = config
-        # Hashes of candidate text this engine has already landed in Central
-        # (written and accepted, or confirmed already-present by the ingest
-        # dedupe). Lets decide() skip the classifier for content whose Central
-        # write can only be rejected as duplicate_in_process. Instance-scoped
-        # on purpose: it can only UNDER-report what the ingest dedupe knows, so
-        # a stale entry is impossible and a miss just costs one honest write.
+        # _central_write_key hashes of candidate text this engine has already
+        # landed in Central (written and accepted, or confirmed already-present
+        # by the ingest dedupe). Lets decide() skip the classifier for content
+        # whose Central write can only be rejected as duplicate_in_process.
+        # Keyed on the raw text so it is never coarser than the ingest key it
+        # models, and instance-scoped on purpose: a fresh engine starts empty,
+        # so it can only UNDER-report what the ingest dedupe knows; a stale
+        # entry is impossible and a miss just costs one honest write.
         self._delivered_central_hashes: set[str] = set()
 
     async def enumerate(self, seat_dataset: str, max_items: int) -> list[PromotionCandidate]:
@@ -395,7 +413,7 @@ class PromotionEngine:
         if (
             reference.status == "known_org_work"
             and capture_block is None
-            and candidate_hash(candidate.text) in self._delivered_central_hashes
+            and _central_write_key(candidate.text) in self._delivered_central_hashes
         ):
             # This exact text already reached Central through this engine, and
             # on this reference path the only outcome a verdict could unlock is
@@ -594,7 +612,7 @@ class PromotionEngine:
         # The full-tier (Central) outcome is what "promoted" attests, so read
         # it instead of assuming the write landed. ``learn`` returns rejections
         # (duplicate_in_process, filter refusals) as accepted=False, not raises.
-        content_hash = candidate_hash(proposal.candidate)
+        content_hash = _central_write_key(proposal.candidate)
         if not primary.ingest.accepted:
             write_reason = primary.ingest.reason or "not_accepted"
             if write_reason == "duplicate_in_process":
@@ -814,7 +832,8 @@ class PromotionEngine:
             reference_status=item.reference_status,
         )
         identity = self._promotion_identity(item.seat_dataset)
-        promoted = await self._promote(item.seat_dataset, identity, proposal) == "promoted"
+        outcome = await self._promote(item.seat_dataset, identity, proposal)
+        promoted = outcome == "promoted"
         decided = self.access_store.decide_promotion_pending(
             item_id,
             decision=APPROVED_STATUS,
@@ -839,6 +858,11 @@ class PromotionEngine:
             "ok": promoted,
             "item": decided.to_dict(),
             "promoted": promoted,
+            # The item is consumed either way, so the caller needs the server's
+            # reason to tell "the write failed" from "this content is already
+            # in Central" (an approval of the second of two identical pending
+            # items is the ordinary way to hit the latter).
+            "write_reason": None if promoted else outcome,
         }
 
     async def reject_pending(

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -18,6 +18,7 @@ classification failures degrade to a safe SKIP rather than raising.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import logging
 from pathlib import Path
@@ -237,6 +238,13 @@ class PromotionEngine:
         self.learning = learning
         self.access_store = access_store
         self.config = config
+        # Hashes of candidate text this engine has already landed in Central
+        # (written and accepted, or confirmed already-present by the ingest
+        # dedupe). Lets decide() skip the classifier for content whose Central
+        # write can only be rejected as duplicate_in_process. Instance-scoped
+        # on purpose: it can only UNDER-report what the ingest dedupe knows, so
+        # a stale entry is impossible and a miss just costs one honest write.
+        self._delivered_central_hashes: set[str] = set()
 
     async def enumerate(self, seat_dataset: str, max_items: int) -> list[PromotionCandidate]:
         """Best-effort list of a seat node's promotable content, capped at ``max_items``."""
@@ -311,6 +319,11 @@ class PromotionEngine:
         Returns ``None`` on ANY failure (missing key, HTTP/URL/timeout error,
         unparseable output, or a missing/malformed field) so the caller can
         deterministically SKIP. Never raises.
+
+        Synchronous by design (plain urllib under run_with_retries, a 60s
+        timeout per attempt plus backoff sleeps). Callers running on the event
+        loop must dispatch it via ``asyncio.to_thread``; awaiting it inline
+        stalls every other request for the duration of the call.
         """
         try:
             content = openrouter_chat(
@@ -379,7 +392,35 @@ class PromotionEngine:
             github_org=self.config.github_org,
         )
 
-        verdict = self.classify(candidate.text)
+        if (
+            reference.status == "known_org_work"
+            and capture_block is None
+            and candidate_hash(candidate.text) in self._delivered_central_hashes
+        ):
+            # This exact text already reached Central through this engine, and
+            # on this reference path the only outcome a verdict could unlock is
+            # a Central write the ingest dedupe will reject as
+            # duplicate_in_process. Skip before paying for the classifier call.
+            # One pass re-classified and re-submitted identical cross-seat
+            # content ~150 times; every write bounced. Other reference statuses
+            # (pending-approval queueing, no_reference_signal) still classify,
+            # so no selection path changes; only doomed re-deliveries stop.
+            return ProposedPromotion(
+                candidate=candidate.text,
+                decision="skip",
+                reason="duplicate_in_process",
+                reference_status=reference.status,
+                capture_tags=candidate.tags,
+            )
+
+        # classify() blocks in urllib for up to 60s per retry attempt. Off the
+        # loop it goes: this is plain HTTP to OpenRouter, NOT a cognee call, so
+        # a worker thread is safe. The cognee reads above (enumerate, the
+        # reference searches) must stay on this loop: cognee binds its async
+        # engine to the first loop that touches it and Kuzu is single-writer.
+        # Nine consecutive evolve passes spent 16-27 minutes here with the call
+        # inline, and every route on the node queued behind it.
+        verdict = await asyncio.to_thread(self.classify, candidate.text)
         if verdict is None:
             return ProposedPromotion(
                 candidate=candidate.text,
@@ -470,7 +511,7 @@ class PromotionEngine:
         seat_dataset: str,
         identity: AccessIdentity,
         proposal: ProposedPromotion,
-    ) -> bool:
+    ) -> str:
         """Promote one qualifying item via the org-ready dual-write path.
 
         Reuses ``resolve_write_targets`` (is_promotion -> [seat light, Central
@@ -478,6 +519,14 @@ class PromotionEngine:
         re-runs inside ``learning.learn``. Records one audit event per promotion.
         On a secret block at write time the item is recorded as skipped, not
         promoted. Never raises out of the run loop.
+
+        Returns ``"promoted"`` only when the Central write was actually
+        accepted, ``"write_blocked"`` on a secret block or write error, and
+        otherwise the ingest rejection reason (e.g. ``duplicate_in_process``).
+        The outcome of ``execute_learning_writes`` used to be discarded, so a
+        pass whose Central writes all bounced as duplicate_in_process still
+        logged every one as ``success=True, accepted=True`` and inflated the
+        promoted= count.
         """
         # Imported lazily to avoid a circular import (server imports promotion).
         from kb.security_scan import SecretContentError
@@ -501,7 +550,7 @@ class PromotionEngine:
                 (t.dataset for t in targets if t.tier == "full"),
                 targets[-1].dataset,
             )
-            await execute_learning_writes(
+            primary, _outcomes = await execute_learning_writes(
                 self.learning,
                 data=proposal.candidate,
                 targets=targets,
@@ -526,7 +575,7 @@ class PromotionEngine:
                     "reason": proposal.reason,
                 },
             )
-            return False
+            return "write_blocked"
         except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
             self.access_store.record_event(
                 action="promotion.promote",
@@ -540,8 +589,36 @@ class PromotionEngine:
                     "reason": proposal.reason,
                 },
             )
-            return False
+            return "write_blocked"
 
+        # The full-tier (Central) outcome is what "promoted" attests, so read
+        # it instead of assuming the write landed. ``learn`` returns rejections
+        # (duplicate_in_process, filter refusals) as accepted=False, not raises.
+        content_hash = candidate_hash(proposal.candidate)
+        if not primary.ingest.accepted:
+            write_reason = primary.ingest.reason or "not_accepted"
+            if write_reason == "duplicate_in_process":
+                # Central already holds this exact text in this process, so
+                # later identical candidates can skip their classifier call.
+                self._delivered_central_hashes.add(content_hash)
+            self.access_store.record_event(
+                action="promotion.promote",
+                actor=identity,
+                success=False,
+                dataset=central,
+                detail={
+                    "seat": seat_dataset,
+                    "accepted": False,
+                    "write_reason": write_reason,
+                    "score": proposal.score,
+                    "relevant": proposal.relevant,
+                    "sensitive": proposal.sensitive,
+                    "reason": proposal.reason,
+                },
+            )
+            return write_reason
+
+        self._delivered_central_hashes.add(content_hash)
         self.access_store.record_event(
             action="promotion.promote",
             actor=identity,
@@ -559,7 +636,7 @@ class PromotionEngine:
                 "capture_tags": list(proposal.capture_tags),
             },
         )
-        return True
+        return "promoted"
 
     async def run(
         self,
@@ -574,7 +651,9 @@ class PromotionEngine:
         writes NOTHING. ``dry_run=False`` actually promotes qualifying items via
         the org-ready dual-write and records one audit event each. Gated on
         ``config.promotion_enabled`` (opt-in): when disabled, returns a disabled
-        status and does nothing.
+        status and does nothing. ``promoted`` counts only writes Central
+        actually accepted; a rejected write settles as a skip carrying the
+        server's rejection reason.
         """
         if not self.config.promotion_enabled:
             return {
@@ -611,8 +690,8 @@ class PromotionEngine:
                 if proposal.decision != "promote":
                     settled.append(proposal)
                     continue
-                ok = await self._promote(seat_dataset, identity, proposal)
-                if ok:
+                outcome = await self._promote(seat_dataset, identity, proposal)
+                if outcome == "promoted":
                     promoted += 1
                     settled.append(
                         ProposedPromotion(
@@ -627,7 +706,7 @@ class PromotionEngine:
                             capture_tags=proposal.capture_tags,
                         )
                     )
-                else:
+                elif outcome == "write_blocked":
                     settled.append(
                         ProposedPromotion(
                             candidate=proposal.candidate,
@@ -637,6 +716,22 @@ class PromotionEngine:
                             sensitive=proposal.sensitive,
                             score=proposal.score,
                             secret_blocked=True,
+                            reference_status=proposal.reference_status,
+                            capture_tags=proposal.capture_tags,
+                        )
+                    )
+                else:
+                    # The write ran but Central refused the content (e.g.
+                    # duplicate_in_process). Not a secret block, and not a
+                    # delivery: record what the server actually returned.
+                    settled.append(
+                        ProposedPromotion(
+                            candidate=proposal.candidate,
+                            decision="skip",
+                            reason=outcome,
+                            relevant=proposal.relevant,
+                            sensitive=proposal.sensitive,
+                            score=proposal.score,
                             reference_status=proposal.reference_status,
                             capture_tags=proposal.capture_tags,
                         )
@@ -719,7 +814,7 @@ class PromotionEngine:
             reference_status=item.reference_status,
         )
         identity = self._promotion_identity(item.seat_dataset)
-        promoted = await self._promote(item.seat_dataset, identity, proposal)
+        promoted = await self._promote(item.seat_dataset, identity, proposal) == "promoted"
         decided = self.access_store.decide_promotion_pending(
             item_id,
             decision=APPROVED_STATUS,

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -645,3 +645,90 @@ async def test_duplicate_across_seats_skips_the_classifier_call(
     assert len(learning.central_writes) == 1, (
         "identical content must not be re-submitted to Central"
     )
+
+
+async def test_case_divergent_duplicate_still_promotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The delivered-set key must match the ingest dedupe key exactly.
+
+    Citadel.ingest dedupes on sha256 of the RAW text (kb/service.py), while
+    candidate_hash() strips and lowercases first. Keying the delivered set on
+    the normalized hash is coarser than the guard it models: a case-variant of
+    promoted content hashes differently at ingest (Central would accept the
+    write) but identically under normalization (the engine would suppress it).
+    Two case-divergent candidates must cost two classifier calls and two
+    Central writes, exactly as on the base branch.
+    """
+    config = _github_state(tmp_path)
+    learning = FakeLearning()
+    store = AccessStore(str(tmp_path / "access.json"))
+    citadel = FakeCitadel(config, [_org_note()])
+    engine = PromotionEngine(citadel, learning, store, config)
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    first = await engine.run(SEAT, dry_run=False)
+    assert first["promoted"] == 1
+
+    variant = _org_note().replace("Org note", "ORG NOTE")
+    assert variant != _org_note()
+    assert variant.lower() == _org_note().lower()
+    citadel._nodes = [variant]
+
+    second = await engine.run(seat_dataset("bob"), dry_run=False)
+
+    assert second["promoted"] == 1, (
+        "a case-variant hashes differently at ingest, so Central would accept "
+        "it; the engine must not suppress the write"
+    )
+    assert second["proposals"][0]["decision"] == "promote"
+    assert len(learning.central_writes) == 2
+
+
+async def test_approve_pending_surfaces_the_write_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An approver must be able to tell a failed write from already-delivered.
+
+    approve_pending consumes the item either way (pre-existing contract), and
+    with honest write accounting a duplicate bounce returns ok=False. Without
+    the server's reason in the response, an admin approving two identical
+    pending items from different seats sees the second as a failure when
+    nothing failed. The write_reason must reach the caller, not only the
+    audit log.
+    """
+    summary = (
+        "# Capture summary: side project\n"
+        "- Remote: `https://github.com/other-org/new-app.git`\n"
+        "- Capture Root Tags: org-work\n"
+    )
+    state_path = tmp_path / "github-state.json"
+    state_path.write_text(
+        '{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8"
+    )
+    config = _config(github_sync_state_path=str(state_path))
+    learning = FakeLearning(central_reject_reason="duplicate_in_process")
+    store = AccessStore(str(tmp_path / "access.json"))
+    engine = PromotionEngine(FakeCitadel(config, [summary]), learning, store, config)
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.95)
+
+    queued = await engine.run(SEAT, dry_run=False)
+    assert queued["queued"] == 1
+    item = store.list_promotion_pending(seat_slug="alice")[0]
+    actor = AccessIdentity(
+        role="writer",
+        actor_id="alice",
+        actor_kind="user",
+        actor_name="Alice",
+        source="token",
+        default_dataset=SEAT,
+        seat_slug="alice",
+    )
+
+    result = await engine.approve_pending(item.id, actor)
+
+    assert result["promoted"] is False
+    assert result["ok"] is False
+    assert result["write_reason"] == "duplicate_in_process"
+    # The item is consumed regardless, matching the contract on main.
+    assert store.get_promotion_pending(item.id).status != "pending"

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +10,7 @@ import pytest
 
 from kb.access import AccessStore, AccessIdentity, seat_dataset
 from kb.config import CitadelConfig
+from kb.learning import LearningOutcome
 from kb.models import IngestResult
 from kb.promotion import PromotionEngine, _coerce_classification
 import kb.promotion as promotion
@@ -37,14 +40,27 @@ class FakeCitadel:
 
 
 class FakeLearning:
-    """Records every learn() call so tests can assert on the write targets."""
+    """Records every learn() call so tests can assert on the write targets.
 
-    def __init__(self) -> None:
+    Returns the real :class:`LearningOutcome` shape the engine reads, because a
+    fake inventing its own shape is how a guard ships inert. ``central_reject_reason``
+    makes Central writes come back ``accepted=False`` with that reason, the
+    contract ``Citadel.ingest`` uses for rejections like duplicate_in_process.
+    """
+
+    def __init__(self, central_reject_reason: str | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.central_reject_reason = central_reject_reason
 
-    async def learn(self, data: str, **kwargs: Any) -> IngestResult:
+    async def learn(self, data: str, **kwargs: Any) -> LearningOutcome:
+        dataset = kwargs.get("dataset") or CENTRAL
+        tags = tuple(kwargs.get("tags") or ())
         self.calls.append({"data": data, "dataset": kwargs.get("dataset"), "tier": kwargs.get("tier"), "tags": kwargs.get("tags")})
-        return IngestResult(True, "accepted", kwargs.get("dataset") or CENTRAL, tuple(kwargs.get("tags") or ()))
+        if self.central_reject_reason and dataset == CENTRAL:
+            result = IngestResult(False, self.central_reject_reason, dataset, tags)
+        else:
+            result = IngestResult(True, "accepted", dataset, tags)
+        return LearningOutcome(ingest=result, dataset=dataset)
 
     @property
     def central_writes(self) -> list[dict[str, Any]]:
@@ -507,3 +523,125 @@ async def test_enumerate_returns_empty_without_raising_when_searches_succeed(
     engine, _, _ = _engine(tmp_path, [])
 
     assert await engine.enumerate(SEAT, 20) == []
+
+
+async def test_slow_classifier_does_not_block_the_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Other coroutines must keep running while the classifier is in flight.
+
+    The classifier is a synchronous HTTP call with a 60s timeout per retry
+    attempt. Awaited inline it parks the whole event loop: nine consecutive
+    evolve passes spent 16-27 minutes in promotion and every route on the node
+    queued behind the blocked loop for the duration (search 22.9s, /mcp 41.9s,
+    an ingest abandoned at 120s). This asserts the observable behaviour (the
+    loop schedules this test's coroutine while classify is mid-call), not the
+    presence of any particular dispatch mechanism.
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    def stalled_chat(*args: Any, **kwargs: Any) -> str | None:
+        started.set()
+        if not release.wait(timeout=2.0):
+            # The loop never freed us: degrade to the llm_unavailable skip so
+            # the red direction fails on the liveness assert, not a hang.
+            return None
+        return json.dumps(
+            {"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"}
+        )
+
+    monkeypatch.setattr(promotion, "openrouter_chat", stalled_chat)
+    engine, _learning, _store = _engine(tmp_path, [_org_note()], _github_state(tmp_path))
+
+    run_task = asyncio.create_task(engine.run(SEAT, dry_run=False))
+    alive_during_classify = False
+    for _ in range(400):
+        await asyncio.sleep(0.005)
+        if started.is_set():
+            # The classifier has started and is still held open (release is
+            # unset), yet this coroutine is running: the loop is alive. When
+            # classify runs ON the loop this line is unreachable until the
+            # call gives up, by which point run_task has already finished.
+            alive_during_classify = not run_task.done()
+            break
+    release.set()
+    result = await run_task
+
+    assert started.is_set(), "the classifier was never invoked"
+    assert alive_during_classify, (
+        "the event loop made no progress while the classifier was in flight"
+    )
+    assert result["promoted"] == 1
+
+
+async def test_central_rejection_is_not_recorded_as_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write Central refuses must not be counted or audited as delivered.
+
+    One production pass logged promoted=169 while ~150 of those Central writes
+    came back duplicate_in_process; each was recorded success=True,
+    accepted=True because the outcome of execute_learning_writes was dropped.
+    """
+    config = _github_state(tmp_path)
+    learning = FakeLearning(central_reject_reason="duplicate_in_process")
+    store = AccessStore(str(tmp_path / "access.json"))
+    engine = PromotionEngine(FakeCitadel(config, [_org_note()]), learning, store, config)
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
+
+    result = await engine.run(SEAT, dry_run=False)
+
+    assert result["promoted"] == 0
+    proposal = result["proposals"][0]
+    assert proposal["decision"] == "skip"
+    assert proposal["reason"] == "duplicate_in_process"
+    assert proposal["promoted"] is False
+    assert proposal["secret_blocked"] is False, "a duplicate is not a secret block"
+    events = store.recent_audit_events(action="promotion.promote")
+    assert len(events) == 1
+    assert events[0]["success"] is False
+    assert events[0]["detail"]["accepted"] is False
+    assert events[0]["detail"]["write_reason"] == "duplicate_in_process"
+
+
+async def test_duplicate_across_seats_skips_the_classifier_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Content already landed in Central this pass is not re-classified.
+
+    The evolve stage runs one engine across every seat, so identical content
+    surfacing from a second seat used to cost a full classifier call and a
+    Central write that the ingest dedupe then rejected: ~150 wasted LLM calls
+    in one measured pass. Once this engine has delivered the exact text, the
+    next identical candidate settles as duplicate_in_process before classify.
+    """
+    config = _github_state(tmp_path)
+    learning = FakeLearning()
+    store = AccessStore(str(tmp_path / "access.json"))
+    engine = PromotionEngine(FakeCitadel(config, [_org_note()]), learning, store, config)
+    classifier_calls = {"count": 0}
+
+    def counting_chat(*args: Any, **kwargs: Any) -> str:
+        classifier_calls["count"] += 1
+        return json.dumps(
+            {"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"}
+        )
+
+    monkeypatch.setattr(promotion, "openrouter_chat", counting_chat)
+
+    first = await engine.run(SEAT, dry_run=False)
+    assert first["promoted"] == 1
+    assert classifier_calls["count"] == 1
+    assert len(learning.central_writes) == 1
+
+    second = await engine.run(seat_dataset("bob"), dry_run=False)
+    assert second["promoted"] == 0
+    assert second["proposals"][0]["decision"] == "skip"
+    assert second["proposals"][0]["reason"] == "duplicate_in_process"
+    assert classifier_calls["count"] == 1, (
+        "identical content must not cost a second classifier call"
+    )
+    assert len(learning.central_writes) == 1, (
+        "identical content must not be re-submitted to Central"
+    )


### PR DESCRIPTION
The promotion stage ran its LLM classifier as a synchronous HTTP call directly on the server's event loop, so every route was unresponsive for the duration of a pass (measured 85-92% of evolve stage time across nine passes).

- `decide()` now dispatches the classifier via `asyncio.to_thread`. No cognee call is relocated: enumerate, the reference searches, and the dual-write stay awaited on the server loop, per the loop-binding and single-writer constraints.
- `_promote()` reads the Central `IngestResult` instead of discarding it, so a rejected write is audited with its reason and no longer counts toward `promoted=`.
- Candidates already delivered to Central in the same pass skip the classifier, keyed on the same hash the ingest layer dedupes on.
- `approve_pending` returns `write_reason` so a caller can tell a failed write from content already present.

Tests written first and verified failing without the fix; the liveness test asserts observable loop progress rather than the presence of a call.

Refs #105 — same event-loop starvation cause class; removes the promotion trigger but does not close it, since #105's own trigger is search load.