### PR TITLE
fix(webui): serve the theme bootstrap; drop the unused style-src relaxation

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -598,25 +598,25 @@ def _content_security_policy(style_src: str) -> str:
 
 CONTENT_SECURITY_POLICY = _content_security_policy("'self'")
 
-# The landing page carries an interactive pipeline diagram built on React Flow,
-# which positions every node and the viewport by writing an inline `transform`
-# style attribute. That is not something the library can be configured out of,
-# so the one page that renders it gets 'unsafe-inline' for styles and nothing
-# else. Script execution stays restricted to same-origin files on every page.
+# The relaxed variant is kept so a page can only ever reach it through the
+# explicit opt-in set below, never by accident. No page uses it today.
+#
+# The landing page's React Flow diagram was the one candidate: it positions
+# every node and the viewport by writing inline `transform` styles, and the
+# library cannot be configured out of that. But it writes them through the
+# CSSOM (element.style), which style-src does not govern; the directive
+# covers <style> elements and style attributes arriving in markup. Measured
+# before the exemption was removed: under style-src 'self' the diagram
+# rendered identically, with zero securitypolicyviolation events (Chrome;
+# the CSSOM carve-out is spec behaviour). Script execution stays restricted
+# to same-origin files on every page under both policies.
 CONTENT_SECURITY_POLICY_INLINE_STYLE = _content_security_policy("'self' 'unsafe-inline'")
 
 # Exact paths, not prefixes, and this set is the only way to reach the relaxed
-# policy. Everything absent from it (/app, /login, /info, /use-cases, /contact,
-# every API route, every static file) gets the strict policy above.
-# Exact paths, not prefixes, and this set is the only way to reach the relaxed
-# policy. Everything absent from it (/app, /login, /info, /use-cases, /contact,
-# every API route, every static file) gets the strict policy above.
-#
-# Only / is here, because only / renders the React Flow pipeline diagram, which
-# positions its nodes with inline `transform` styles and cannot be configured
-# out of it. The page holds no token and no user data, which is why this is an
-# acceptable trade there and would not be on /app or /login.
-CSP_INLINE_STYLE_PATHS: frozenset[str] = frozenset({"/"})
+# policy. It is empty: every route, / and its React Flow diagram included,
+# gets the strict policy above. Adding a path here is a security decision;
+# the tests pin this set so it cannot grow in passing.
+CSP_INLINE_STYLE_PATHS: frozenset[str] = frozenset()
 
 
 def content_security_policy_for(path: str) -> str:

--- a/kb/server.py
+++ b/kb/server.py
@@ -2959,6 +2959,23 @@ async def next_app_view(view: str, request: Request) -> Response:
     return next_app_page(request, f"app/{view}", minimum_role)
 
 
+# The theme bootstrap. Every exported page loads it from <head> before paint,
+# but it is neither a page (the `{page}` allow-list below serves HTML by exact
+# name and stays closed to other filenames) nor a build asset (the static
+# mount covers only /next/_next). So: one literal route, no path parameter.
+#
+# The media type is pinned rather than guessed from the filename, because the
+# site sends X-Content-Type-Options: nosniff and a browser refuses to execute
+# a script that arrives as anything but JavaScript.
+@app.get("/next/theme.js", include_in_schema=False)
+async def next_theme_js() -> FileResponse:
+    script = WEBUI_DIR / "theme.js"
+    if not script.is_file():
+        # A source checkout that has not run `npm run build:web`.
+        raise HTTPException(status_code=404, detail="Not Found")
+    return FileResponse(script, media_type="text/javascript; charset=utf-8")
+
+
 # The rebuilt public pages, one preview route each. Exact names, not a path
 # parameter used as a filename: the export is a directory and "../" is a
 # filename too.

--- a/tests/test_next_preview.py
+++ b/tests/test_next_preview.py
@@ -86,6 +86,36 @@ def test_the_preview_route_set_is_closed() -> None:
         assert client.get(path).status_code == 404, path
 
 
+def test_the_theme_bootstrap_is_served_as_executable_javascript() -> None:
+    """Every exported page loads /next/theme.js from <head>, before paint.
+
+    The site sends X-Content-Type-Options: nosniff, so the browser executes
+    this file only if it arrives with a JavaScript media type. Anything else
+    (the JSON body of a 404 included) is refused, the bootstrap never runs,
+    and a visitor whose remembered choice is dark gets light on every /next
+    page while the live pages still honour it.
+    """
+    client = _client()
+
+    response = client.get("/next/theme.js")
+
+    assert response.status_code == 200
+    media_type = response.headers["content-type"].split(";")[0].strip()
+    assert media_type in {"text/javascript", "application/javascript"}
+    assert response.content == (server_module.WEBUI_DIR / "theme.js").read_bytes()
+
+    # The route is one literal filename, not a pattern: the page allow-list
+    # below it stays closed to every other name.
+    assert client.get("/next/theme.css").status_code == 404
+    assert client.get("/next/landing.js").status_code == 404
+
+    # And every exported document really does depend on it.
+    for page in _exported_html():
+        assert 'src="/next/theme.js"' in page.read_text(encoding="utf-8"), (
+            f"{page.name} does not load the theme bootstrap"
+        )
+
+
 def test_the_landing_preview_ships_its_diagram_as_markup() -> None:
     """The React Flow bundle is a few hundred kilobytes and is fetched only when
     the diagram scrolls into view, so the document has to carry a correct

--- a/tests/test_next_preview.py
+++ b/tests/test_next_preview.py
@@ -69,9 +69,8 @@ def test_every_preview_route_is_served_under_the_strict_policy() -> None:
         assert "object-src 'none'" in policy, path
 
     # No preview path is in the one opt-in list that can relax the policy, and
-    # none may join it: the pages they preview include the page that holds the
-    # opt-in today, so this is exactly where it would be copied across by
-    # reflex.
+    # none may join it. The list is empty today; while / held the opt-in, this
+    # is exactly where it would have been copied across by reflex.
     assert not any(
         path.startswith("/next") for path in server_module.CSP_INLINE_STYLE_PATHS
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -305,37 +305,44 @@ def test_security_headers_are_applied_to_http_responses() -> None:
     )
 
 
-def test_only_the_landing_page_relaxes_style_src() -> None:
-    """/ is the single route allowed inline styles. Everything else is strict.
+def test_no_path_relaxes_style_src() -> None:
+    """Every route, / included, is served under the strict style-src.
 
-    The landing page renders a React Flow diagram, which positions nodes by
-    writing inline transform styles and cannot be configured out of it. That
-    buys exactly one directive on exactly one path, and / holds no token and no
-    user data. If this ever fails on a path other than /, a page has inherited
-    the relaxation, which is how a per-route exception becomes a site-wide one.
+    / renders a React Flow diagram that positions nodes by writing inline
+    `transform` styles, and for a while that bought it the site's one
+    'unsafe-inline' exemption. The exemption protected nothing: React writes
+    those transforms through the CSSOM (element.style), which style-src does
+    not govern. The directive covers <style> elements and style attributes
+    arriving in markup. With the exemption removed, the diagram rendered
+    identically and no securitypolicyviolation fired (measured in Chrome; the
+    CSSOM carve-out is spec behaviour). So / is pinned strict here alongside
+    everything else, and most deliberately of all: it is the one path that
+    would drift back.
     """
     client = authed_client()
 
-    relaxed = "style-src 'self' 'unsafe-inline';"
     strict = "style-src 'self';"
 
-    landing = client.get("/").headers["content-security-policy"]
-    assert relaxed in landing
-    assert strict not in landing
-    # Nothing else moved. Script execution in particular is untouched, so the
-    # exemption cannot be parlayed into running code.
-    assert "script-src 'self';" in landing
-    assert "default-src 'self';" in landing
-    assert "object-src 'none'" in landing
-
-    for path in ("/login", "/app", "/info", "/use-cases", "/contact", "/healthz", "/api/state"):
+    for path in (
+        "/",
+        "/login",
+        "/app",
+        "/info",
+        "/use-cases",
+        "/contact",
+        "/healthz",
+        "/api/state",
+    ):
         policy = client.get(path).headers["content-security-policy"]
         assert strict in policy, f"{path} lost the strict style-src"
-        assert "'unsafe-inline'" not in policy, f"{path} inherited the / relaxation"
+        assert "'unsafe-inline'" not in policy, f"{path} carries an inline-style relaxation"
+        # Script execution stays restricted to same-origin files everywhere.
+        assert "script-src 'self';" in policy, path
 
-    assert server_module.CSP_INLINE_STYLE_PATHS == frozenset({"/"}), (
+    assert server_module.CSP_INLINE_STYLE_PATHS == frozenset(), (
         "Adding a path here is a security decision. Update this test "
-        "deliberately, and check the page really renders something that needs it."
+        "deliberately, and check the page really renders something style-src "
+        "governs: inline styles written through the CSSOM are not it."
     )
 
 


### PR DESCRIPTION
Two independent commits.

1. `/next/theme.js` returned a JSON 404, so the remembered theme was never re-applied on any `/next` page and a dark-mode visitor got light on every navigation. It is now served with a JavaScript content type, without widening the page allowlist.

2. `/` carried a `style-src 'unsafe-inline'` relaxation for the pipeline diagram. Verified unnecessary: with the relaxation removed, the diagram renders identically with zero policy violations, because the library writes transforms through the CSSOM, which `style-src` does not govern. The test now pins `/` to the strict policy.

Fixes #225