### PR TITLE
fix(cli): fail loudly on outages; honest hook and ingest-timeout reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Fixed
 
+- **`citadel activity` no longer reports an outage as an empty vault.**
+  `fetch_events` marks every transport/HTTP failure as `{"error": ...}`, but the
+  feed rendered that as `No recent activity.` (exit 0) and `--json` printed the
+  bare error object, also with exit 0, so an unreachable node was
+  indistinguishable from an empty vault. A missing token now takes the shared
+  no-token error path, and an unreachable node emits
+  `{"ok": false, "error": ..., "code": "NODE_UNREACHABLE"}` under `--json` (a
+  stderr line otherwise) with exit 1. `--global` fails the same way. A genuinely
+  empty feed still prints `No recent activity.` and exits 0.
+- **`citadel activity` shows which operation failed.** `record_error` stores the
+  operation and a redacted reason in the event details, but the feed rendered
+  only the label, so every failure read as a bare `Operation failed`. Error
+  lines now append both, newlines collapsed and the reason capped at 120 chars.
+- **`citadel status` names the repo behind the pre-push hook check.** The check
+  is cwd-scoped, so running from any directory outside the repo reported the
+  hook as `missing` even though it exists and works in the repo. The detail now
+  reads `installed (<repo>)` / `missing in <repo>`, or says plainly that there
+  is no git repo at the inspected path, and the check data carries
+  `{repo, git_repo}`. `citadel doctor` stops claiming "hook missing" when there
+  was no git repo to inspect.
+- **`citadel ingest` takes `--timeout SECONDS` and stops overclaiming on
+  expiry.** The default (cognify) mode blocked up to 180s with no way to bound
+  it, and the timeout message asserted "Your note is saved" (plus
+  `saved: true`), which nothing verified. On expiry the CLI now says the
+  outcome is unknown (`write_state: "unknown"`): a client timeout proves
+  neither that the write failed nor that it landed. urllib-wrapped socket
+  timeouts (`URLError("timed out")`) route to the same `TIMEOUT` path instead
+  of `NODE_UNREACHABLE`.
+- **`citadel status` (human view) says when the mesh block is unreachable.**
+  `fetch_mesh` failures were rendered by dropping the whole block, which read
+  as "no mesh data"; it now prints `Knowledge mesh unavailable: <reason>`.
 - **`requires-python` declared Python 3.10 support that never existed.** Seven
   `kb/` modules import `datetime.UTC` (added in 3.11) and the test suite
   imports `tomllib` (3.11 stdlib). Verified against a real 3.10 interpreter:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -290,16 +290,39 @@ async def _ingest(args: argparse.Namespace) -> int:
     token = capture_token()
     if not token:
         return _emit_no_token("ingest", as_json=getattr(args, "json", False))
-    from kb.status import ingest_node
+    from kb.status import _COGNIFY_TIMEOUT, _INGEST_TIMEOUT, ingest_node
 
     # Cognify inline (server-side) by default so the note is immediately
     # searchable; the one request blocks until cognify finishes (--no-cognify skips).
     cognify = not getattr(args, "no_cognify", False)
     as_json = getattr(args, "json", False)
+    timeout_arg = getattr(args, "timeout", None)
+    if timeout_arg is not None:
+        timeout_s = max(1.0, float(timeout_arg))
+    else:
+        timeout_s = _COGNIFY_TIMEOUT if cognify else _INGEST_TIMEOUT
+
+    def _timeout_exit() -> int:
+        # A client timeout proves only that no response arrived in the budget.
+        # It does NOT prove the write failed — the Node may still be processing
+        # (the capture-timeout lesson) — so claim neither outcome.
+        return _emit_error(
+            "ingest",
+            f"no response after {timeout_s:g}s — the Node may still be processing "
+            "(cognify is slow on cold nodes). A client timeout does not prove the "
+            "write failed: check `citadel activity` (or search for the note) to "
+            "confirm, or retry with a longer --timeout.",
+            as_json=as_json,
+            code="TIMEOUT",
+            extra={"timed_out": True, "write_state": "unknown", "timeout_s": timeout_s},
+        )
+
     spinner_msg = "Ingesting + building the graph…" if cognify else "Ingesting to your Node…"
     try:
         with _Spinner(spinner_msg):
-            result = await asyncio.to_thread(ingest_node, base_url, token, args.data, args.tag, cognify)
+            result = await asyncio.to_thread(
+                ingest_node, base_url, token, args.data, args.tag, cognify, timeout=timeout_s
+            )
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:200] if exc.fp else exc.reason
         if not as_json:
@@ -312,15 +335,12 @@ async def _ingest(args: argparse.Namespace) -> int:
             extra={"http_status": exc.code},
         )
     except TimeoutError:
-        return _emit_error(
-            "ingest",
-            "the Node is still working (cognify can be slow). Your note is saved — it'll "
-            "be searchable shortly; check `citadel search`.",
-            as_json=as_json,
-            code="TIMEOUT",
-            extra={"saved": True},
-        )
+        return _timeout_exit()
     except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
+        # urllib wraps connect-phase socket timeouts as URLError("timed out") —
+        # that is a budget expiry, not an unreachable Node.
+        if _is_timeout_exc(exc):
+            return _timeout_exit()
         return _emit_error("ingest", str(exc), as_json=as_json, code="NODE_UNREACHABLE")
     if not isinstance(result, dict):  # a misconfigured Node could return non-dict JSON
         result = {"accepted": False, "reason": "unexpected response from the Node"}
@@ -1656,6 +1676,10 @@ async def _status(args: argparse.Namespace) -> int:
 
 def _render_mesh(mesh: dict[str, Any], color: bool) -> str:
     """Compact knowledge-mesh summary for `citadel status` (the 'your data' view)."""
+    if isinstance(mesh, dict) and mesh.get("error"):
+        # fetch_mesh marks failures as {"error": ...}; dropping the block made
+        # an unreachable mesh endpoint look like "no mesh data".
+        return paint(f"Knowledge mesh unavailable: {mesh['error']}", "yellow", enable=color)
     stats = (mesh or {}).get("stats")
     if not isinstance(stats, dict) or not stats:
         return ""
@@ -1681,7 +1705,11 @@ def _render_mesh(mesh: dict[str, Any], color: bool) -> str:
 
 
 def _render_event(event: dict[str, Any], color: bool) -> str:
-    """One Vault Activity line: `HH:MM  <type>  <message>  (dataset)`."""
+    """One Vault Activity line: `HH:MM  <type>  <message>  (dataset)`.
+
+    Error events also carry which operation failed and its (already redacted)
+    reason — without them every failure renders as a bare "Operation failed".
+    """
     created = str(event.get("created_at") or "")
     stamp = created[11:16] if len(created) >= 16 else created[:5]
     etype = str(event.get("type") or "event")
@@ -1689,6 +1717,13 @@ def _render_event(event: dict[str, Any], color: bool) -> str:
     details = event.get("details") if isinstance(event.get("details"), dict) else {}
     timeline = event.get("timeline") if isinstance(event.get("timeline"), dict) else {}
     dataset = details.get("dataset") or timeline.get("dataset") or ""
+    if etype == "error":
+        operation = str(details.get("operation") or "").strip()
+        reason = " ".join(str(details.get("error") or "").split())[:120]
+        if operation:
+            message = f"{message}: {operation}" if message else operation
+        if reason:
+            message = f"{message} — {reason}" if message else reason
     line = (
         paint(f"{stamp:>5}", "dim", enable=color)
         + "  "
@@ -1744,9 +1779,11 @@ def _render_presence(board: dict[str, Any], color: bool) -> str:
 async def _activity_global(node_url: str, token: str | None, color: bool, watch: bool) -> int:
     """Live team-presence broadcast — Seat Presence only (ADR-0009), no content."""
     board = await asyncio.to_thread(fetch_presence, node_url, token)
+    if board.get("error"):
+        # An unreachable Node must not render as an empty-but-healthy board.
+        print(f"citadel activity: could not reach {node_url} — {board['error']}", file=sys.stderr)
+        return 1
     print(_render_presence(board, color))
-    if not token and not board.get("error") and not board.get("seats"):
-        print(paint("  (no token configured — run `citadel onboard`)", "yellow", enable=color))
     if not watch:
         return 0
     print(paint("— watching team presence (Ctrl-C to stop) —", "dim", enable=color))
@@ -1776,10 +1813,27 @@ async def _activity(args: argparse.Namespace) -> int:
     token = capture_token() or None
     use_color = supports_color()
 
+    if not token:
+        # Without a token the feed (and the presence board) can only ever be
+        # empty — that is an auth gap, not "no activity", so say so with exit 1
+        # (a JSON object under --json) instead of a bare `{}` / quiet feed.
+        return _emit_no_token("activity", as_json=bool(args.json))
+
     if getattr(args, "global_broadcast", False):
         return await _activity_global(node_url, token, use_color, args.watch)
 
     data = await asyncio.to_thread(fetch_events, node_url, token, limit=limit, event_type=args.type)
+    failure = data.get("error") or (None if data else "empty response from the Node")
+    if failure:
+        # fetch_events marks every transport/HTTP failure as {"error": ...}.
+        # Rendering that as "No recent activity." (exit 0) made a node outage
+        # indistinguishable from an empty vault — fail loudly on both surfaces.
+        return _emit_error(
+            "activity",
+            f"could not reach {node_url} — {failure}",
+            as_json=bool(args.json),
+            code="NODE_UNREACHABLE",
+        )
     if args.json and not args.watch:
         _print_json(data)
         return 0
@@ -1793,12 +1847,9 @@ async def _activity(args: argparse.Namespace) -> int:
 
     if not args.watch:
         if not events:
-            if data.get("error"):
-                print(paint(f"Couldn't reach the Node: {data['error']}", "yellow", enable=use_color))
-            else:
-                print(paint("No recent activity.", "dim", enable=use_color))
-                if not token:
-                    print(paint("  (no token configured — run `citadel onboard`)", "yellow", enable=use_color))
+            # The failure paths (no token / unreachable) exited above, so an
+            # empty feed here really is an empty-but-healthy vault.
+            print(paint("No recent activity.", "dim", enable=use_color))
         return 0
 
     print(paint("— watching your Node (Ctrl-C to stop) —", "dim", enable=use_color))
@@ -1904,8 +1955,17 @@ async def _doctor(args: argparse.Namespace) -> int:
         issues.append({"problem": f".mcp.json Node ({mcp_node}) disagrees with capture config ({cap_node})",
                        "fix": f"citadel onboard --node-url {cap_node}"})
 
-    if checks.get("pre_push_hook") and not checks["pre_push_hook"].ok:
-        issues.append({"problem": "git pre-push autosync hook missing", "fix": "citadel doctor --fix", "kind": "pre_push"})
+    hook_check = checks.get("pre_push_hook")
+    if hook_check and not hook_check.ok:
+        if (hook_check.data or {}).get("git_repo") is False:
+            # Not a git repo here — "hook missing" would read as "your hook is
+            # gone" when there was simply nothing to inspect at this cwd.
+            issues.append({
+                "problem": f"pre-push hook not checked — {hook_check.detail}",
+                "fix": "run `citadel doctor` from inside a git repo (or pass --repo)",
+            })
+        else:
+            issues.append({"problem": "git pre-push autosync hook missing", "fix": "citadel doctor --fix", "kind": "pre_push"})
     if checks.get("session_hook") and not checks["session_hook"].ok:
         issues.append({"problem": "Claude SessionEnd/SessionStart hooks missing", "fix": "citadel doctor --fix", "kind": "session"})
     if checks.get("mcp") and not checks["mcp"].ok:
@@ -2886,6 +2946,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-cognify",
         action="store_true",
         help="Skip the post-ingest cognify (faster; data appears in search later)",
+    )
+    ingest.add_argument(
+        "--timeout",
+        type=float,
+        metavar="SECONDS",
+        help="Max seconds to wait for the Node (default: 180 while cognifying, 60 with --no-cognify)",
     )
     ingest.add_argument("--json", action="store_true", help="Machine-readable output")
     ingest.add_argument("--node-url", help="Override Node URL")

--- a/kb/status.py
+++ b/kb/status.py
@@ -619,9 +619,25 @@ def check_local_setup(repo: Path, config_path: Path | None = None) -> list[Check
     )
     checks.append(assess_mcp_setup(repo))
 
-    pre_push = repo / ".git" / "hooks" / "pre-push"
+    # The hook is per-repo, so this check only ever sees the repo it was pointed
+    # at (the cwd's git toplevel by default). Name that repo in the detail —
+    # a bare "missing" from the wrong directory reads as "your hook is gone".
+    git_dir = repo / ".git"
+    is_git_repo = git_dir.exists()
+    pre_push = git_dir / "hooks" / "pre-push"
+    if not is_git_repo:
+        hook_ok = False
+        hook_detail = f"no git repo at {repo} — nothing to inspect (the hook is per-repo)"
+    else:
+        hook_ok = pre_push.exists()
+        hook_detail = f"installed ({repo})" if hook_ok else f"missing in {repo}"
     checks.append(
-        Check("pre_push_hook", ok=pre_push.exists(), detail="installed" if pre_push.exists() else "missing")
+        Check(
+            "pre_push_hook",
+            ok=hook_ok,
+            detail=hook_detail,
+            data={"repo": str(repo), "git_repo": is_git_repo},
+        )
     )
 
     # Session hooks live in user-scope ~/.claude/settings.json (cross-repo), not

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1022,3 +1022,99 @@ def test_token_create_standalone_flags_skip_picker_on_tty(monkeypatch, capsys) -
     assert calls["standalone"]["role"] == "writer"
     assert calls["standalone"]["expires_at"] == "2027-01-01T00:00:00Z"
     assert "seat" not in calls
+
+
+# ---- citadel ingest --timeout / honest expiry ---------------------------------
+
+
+def test_ingest_timeout_flag_reaches_request(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, *, timeout=None):
+        seen["timeout"] = timeout
+        return {"accepted": True, "dataset": "seat:alice"}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
+    rc = asyncio.run(_ingest(_ingest_args(timeout=5)))
+    assert rc == 0
+    assert seen["timeout"] == 5.0
+
+
+def test_ingest_timeout_does_not_claim_an_outcome(monkeypatch, capsys) -> None:
+    # A client timeout proves only that no response arrived in the budget — the
+    # write may or may not have landed. The old message claimed "Your note is
+    # saved" (and `saved: true`), which nothing verified.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+
+    def boom(*_a, **_k):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr("kb.status.ingest_node", boom)
+    rc = asyncio.run(_ingest(_ingest_args(timeout=2)))
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["code"] == "TIMEOUT"
+    assert out["write_state"] == "unknown"
+    assert "saved" not in out
+    assert "not prove" in out["error"]
+
+
+def test_ingest_timeout_plain_mode_is_honest(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+
+    def boom(*_a, **_k):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr("kb.status.ingest_node", boom)
+    rc = asyncio.run(_ingest(_ingest_args(json=False, timeout=2)))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "not prove" in captured.err
+    assert "is saved" not in captured.err
+    assert "is saved" not in captured.out
+
+
+def test_ingest_wrapped_socket_timeout_is_a_timeout(monkeypatch, capsys) -> None:
+    # urllib wraps connect-phase socket timeouts as URLError("timed out") — that
+    # is a budget expiry, not an unreachable Node, and must say so.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+
+    def boom(*_a, **_k):
+        raise urllib.error.URLError("urlopen error timed out")
+
+    monkeypatch.setattr("kb.status.ingest_node", boom)
+    rc = asyncio.run(_ingest(_ingest_args()))
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "TIMEOUT"
+
+
+def test_doctor_pre_push_from_non_repo_says_so(tmp_path: Path, monkeypatch, capsys) -> None:
+    # From a cwd with no git repo, doctor must not report "hook missing" —
+    # that reads as "your hook is gone" when there was simply nothing to inspect.
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_x")
+    checks = [
+        Check("node", True, "healthy"),
+        Check("auth", True, "valid"),
+        Check("mcp", True, "present"),
+        Check(
+            "pre_push_hook",
+            False,
+            f"no git repo at {tmp_path} — nothing to inspect (the hook is per-repo)",
+            data={"repo": str(tmp_path), "git_repo": False},
+        ),
+        Check("session_hook", True, "installed"),
+        Check("capture_roots", True, "none"),
+    ]
+    monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(checks))
+    args = argparse.Namespace(
+        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
+        node_url=None, json=True, fix=False,
+    )
+    rc = asyncio.run(_doctor(args))
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert not any("hook missing" in i["problem"] for i in out["issues"])
+    assert any("no git repo" in i["problem"] for i in out["issues"])

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -658,3 +658,144 @@ def test_render_presence_board_sorts_by_count() -> None:
     assert "seat:sarthi" in out
     assert "23 docs" in out
     assert out.index("masumi-network") < out.index("seat:sarthi")
+
+
+# --- CLI fails loudly: activity / mesh / pre-push hook honesty ---------------
+
+
+def _activity_args(**kw) -> argparse.Namespace:
+    base = dict(
+        limit=20, local=False, config=None, node_url="https://node.example",
+        json=True, watch=False, type=None, global_broadcast=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_render_event_error_shows_operation_and_reason() -> None:
+    # `record_error` stores the operation + redacted reason in details; a bare
+    # "Operation failed" line is unactionable, so both must reach the feed.
+    from kb.cli import _render_event
+
+    event = {
+        "id": 6,
+        "type": "error",
+        "message": "Operation failed",
+        "details": {"operation": "search", "error": "DatasetNotFoundError:\n  no default dataset"},
+        "created_at": "2026-07-16T15:38:02Z",
+    }
+    line = _render_event(event, color=False)
+    assert "search" in line
+    # Newlines are collapsed so one event stays one line.
+    assert "DatasetNotFoundError: no default dataset" in line
+    assert "\n" not in line
+
+
+def test_activity_without_token_errors_as_json(monkeypatch, capsys) -> None:
+    # --json must stay machine-readable on the failure path: a bare `{}` with
+    # exit 0 reads as "no activity" when the real cause is a missing token.
+    from kb import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "capture_token", lambda: "")
+    code = asyncio.run(cli_mod._activity(_activity_args()))
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert "token" in payload["error"].lower()
+
+
+def test_activity_reports_unreachable_node_as_failure_json(monkeypatch, capsys) -> None:
+    # fetch_events marks transport errors as {"error": ...}; an outage must not
+    # render as an empty-but-healthy vault (exit 0).
+    from kb import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "capture_token", lambda: "ctdl_tok")
+    monkeypatch.setattr(cli_mod, "fetch_events", lambda *a, **k: {"error": "connection refused"})
+    code = asyncio.run(cli_mod._activity(_activity_args()))
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert "node.example" in payload["error"]
+
+
+def test_activity_unreachable_plain_prints_stderr_and_exits_one(monkeypatch, capsys) -> None:
+    from kb import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "capture_token", lambda: "ctdl_tok")
+    monkeypatch.setattr(cli_mod, "fetch_events", lambda *a, **k: {"error": "connection refused"})
+    code = asyncio.run(cli_mod._activity(_activity_args(json=False)))
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "could not reach" in captured.err
+    assert "No recent activity" not in captured.out
+
+
+def test_activity_empty_vault_still_exits_zero(monkeypatch, capsys) -> None:
+    # An outage must be loud, but a genuinely empty feed stays a quiet success —
+    # the two must never collapse into one another.
+    from kb import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "capture_token", lambda: "ctdl_tok")
+    monkeypatch.setattr(
+        cli_mod, "fetch_events", lambda *a, **k: {"events": [], "latest_event_id": 0}
+    )
+    code = asyncio.run(cli_mod._activity(_activity_args(json=False)))
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "No recent activity" in captured.out
+
+    code = asyncio.run(cli_mod._activity(_activity_args()))
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["events"] == []
+
+
+def test_activity_global_unreachable_exits_one(monkeypatch, capsys) -> None:
+    from kb import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "capture_token", lambda: "ctdl_tok")
+    monkeypatch.setattr(cli_mod, "fetch_presence", lambda *a, **k: {"error": "no route to host"})
+    code = asyncio.run(cli_mod._activity(_activity_args(json=False, global_broadcast=True)))
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "no route to host" in captured.err
+
+
+def test_render_mesh_shows_unreachable_error() -> None:
+    # fetch_mesh marks failures as {"error": ...}; the human status view used to
+    # drop the whole block, which read as "no mesh data" instead of an outage.
+    from kb.cli import _render_mesh
+
+    out = _render_mesh({"error": "no route to host"}, color=False)
+    assert "no route to host" in out
+
+
+def test_pre_push_check_names_inspected_repo(tmp_path: Path) -> None:
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    (tmp_path / ".git" / "hooks" / "pre-push").write_text("#!/bin/sh\n")
+    checks = {c.name: c for c in check_local_setup(tmp_path, tmp_path / "cap.json")}
+    hook = checks["pre_push_hook"]
+    assert hook.ok
+    assert str(tmp_path) in hook.detail
+    assert hook.data["git_repo"] is True
+
+
+def test_pre_push_check_missing_names_repo(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    checks = {c.name: c for c in check_local_setup(tmp_path, tmp_path / "cap.json")}
+    hook = checks["pre_push_hook"]
+    assert not hook.ok
+    assert "missing" in hook.detail
+    assert str(tmp_path) in hook.detail
+    assert hook.data["git_repo"] is True
+
+
+def test_pre_push_check_distinguishes_no_git_repo(tmp_path: Path) -> None:
+    # From a cwd with no .git the hook cannot be inspected at all — the check
+    # must say that plainly, never "missing" (which reads as "your hook is gone").
+    checks = {c.name: c for c in check_local_setup(tmp_path, tmp_path / "cap.json")}
+    hook = checks["pre_push_hook"]
+    assert not hook.ok
+    assert "no git repo" in hook.detail
+    assert str(tmp_path) in hook.detail
+    assert hook.data["git_repo"] is False


### PR DESCRIPTION
`citadel activity` exited 0 when the node was unreachable, making an outage indistinguishable from an empty vault. Ports the never-merged fix forward and audits the same class across the CLI.

- Unreachable node now exits non-zero with the error visible in both plain and `--json` output; an empty vault stays distinguishable from an outage and from a missing token.
- `pre_push_hook` status names the repository it inspected instead of implying the hook is gone.
- `citadel ingest` gains a bounded, configurable timeout with an honest message on expiry.

Fixes #223