### PR TITLE
fix(capture): pre-push receipt records the server's decision

### DIFF
--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -328,7 +328,14 @@ def build_tags(cwd: str, branch: str = "") -> list[str]:
     return tags
 
 
-def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> None:
+def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[str, Any] | None:
+    """POST {data, tags} to {base}/ingest over HTTPS. No dataset field.
+
+    Returns the parsed JSON response body (or ``None`` when the 2xx body is not
+    a JSON object): a 2xx alone is not proof of storage, because the server
+    states its decision in the body's ``accepted``/``reason`` fields and the
+    receipt must record that decision, not the transport outcome.
+    """
     if not base_url.lower().startswith("https://"):
         raise ValueError("refusing non-HTTPS Citadel base URL")
     url = f"{base_url}/ingest"
@@ -343,7 +350,45 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> None:
         },
     )
     with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-        response.read()
+        raw = response.read()
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def receipt_summary(response: dict[str, Any] | None, *, short_sha: str, branch: str) -> str:
+    """Receipt line for a completed POST, mirroring the server's decision."""
+    if response is None:
+        return f"commit {short_sha} sent: server replied 2xx but the response body was unreadable"
+    if response.get("accepted") is not False:
+        return f"captured commit {short_sha} on {branch} → your Node"
+    reason = response.get("reason") or "rejected"
+    return f"commit {short_sha} not stored: server rejected the write ({reason})"
+
+
+def _send_failure_summary(exc: BaseException, *, short_sha: str) -> str:
+    """Receipt line for a POST that raised before a response was read."""
+    if isinstance(exc, TimeoutError) or isinstance(getattr(exc, "reason", None), TimeoutError):
+        # A client timeout is not proof of failure: the server can finish the
+        # write after the deadline, so the honest verdict is "unconfirmed".
+        return (
+            f"commit {short_sha} capture unconfirmed: no response within "
+            f"{HTTP_TIMEOUT_SECONDS}s; the write may still have completed on the server"
+        )
+    # Class name only: an exception message could echo request details.
+    return f"commit {short_sha} not captured: send failed ({exc.__class__.__name__})"
+
+
+def _write_receipt(summary: str) -> None:
+    """Best-effort DX-5 receipt (never raises, never surfaces the token)."""
+    try:
+        from kb.hooks.receipt import write_receipt
+
+        write_receipt("push", summary)
+    except Exception:
+        pass
 
 
 def _sync_one(
@@ -371,12 +416,16 @@ def _sync_one(
     for tag in capture_tags:
         if tag not in tags:
             tags.append(tag)
-    post_ingest(_base_url(), token, note, tags)
-    # DX-5 receipt: make the silent capture visible. write_receipt never raises,
-    # and any import/call failure is caught by run()'s fail-silent except.
-    from kb.hooks.receipt import write_receipt
-
-    write_receipt("push", f"captured commit {sha[:7]} on {branch} → your Node")
+    # DX-5 receipt: make the silent capture visible AND truthful. The receipt
+    # records what the server said (or that we cannot know), never an
+    # unconditional "captured". A failed send is recorded here rather than
+    # raised, so one bad ref still leaves a receipt and never blocks the push.
+    try:
+        response = post_ingest(_base_url(), token, note, tags)
+    except Exception as exc:
+        _write_receipt(_send_failure_summary(exc, short_sha=sha[:7]))
+        return
+    _write_receipt(receipt_summary(response, short_sha=sha[:7], branch=branch))
 
 
 def run(stdin: Any, remote_name: str = "") -> int:

--- a/tests/test_sync_push.py
+++ b/tests/test_sync_push.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import urllib.error
 from pathlib import Path
 from typing import Any
 
@@ -259,3 +260,155 @@ def test_run_captures_approved_repo_with_root_tags(monkeypatch: Any, tmp_path: P
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert len(calls) == 1
     assert calls[0]["capture_tags"] == ["org-work"]
+
+
+# --- receipts tell the truth about what the server decided -------------------
+
+
+_PUSH_STDIN = (
+    "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
+)
+
+
+def _approve_repo_for_real_sync(monkeypatch: Any, tmp_path: Path) -> None:
+    """Approve /tmp/repo and stub git so _sync_one runs for real up to the POST."""
+    config = tmp_path / "capture.json"
+    _write_capture_config(config, [{"path": "/tmp/repo", "tags": []}])
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(config))
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/repo")
+    monkeypatch.setattr(
+        sync_push,
+        "build_commit_snapshot",
+        lambda *args, **kwargs: "# Git commit snapshot\n\n**test**",
+    )
+    monkeypatch.setattr(sync_push, "build_tags", lambda cwd, branch="": ["git-push"])
+
+
+def _fake_urlopen_with_body(monkeypatch: Any, body: bytes) -> None:
+    class _Resp:
+        def __enter__(self) -> "_Resp":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return body
+
+    monkeypatch.setattr(
+        sync_push.urllib.request, "urlopen", lambda request, timeout=None: _Resp()
+    )
+
+
+def _receipt_text() -> str:
+    from kb.hooks.receipt import activity_log_path
+
+    path = activity_log_path()
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_receipt_on_accepted_says_captured(monkeypatch: Any, tmp_path: Path) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(
+        monkeypatch,
+        json.dumps({"accepted": True, "reason": "accepted", "cognee_result": {}}).encode(),
+    )
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "captured commit abcdef0" in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_records_rejection_not_capture(monkeypatch: Any, tmp_path: Path) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(
+        monkeypatch,
+        json.dumps(
+            {
+                "accepted": False,
+                "reason": "duplicate_in_process",
+                "dataset": "seat:test",
+                "tags": ["git-push"],
+                "cognee_result": None,
+            }
+        ).encode(),
+    )
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "not stored" in receipt
+    assert "duplicate_in_process" in receipt
+    assert "captured commit" not in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_on_unreadable_body_does_not_claim_capture(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(monkeypatch, b"not json")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "unreadable" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_receipt_on_timeout_says_write_may_have_completed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+
+    def boom(request: Any, timeout: int | None = None) -> None:
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr(sync_push.urllib.request, "urlopen", boom)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "may still have completed" in receipt
+    assert "captured commit" not in receipt
+    assert "ctdl_test_token" not in receipt
+
+
+def test_receipt_on_wrapped_timeout_says_write_may_have_completed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    # urllib wraps a connect timeout as URLError(reason=TimeoutError).
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+
+    def boom(request: Any, timeout: int | None = None) -> None:
+        raise urllib.error.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(sync_push.urllib.request, "urlopen", boom)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "may still have completed" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_receipt_on_send_failure_names_class_only(monkeypatch: Any, tmp_path: Path) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+
+    def boom(request: Any, timeout: int | None = None) -> None:
+        raise RuntimeError("boom with sensitive detail")
+
+    monkeypatch.setattr(sync_push.urllib.request, "urlopen", boom)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "not captured" in receipt
+    assert "RuntimeError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "captured commit" not in receipt
+
+
+def test_unreachable_node_still_exits_zero(monkeypatch: Any, tmp_path: Path) -> None:
+    # The pre-push hook must never block a `git push`, whatever the network does.
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+
+    def boom(request: Any, timeout: int | None = None) -> None:
+        raise urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+
+    monkeypatch.setattr(sync_push.urllib.request, "urlopen", boom)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "not captured" in receipt
+    assert "captured commit" not in receipt


### PR DESCRIPTION
The pre-push hook wrote a "captured commit" receipt after any 2xx without reading the response, and left no receipt at all when the send raised.

The receipt now distinguishes captured, not stored (with the server's reason), unconfirmed after a timeout, and not captured. The hook remains fail-silent and always exits 0. Mirrors the SessionEnd hook's vocabulary.

Refs #222 — the pre-push half of the same reporting defect.