### PR TITLE
fix(capture): stop misreporting write outcomes

### DIFF
--- a/kb/capture.py
+++ b/kb/capture.py
@@ -25,7 +25,11 @@ from kb.capture_config import CaptureRoot, normalize_tags
 CAPTURE_TAG = "capture"
 _README_NAMES = ("README.md", "README.rst", "README.txt", "README")
 _GIT_TIMEOUT_SECONDS = 8
-_HTTP_TIMEOUT_SECONDS = 120
+# Raised from 120: a production /ingest write was measured completing after
+# ~134s, so a 120s client read timeout reported "timed out" while the server
+# went on to store the document. Overridable per environment (see below).
+DEFAULT_HTTP_TIMEOUT_SECONDS = 300.0
+_HTTP_TIMEOUT_ENV = "CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS"
 _README_LINE_LIMIT = 6
 _README_LINE_MAX_CHARS = 500
 DEFAULT_MAX_INGEST_BYTES = 200_000
@@ -57,6 +61,30 @@ def _truncate_utf8(text: str, max_bytes: int) -> str:
     if len(encoded) <= max_bytes:
         return text
     return encoded[:max_bytes].decode("utf-8", "ignore")
+
+
+def http_timeout_seconds() -> float:
+    """Effective capture read timeout: ``CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS`` or default."""
+    raw = os.getenv(_HTTP_TIMEOUT_ENV)
+    if not raw:
+        return DEFAULT_HTTP_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_HTTP_TIMEOUT_SECONDS
+    return max(1.0, value)
+
+
+def is_timeout_error(exc: BaseException) -> bool:
+    """True when ``exc`` is a client-side timeout (bare or URLError-wrapped).
+
+    A timeout only proves the client stopped waiting; the server may still
+    finish the write after the deadline, so callers must report the outcome as
+    unknown rather than failed.
+    """
+    if isinstance(exc, TimeoutError):
+        return True
+    return isinstance(getattr(exc, "reason", None), TimeoutError)
 
 
 def capture_token() -> str:
@@ -163,9 +191,15 @@ def post_capture(
     token: str,
     payload: dict[str, Any],
     *,
-    timeout: float = _HTTP_TIMEOUT_SECONDS,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    """POST a capture summary to the Node `/ingest` endpoint (HTTPS-only)."""
+    """POST a capture summary to the Node `/ingest` endpoint (HTTPS-only).
+
+    ``timeout=None`` resolves to :func:`http_timeout_seconds` at call time so
+    the env override applies without threading a value through every caller.
+    """
+    if timeout is None:
+        timeout = http_timeout_seconds()
     if not node_url.lower().startswith("https://"):
         raise ValueError("refusing non-HTTPS Node URL")
     req = urllib.request.Request(

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -36,7 +36,13 @@ from kb.capture_config import (
     normalize_tags,
     save_capture_config,
 )
-from kb.capture import build_capture_payload, capture_token, post_capture
+from kb.capture import (
+    build_capture_payload,
+    capture_token,
+    http_timeout_seconds,
+    is_timeout_error,
+    post_capture,
+)
 from kb.capture_roots_sync import sync_local_capture_roots_to_server, sync_warning_message
 from kb.onboard import (
     TOKEN_ENV,
@@ -1036,17 +1042,19 @@ async def _capture(args: argparse.Namespace) -> int:
     if not token:
         return _emit_no_token("capture", as_json=getattr(args, "json", False))
 
+    # Per-root truth contract: ok=True stored, ok=False definitively not stored
+    # (reason/error says why), ok=None unknown (client timed out; the server may
+    # still have completed the write). Exit 0 only when every root is stored or
+    # already present on the server; a duplicate skip is a no-op, not a failure.
     as_json = getattr(args, "json", False)
     results: list[dict[str, Any]] = []
     failures = 0
+    unknowns = 0
     auth_fail_code = 0
+    timeout_seconds = http_timeout_seconds()
     for root, payload in payloads:
         try:
             response = post_capture(config.node_url, token, payload)
-            status = response.get("cognee_result", {}).get("status") or response.get("status")
-            results.append({"root": root.path, "ok": True, "status": status, "tags": payload["tags"]})
-            if not as_json:
-                print(f"OK  {root.path} ({status})")
         except urllib.error.HTTPError as exc:
             failures += 1
             auth_fail_code = auth_fail_code or exc.code
@@ -1054,18 +1062,75 @@ async def _capture(args: argparse.Namespace) -> int:
             results.append({"root": root.path, "ok": False, "error": f"HTTP {exc.code} {detail}"})
             if not as_json:
                 print(f"FAIL {root.path}: HTTP {exc.code} {detail}", file=sys.stderr)
+            continue
         except (urllib.error.URLError, OSError, ValueError) as exc:
-            # Node unreachable / DNS / timeout / non-HTTPS URL — isolate per root.
-            failures += 1
-            results.append({"root": root.path, "ok": False, "error": str(exc)})
+            if is_timeout_error(exc):
+                # A read timeout proves only that the client stopped waiting.
+                # A production write was observed landing after the deadline,
+                # so this outcome is unknown, never a claimed failure.
+                unknowns += 1
+                detail = (
+                    f"no response within {timeout_seconds:.0f}s; "
+                    "the write may still have completed on the server"
+                )
+                results.append({"root": root.path, "ok": None, "error": detail})
+                if not as_json:
+                    print(f"UNKNOWN {root.path}: {detail}", file=sys.stderr)
+            else:
+                # Node unreachable / DNS / non-HTTPS URL: isolate per root.
+                failures += 1
+                results.append({"root": root.path, "ok": False, "error": str(exc)})
+                if not as_json:
+                    print(f"FAIL {root.path}: {exc}", file=sys.stderr)
+            continue
+        # HTTP 200 is not proof of storage: the server states its decision in
+        # `accepted`. Only an explicit false is a rejection (legacy bodies
+        # without the field keep the old 200-means-stored contract).
+        accepted = response.get("accepted") is not False
+        reason = response.get("reason")
+        cognee_result = response.get("cognee_result")
+        status = (
+            cognee_result.get("status") if isinstance(cognee_result, dict) else None
+        ) or response.get("status")
+        if accepted:
+            results.append(
+                {"root": root.path, "ok": True, "status": status, "tags": payload["tags"]}
+            )
             if not as_json:
-                print(f"FAIL {root.path}: {exc}", file=sys.stderr)
+                print(f"OK  {root.path} ({status})")
+        elif reason == "duplicate_in_process":
+            # The server already holds identical content, so the desired end
+            # state exists. Visible skip, exit 0: failing here would teach
+            # automation to ignore exit codes on every unchanged re-run.
+            results.append(
+                {"root": root.path, "ok": False, "reason": reason, "tags": payload["tags"]}
+            )
+            if not as_json:
+                print(f"SKIP {root.path}: nothing stored ({reason})")
+        else:
+            failures += 1
+            results.append(
+                {
+                    "root": root.path,
+                    "ok": False,
+                    "reason": reason or "rejected",
+                    "tags": payload["tags"],
+                }
+            )
+            if not as_json:
+                print(f"FAIL {root.path}: nothing stored ({reason or 'rejected'})", file=sys.stderr)
     if not as_json and auth_fail_code:
         _print_auth_hint("capture", auth_fail_code)  # once, not per failing root
+    if not as_json and unknowns:
+        print(
+            "Re-run `citadel capture` to confirm: a write that landed after the "
+            "timeout will show as SKIP (duplicate_in_process).",
+            file=sys.stderr,
+        )
     if as_json:
-        _print_json({"ok": failures == 0, "results": results})
-    # Human mode already printed a per-root OK/FAIL line during the loop.
-    return 1 if failures else 0
+        _print_json({"ok": failures == 0 and unknowns == 0, "results": results})
+    # Human mode already printed a per-root OK/SKIP/UNKNOWN/FAIL line during the loop.
+    return 1 if failures or unknowns else 0
 
 
 def _promotion_base_url(args: argparse.Namespace) -> str:

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -214,12 +214,17 @@ def build_tags(cwd: str) -> list[str]:
     return tags
 
 
-def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> None:
+def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[str, Any] | None:
     """POST {data, tags} to {base}/ingest over HTTPS. No dataset field.
 
     Personal-by-default: omitting ``dataset`` lets the seat-writer token's
     ``default_dataset=seat:{slug}`` route the write to the dev's private node.
-    HTTPS is required. Raises on any transport problem; the caller swallows it.
+    HTTPS is required. Raises on any transport problem; the caller handles it.
+
+    Returns the parsed JSON response body (or ``None`` when the 2xx body is not
+    a JSON object): a 2xx alone is not proof of storage, because the server
+    states its decision in the body's ``accepted``/``reason`` fields and the
+    receipt must record that decision, not the transport outcome.
     """
     if not base_url.lower().startswith("https://"):
         # HTTPS-only invariant: never send a token over plaintext.
@@ -236,8 +241,45 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> None:
         },
     )
     with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-        # Drain so the connection closes cleanly; status is enough.
-        response.read()
+        raw = response.read()
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def receipt_summary(response: dict[str, Any] | None) -> str:
+    """Receipt line for a completed POST, mirroring the server's decision."""
+    if response is None:
+        return "session sent: server replied 2xx but the response body was unreadable"
+    if response.get("accepted") is not False:
+        return "session captured → your Node"
+    reason = response.get("reason") or "rejected"
+    return f"session not stored: server rejected the write ({reason})"
+
+
+def _send_failure_summary(exc: BaseException) -> str:
+    """Receipt line for a POST that raised before a response was read."""
+    if isinstance(exc, TimeoutError) or isinstance(getattr(exc, "reason", None), TimeoutError):
+        # A client timeout is not proof of failure: the server can finish the
+        # write after the deadline, so the honest verdict is "unconfirmed".
+        return (
+            f"session capture unconfirmed: no response within {HTTP_TIMEOUT_SECONDS}s; "
+            "the write may still have completed on the server"
+        )
+    # Class name only: an exception message could echo request details.
+    return f"session not captured: send failed ({exc.__class__.__name__})"
+
+
+def _write_receipt(summary: str) -> None:
+    """Best-effort DX-5 receipt (never raises, never surfaces the token)."""
+    try:
+        from kb.hooks.receipt import write_receipt
+
+        write_receipt("session", summary)
+    except Exception:
+        pass
 
 
 def run(stream_in: Any) -> int:
@@ -259,17 +301,24 @@ def run(stream_in: Any) -> int:
 
         note = distill_transcript(entries)
         if not note.strip():
+            # Nothing extractable, so nothing is sent. A constant placeholder
+            # note carries zero session content; the receipt still records that
+            # the hook ran and chose to skip.
+            _write_receipt("session skipped: no extractable session content (nothing sent)")
             return 0
 
         note = _truncate_utf8(note, _max_ingest_bytes())
         tags = build_tags(cwd if isinstance(cwd, str) else "")
 
-        post_ingest(_base_url(), token, note, tags)
-        # DX-5 receipt: make the silent session capture visible (never raises,
-        # never surfaces the token; any failure is caught below).
-        from kb.hooks.receipt import write_receipt
-
-        write_receipt("session", "session captured → your Node")
+        # DX-5 receipt: make the silent session capture visible AND truthful.
+        # The receipt records what the server said (or that we cannot know),
+        # never an unconditional "captured".
+        try:
+            response = post_ingest(_base_url(), token, note, tags)
+        except Exception as exc:
+            _write_receipt(_send_failure_summary(exc))
+            return 0
+        _write_receipt(receipt_summary(response))
     except Exception:
         # Fail-silent: never block session close, never surface the token.
         return 0

--- a/kb/session_trace_distill.py
+++ b/kb/session_trace_distill.py
@@ -292,6 +292,12 @@ def distill_node_note(entries: list[dict[str, Any]]) -> str:
                         decisions.append(snippet)
 
     first_prompt = first_user_prompt(entries)
+    if not (first_prompt or last_assistant_text or decisions or files):
+        # Nothing extractable. Return "" so the caller can skip the send: a
+        # placeholder note would be byte-identical for every empty session, so
+        # it could be stored at most once and each later send would be refused
+        # as already-seen content while the receipt claimed capture.
+        return ""
     lines: list[str] = ["# Dev session note"]
     recap_bits: list[str] = []
     if first_prompt:

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import subprocess
+import urllib.error
 from pathlib import Path
 from typing import Any
 
@@ -201,3 +202,179 @@ def test_git_helper_survives_missing_git(monkeypatch) -> None:
 
     monkeypatch.setattr(capture_mod.subprocess, "run", boom)
     assert capture_mod._git("/tmp", "status") is None
+
+
+# --- server-decision truth: accepted / rejected / timeout --------------------
+
+
+def _configured_args(tmp_path: Path, *, as_json: bool) -> argparse.Namespace:
+    config_path = tmp_path / "capture.json"
+    save_capture_config(
+        CaptureConfig(node_url="https://node.example").with_root(str(tmp_path), ["personal"]),
+        path=config_path,
+    )
+    return argparse.Namespace(config=str(config_path), root=None, dry_run=False, json=as_json)
+
+
+def _rejection(reason: str) -> dict[str, Any]:
+    # Shape of a rejected /ingest write: cognee_result is null, NOT absent.
+    return {
+        "accepted": False,
+        "reason": reason,
+        "dataset": "seat:test",
+        "tags": ["personal", "capture"],
+        "cognee_result": None,
+    }
+
+
+def test_capture_duplicate_rejection_reports_ok_false_with_reason(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+    monkeypatch.setattr(
+        "kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process")
+    )
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
+    out = json.loads(capsys.readouterr().out)
+    entry = out["results"][0]
+    assert entry["ok"] is False
+    assert entry["reason"] == "duplicate_in_process"
+    # The desired end state (content on the server) already holds, so an
+    # unchanged root is a visible no-op, not a failure.
+    assert rc == 0
+    assert out["ok"] is True
+
+
+def test_capture_duplicate_human_output_says_nothing_stored(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+    monkeypatch.setattr(
+        "kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process")
+    )
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=False)))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "nothing stored" in captured.out
+    assert "duplicate_in_process" in captured.out
+
+
+def test_capture_non_duplicate_rejection_is_a_failure(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: _rejection("content_too_short"))
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=False)))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "nothing stored" in captured.err
+    assert "content_too_short" in captured.err
+
+
+def test_capture_accepted_reports_ok_true(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+    monkeypatch.setattr(
+        "kb.cli.post_capture",
+        lambda *a, **k: {
+            "accepted": True,
+            "reason": "accepted",
+            "dataset": "seat:test",
+            "tags": ["personal", "capture"],
+            "cognee_result": {"status": "ok"},
+        },
+    )
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["ok"] is True
+    assert out["results"][0]["ok"] is True
+    assert out["results"][0]["status"] == "ok"
+
+
+def test_capture_response_without_accepted_field_still_ok(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    # Legacy shape: a 200 body with no explicit rejection reads as accepted.
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: {"status": "ok"})
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["results"][0]["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        TimeoutError("The read operation timed out"),
+        urllib.error.URLError(TimeoutError("timed out")),
+    ],
+    ids=["read-timeout", "urlerror-wrapped-timeout"],
+)
+def test_capture_timeout_is_reported_unknown_not_failed(
+    tmp_path: Path, monkeypatch, capsys, exc: Exception
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+
+    def boom(*a: Any, **k: Any) -> None:
+        raise exc
+
+    monkeypatch.setattr("kb.cli.post_capture", boom)
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
+    out = json.loads(capsys.readouterr().out)
+    entry = out["results"][0]
+    # A timeout proves only that the client stopped waiting, so the outcome is
+    # unknown (null), never a claimed failure.
+    assert entry["ok"] is None
+    assert "may still have completed" in entry["error"]
+    assert out["ok"] is False
+    assert rc == 1
+
+
+def test_capture_timeout_human_output_is_unknown_not_fail(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
+
+    def boom(*a: Any, **k: Any) -> None:
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr("kb.cli.post_capture", boom)
+    rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=False)))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "UNKNOWN" in captured.err
+    assert "may still have completed" in captured.err
+    assert "FAIL" not in captured.err
+
+
+def test_http_timeout_default_raised_and_env_override(monkeypatch) -> None:
+    monkeypatch.delenv("CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS", raising=False)
+    assert capture_mod.http_timeout_seconds() == 300.0
+    monkeypatch.setenv("CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS", "45")
+    assert capture_mod.http_timeout_seconds() == 45.0
+    monkeypatch.setenv("CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS", "not-a-number")
+    assert capture_mod.http_timeout_seconds() == 300.0
+
+
+def test_post_capture_uses_configured_timeout(monkeypatch) -> None:
+    seen: dict[str, Any] = {}
+
+    class _FakeResp:
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *a: Any) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
+        seen["timeout"] = timeout
+        return _FakeResp()
+
+    monkeypatch.setattr(capture_mod._OPENER, "open", fake_open)
+    monkeypatch.setenv("CITADEL_CAPTURE_HTTP_TIMEOUT_SECONDS", "77")
+    post_capture("https://node.example", "ctdl_t", {"data": "d", "tags": []})
+    assert seen["timeout"] == 77.0

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -77,10 +77,16 @@ def test_distill_produces_nonempty_short_note() -> None:
     assert "sync_session.py" in note
 
 
-def test_distill_empty_transcript_is_safe() -> None:
-    note = sync_session.distill_transcript([])
-    assert isinstance(note, str)
-    assert note.strip()  # still a valid (placeholder) note, never crashes
+def test_distill_empty_transcript_returns_empty() -> None:
+    # An empty session has nothing worth storing. Returning "" lets the hook
+    # skip the send instead of shipping a constant placeholder note.
+    assert sync_session.distill_transcript([]) == ""
+
+
+def test_distill_files_only_session_still_produces_note() -> None:
+    # A session with edits but no prompt/outcome text is NOT empty.
+    note = sync_session.distill_transcript([_assistant_edit("a.py")])
+    assert "a.py" in note
 
 
 # --- size cap ---------------------------------------------------------------
@@ -254,3 +260,138 @@ def test_run_swallows_post_errors(monkeypatch: Any, tmp_path: Path) -> None:
 def test_run_handles_garbage_stdin() -> None:
     # Non-JSON STDIN must not crash; clean exit.
     assert sync_session.run(io.StringIO("not json at all {{{")) == 0
+
+
+# --- receipts tell the truth about what the server decided -------------------
+
+
+def _hook_payload(path: Path, tmp_path: Path) -> str:
+    return json.dumps(
+        {
+            "transcript_path": str(path),
+            "cwd": str(tmp_path),
+            "session_id": "s1",
+            "hook_event_name": "SessionEnd",
+        }
+    )
+
+
+def _fake_urlopen_with_body(monkeypatch: Any, body: bytes) -> None:
+    class _Resp:
+        def __enter__(self) -> "_Resp":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return body
+
+    monkeypatch.setattr(
+        sync_session.urllib.request, "urlopen", lambda request, timeout=None: _Resp()
+    )
+
+
+def _receipt_text() -> str:
+    from kb.hooks.receipt import activity_log_path
+
+    path = activity_log_path()
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_receipt_on_accepted_says_captured(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(
+        monkeypatch,
+        json.dumps({"accepted": True, "reason": "accepted", "cognee_result": {}}).encode(),
+    )
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "session captured" in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_records_rejection_not_capture(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(
+        monkeypatch,
+        json.dumps(
+            {
+                "accepted": False,
+                "reason": "duplicate_in_process",
+                "dataset": "seat:test",
+                "tags": ["dev-session"],
+                "cognee_result": None,
+            }
+        ).encode(),
+    )
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "not stored" in receipt
+    assert "duplicate_in_process" in receipt
+    assert "session captured" not in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_on_unreadable_body_does_not_claim_capture(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(monkeypatch, b"not json")
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "unreadable" in receipt
+    assert "session captured" not in receipt
+
+
+def test_receipt_on_timeout_says_write_may_have_completed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr(sync_session, "post_ingest", boom)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "may still have completed" in receipt
+    assert "session captured" not in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_on_send_failure_names_class_only(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("boom with sensitive detail")
+
+    monkeypatch.setattr(sync_session, "post_ingest", boom)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "not captured" in receipt
+    assert "RuntimeError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "session captured" not in receipt
+
+
+def test_empty_session_is_not_sent(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    recorder = _RecordingPost()
+    monkeypatch.setattr(sync_session, "post_ingest", recorder)
+    path = _write_transcript(tmp_path, [], monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    assert recorder.calls == []  # nothing extractable -> nothing sent
+    receipt = _receipt_text()
+    assert "skipped" in receipt
+    assert "captured" not in receipt


### PR DESCRIPTION
`citadel capture` reported success for rejected writes, crashed on a duplicate response, and reported failure for writes that actually completed.

- No longer calls `.get()` on a null `cognee_result`.
- Per-root `ok` mirrors the server's `accepted` field; rejections surface the server's reason.
- A client timeout reports UNKNOWN rather than failure, since a timeout is not proof the write failed. Default read timeout raised to 300s and made configurable.
- The SessionEnd receipt records what the server actually returned.
- Sessions with no extractable content are no longer sent.

Fixes #222