### PR TITLE
fix(access): stop rewriting the whole store on every authentication

### DIFF
--- a/kb/access.py
+++ b/kb/access.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+import functools
 import hashlib
 import json
 import logging
 from pathlib import Path
+from contextlib import contextmanager
+import fcntl
+import os
 import re
 import secrets
+import tempfile
+import threading
+from collections.abc import Iterator
 from typing import Any
 from uuid import uuid4
 
@@ -26,6 +33,11 @@ CENTRAL_DATASET = "masumi-network"
 SESSION_TRACES_DATASET = "session-traces"
 SEAT_DATASET_PREFIX = "seat:"
 SEAT_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+# How stale last_used_at may get. It is a "roughly when was this last used"
+# display value, and stamping it on every request made every authentication pay
+# a full read-modify-write of the whole store on the event loop (#105).
+LAST_USED_STAMP_INTERVAL_SECONDS = 60.0
 
 ROLE_ORDER = {"reader": 1, "writer": 2, "admin": 3}
 VALID_ROLES = frozenset(ROLE_ORDER)
@@ -245,6 +257,15 @@ def validate_expires_at(value: str | None) -> str | None:
     return text
 
 
+def _stamp_is_due(last_used_at: str | None) -> bool:
+    """True when last_used_at is missing or older than the stamp interval."""
+    parsed = _parse_time(last_used_at)
+    if parsed is None:
+        return True
+    age = (datetime.now(timezone.utc) - parsed).total_seconds()
+    return age >= LAST_USED_STAMP_INTERVAL_SECONDS
+
+
 def _is_expired(value: str | None) -> bool:
     if not value:
         # No expiry set. Permanent by design.
@@ -287,10 +308,30 @@ def _resolve_token_memory_scope(
     return default_dataset, default_session, api_token.allowed_datasets
 
 
+def _serialized(method):
+    """Run a mutating AccessStore method under the store's exclusive lock.
+
+    A decorator rather than nine hand-edited bodies so the lock boundary is one
+    visible line per method and cannot drift from the load-modify-save it must
+    span.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._exclusive():
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 class AccessStore:
     def __init__(self, path: Path | str, *, max_audit_events: int = 1000) -> None:
         self.path = Path(path)
         self.max_audit_events = max_audit_events
+        # Guards the read-modify-write; see _exclusive.
+        self._thread_lock = threading.RLock()
+        self._lock_depth = 0
+        self._lock_file: Any | None = None
 
     def has_tokens(self) -> bool:
         return any(token.revoked_at is None for token in self._tokens(self._load()))
@@ -317,26 +358,57 @@ class AccessStore:
         ]
 
     def authenticate_token(self, token: str) -> TokenSession | None:
+        """Resolve a token to a session, stamping last_used_at at most periodically.
+
+        Deliberately NOT wrapped in @_serialized. This runs on every
+        authenticated request, and the only thing it wrote was the last_used_at
+        timestamp, which made every request pay a full read-modify-write of the
+        whole store: 9.5ms before the lock existed, 17.7ms with it. That cost is
+        awaited on the FastAPI event loop, so it is not just this request's
+        latency, it is every other request's too (#105).
+
+        last_used_at answers "roughly when was this token last used", where
+        sub-minute precision buys nothing. Stamping at most once per
+        LAST_USED_STAMP_INTERVAL_SECONDS makes the overwhelming majority of
+        authentications read-only, so they take no lock and write no file. The
+        rare stamping path takes the lock properly and re-reads under it, so it
+        cannot clobber a concurrent revocation.
+
+        Nothing security-relevant is skipped: the rejection audit path below is
+        unconditional, and expiry/revocation are evaluated on every call.
+        """
         token_hash = hash_api_token(token)
         data = self._load()
         tokens = self._tokens(data)
-        for index, api_token in enumerate(tokens):
+        for api_token in tokens:
             if not secrets.compare_digest(api_token.token_hash, token_hash):
                 continue
             session = self._session_for_token(data, api_token)
             if not session:
-                self._record_token_rejection(data, api_token)
+                with self._exclusive():
+                    self._record_token_rejection(self._load(), api_token)
                 return None
-            tokens[index] = ApiToken(
-                **{
-                    **asdict(api_token),
-                    "last_used_at": now_iso(),
-                }
-            )
-            data["tokens"] = [asdict(token_item) for token_item in tokens]
-            self._save(data)
+            if _stamp_is_due(api_token.last_used_at):
+                self._stamp_last_used(api_token.id)
             return session
         return None
+
+    @_serialized
+    def _stamp_last_used(self, token_id: str) -> None:
+        """Refresh one token's last_used_at, re-reading under the lock.
+
+        Re-reads rather than reusing the caller's snapshot so a revocation that
+        landed between the read and this write is not overwritten.
+        """
+        data = self._load()
+        tokens = self._tokens(data)
+        for index, api_token in enumerate(tokens):
+            if api_token.id != token_id:
+                continue
+            tokens[index] = ApiToken(**{**asdict(api_token), "last_used_at": now_iso()})
+            data["tokens"] = [asdict(item) for item in tokens]
+            self._save(data)
+            return
 
     def token_session(self, token_id: str) -> TokenSession | None:
         data = self._load()
@@ -348,6 +420,7 @@ class AccessStore:
                 return session
         return None
 
+    @_serialized
     def create_principal(
         self,
         *,
@@ -462,6 +535,7 @@ class AccessStore:
             allowed_datasets=[node_dataset, central_dataset, SESSION_TRACES_DATASET],
         )
 
+    @_serialized
     def create_token(
         self,
         *,
@@ -548,6 +622,7 @@ class AccessStore:
             allowed_datasets=allowed_datasets,
         )
 
+    @_serialized
     def revoke_token(self, token_id: str) -> ApiToken | None:
         data = self._load()
         tokens = self._tokens(data)
@@ -565,6 +640,7 @@ class AccessStore:
         self._save(data)
         return revoked
 
+    @_serialized
     def record_event(
         self,
         *,
@@ -668,6 +744,7 @@ class AccessStore:
             updated_by=stored.get("updated_by"),
         )
 
+    @_serialized
     def set_capture_policy(
         self,
         slug: str,
@@ -700,6 +777,7 @@ class AccessStore:
             updated_by=stored.get("updated_by"),
         )
 
+    @_serialized
     def set_approved_capture_roots(
         self,
         slug: str,
@@ -766,6 +844,7 @@ class AccessStore:
                 return item
         return None
 
+    @_serialized
     def add_promotion_pending(self, item: PromotionPendingItem) -> PromotionPendingItem:
         data = self._load()
         pending: list[PromotionPendingItem] = []
@@ -802,6 +881,7 @@ class AccessStore:
                 return True
         return False
 
+    @_serialized
     def decide_promotion_pending(
         self,
         item_id: str,
@@ -946,10 +1026,86 @@ class AccessStore:
             "promotion_pending": data.get("promotion_pending", []),
         }
 
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Hold an exclusive lock across a whole read-modify-write.
+
+        Every mutating method here loads the file, edits it in memory and writes
+        it back. Without a lock spanning all three steps, two writers each read
+        the same state and the second write silently discards the first's edit.
+        That is not theoretical: the web process and the Railway cron services
+        (scripts/run_railway.py, scripts/run_self_improve.py) all construct an
+        AccessStore over the same path. Measured with two concurrent writers,
+        half of 120 events were lost.
+
+        A lost update here is worse than a lost log line, because this file also
+        holds tokens and principals: the write that vanishes can be a token
+        REVOCATION, which fails open.
+
+        The lock is a sidecar file rather than the store itself, so it survives
+        the atomic replace in _save (which swaps the inode out from under any
+        lock held on the old one).
+
+        Re-entrant, and it has to be. authenticate_token holds the lock and then
+        calls _record_token_rejection, which calls record_event, which wants it
+        again. flock is per open-file-description, so a second acquire from the
+        same process on a fresh handle blocks against itself forever. The depth
+        counter makes the nested acquire a no-op; the RLock makes it safe when
+        two threads in one process share the instance (FastAPI runs sync route
+        handlers in a threadpool).
+        """
+        with self._thread_lock:
+            if self._lock_depth:
+                self._lock_depth += 1
+                try:
+                    yield
+                finally:
+                    self._lock_depth -= 1
+                return
+            handle = self._lock_handle()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            self._lock_depth = 1
+            try:
+                yield
+            finally:
+                self._lock_depth = 0
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _lock_handle(self) -> Any:
+        """The long-lived handle the flock is taken on.
+
+        Opened once and kept, rather than per call: authenticate_token runs on
+        every authenticated request, and an open/close pair there is measurable
+        against a lock hold of a few hundred microseconds. Reopened if the file
+        was replaced or removed underneath us.
+        """
+        existing = getattr(self, "_lock_file", None)
+        if existing is not None and not existing.closed:
+            return existing
+        lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_file = lock_path.open("a+")
+        return self._lock_file
+
     def _save(self, data: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        with temp_path.open("w", encoding="utf-8") as handle:
-            json.dump(data, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-        temp_path.replace(self.path)
+        # A UNIQUE temp file per write. The fixed `<name>.tmp` this used to use
+        # is shared by every writer, and open("w") truncates: one process could
+        # truncate the file another was midway through json.dump-ing, and then
+        # rename the half-written result into place. That produced two failure
+        # modes under two concurrent writers, both reproduced: FileNotFoundError
+        # raised into the caller when one writer's replace() pulled the temp out
+        # from under another, and an unparseable access.json, which would take
+        # authentication down for everyone.
+        handle_fd, temp_name = tempfile.mkstemp(
+            dir=self.path.parent, prefix=f"{self.path.name}.", suffix=".tmp"
+        )
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            temp_path.replace(self.path)
+        except BaseException:
+            temp_path.unlink(missing_ok=True)
+            raise

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -201,6 +201,128 @@ def test_capture_roots_store_refuses_more_than_the_api_accepts(tmp_path: Path) -
         )
 
 
+def test_concurrent_writers_do_not_lose_events(tmp_path: Path) -> None:
+    """Two writers must not silently discard each other's edits.
+
+    The web process and the Railway cron services all construct an AccessStore
+    over the same file, and every mutation is load-modify-save. Without a lock
+    spanning all three steps the second save writes back a snapshot taken before
+    the first, and the first edit is gone.
+
+    Measured before the fix: 60 of 120 events survived with two writers, 44 of
+    160 with four, plus FileNotFoundError raised into callers because every
+    writer shared one fixed `.tmp` path.
+    """
+    import threading
+
+    path = tmp_path / "access.json"
+    AccessStore(path).create_principal_token(
+        name="seed", kind="service_account", role="reader"
+    )
+
+    def writer(tag: str) -> None:
+        # A separate instance per thread, which is the cross-process shape.
+        local = AccessStore(path)
+        for index in range(40):
+            local.record_event(
+                action=f"probe.{tag}", actor=None, success=True, detail={"i": index}
+            )
+
+    threads = [threading.Thread(target=writer, args=(f"w{n}",)) for n in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    events = AccessStore(path).snapshot()["audit_events"]
+    probes = [e for e in events if e["action"].startswith("probe.")]
+    assert len(probes) == 160, f"{160 - len(probes)} events lost to concurrent writes"
+
+
+def test_a_concurrent_write_cannot_resurrect_a_revoked_token(tmp_path: Path) -> None:
+    """The lost update that matters: a vanished revocation fails OPEN.
+
+    authenticate_token refreshes last_used_at. If that refresh writes back a
+    snapshot taken before a revocation landed, the revocation is erased and the
+    token works again. This is why the stamping path re-reads under the lock
+    rather than reusing the snapshot it authenticated from.
+    """
+    import threading
+
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    created = store.create_principal_token(
+        name="victim", kind="service_account", role="writer"
+    )
+
+    # Authenticate (loads a pre-revocation snapshot), revoke concurrently, then
+    # let the stamp write land.
+    barrier = threading.Barrier(2)
+
+    def revoke() -> None:
+        barrier.wait()
+        AccessStore(path).revoke_token(created.api_token.id)
+
+    def authenticate() -> None:
+        other = AccessStore(path)
+        barrier.wait()
+        for _ in range(20):
+            other.authenticate_token(created.token)
+
+    threads = [threading.Thread(target=revoke), threading.Thread(target=authenticate)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert AccessStore(path).authenticate_token(created.token) is None, (
+        "the revocation was overwritten by a concurrent last_used_at stamp"
+    )
+    assert AccessStore(path).has_tokens() is False
+
+
+def test_save_uses_a_unique_temp_file(tmp_path: Path) -> None:
+    """A shared temp path lets one writer truncate another's half-written file.
+
+    open("w") truncates, so with a fixed `<name>.tmp` two writers could
+    interleave into the same file and then rename the result into place. That
+    produced an unparseable access.json in testing, which takes authentication
+    down for everyone.
+    """
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    store.create_principal_token(name="a", kind="service_account", role="reader")
+
+    assert not (tmp_path / "access.json.tmp").exists(), "still using a fixed temp path"
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_last_used_is_stamped_but_not_on_every_request(tmp_path: Path) -> None:
+    """Stamping every request made each auth rewrite the whole store (#105).
+
+    First use still stamps, so "when was this last used" stays answerable. A
+    burst of subsequent authentications inside the interval writes nothing, and
+    the file is left byte-identical.
+    """
+    path = tmp_path / "access.json"
+    store = AccessStore(path)
+    created = store.create_principal_token(
+        name="hot", kind="service_account", role="reader"
+    )
+
+    assert store.authenticate_token(created.token) is not None
+    stamped = store.snapshot()["tokens"][0]["last_used_at"]
+    assert stamped is not None, "first use must record last_used_at"
+
+    before = path.read_bytes()
+    for _ in range(25):
+        assert store.authenticate_token(created.token) is not None
+
+    assert path.read_bytes() == before, "an authentication rewrote the store"
+    assert store.snapshot()["tokens"][0]["last_used_at"] == stamped
+
+
 def test_token_session_lookup_enforces_expiry(tmp_path: Path) -> None:
     access_store = store(tmp_path)
     created = access_store.create_principal_token(


### PR DESCRIPTION
Stage one, item two of [the execution plan](docs/superpowers/specs/2026-08-04-citadel-execution-plan.md). This is the access-store half of #169, rebased onto current main.

## The defect

`authenticate_token` performed a full load **and** a full save of the access store on every successful authentication, purely to stamp `last_used_at`. That cost is paid on the FastAPI event loop, so it is not this request's latency alone, it is every concurrent request's too.

`last_used_at` answers "roughly when was this token last used". Sub-minute precision buys nothing, so it is now stamped at most once per interval. The overwhelming majority of authentications become read-only: no lock, no write. The rare stamping path takes the lock properly and re-reads under it, so it cannot clobber a concurrent revocation.

Nothing security-relevant is skipped. The rejection audit path stays unconditional, and expiry and revocation are evaluated on every call.

Mutating methods are serialised through a decorator rather than nine hand-edited bodies, so the lock boundary is one visible line per method and cannot drift from the load-modify-save it has to span.

## Measured, both sides re-run under identical conditions

```
                        200 auths    per auth    store rewrites   last_used_at moved
BEFORE (origin/main)         45ms    0.226ms     200 of 200       yes
AFTER  (this branch)          6ms    0.031ms       0 of 200       no
```

Fresh processes, `__pycache__` cleared between runs. The `last_used_at` column is the load-bearing one: it is direct evidence the write was skipped, rather than an mtime proxy.

An earlier paired run reported 200 rewrites on *both* sides. That contradicted a clean run showing zero, so it was re-measured standalone rather than published; the paired number was an artefact of swapping `kb/access.py` mid-sequence with stale bytecode.

Blind spot, stated where the number is: single-process, no contention, temp filesystem. This measures the write elimination, not lock behaviour under real concurrency.

## Two differences from #169

- #169 also carried an unrelated 215-line skill document and a symlink. Dropped; they have nothing to do with this defect.
- **#169 branched before `5018aa2`**, which added `validate_expires_at` so an unparseable expiry can no longer read as "never expires". Taking its file wholesale would have silently reverted that security fix. The change was applied as a three-way merge instead, and both functions are verified present.

```
full suite: 1378 passed, 1 skipped
```

Supersedes #169. Refs #105