### PR TITLE
fix(evolve): resume the scheduler interval across a redeploy, and report staleness

### DIFF
--- a/kb/config.py
+++ b/kb/config.py
@@ -65,6 +65,15 @@ def _repo_content_sync_state_path(value: str | None) -> str:
     return str(Path(_state_root()) / "repo_content_sync_state.json")
 
 
+def _evolve_state_path(value: str | None) -> str:
+    if value:
+        return value
+    # Beside the sync state, which on Railway is the mounted volume. It has to
+    # outlive the container: the whole point is that a redeploy resumes the
+    # interval instead of restarting it (#153).
+    return str(Path(_state_root()) / "evolve_state.json")
+
+
 def _repo_stats_state_path(value: str | None) -> str:
     if value:
         return value
@@ -230,6 +239,7 @@ class CitadelConfig:
     repo_content_sync_dataset: str = "masumi-network"
     repo_content_sync_session: str = "masumi-repo-content"
     repo_content_sync_state_path: str = ".citadel/repo_content_sync_state.json"
+    evolve_state_path: str = ".citadel/evolve_state.json"
     repo_content_sync_repos: tuple[str, ...] = field(default_factory=tuple)
     repo_content_sync_root_paths: tuple[str, ...] = field(default_factory=tuple)
     repo_content_sync_tree_prefixes: tuple[str, ...] = field(default_factory=tuple)
@@ -434,6 +444,7 @@ class CitadelConfig:
             repo_content_sync_state_path=_repo_content_sync_state_path(
                 os.getenv("CITADEL_REPO_CONTENT_SYNC_STATE_PATH")
             ),
+            evolve_state_path=_evolve_state_path(os.getenv("CITADEL_EVOLVE_STATE_PATH")),
             repo_content_sync_repos=tuple(
                 _csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_REPOS"))
             ),

--- a/kb/evolve_state.py
+++ b/kb/evolve_state.py
@@ -1,0 +1,119 @@
+"""When the evolve cycle last completed, and how long to wait before the next one.
+
+The scheduler sleeps a full interval before its first pass so that a redeploy
+never triggers a heavy cycle on boot. That is deliberate and stays. The defect
+(#153) is that the clock RESTARTS on every boot rather than resuming, so on a day
+with deploys closer together than the interval the cycle never fires at all.
+Seven deploys on 2026-07-29 produced exactly one pass, inside the only gap that
+happened to exceed the interval.
+
+Nothing reported it. There was no record of a last successful pass anywhere, so a
+node that had not evolved in a week looked identical to one that evolved five
+minutes ago. That is the same silent-success shape as #89, #114, #148 and #151:
+the absence of a signal read as the absence of a problem.
+
+Two pieces, deliberately small: persist the completion time, and compute the
+first sleep from it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from kb.state_io import StateFileError, load_state_file, save_state_file
+
+STATE_VERSION = 1
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def read_last_completed(path: str | Path) -> datetime | None:
+    """The last recorded completion, or None when there is no usable record.
+
+    Fail-soft on purpose. A missing or corrupt file must not stop the scheduler
+    from running; it only costs the resume, which degrades to today's behaviour
+    of a full first interval. That trade is the opposite of #148's (where
+    flattening a corrupt state to empty caused silent re-ingestion), because here
+    the fallback is to wait LONGER, never to redo work.
+    """
+    try:
+        data = load_state_file(Path(path))
+    except (StateFileError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _parse(data.get("last_completed_at"))
+
+
+def record_completed(path: str | Path, when: datetime | None = None) -> None:
+    """Stamp a completed pass. Never raises: bookkeeping must not fail a cycle."""
+    try:
+        save_state_file(
+            Path(path),
+            {
+                "version": STATE_VERSION,
+                "last_completed_at": (when or _now()).isoformat().replace("+00:00", "Z"),
+            },
+        )
+    except (StateFileError, OSError):
+        pass
+
+
+def first_sleep_seconds(
+    interval_seconds: int,
+    last_completed: datetime | None,
+    now: datetime | None = None,
+) -> float:
+    """How long to wait before the FIRST pass after a boot.
+
+    With no record, a full interval, preserving the deliberate boot delay. With a
+    record, the remainder of the interval that was already running, so a restart
+    resumes instead of resetting.
+
+    A completion timestamp in the future is treated as "just now" rather than
+    trusted. A clock that jumped, or a state file copied from elsewhere, would
+    otherwise park the scheduler for an unbounded time while every counter still
+    reported healthy -- the failure mode recorded in the monotone-cursor lesson,
+    where one future date stalled all writes and reported ok.
+    """
+    interval = max(0, int(interval_seconds))
+    if last_completed is None:
+        return float(interval)
+    elapsed = ((now or _now()) - last_completed).total_seconds()
+    if elapsed < 0:
+        return float(interval)
+    return float(max(0, interval - elapsed))
+
+
+def staleness(
+    path: str | Path, interval_seconds: int, now: datetime | None = None
+) -> dict[str, Any]:
+    """A reader-visible answer to "has the cycle actually been running?".
+
+    `overdue` compares against twice the interval rather than one, so a pass that
+    merely started late does not read as broken while a cycle that genuinely
+    stopped does.
+    """
+    last = read_last_completed(path)
+    if last is None:
+        return {"last_completed_at": None, "age_seconds": None, "overdue": None}
+    age = max(0.0, ((now or _now()) - last).total_seconds())
+    return {
+        "last_completed_at": last.isoformat().replace("+00:00", "Z"),
+        "age_seconds": int(age),
+        "overdue": age > 2 * max(1, int(interval_seconds)),
+    }

--- a/kb/evolve_state.py
+++ b/kb/evolve_state.py
@@ -19,10 +19,13 @@ first sleep from it.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 from pathlib import Path
 from typing import Any
 
 from kb.state_io import StateFileError, load_state_file, save_state_file
+
+logger = logging.getLogger(__name__)
 
 STATE_VERSION = 1
 
@@ -52,7 +55,16 @@ def read_last_completed(path: str | Path) -> datetime | None:
     """
     try:
         data = load_state_file(Path(path))
-    except (StateFileError, OSError):
+    except (StateFileError, OSError) as exc:
+        # Degrading to a full first interval is safe; degrading SILENTLY is not.
+        # Without this line an unreadable state file looks exactly like a first
+        # boot, and the resume this module exists for is quietly not happening.
+        logger.warning(
+            "Evolve state at %s is unreadable (%s); the interval will restart "
+            "rather than resume this boot",
+            path,
+            exc.__class__.__name__,
+        )
         return None
     if not isinstance(data, dict):
         return None
@@ -69,8 +81,18 @@ def record_completed(path: str | Path, when: datetime | None = None) -> None:
                 "last_completed_at": (when or _now()).isoformat().replace("+00:00", "Z"),
             },
         )
-    except (StateFileError, OSError):
-        pass
+    except (StateFileError, OSError) as exc:
+        # Swallowed on purpose: a bookkeeping write must never fail an evolve
+        # pass that has already done its work. But it is LOGGED, because the
+        # cost is the next boot restarting its interval instead of resuming,
+        # which is the defect this module fixes. A silent failure here would
+        # reintroduce #153 while every counter still read healthy.
+        logger.warning(
+            "Could not record the evolve completion at %s (%s); the next boot "
+            "will wait a full interval instead of resuming",
+            path,
+            exc.__class__.__name__,
+        )
 
 
 def first_sleep_seconds(

--- a/kb/server.py
+++ b/kb/server.py
@@ -262,7 +262,7 @@ class _McpAcceptShim:
         await self.app({**scope, "headers": kept}, receive, send)
 
 
-async def _evolve_scheduler_loop(interval_seconds: int) -> None:
+async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None:
     """Run the evolve cycle every ``interval_seconds``: heavy stages in a
     subprocess, then cognify in-loop.
 
@@ -283,8 +283,21 @@ async def _evolve_scheduler_loop(interval_seconds: int) -> None:
     from kb.cognee_client import suppress_inline_cognify
     from scripts.run_railway import run_evolve_in_loop
 
+    from kb.evolve_state import first_sleep_seconds, read_last_completed, record_completed
+
+    # Resume the interval rather than restart it. The boot delay stays: a
+    # redeploy must not trigger a heavy cycle. What changes is that the clock
+    # carries across restarts, so a day of deploys closer together than the
+    # interval still reaches a pass (#153).
+    last = read_last_completed(state_path)
+    delay = first_sleep_seconds(interval_seconds, last)
+    logger.info(
+        "Evolve scheduler: first pass in %.0fs of a %ss interval (last pass: %s)",
+        delay, interval_seconds, last or "none recorded",
+    )
     while True:
-        await asyncio.sleep(interval_seconds)
+        await asyncio.sleep(delay)
+        delay = float(interval_seconds)
         logger.info("Evolve scheduler: starting scheduled pass")
         # Phase 1 — heavy stages, in this loop. Hold the in-process writer lock
         # across them so no interactive cognify (an ingest's, /api/cognify/run)
@@ -353,6 +366,14 @@ async def _evolve_scheduler_loop(interval_seconds: int) -> None:
             raise
         except Exception:
             logger.exception("Evolve scheduler: cognify failed")
+        finally:
+            # Stamp the pass even when a stage failed. This records that the
+            # cycle RAN, which is what the next boot needs to resume the
+            # interval; whether the stages succeeded is already on the "Evolve
+            # finished" line and in /readyz. Recording only clean passes would
+            # make a node with one broken stage restart its clock forever, which
+            # is the bug this fixes (#153).
+            record_completed(state_path)
 
 
 def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":
@@ -370,7 +391,10 @@ def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":
         return None
     interval = max(60, config.evolve_interval_seconds)
     logger.info("Evolve scheduler enabled: interval=%ss", interval)
-    task = asyncio.create_task(_evolve_scheduler_loop(interval), name="evolve-scheduler")
+    task = asyncio.create_task(
+        _evolve_scheduler_loop(interval, config.evolve_state_path),
+        name="evolve-scheduler",
+    )
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_forget_background_task)
     return task
@@ -4717,7 +4741,17 @@ def _last_source_error(source_type: str) -> tuple[str | None, str | None]:
 async def sources(request: Request, type: str | None = None) -> Any:
     require_access(request, "reader", "sources:read")
     sources_payload: list[dict[str, Any]] = []
-    summary: dict[str, Any] = {}
+    # When the evolve cycle last completed. Without it, a node that has not
+    # evolved in a week looks identical to one that evolved five minutes ago,
+    # and every per-source "last synced" figure below is a stale number with no
+    # way to tell (#153). Reader-scoped deliberately: staleness is exactly what
+    # a teammate needs before trusting a search result.
+    from kb.evolve_state import staleness as _evolve_staleness
+
+    _cfg = get_citadel().config
+    summary: dict[str, Any] = {
+        "evolve": _evolve_staleness(_cfg.evolve_state_path, _cfg.evolve_interval_seconds)
+    }
 
     if type in {None, "github"}:
         github_status = await get_github_syncer().status()

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from types import SimpleNamespace
+from pathlib import Path
 from typing import Any
 
 from kb.config import CitadelConfig
@@ -30,11 +31,17 @@ def test_evolve_scheduler_config_defaults(monkeypatch: Any) -> None:
 # --- scheduler wiring ------------------------------------------------------
 
 
-def _fake_citadel(*, enabled: bool, interval: int = 21600) -> SimpleNamespace:
+def _fake_citadel(
+    *, enabled: bool, interval: int = 21600, state_path: str = ""
+) -> SimpleNamespace:
     return SimpleNamespace(
         config=SimpleNamespace(
             evolve_scheduler_enabled=enabled,
             evolve_interval_seconds=interval,
+            # #153: the scheduler resumes its interval from this file, so the
+            # fake config has to carry it. Empty means "nowhere to persist",
+            # which read/record both tolerate.
+            evolve_state_path=state_path,
         )
     )
 
@@ -107,7 +114,7 @@ def _patch_phase1(monkeypatch: Any, *, code: int = 0, raises: bool = False) -> l
 
 
 async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
-    monkeypatch: Any,
+    monkeypatch: Any, tmp_path: Path
 ) -> None:
     """Phase 1 runs in THIS process now, not a subprocess (#88).
 
@@ -129,7 +136,7 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
     monkeypatch.setattr(server.asyncio, "create_subprocess_exec", forbidden_exec)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
-    task = asyncio.create_task(server._evolve_scheduler_loop(0.001))
+    task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
     try:
         for _ in range(300):
             if len(cognify_calls) >= 2:
@@ -150,7 +157,7 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
     assert server._LAST_CANARY is not None and server._LAST_CANARY["ok"] is True
 
 
-async def test_add_only_mode_does_not_leak_outside_the_pass() -> None:
+async def test_add_only_mode_does_not_leak_outside_the_pass(tmp_path: Path) -> None:
     """The suppression is scoped to the task tree, never process-wide (#88).
 
     It used to be an env var on a subprocess. In the web process an env var
@@ -173,14 +180,16 @@ async def test_add_only_mode_does_not_leak_outside_the_pass() -> None:
     assert await asyncio.create_task(observer()) is False
 
 
-async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(monkeypatch: Any) -> None:
+async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     import kb.server as server
 
     cognify_calls: list[bool] = []
     _patch_phase1(monkeypatch, raises=True)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
-    task = asyncio.create_task(server._evolve_scheduler_loop(0.001))
+    task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
     try:
         for _ in range(300):
             if len(cognify_calls) >= 2:
@@ -196,7 +205,7 @@ async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(monkeypatch
 
 
 async def test_evolve_scheduler_logs_error_when_stages_exit_nonzero(
-    monkeypatch: Any, caplog: Any
+    monkeypatch: Any, caplog: Any, tmp_path: Path
 ) -> None:
     """A partially failed cycle must be loud (#89).
 
@@ -213,7 +222,7 @@ async def test_evolve_scheduler_logs_error_when_stages_exit_nonzero(
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
     with caplog.at_level(logging.ERROR, logger=server.logger.name):
-        task = asyncio.create_task(server._evolve_scheduler_loop(0.001))
+        task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
         try:
             for _ in range(300):
                 if cognify_calls:
@@ -241,7 +250,7 @@ async def test_a_dying_scheduler_task_is_logged(monkeypatch: Any, caplog: Any) -
 
     import kb.server as server
 
-    async def boom(_interval: float) -> None:
+    async def boom(_interval: float, _state_path: str) -> None:
         raise RuntimeError("scheduler could not start")
 
     monkeypatch.setattr(server, "_evolve_scheduler_loop", boom)

--- a/tests/test_evolve_scheduler_resumes.py
+++ b/tests/test_evolve_scheduler_resumes.py
@@ -1,0 +1,111 @@
+"""#153: a redeploy must resume the evolve interval, not restart it."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from kb.evolve_state import (
+    first_sleep_seconds,
+    read_last_completed,
+    record_completed,
+    staleness,
+)
+
+HOUR = 3600
+NOW = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def test_a_redeploy_resumes_the_interval_instead_of_restarting_it() -> None:
+    """The defect itself.
+
+    Seven deploys on 2026-07-29 produced exactly one evolve pass, because each
+    boot restarted a 3600s timer that no gap between deploys outlived. With the
+    remainder carried across the restart, a boot 50 minutes into the interval
+    waits the remaining 10, so the pass survives a busy merge day.
+    """
+    last = NOW - timedelta(minutes=50)
+    assert first_sleep_seconds(HOUR, last, now=NOW) == 600.0
+
+
+def test_deploys_closer_together_than_the_interval_still_reach_a_pass() -> None:
+    """The scenario from the issue, as arithmetic rather than as a claim.
+
+    The 2026-07-29 gaps with the one long window removed, which is the case the
+    issue is actually about: a day where every deploy lands inside the interval.
+    A restarting clock fires ZERO times across 79 minutes of uptime at a
+    60-minute interval. A resuming clock fires once, on schedule.
+    """
+    gaps = [18, 7, 20, 1, 0, 33]
+    assert sum(gaps) * 60 > HOUR, "the run must be long enough that a pass is due"
+    assert all(g * 60 < HOUR for g in gaps), "every gap is shorter than the interval"
+
+    restarting = sum(1 for g in gaps if g * 60 >= HOUR)
+    assert restarting == 0, "this is the defect: no single gap ever reaches the interval"
+
+    remaining, resuming = float(HOUR), 0
+    for gap in gaps:
+        if gap * 60 >= remaining:
+            resuming += 1
+            remaining = float(HOUR) - (gap * 60 - remaining)
+        else:
+            remaining -= gap * 60
+    assert resuming >= 1, "resuming must reach a pass where restarting never can"
+
+
+def test_a_genuine_first_boot_still_waits_a_full_interval() -> None:
+    """The boot delay is deliberate and stays: no record means a full wait.
+
+    The bug is the reset, not the delay. A fix that also removed the delay would
+    make every redeploy trigger a heavy cycle on boot, which is what the delay
+    exists to prevent.
+    """
+    assert first_sleep_seconds(HOUR, None, now=NOW) == float(HOUR)
+
+
+def test_an_overdue_interval_runs_immediately_rather_than_waiting_again() -> None:
+    last = NOW - timedelta(hours=9)
+    assert first_sleep_seconds(HOUR, last, now=NOW) == 0.0
+
+
+def test_a_future_timestamp_does_not_park_the_scheduler() -> None:
+    """A clock jump or a copied state file must not stall the cycle silently.
+
+    Without the clamp this returns interval + skew, so one bad timestamp parks
+    evolve for an unbounded time while every counter still reads healthy. That is
+    the monotone-cursor failure this codebase has already had once.
+    """
+    assert first_sleep_seconds(HOUR, NOW + timedelta(days=30), now=NOW) == float(HOUR)
+
+
+def test_the_completion_survives_a_restart(tmp_path: Path) -> None:
+    path = tmp_path / "evolve_state.json"
+    record_completed(path, when=NOW)
+    assert read_last_completed(path) == NOW
+
+
+def test_a_corrupt_state_file_costs_the_resume_and_nothing_else(tmp_path: Path) -> None:
+    """Fail-soft, and in the safe direction: wait longer, never redo work."""
+    path = tmp_path / "evolve_state.json"
+    path.write_text("{ this is not json", encoding="utf-8")
+    assert read_last_completed(path) is None
+    assert first_sleep_seconds(HOUR, read_last_completed(path), now=NOW) == float(HOUR)
+
+
+def test_staleness_is_reportable_so_a_stopped_cycle_is_visible(tmp_path: Path) -> None:
+    """#153: 'a node that has not evolved in a week looks identical to one that
+    evolved five minutes ago'. It must not."""
+    path = tmp_path / "evolve_state.json"
+
+    fresh = staleness(path, HOUR, now=NOW)
+    assert fresh == {"last_completed_at": None, "age_seconds": None, "overdue": None}
+
+    record_completed(path, when=NOW - timedelta(minutes=5))
+    recent = staleness(path, HOUR, now=NOW)
+    assert recent["age_seconds"] == 300
+    assert recent["overdue"] is False
+
+    record_completed(path, when=NOW - timedelta(days=7))
+    stopped = staleness(path, HOUR, now=NOW)
+    assert stopped["overdue"] is True
+    assert stopped["age_seconds"] == 7 * 24 * HOUR

--- a/tests/test_evolve_scheduler_resumes.py
+++ b/tests/test_evolve_scheduler_resumes.py
@@ -109,3 +109,35 @@ def test_staleness_is_reportable_so_a_stopped_cycle_is_visible(tmp_path: Path) -
     stopped = staleness(path, HOUR, now=NOW)
     assert stopped["overdue"] is True
     assert stopped["age_seconds"] == 7 * 24 * HOUR
+
+
+def test_a_failed_stamp_is_logged_rather_than_swallowed(tmp_path: Path, caplog) -> None:
+    """Degrading to a full interval is safe; degrading silently is not.
+
+    CodeQL flagged the bare `except: pass` here, and it was right for a reason
+    beyond style: if the completion cannot be written, the next boot restarts its
+    interval instead of resuming, which is exactly the defect this module exists
+    to fix. Swallowed without a word, #153 comes back while every counter still
+    reads healthy.
+    """
+    import logging
+
+    # A directory where the file should be: save cannot succeed, and the failure
+    # is a real OSError rather than a mocked one.
+    blocked = tmp_path / "evolve_state.json"
+    blocked.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="kb.evolve_state"):
+        record_completed(blocked, when=NOW)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("record the evolve completion" in m for m in messages), (
+        f"a failed stamp must say so; silence here reintroduces #153 invisibly: {messages}"
+    )
+    # The consequence has to be in the line, not just the fact of a failure:
+    # someone reading it at 2am needs to know what it costs them.
+    assert any("resuming" in m for m in messages)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="kb.evolve_state"):
+        assert read_last_completed(blocked) is None
+    assert caplog.records, "an unreadable state file must be reported, not treated as a first boot"


### PR DESCRIPTION
First item of stage one in [the execution plan](docs/superpowers/specs/2026-08-04-citadel-execution-plan.md), which places it first because it is the instrument every later sync-side fix gets verified through.

## The defect

The scheduler sleeps a full interval before its first pass so a redeploy never triggers a heavy cycle on boot. That is deliberate and stays. The bug is that the clock **restarts** on every boot instead of resuming, so on a day when deploys land closer together than the interval, the cycle never fires at all.

Seven deploys on 2026-07-29 produced exactly one evolve pass, inside the only gap that happened to exceed the interval. Nothing reported it, because there was no record of a last completed pass anywhere: a node that had not evolved in a week looked identical to one that evolved five minutes ago.

Taking the observed gaps with that one long window removed, which is the case the issue is about:

```
gaps (min):   18, 7, 20, 1, 0, 33     total 79 min, interval 60 min
restarting:   0 passes    no single gap ever reaches the interval
resuming:     1 pass      on schedule
```

## What changed

`kb/evolve_state.py` records the completion time and computes the first sleep from it, so a boot part-way through an interval waits only the remainder.

The loop now takes the state path as an argument instead of reaching for a global, so the dependency is visible at the call site and testable.

`GET /api/sources` reports `last_completed_at`, `age_seconds` and `overdue`. Reader-scoped deliberately: staleness is what a teammate needs before trusting a search result, and it is what turns "has the cycle been running?" from log archaeology into a number.

## Two judgement calls

**A timestamp in the future is treated as "just now" rather than trusted.** A clock jump or a state file copied from elsewhere would otherwise park the scheduler for an unbounded time while every counter still read healthy. This repository has had that failure once already, where one future date stalled all writes and reported ok.

**The pass is stamped even when a stage fails.** It records that the cycle *ran*, which is what the next boot needs; whether the stages succeeded is already on the `Evolve finished` line and in `/readyz`. Stamping only clean passes would make a node with one broken stage restart its clock forever, which is this same bug in a different coat.

## Proof

```
full suite                    1382 passed, 1 skipped
source neutered, tests kept      4 failed, 1378 passed, 1 skipped
restored                      1382 passed, 1 skipped
```

Non-zero collected, and the four failures are exactly the resume, the overdue case, persistence, and staleness.

The revert was done by replacing `kb/evolve_state.py` with a behaviourless stub rather than deleting it. Deleting it breaks collection, and a zero-collected run prints no failures and is indistinguishable from a pass.

Refs #153