### PR TITLE
feat(api): GET /api/corpus, a paginated corpus census with presence flags

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import contextvars
+import json
 import logging
 import os
 from collections.abc import Iterator
+from datetime import datetime, timezone
 from time import monotonic, perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
@@ -25,6 +27,47 @@ def _float_env(name: str, default: float) -> float:
         return float(raw)
     except ValueError:
         return default
+
+
+def _utc_datetime(value: datetime) -> datetime:
+    """Treat a naive timestamp as UTC.
+
+    Postgres returns ``data.created_at`` timezone-aware; sqlite (the test and
+    default local store) drops the offset and returns it naive. Every write
+    path stamps UTC, so pinning naive values to UTC keeps cursor comparisons
+    from mixing naive and aware datetimes (which raises) or shifting rows by a
+    local offset.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _isoformat_utc(value: Any) -> str | None:
+    if not isinstance(value, datetime):
+        return None
+    return _utc_datetime(value).isoformat()
+
+
+def _parse_citadel_tags(external_metadata: Any) -> list[str]:
+    """Our tags out of cognee's external_metadata, [] when absent or malformed.
+
+    cognee itself stores this column as a dict but tolerates JSON strings on
+    read (``parse_external_metadata``), so accept both. Display-only: a row
+    whose metadata does not parse still enumerates, just without tags.
+    """
+    metadata = external_metadata
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (ValueError, TypeError):
+            return []
+    if not isinstance(metadata, dict):
+        return []
+    tags = metadata.get("citadel_tags")
+    if not isinstance(tags, list):
+        return []
+    return [str(tag) for tag in tags]
 
 
 # Dataset-attribution tuning (#50): /api/mesh/graph calls node_dataset_map on
@@ -85,6 +128,56 @@ def assert_cognee_dataset_api() -> None:
             raise RuntimeError(
                 f"cognee {model.__name__} no longer declares data_ingestion_info; "
                 "kb.repo_content_sync._cognee_data_ids needs updating"
+            )
+
+    # The corpus census (corpus_page / corpus_totals / corpus_chunk_counts /
+    # corpus_graph_presence) leans on more private surface than dataset
+    # attribution does: specific Data/Dataset/DatasetData columns, the pgvector
+    # adapter's table reflection + session, and the graph adapter's batched
+    # node lookup. Pin each one so a cognee bump that moves any of them fails
+    # loudly at boot and in CI instead of quietly breaking the census.
+    from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+    from cognee.infrastructure.databases.vector import get_vector_engine  # noqa: F401
+    from cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter import (
+        PGVectorAdapter,
+    )
+    from cognee.modules.data.models import Data
+
+    for model, required in (
+        (
+            Data,
+            {
+                "id",
+                "name",
+                "content_hash",
+                "raw_content_hash",
+                "mime_type",
+                "external_metadata",
+                "token_count",
+                "data_size",
+                "created_at",
+                "updated_at",
+                "owner_id",
+            },
+        ),
+        (Dataset, {"id", "name", "owner_id"}),
+        (DatasetData, {"dataset_id", "data_id"}),
+    ):
+        missing = required - set(model.__table__.c.keys())
+        if missing:
+            raise RuntimeError(
+                f"cognee {model.__name__} table no longer carries {sorted(missing)}; "
+                "the kb.cognee_client corpus census needs updating"
+            )
+    for adapter, method_name in (
+        (PGVectorAdapter, "get_table"),
+        (PGVectorAdapter, "get_async_session"),
+        (LadybugAdapter, "get_nodes"),
+    ):
+        if not callable(getattr(adapter, method_name, None)):
+            raise RuntimeError(
+                f"cognee {adapter.__name__} no longer exposes {method_name}; "
+                "the kb.cognee_client corpus census needs updating"
             )
 
 
@@ -777,6 +870,236 @@ class CogneePublicClient:
             for dataset_name, total in rows.all():
                 counts[str(dataset_name)] = int(total or 0)
         return counts
+
+    async def corpus_page(
+        self,
+        *,
+        after_created_at: str | None = None,
+        after_id: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """One keyset page of the relational corpus, ordered by (created_at, id).
+
+        The ``data`` table is the durable record of everything cognee accepted,
+        so it is the only store a row-level census can enumerate: the graph
+        endpoint caps at 1000 nodes and per-source "documents" counters are
+        sync bookkeeping, not corpus rows. Deliberately NOT filtered by
+        ``get_default_user()`` like the attribution reads above — an
+        owner-scoped census would silently drop rows held by another owner_id;
+        ``corpus_totals`` reports that split instead.
+
+        Keyset over (created_at, id) rather than OFFSET so a deep page does not
+        rescan everything before it. Both cursor parts cross this boundary as
+        strings (ISO timestamp, str UUID) like every other id in this module;
+        rows come back with ISO UTC timestamps, dataset names batched in via
+        one join query per page, and ``citadel_tags`` parsed out of
+        ``external_metadata`` (empty list when absent or unparseable).
+        """
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.data.models import Data, Dataset, DatasetData
+
+        from sqlalchemy import and_, or_, select
+
+        query = select(
+            Data.id,
+            Data.name,
+            Data.content_hash,
+            Data.raw_content_hash,
+            Data.mime_type,
+            Data.token_count,
+            Data.data_size,
+            Data.created_at,
+            Data.updated_at,
+            Data.owner_id,
+            Data.external_metadata,
+        ).order_by(Data.created_at.asc(), Data.id.asc())
+        if after_created_at and after_id:
+            after_dt = _utc_datetime(datetime.fromisoformat(after_created_at))
+            after_uuid = UUID(after_id)
+            query = query.where(
+                or_(
+                    Data.created_at > after_dt,
+                    and_(Data.created_at == after_dt, Data.id > after_uuid),
+                )
+            )
+        query = query.limit(max(1, int(limit)))
+
+        engine = get_relational_engine()
+        rows: list[dict[str, Any]] = []
+        async with engine.get_async_session() as session:
+            for row in (await session.execute(query)).all():
+                rows.append(
+                    {
+                        "id": str(row.id),
+                        "name": row.name,
+                        "content_hash": row.content_hash,
+                        "raw_content_hash": row.raw_content_hash,
+                        "mime_type": row.mime_type,
+                        "token_count": row.token_count,
+                        "data_size": row.data_size,
+                        "created_at": _isoformat_utc(row.created_at),
+                        "updated_at": _isoformat_utc(row.updated_at),
+                        "owner_id": str(row.owner_id) if row.owner_id else None,
+                        "datasets": [],
+                        "citadel_tags": _parse_citadel_tags(row.external_metadata),
+                    }
+                )
+            if rows:
+                # Dataset names for the whole page in one join query, unscoped
+                # for the same reason as the page itself.
+                membership = await session.execute(
+                    select(DatasetData.data_id, Dataset.name)
+                    .join(Dataset, Dataset.id == DatasetData.dataset_id)
+                    .where(
+                        DatasetData.data_id.in_([UUID(row["id"]) for row in rows])
+                    )
+                )
+                names_by_id: dict[str, list[str]] = {}
+                for data_id, dataset_name in membership.all():
+                    names_by_id.setdefault(str(data_id), []).append(str(dataset_name))
+                for row in rows:
+                    row["datasets"] = sorted(names_by_id.get(row["id"], []))
+        return rows
+
+    async def corpus_totals(self) -> dict[str, Any]:
+        """Corpus row counts, both unscoped and scoped to the default owner.
+
+        The attribution reads above filter by ``get_default_user().id``. The
+        census must not inherit that silently: rows under another owner_id
+        would vanish from a scoped count with nothing saying so. Return both
+        and let the endpoint surface the difference.
+        """
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.data.models import Data, Dataset, DatasetData
+        from cognee.modules.users.methods import get_default_user
+
+        from sqlalchemy import func, select
+
+        user = await get_default_user()
+        engine = get_relational_engine()
+        async with engine.get_async_session() as session:
+            documents = int(
+                (await session.execute(select(func.count()).select_from(Data))).scalar()
+                or 0
+            )
+            documents_default_owner = int(
+                (
+                    await session.execute(
+                        select(func.count())
+                        .select_from(Data)
+                        .where(Data.owner_id == user.id)
+                    )
+                ).scalar()
+                or 0
+            )
+            by_dataset_query = select(
+                Dataset.name, func.count(DatasetData.data_id)
+            ).join(Dataset, Dataset.id == DatasetData.dataset_id)
+            by_dataset = {
+                str(name): int(total or 0)
+                for name, total in (
+                    await session.execute(by_dataset_query.group_by(Dataset.name))
+                ).all()
+            }
+            by_dataset_default_owner = {
+                str(name): int(total or 0)
+                for name, total in (
+                    await session.execute(
+                        by_dataset_query.where(Dataset.owner_id == user.id).group_by(
+                            Dataset.name
+                        )
+                    )
+                ).all()
+            }
+        return {
+            "documents": documents,
+            "documents_default_owner": documents_default_owner,
+            "documents_other_owners": documents - documents_default_owner,
+            "by_dataset": by_dataset,
+            "by_dataset_default_owner": by_dataset_default_owner,
+        }
+
+    async def corpus_chunk_counts(
+        self, document_ids: list[str]
+    ) -> dict[str, int] | None:
+        """Chunk rows per document from the vector store; None when not measured.
+
+        None and 0 are different answers: 0 claims cognee accepted a document
+        and indexed no chunk for it, None says this node could not look (the
+        provider is not pgvector, so there is no chunk table to count). A
+        MISSING chunk collection, by contrast, is a real measurement — nothing
+        was ever indexed — and returns an empty mapping (absent id = 0).
+
+        One grouped query per page over the ``DocumentChunk_text`` collection,
+        keyed on the ``document_id`` each chunk row carries in its payload; the
+        ids are compared as strings because that is how the payload stores them.
+        """
+        if not document_ids:
+            return {}
+        self._prepare_cognee_environment()
+        if os.getenv("VECTOR_DB_PROVIDER", "").lower() != "pgvector":
+            return None
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector.exceptions import (
+            CollectionNotFoundError,
+        )
+
+        from sqlalchemy import func, select
+
+        engine = get_vector_engine()
+        try:
+            table = await engine.get_table("DocumentChunk_text")
+        except CollectionNotFoundError:
+            return {}
+
+        payload_document_id = table.c.payload["document_id"].as_string()
+        wanted = [str(document_id) for document_id in document_ids]
+        counts: dict[str, int] = {}
+        async with engine.get_async_session() as session:
+            grouped = await session.execute(
+                select(payload_document_id, func.count())
+                .where(payload_document_id.in_(wanted))
+                .group_by(payload_document_id)
+            )
+            for document_id, total in grouped.all():
+                if document_id:
+                    counts[str(document_id)] = int(total or 0)
+        return counts
+
+    async def corpus_graph_presence(self, document_ids: list[str]) -> set[str] | None:
+        """Which of these document ids exist as graph nodes; None when not measured.
+
+        A document graph node's id equals the relational ``Data.id``, so
+        presence here means the document was cognified, not merely accepted.
+        Uses the engine's batched ``get_nodes`` (one query per page) through
+        ``get_graph_engine()`` — never the graph file directly, which would
+        contend with the single writer — and passes str ids. An engine without
+        ``get_nodes`` returns None rather than pretending it looked.
+        """
+        if not document_ids:
+            return set()
+        engine = await self._graph_engine()
+        get_nodes = getattr(engine, "get_nodes", None)
+        if not callable(get_nodes):
+            return None
+        nodes = await get_nodes([str(document_id) for document_id in document_ids])
+        present: set[str] = set()
+        for node in nodes or []:
+            node_id = node.get("id") if isinstance(node, dict) else None
+            if node_id:
+                present.add(str(node_id))
+        return present
 
     async def ensure_dataset(self, name: str) -> bool:
         """Provision the cognee Dataset row for ``name``, returning whether it was new.

--- a/kb/server.py
+++ b/kb/server.py
@@ -160,6 +160,9 @@ _INDEXED_FLOOR = 1
 # budget (both would 429). Same limiter shape, independent counters.
 _search_inflight = 0
 _mesh_graph_inflight = 0
+# The corpus census budget is separate for the same reason mesh's is: an admin
+# paging the corpus during an evolve pass must not eat /search's slots.
+_corpus_inflight = 0
 
 
 class _SearchSlot:
@@ -3506,6 +3509,203 @@ async def access_snapshot(
         # The oldest id on this page. Pass it back as `cursor` for the next,
         # older page. Null when there is nothing older left.
         "next_cursor": (page[0].get("id") if start > 0 and page and isinstance(page[0], dict) else None),
+    }
+
+
+CORPUS_DEFAULT_LIMIT = 200
+CORPUS_MAX_LIMIT = 1000
+CORPUS_INFLIGHT_LIMIT = 2
+# A census cursor is (created_at, id) and only moves forward. One row with a
+# future-dated created_at would otherwise become a cursor no real row can ever
+# exceed, stalling every later page while the endpoint reports ok. Clamp the
+# timestamp to now+skew when a cursor is BUILT and again when one is READ BACK
+# (a stored cursor outlives the request that built it). The cost is bounded:
+# rows inside the skew window can repeat across pages, which beats never
+# seeing a row again.
+CORPUS_CURSOR_MAX_SKEW_SECONDS = 300.0
+
+
+def _encode_corpus_cursor(created_at_iso: str, document_id: str) -> str:
+    import base64
+
+    payload = json.dumps(
+        {"t": created_at_iso, "id": document_id}, separators=(",", ":")
+    )
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
+
+
+def _decode_corpus_cursor(cursor: str | None) -> "tuple[Any, str] | None":
+    """(created_at, id) out of an opaque cursor, or None to start from the top.
+
+    Malformed and stale cursors restart the walk rather than 4xx — the same
+    stance /api/access takes, so a saved cursor can never wedge the caller.
+    """
+    import base64
+    from datetime import datetime, timezone
+
+    if not cursor:
+        return None
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")))
+        created_at = datetime.fromisoformat(str(payload["t"]))
+        document_id = str(payload["id"])
+    except Exception:  # noqa: BLE001 - any malformed cursor means start over
+        return None
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return created_at, document_id
+
+
+def _clamp_corpus_cursor_time(created_at: Any) -> Any:
+    from datetime import datetime, timedelta, timezone
+
+    ceiling = datetime.now(timezone.utc) + timedelta(
+        seconds=CORPUS_CURSOR_MAX_SKEW_SECONDS
+    )
+    return min(created_at, ceiling)
+
+
+@app.get("/api/corpus")
+async def corpus_census(
+    request: Request,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Row-level census of the corpus, from the durable relational store.
+
+    Nothing else on the node can enumerate the corpus: /api/mesh/graph caps at
+    1000 nodes and returns labels only, and per-source "documents" counters
+    are sync-state bookkeeping. This pages over the rows cognee writes when it
+    accepts content, and marks each row with whether the vector store
+    (``chunk_count``) and the graph (``in_graph``) have actually seen it —
+    the difference between "accepted but never indexed" and "indexed".
+
+    Presence flags degrade to null with a top-level note, never to 0: a 0 is a
+    measurement ("we looked, nothing there") and null is "this node could not
+    look", and cleanup decisions hang on that difference. Totals report both
+    the unscoped corpus and the default-owner slice so rows under another
+    owner_id surface instead of silently vanishing from the count.
+    """
+    from datetime import datetime, timezone
+
+    require_access(request, "admin", "audit:read")
+
+    cognee_client = getattr(get_citadel(), "cognee", None)
+    corpus_page = getattr(cognee_client, "corpus_page", None)
+    corpus_totals = getattr(cognee_client, "corpus_totals", None)
+    if not callable(corpus_page) or not callable(corpus_totals):
+        raise HTTPException(
+            status_code=503, detail="Corpus census is unavailable on this node."
+        )
+
+    if limit is None:
+        page_size = CORPUS_DEFAULT_LIMIT
+    else:
+        page_size = max(1, min(int(limit), CORPUS_MAX_LIMIT))
+
+    after = _decode_corpus_cursor(cursor)
+    after_created_at: str | None = None
+    after_id: str | None = None
+    if after is not None:
+        after_created_at = _clamp_corpus_cursor_time(after[0]).isoformat()
+        after_id = after[1]
+
+    with _SearchSlot(CORPUS_INFLIGHT_LIMIT, "_corpus_inflight"):
+        # One extra row decides has_more, so next_cursor is null exactly at the
+        # end instead of costing every caller a final empty page.
+        rows = list(
+            await corpus_page(
+                after_created_at=after_created_at,
+                after_id=after_id,
+                limit=page_size + 1,
+            )
+            or []
+        )
+        has_more = len(rows) > page_size
+        rows = rows[:page_size]
+        totals = await corpus_totals()
+
+        notes: list[str] = []
+        document_ids = [str(row["id"]) for row in rows if row.get("id")]
+
+        chunk_counts: dict[str, int] | None = None
+        try:
+            chunk_counts_read = getattr(cognee_client, "corpus_chunk_counts", None)
+            if callable(chunk_counts_read):
+                chunk_counts = await chunk_counts_read(document_ids)
+        except Exception:  # noqa: BLE001 - degrade to "not measured", never to 0
+            logger.exception("corpus census: chunk-count lookup failed")
+        if chunk_counts is None:
+            notes.append(
+                "chunk_count was not determined for this page (vector store "
+                "lookup unavailable); null means not measured, not zero"
+            )
+
+        in_graph_ids: set[str] | None = None
+        try:
+            graph_presence_read = getattr(cognee_client, "corpus_graph_presence", None)
+            if callable(graph_presence_read):
+                in_graph_ids = await graph_presence_read(document_ids)
+        except Exception:  # noqa: BLE001 - degrade to "not measured", never to 0
+            logger.exception("corpus census: graph presence lookup failed")
+        if in_graph_ids is None:
+            notes.append(
+                "in_graph was not determined for this page (graph lookup "
+                "unavailable); null means not measured, not absent"
+            )
+        elif document_ids and not in_graph_ids:
+            # The graph adapter answers a FAILED batch lookup and a no-match
+            # batch identically (empty), so an all-absent page is a weaker
+            # claim than a mixed one. Say so instead of letting false read as
+            # fully attested.
+            notes.append(
+                "no document on this page was found in the graph; the graph "
+                "adapter reports a failed lookup the same way as no matches, "
+                "so treat an all-absent page as weakly attested"
+            )
+
+        for row in rows:
+            row_id = str(row.get("id"))
+            row["chunk_count"] = (
+                None if chunk_counts is None else int(chunk_counts.get(row_id, 0))
+            )
+            row["in_graph"] = (
+                None if in_graph_ids is None else (row_id in in_graph_ids)
+            )
+
+        next_cursor: str | None = None
+        if has_more and rows:
+            last = rows[-1]
+            last_created_at = last.get("created_at")
+            last_id = last.get("id")
+            if last_created_at and last_id:
+                parsed = datetime.fromisoformat(str(last_created_at))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                next_cursor = _encode_corpus_cursor(
+                    _clamp_corpus_cursor_time(parsed).isoformat(), str(last_id)
+                )
+            else:
+                notes.append(
+                    "pagination stopped early: the page ends on a row without "
+                    "created_at/id, which cannot form a cursor"
+                )
+
+        other_owner_rows = int(totals.get("documents_other_owners") or 0)
+        if other_owner_rows > 0:
+            notes.append(
+                f"{other_owner_rows} rows belong to owners other than the "
+                "default user and are invisible to owner-scoped reads"
+            )
+
+    return {
+        "ok": True,
+        "documents": rows,
+        "documents_returned": len(rows),
+        "documents_total": totals.get("documents"),
+        "next_cursor": next_cursor,
+        "totals": totals,
+        "notes": notes,
     }
 
 

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -1387,3 +1387,169 @@ def test_cognee_public_client_derives_postgres_graph_env(monkeypatch: Any) -> No
     assert os.environ["GRAPH_DATABASE_NAME"] == "railway"
     assert os.environ["GRAPH_DATABASE_USERNAME"] == "postgres"
     assert os.environ["GRAPH_DATABASE_PASSWORD"] == "secret"
+
+
+async def _seed_corpus(user: Any) -> dict[str, Any]:
+    """Three real Data rows: two owned by the default user sharing one
+    created_at (so the id tie-break is exercised), one under ANOTHER owner —
+    the row an owner-scoped read would silently drop."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.data.models import Data, Dataset, DatasetData
+
+    t_tied = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t_late = datetime(2026, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+    tied_ids = sorted((uuid4(), uuid4()), key=lambda item: item.hex)
+    other_owner = uuid4()
+    other_data_id = uuid4()
+
+    central = Dataset(
+        id=uuid4(), name="masumi-network", owner_id=user.id, tenant_id=user.tenant_id
+    )
+    ghost = Dataset(
+        id=uuid4(), name="seat:ghost", owner_id=other_owner, tenant_id=user.tenant_id
+    )
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        session.add(central)
+        session.add(ghost)
+        session.add(
+            Data(
+                id=tied_ids[0],
+                name="first",
+                content_hash="hash-1",
+                mime_type="text/plain",
+                token_count=10,
+                data_size=100,
+                created_at=t_tied,
+                owner_id=user.id,
+                tenant_id=user.tenant_id,
+                external_metadata={"citadel_tags": ["alpha", "beta"]},
+            )
+        )
+        session.add(
+            Data(
+                id=tied_ids[1],
+                name="second",
+                content_hash="hash-2",
+                mime_type="text/plain",
+                created_at=t_tied,
+                owner_id=user.id,
+                tenant_id=user.tenant_id,
+            )
+        )
+        session.add(
+            Data(
+                id=other_data_id,
+                name="ghost-note",
+                content_hash="hash-3",
+                mime_type="text/plain",
+                created_at=t_late,
+                owner_id=other_owner,
+                tenant_id=user.tenant_id,
+            )
+        )
+        session.add(DatasetData(dataset_id=central.id, data_id=tied_ids[0]))
+        session.add(DatasetData(dataset_id=central.id, data_id=tied_ids[1]))
+        session.add(DatasetData(dataset_id=ghost.id, data_id=other_data_id))
+        await session.commit()
+    return {
+        "t_tied": t_tied,
+        "tied_ids": tied_ids,
+        "other_owner": other_owner,
+        "other_data_id": other_data_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_corpus_page_enumerates_the_real_store_with_keyset_pages(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    """The census read against the REAL relational stack.
+
+    Pins the row shape, the (created_at, id) ordering with the id tie-break,
+    the keyset boundary handoff, tag parsing out of external_metadata, and —
+    what the owner-scoped attribution reads above deliberately never claim —
+    that a row held by ANOTHER owner_id still enumerates.
+    """
+    from cognee.infrastructure.databases.relational import create_db_and_tables
+    from cognee.modules.users.methods import get_default_user
+
+    await create_db_and_tables()
+    user = await get_default_user()
+    seeded = await _seed_corpus(user)
+    client = _real_cognee_client(monkeypatch)
+
+    page_one = await client.corpus_page(limit=2)
+
+    assert [row["id"] for row in page_one] == [str(uid) for uid in seeded["tied_ids"]]
+    first = page_one[0]
+    assert first["name"] == "first"
+    assert first["content_hash"] == "hash-1"
+    assert first["mime_type"] == "text/plain"
+    assert first["token_count"] == 10
+    assert first["data_size"] == 100
+    assert first["created_at"] == seeded["t_tied"].isoformat()
+    assert first["datasets"] == ["masumi-network"]
+    assert first["citadel_tags"] == ["alpha", "beta"]
+
+    boundary = page_one[-1]
+    page_two = await client.corpus_page(
+        after_created_at=boundary["created_at"],
+        after_id=boundary["id"],
+        limit=2,
+    )
+
+    assert [row["id"] for row in page_two] == [str(seeded["other_data_id"])]
+    assert page_two[0]["datasets"] == ["seat:ghost"]
+    assert page_two[0]["owner_id"] == str(seeded["other_owner"])
+
+    page_three = await client.corpus_page(
+        after_created_at=page_two[0]["created_at"],
+        after_id=page_two[0]["id"],
+        limit=2,
+    )
+
+    assert page_three == []
+
+
+@pytest.mark.asyncio
+async def test_corpus_totals_reports_the_owner_split(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    """Both counts, so a row under another owner_id shows up as a difference
+    instead of silently missing from an owner-scoped number."""
+    from cognee.infrastructure.databases.relational import create_db_and_tables
+    from cognee.modules.users.methods import get_default_user
+
+    await create_db_and_tables()
+    user = await get_default_user()
+    await _seed_corpus(user)
+    client = _real_cognee_client(monkeypatch)
+
+    totals = await client.corpus_totals()
+
+    assert totals == {
+        "documents": 3,
+        "documents_default_owner": 2,
+        "documents_other_owners": 1,
+        "by_dataset": {"masumi-network": 2, "seat:ghost": 1},
+        "by_dataset_default_owner": {"masumi-network": 2},
+    }
+
+
+@pytest.mark.asyncio
+async def test_corpus_chunk_counts_says_not_measured_off_pgvector(
+    monkeypatch: Any,
+) -> None:
+    """None, never 0: on a node whose vector provider is not pgvector there is
+    no chunk table to count, and a 0 would read as 'accepted but never
+    indexed' — a claim nothing measured. An empty page needs no store at all
+    and is an honest empty measurement."""
+    monkeypatch.delenv("VECTOR_DB_PROVIDER", raising=False)
+    client = _real_cognee_client(monkeypatch)
+
+    assert await client.corpus_chunk_counts(["3b9c0d05-0000-0000-0000-000000000001"]) is None
+    assert await client.corpus_chunk_counts([]) == {}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6319,3 +6319,286 @@ def test_api_mesh_falls_back_to_uptime_counters_when_corpus_read_fails(
     stats = response.json()["stats"]
     assert stats["documents"] is not None
     assert stats["indexed_chunks"] is not None
+
+
+class FakeCorpusCognee:
+    """Fake at the kb.cognee_client METHOD boundary.
+
+    Every shape here (row dicts, totals dict, counts mapping, presence set) is
+    the contract corpus_page/corpus_totals/corpus_chunk_counts/
+    corpus_graph_presence themselves declare — cognee's own row shapes are
+    pinned by the real-import tests in test_cognee_client.py, never invented
+    here.
+    """
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        totals: dict[str, Any],
+        chunk_counts: dict[str, int] | None = None,
+        graph_ids: set[str] | None = None,
+        chunk_lookup_raises: bool = False,
+    ) -> None:
+        self.rows = rows
+        self.totals = totals
+        self.chunk_counts = chunk_counts
+        self.graph_ids = graph_ids
+        self.chunk_lookup_raises = chunk_lookup_raises
+        self.seen_after: list[tuple[str | None, str | None]] = []
+
+    @staticmethod
+    def _key(row: dict[str, Any]) -> tuple[Any, str]:
+        from datetime import datetime
+
+        return (datetime.fromisoformat(row["created_at"]), row["id"])
+
+    async def corpus_page(
+        self,
+        *,
+        after_created_at: str | None = None,
+        after_id: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        from datetime import datetime
+
+        self.seen_after.append((after_created_at, after_id))
+        rows = sorted((dict(row) for row in self.rows), key=self._key)
+        if after_created_at and after_id:
+            boundary = (datetime.fromisoformat(after_created_at), after_id)
+            rows = [row for row in rows if self._key(row) > boundary]
+        return rows[:limit]
+
+    async def corpus_totals(self) -> dict[str, Any]:
+        return dict(self.totals)
+
+    async def corpus_chunk_counts(self, document_ids: list[str]) -> dict[str, int] | None:
+        if self.chunk_lookup_raises:
+            raise RuntimeError("vector store unavailable")
+        if self.chunk_counts is None:
+            return None
+        return {
+            document_id: self.chunk_counts[document_id]
+            for document_id in document_ids
+            if document_id in self.chunk_counts
+        }
+
+    async def corpus_graph_presence(self, document_ids: list[str]) -> set[str] | None:
+        if self.graph_ids is None:
+            return None
+        return {doc_id for doc_id in document_ids if doc_id in self.graph_ids}
+
+
+def _corpus_row(row_id: str, created_at: str, **overrides: Any) -> dict[str, Any]:
+    row = {
+        "id": row_id,
+        "name": f"doc-{row_id}",
+        "content_hash": f"hash-{row_id}",
+        "raw_content_hash": None,
+        "mime_type": "text/plain",
+        "token_count": 10,
+        "data_size": 100,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "owner_id": "owner-1",
+        "datasets": ["masumi-network"],
+        "citadel_tags": [],
+    }
+    row.update(overrides)
+    return row
+
+
+def _corpus_totals(documents: int, default_owner: int | None = None) -> dict[str, Any]:
+    owned = documents if default_owner is None else default_owner
+    return {
+        "documents": documents,
+        "documents_default_owner": owned,
+        "documents_other_owners": documents - owned,
+        "by_dataset": {"masumi-network": documents},
+        "by_dataset_default_owner": {"masumi-network": owned},
+    }
+
+
+def _corpus_client(fake: FakeCorpusCognee) -> TestClient:
+    client = authed_client()
+    server_module.app.state.citadel.cognee = fake
+    return client
+
+
+def test_corpus_census_reports_rows_presence_and_totals() -> None:
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    fake = FakeCorpusCognee(
+        [
+            _corpus_row(
+                "doc-a",
+                (now - timedelta(hours=2)).isoformat(),
+                citadel_tags=["alpha"],
+            ),
+            _corpus_row("doc-b", (now - timedelta(hours=1)).isoformat()),
+        ],
+        totals=_corpus_totals(2),
+        chunk_counts={"doc-a": 3},
+        graph_ids={"doc-a"},
+    )
+    client = _corpus_client(fake)
+
+    response = client.get("/api/corpus")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["documents_returned"] == 2
+    assert body["documents_total"] == 2
+    assert body["next_cursor"] is None
+    assert body["totals"] == _corpus_totals(2)
+    first, second = body["documents"]
+    assert first["id"] == "doc-a"
+    assert first["citadel_tags"] == ["alpha"]
+    assert first["datasets"] == ["masumi-network"]
+    assert first["chunk_count"] == 3
+    assert first["in_graph"] is True
+    # doc-b was measured and has nothing indexed: 0/False, not null.
+    assert second["chunk_count"] == 0
+    assert second["in_graph"] is False
+    assert body["notes"] == []
+
+
+def test_corpus_census_pages_with_an_opaque_cursor() -> None:
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    all_ids = ["doc-a", "doc-b", "doc-c"]
+    fake = FakeCorpusCognee(
+        [
+            _corpus_row(row_id, (now - timedelta(hours=hours)).isoformat())
+            for row_id, hours in (("doc-a", 3), ("doc-b", 2), ("doc-c", 1))
+        ],
+        totals=_corpus_totals(3),
+        chunk_counts={},
+        graph_ids=set(all_ids),
+    )
+    client = _corpus_client(fake)
+
+    page_one = client.get("/api/corpus?limit=2").json()
+    assert [row["id"] for row in page_one["documents"]] == ["doc-a", "doc-b"]
+    assert page_one["documents_returned"] == 2
+    assert page_one["next_cursor"]
+
+    page_two = client.get(f"/api/corpus?limit=2&cursor={page_one['next_cursor']}").json()
+    assert [row["id"] for row in page_two["documents"]] == ["doc-c"]
+    assert page_two["next_cursor"] is None
+
+
+def test_corpus_census_clamps_a_future_dated_cursor_so_later_rows_land() -> None:
+    """One future-dated created_at must not pin the cursor past every real row.
+
+    doc-future sits 30 days ahead and ends the first page. Unclamped, its
+    timestamp becomes a cursor that no row written in the next month can
+    exceed, so the walk silently stalls while reporting ok. Clamped to
+    now+skew, a row that lands after the cursor was minted still comes back on
+    the next page (rows inside the skew window may repeat, which is the
+    accepted cost).
+    """
+    import base64 as _base64
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    fake = FakeCorpusCognee(
+        [
+            _corpus_row("doc-a", (now - timedelta(hours=1)).isoformat()),
+            _corpus_row("doc-future", (now + timedelta(days=30)).isoformat()),
+            _corpus_row("doc-far-future", (now + timedelta(days=60)).isoformat()),
+        ],
+        totals=_corpus_totals(3),
+        chunk_counts={},
+        graph_ids={"doc-a", "doc-future", "doc-far-future"},
+    )
+    client = _corpus_client(fake)
+
+    page_one = client.get("/api/corpus?limit=2").json()
+    assert [row["id"] for row in page_one["documents"]] == ["doc-a", "doc-future"]
+    cursor = page_one["next_cursor"]
+    assert cursor
+
+    decoded = json.loads(_base64.urlsafe_b64decode(cursor.encode("ascii")))
+    cursor_time = datetime.fromisoformat(decoded["t"])
+    ceiling = datetime.now(timezone.utc) + timedelta(
+        seconds=server_module.CORPUS_CURSOR_MAX_SKEW_SECONDS + 5
+    )
+    assert cursor_time <= ceiling, "cursor was not clamped to now+skew"
+
+    # A real row arrives after the cursor was handed out, just past the skew
+    # window. With the future-dated cursor it would never be seen.
+    fake.rows.append(
+        _corpus_row("doc-later", (now + timedelta(seconds=601)).isoformat())
+    )
+
+    page_two = client.get(f"/api/corpus?limit=3&cursor={cursor}").json()
+    assert "doc-later" in [row["id"] for row in page_two["documents"]]
+
+
+def test_corpus_census_clamps_a_stored_future_cursor_on_read() -> None:
+    """The write-side clamp is not enough: a cursor minted elsewhere (or before
+    a clamp change) can still carry a far-future timestamp, so the read side
+    clamps too."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    fake = FakeCorpusCognee(
+        [
+            _corpus_row("doc-later", (now + timedelta(seconds=601)).isoformat()),
+            _corpus_row("doc-far-future", (now + timedelta(days=60)).isoformat()),
+        ],
+        totals=_corpus_totals(2),
+        chunk_counts={},
+        graph_ids={"doc-later", "doc-far-future"},
+    )
+    client = _corpus_client(fake)
+    handcrafted = server_module._encode_corpus_cursor(
+        (now + timedelta(days=30)).isoformat(), "doc-zzz"
+    )
+
+    body = client.get(f"/api/corpus?cursor={handcrafted}").json()
+
+    assert "doc-later" in [row["id"] for row in body["documents"]]
+
+
+def test_corpus_census_degrades_presence_to_null_not_zero() -> None:
+    """0 and 'not measured' are different answers — the difference between
+    'accepted but never indexed' and 'we did not look'."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    fake = FakeCorpusCognee(
+        [_corpus_row("doc-a", (now - timedelta(hours=1)).isoformat())],
+        totals=_corpus_totals(1),
+        chunk_lookup_raises=True,
+        graph_ids=None,
+    )
+    client = _corpus_client(fake)
+
+    response = client.get("/api/corpus")
+
+    assert response.status_code == 200
+    body = response.json()
+    row = body["documents"][0]
+    assert row["chunk_count"] is None
+    assert row["in_graph"] is None
+    notes = " ".join(body["notes"])
+    assert "chunk_count" in notes and "not measured" in notes
+    assert "in_graph" in notes
+
+
+def test_corpus_census_requires_an_admin() -> None:
+    writer = authed_client("test-writer")
+
+    assert writer.get("/api/corpus").status_code == 403
+
+
+def test_corpus_census_rejects_unauthenticated_callers() -> None:
+    server_module.app.state.citadel = FakeCitadel()
+    client = TestClient(app, base_url="https://testserver")
+
+    assert client.get("/api/corpus").status_code == 401


### PR DESCRIPTION
Nothing could enumerate the corpus, so cleanup could not be scoped or verified and per-source totals could not be reconciled.

Adds an admin-only (`audit:read`) keyset-paginated census over the relational store returning document identity, content hash, dataset attribution and tags, plus per-row chunk and graph presence. Presence degrades to null with an explicit note rather than 0, so "not measured" is never reported as "none". Totals are reported both owner-scoped and unscoped so a hidden-owner difference surfaces as data.

The cursor is clamped on both write and read so a future-dated timestamp cannot stall pagination. The boot-time API self-check is extended to pin every column and adapter method the census depends on.

Refs #123 — vault lint is blocked on corpus enumeration, which this provides.