### PR TITLE
fix(mcp): three tool surfaces that reported something untrue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ CITADEL_MCP_ACCESS_TOKEN=
 CITADEL_MCP_DEFAULT_DATASET=masumi-network
 CITADEL_MCP_MAX_INGEST_BYTES=200000
 CITADEL_MCP_ALLOW_INSECURE_HTTP=false
+# Budget for one citadel_ingest with inline cognify (default 180). The deadline
+# a caller actually meets is the smaller of this and the MCP client's own tool
+# timeout; when the client gives up first, the agent gets that client's opaque
+# error instead of the tool's "submitted, outcome unconfirmed" answer. Set this
+# below the client's limit to keep the honest answer reachable.
+CITADEL_MCP_INGEST_TIMEOUT_SECONDS=180
 
 # Railway run mode: web, pipeline (full scheduled run: GitHub org sync,
 # skills refresh, self-improvement, backup mirror), evolve (6h self-evolving

--- a/kb/access.py
+++ b/kb/access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 import hashlib
@@ -906,15 +907,29 @@ class AccessStore:
         self,
         *,
         action: str | None = None,
+        actions: Iterable[str] | None = None,
         actor_id: str | None = None,
+        success: bool | None = None,
         limit: int = 20,
     ) -> list[dict[str, Any]]:
+        """Newest-first audit rows, optionally narrowed.
+
+        ``actions`` accepts a SET of action names because one act can be
+        recorded under several of them: a write reaches the store as
+        ``ingest``, ``contribute``, ``share_session`` or ``mcp.<tool>``
+        depending on the surface it arrived on, and a reader that names one of
+        them sees only that surface.
+        """
+        wanted = {name for name in (actions or ()) if name}
+        if action:
+            wanted.add(action)
         events = self._audit_events(self._load())
         filtered = [
             asdict(event)
             for event in reversed(events)
-            if (action is None or event.action == action)
+            if (not wanted or event.action in wanted)
             and (actor_id is None or event.actor_id == actor_id)
+            and (success is None or bool(event.success) is success)
         ]
         return filtered[: max(1, min(limit, 100))]
 

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -1172,7 +1172,16 @@ def create_mcp_server(
         ctx: Context,
         top_k: int = 10,
     ) -> dict[str, Any]:
-        """Search org-wide Linear issues synced to shared Central."""
+        """Search org-wide Linear issues synced to shared Central.
+
+        Scoped server-side to hits the Linear syncer wrote (`source=linear-issue`),
+        so a repo document that merely discusses Linear is not returned. The scope
+        is read from the issue header at the start of the document, which is body
+        text and therefore author-influenced: it selects what to search, it
+        attests nothing. The `filtering` block in the response reports how many
+        candidates the scope kept. The Linear workspace DIGEST carries no
+        per-issue header and is excluded; use citadel_search for it.
+        """
         return await _call_async(
             "citadel_linear_search",
             lambda: resolve_client(ctx).post(
@@ -1181,6 +1190,10 @@ def create_mcp_server(
                     "query": _require_non_empty(query, "query"),
                     "dataset": "masumi-network",
                     "top_k": _clamp_top_k(top_k),
+                    # Dataset alone is not a scope: shared Central holds every
+                    # synced source, so an unfiltered search here answered a
+                    # Linear question with another repo's documentation.
+                    "source": "linear-issue",
                 },
                 tool_name="citadel_linear_search",
             ),

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -34,6 +34,9 @@ MAX_AUDIT_LIMIT = 100
 DEFAULT_MAX_INGEST_BYTES = 200_000
 LOCAL_MCP_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 TRUTHY = frozenset({"1", "true", "yes", "on"})
+# The provenance kind the Linear syncer's per-issue documents resolve to
+# (kb.search_format.parse_content_header). citadel_linear_search scopes to it.
+LINEAR_ISSUE_SOURCE = "linear-issue"
 AUDIT_VIEWS = frozenset({"all", "mcp", "access", "failures"})
 PUBLIC_HOST_RE = re.compile(r"^(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?$")
 # tools/list must never block the hosted event loop on a nested self-HTTP call
@@ -1182,9 +1185,8 @@ def create_mcp_server(
         candidates the scope kept. The Linear workspace DIGEST carries no
         per-issue header and is excluded; use citadel_search for it.
         """
-        return await _call_async(
-            "citadel_linear_search",
-            lambda: resolve_client(ctx).post(
+        def search_linear() -> dict[str, Any]:
+            payload = resolve_client(ctx).post(
                 "/search",
                 {
                     "query": _require_non_empty(query, "query"),
@@ -1193,11 +1195,30 @@ def create_mcp_server(
                     # Dataset alone is not a scope: shared Central holds every
                     # synced source, so an unfiltered search here answered a
                     # Linear question with another repo's documentation.
-                    "source": "linear-issue",
+                    "source": LINEAR_ISSUE_SOURCE,
                 },
                 tool_name="citadel_linear_search",
-            ),
-        )
+            )
+            # Asking for the scope is not getting it: a Node older than this
+            # tool drops the unknown field (pydantic ignores extras) and answers
+            # with an unscoped page. Report the scope the Node confirms applying,
+            # never the one the request asked for.
+            filtering = payload.get("filtering") if isinstance(payload, dict) else None
+            applied = filtering.get("applied") if isinstance(filtering, dict) else None
+            confirmed = (
+                isinstance(applied, dict) and applied.get("source") == LINEAR_ISSUE_SOURCE
+            )
+            scoped: dict[str, Any] = {**payload, "scope_applied": confirmed}
+            if not confirmed:
+                warnings = [w for w in (payload.get("warnings") or []) if w]
+                warnings.append(
+                    "This Node did not confirm the linear-issue scope, so these results "
+                    "are NOT Linear-only — treat them as a general Central search."
+                )
+                scoped["warnings"] = warnings
+            return scoped
+
+        return await _call_async("citadel_linear_search", search_linear)
 
     @mcp.tool(annotations=TOOL_POLICIES["citadel_ingest"].annotations)
     async def citadel_ingest(

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -135,6 +135,20 @@ class CitadelMcpError(RuntimeError):
         self.status_code = status_code
 
 
+class CitadelMcpTimeout(CitadelMcpError):
+    """The budget expired before a response arrived.
+
+    Distinct from every other transport failure because it says nothing about
+    what the Node did: the request was written to the socket, so a write may
+    have landed, be landing, or never have been applied. A caller that treats
+    this as a failure retries and duplicates the write.
+    """
+
+    def __init__(self, message: str, *, timeout_s: float | None = None) -> None:
+        super().__init__(message)
+        self.timeout_s = timeout_s
+
+
 @dataclass(frozen=True)
 class ToolPolicy:
     role: str
@@ -707,6 +721,64 @@ def _validate_ingest_size(data: str) -> None:
 _INGEST_COGNIFY_TIMEOUT = 180.0
 
 
+def _ingest_cognify_timeout() -> float:
+    """Budget for one inline-cognify ingest, in seconds.
+
+    Overridable because the budget that decides what the caller sees is the
+    SMALLER of this one and the MCP client's own tool timeout. When the client
+    gives up first, the agent gets that client's opaque error and this tool
+    never runs its timeout path, so a deployment whose clients cut off earlier
+    than 180s should set this below their limit to keep the honest,
+    "outcome unconfirmed" answer reachable.
+    """
+    raw = os.getenv("CITADEL_MCP_INGEST_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return _INGEST_COGNIFY_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError:
+        return _INGEST_COGNIFY_TIMEOUT
+    return value if value > 0 else _INGEST_COGNIFY_TIMEOUT
+
+
+def _unconfirmed_ingest(
+    data: str,
+    tags: list[str],
+    dataset: str | None,
+    timeout_s: float | None,
+) -> dict[str, Any]:
+    """What a caller may honestly conclude when the ingest budget expired.
+
+    Not an error: an error means "this did not happen", and that is precisely
+    what a timeout cannot establish. The note went out on the wire, so the two
+    live possibilities are "landed" and "still landing"; the caller is given
+    the fingerprint needed to tell which, and told not to retry until it has.
+    """
+    budget = f"{timeout_s:g}s" if timeout_s else "the configured budget"
+    first_line = " ".join(data.strip().splitlines()[0].split())[:120]
+    return {
+        "ok": False,
+        "accepted": None,
+        "write_state": "unknown",
+        "timed_out": True,
+        "timeout_s": timeout_s,
+        "code": "TIMEOUT",
+        "submitted": {
+            "first_line": first_line,
+            "tags": list(tags),
+            "dataset": dataset,
+        },
+        "message": (
+            f"No response from your Node within {budget}. The note was SUBMITTED and its "
+            "outcome is not confirmed — inline cognify can outlast the budget, and a write "
+            "that timed out has been observed to land anyway. Do not re-ingest yet: a retry "
+            "duplicates a note that succeeded. Confirm first with citadel_recent_contributions "
+            "(mine=true), or citadel_search for a distinctive phrase from the note; re-ingest "
+            "only if neither finds it."
+        ),
+    }
+
+
 class CitadelHttpClient:
     def __init__(
         self,
@@ -811,7 +883,34 @@ class CitadelHttpClient:
             raise CitadelMcpError(
                 f"Citadel returned HTTP {exc.code}: {detail}", status_code=exc.code
             ) from exc
+        except TimeoutError as exc:
+            # A read timeout escapes urlopen unwrapped (only the connect phase
+            # is turned into URLError), so this used to leave the tool as a
+            # bare TimeoutError — "The operation timed out." with no statement
+            # about the request's fate. Name it so callers can tell an expired
+            # budget from a refused or unreachable Node.
+            logger.warning(
+                "Citadel API call %s %s exceeded its %.0fs budget",
+                method,
+                path,
+                effective_timeout,
+            )
+            raise CitadelMcpTimeout(
+                f"No response from Citadel within {effective_timeout:g}s.",
+                timeout_s=effective_timeout,
+            ) from exc
         except URLError as exc:
+            if isinstance(exc.reason, TimeoutError) or "timed out" in str(exc.reason).lower():
+                logger.warning(
+                    "Citadel API call %s %s exceeded its %.0fs budget",
+                    method,
+                    path,
+                    effective_timeout,
+                )
+                raise CitadelMcpTimeout(
+                    f"No response from Citadel within {effective_timeout:g}s.",
+                    timeout_s=effective_timeout,
+                ) from exc
             reason = redact_secrets(str(exc.reason), self.access_token)
             logger.error(
                 "Citadel API call %s %s failed: %s: %s",
@@ -1116,18 +1215,30 @@ def create_mcp_server(
         def post_ingest() -> dict[str, Any]:
             normalized_data = _require_non_empty(data, "data")
             _validate_ingest_size(normalized_data)
-            return resolve_client(ctx).post(
-                "/ingest",
-                {
-                    "data": normalized_data,
-                    "dataset": dataset,
-                    "tags": tags or [],
-                    "session_id": session_id,
-                    "cognify": cognify,
-                },
-                tool_name="citadel_ingest",
-                timeout=_INGEST_COGNIFY_TIMEOUT if cognify else None,
-            )
+            try:
+                return resolve_client(ctx).post(
+                    "/ingest",
+                    {
+                        "data": normalized_data,
+                        "dataset": dataset,
+                        "tags": tags or [],
+                        "session_id": session_id,
+                        "cognify": cognify,
+                    },
+                    tool_name="citadel_ingest",
+                    timeout=_ingest_cognify_timeout() if cognify else None,
+                )
+            except CitadelMcpTimeout as exc:
+                # An expired budget proves only that no response arrived. The
+                # request was already on the wire, and a note whose ingest
+                # "failed" this way was afterwards retrievable by id with a
+                # matching body and tags — so raising here taught agents to
+                # retry a write that had landed, duplicating it. Report what is
+                # known instead: submitted, outcome unconfirmed, here is how to
+                # settle it.
+                return _unconfirmed_ingest(
+                    normalized_data, tags or [], dataset, exc.timeout_s
+                )
 
         return await _call_async(
             "citadel_ingest",

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -830,11 +830,33 @@ def _hit_path_identity(hit: dict[str, Any]) -> str | None:
     return header.get("path") or header.get("title")
 
 
+def _hit_source_identity(hit: dict[str, Any]) -> str | None:
+    """WHICH syncer wrote this hit — from the server envelope or the header.
+
+    The kind of source a hit IS, not what its body discusses: a repository's
+    ``docs/agents/issue-tracker.md`` is about Linear on every line and is still
+    repo content. Prefer the server's resolved provenance, fall back to parsing
+    the structural header the syncer wrote (start of chunk 0 only, so a quoted
+    or mid-document header cannot claim another source's identity).
+
+    Header-derived, therefore author-controlled: this scopes a search, it does
+    not attest anything, and it must never feed ``trust_tier``.
+    """
+    provenance = _hit_provenance(hit)
+    source = _first_str(provenance.get("source"), hit.get("source"), hit.get("source_type"))
+    if source:
+        return source.strip().lower()
+    header = parse_content_header(_hit_raw_text(hit), chunk_index=_hit_chunk_index(hit))
+    kind = header.get("kind")
+    return kind.strip().lower() if isinstance(kind, str) and kind.strip() else None
+
+
 def compact_search_filters(
     *,
     types: list[str] | None = None,
     repo: str | None = None,
     path: str | None = None,
+    source: str | None = None,
     canonical_only: bool = False,
     exclude_ambient: bool = False,
     mode: str | None = None,
@@ -852,6 +874,8 @@ def compact_search_filters(
         filters["repo"] = repo.strip()
     if isinstance(path, str) and path.strip():
         filters["path"] = path.strip()
+    if isinstance(source, str) and source.strip():
+        filters["source"] = source.strip()
     if canonical_only:
         filters["canonical_only"] = True
     if exclude_ambient:
@@ -873,10 +897,17 @@ def filter_hits(
     types: list[str] | None = None,
     repo: str | None = None,
     path: str | None = None,
+    source: str | None = None,
     canonical_only: bool = False,
     exclude_ambient: bool = False,
 ) -> list[dict[str, Any]]:
     filtered = hits
+    if source:
+        # Fail-closed, like repo=: a hit that cannot state which source it came
+        # from does not satisfy a source filter. A tool that promises one
+        # source must return nothing rather than something else.
+        wanted_source = source.strip().lower()
+        filtered = [h for h in filtered if _hit_source_identity(h) == wanted_source]
     if types:
         wanted = {t.strip().lower() for t in types if t.strip()}
         filtered = [h for h in filtered if _hit_doc_type(h) in wanted]

--- a/kb/server.py
+++ b/kb/server.py
@@ -6194,6 +6194,24 @@ def share_session_tags_from_body(seat_slug: str, body: ShareSessionBody) -> list
     return tags
 
 
+# Every action name under which an accepted write into the Vault is recorded.
+# One act carries several names, and selecting a single one hid whole surfaces:
+#
+#   /api/contribute       -> "contribute"            (both HTTP and MCP)
+#   /ingest, CLI or HTTP  -> "ingest"
+#   /ingest via MCP       -> "mcp.citadel_ingest"    ONLY: the durable "ingest"
+#                            row is deliberately skipped for MCP requests to
+#                            avoid a second store write per call (see the
+#                            `not mcp_tool_name(request)` guard in ingest()).
+#   /api/share-session    -> "share_session"         (both HTTP and MCP)
+#
+# The MCP twins of contribute and share_session are excluded because their
+# non-MCP row is always written too, and listing both double-counts one write.
+CONTRIBUTION_ACTIONS = frozenset(
+    {"contribute", "ingest", "share_session", "mcp.citadel_ingest"}
+)
+
+
 @app.get("/api/contributions/recent")
 async def recent_contributions(
     request: Request,
@@ -6202,15 +6220,24 @@ async def recent_contributions(
 ) -> Any:
     actor = require_access(request, "reader", "kb:read")
     actor_id = actor.actor_id if mine else None
+    # success=True only: several of these surfaces audit their rejections under
+    # the same action (a secret-blocked ingest records success=False), and a
+    # write that was refused is not a contribution.
     events = get_access_store().recent_audit_events(
-        action="contribute",
+        actions=CONTRIBUTION_ACTIONS,
         actor_id=actor_id,
+        success=True,
         limit=limit,
     )
     return {
         "ok": True,
         "contributions": events,
-        "filter": {"mine": mine, "limit": limit},
+        "filter": {
+            "mine": mine,
+            "limit": limit,
+            "actions": sorted(CONTRIBUTION_ACTIONS),
+            "accepted_only": True,
+        },
     }
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -828,6 +828,10 @@ class SearchBody(BaseModel):
     types: list[str] | None = None
     repo: str | None = Field(default=None, max_length=200)
     path: str | None = Field(default=None, max_length=400)
+    # Which syncer wrote the hit (``linear-issue``, ``repo-content``): the scope
+    # a source-specific tool needs. Fail-closed — a hit that cannot say where it
+    # came from never satisfies it.
+    source: str | None = Field(default=None, max_length=64)
     canonical_only: bool = False
     exclude_ambient: bool = False
     mode: str | None = Field(default=None, max_length=32)
@@ -851,6 +855,11 @@ class SearchBody(BaseModel):
             "types": self.cleaned_types(),
             "repo": self.repo.strip() if isinstance(self.repo, str) and self.repo.strip() else None,
             "path": self.path.strip() if isinstance(self.path, str) and self.path.strip() else None,
+            "source": (
+                self.source.strip().lower()
+                if isinstance(self.source, str) and self.source.strip()
+                else None
+            ),
             "canonical_only": bool(self.canonical_only),
             "exclude_ambient": exclude_ambient,
         }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1315,6 +1315,63 @@ def test_linear_search_description_does_not_overclaim() -> None:
     assert "header" in description.lower()
 
 
+def test_linear_search_says_so_when_the_node_did_not_apply_the_scope() -> None:
+    """Asking for a scope is not the same as getting one.
+
+    A node older than this tool ignores the unknown ``source`` field (pydantic
+    drops extras) and answers with an unscoped page. Trusting the request would
+    label those results Linear-only, which is the defect this filter fixes.
+    """
+
+    class UnscopedNode(FakeHttpClient):
+        def post(
+            self,
+            path: str,
+            payload: dict[str, Any],
+            *,
+            tool_name: str | None = None,
+            timeout: float | None = None,
+        ) -> dict[str, Any]:
+            super().post(path, payload, tool_name=tool_name, timeout=timeout)
+            return {"results": [{"id": "1"}], "dataset": "masumi-network"}
+
+    server = create_mcp_server(UnscopedNode())
+
+    result = run_tool(server, "citadel_linear_search", "subscription credits", None)
+
+    assert result["scope_applied"] is False
+    assert any("scope" in str(w).lower() for w in result["warnings"])
+
+
+def test_linear_search_reports_the_scope_the_node_confirms() -> None:
+    class ScopedNode(FakeHttpClient):
+        def post(
+            self,
+            path: str,
+            payload: dict[str, Any],
+            *,
+            tool_name: str | None = None,
+            timeout: float | None = None,
+        ) -> dict[str, Any]:
+            super().post(path, payload, tool_name=tool_name, timeout=timeout)
+            return {
+                "results": [{"id": "1"}],
+                "filtering": {
+                    "applied": {"source": "linear-issue"},
+                    "candidates_fetched": 30,
+                    "candidates_matched": 1,
+                    "returned": 1,
+                },
+            }
+
+    server = create_mcp_server(ScopedNode())
+
+    result = run_tool(server, "citadel_linear_search", "subscription credits", None)
+
+    assert result["scope_applied"] is True
+    assert "warnings" not in result
+
+
 def test_contribute_tool_rejects_empty_or_oversized_payloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -647,6 +647,52 @@ def test_ingest_tool_honors_cognify_opt_out() -> None:
     assert post["timeout"] is None
 
 
+def test_ingest_timeout_reports_an_unconfirmed_write_not_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client budget expiry proves no response arrived — never that the write failed.
+
+    Reproduced live: the tool errored while the document was afterwards
+    retrievable by id with matching body and tags. An error tells the agent to
+    retry, and the retry duplicates the note, so the timeout path has to say
+    what is actually known (submitted, outcome unconfirmed) and how to check.
+    """
+
+    def fake_urlopen(request: Any, timeout: float) -> Any:
+        raise TimeoutError("The operation timed out.")
+
+    monkeypatch.setattr(mcp_server, "urlopen", fake_urlopen)
+    server = create_mcp_server(
+        CitadelHttpClient(base_url="http://localhost:8000", access_token="ctdl_t")
+    )
+
+    result = run_tool(server, "citadel_ingest", "a durable note", None)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert result["write_state"] == "unknown"
+    assert result["accepted"] is None
+    assert result["code"] == "TIMEOUT"
+    # The caller needs a way to check before writing again.
+    assert "citadel_recent_contributions" in result["message"]
+
+
+def test_ingest_timeout_budget_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The honest timeout payload only reaches the caller if OUR budget expires first.
+
+    The observed production cut-off was the MCP CLIENT's tool budget (~67s),
+    well under the 180s the tool asks urlopen for, so the tool never saw its
+    own expiry and the agent got an opaque error instead.
+    """
+    monkeypatch.setenv("CITADEL_MCP_INGEST_TIMEOUT_SECONDS", "45")
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    run_tool(server, "citadel_ingest", "a durable note", None)
+
+    assert client.posts[0]["timeout"] == 45.0
+
+
 class _OkResp:
     def __enter__(self) -> Any:
         return self
@@ -1236,6 +1282,37 @@ def test_recent_contributions_tool_reads_audit_feed() -> None:
 
     assert result["path"] == "/api/contributions/recent?limit=5&mine=true"
     assert client.gets[-1]["tool_name"] == "citadel_recent_contributions"
+
+
+def test_linear_search_asks_the_server_to_scope_to_linear() -> None:
+    """A tool that says it searches Linear must not run the general vault search.
+
+    Measured on production: the top hit for a Linear-shaped query was a
+    `docs/agents/issue-tracker.md` from an unrelated repo. Scoping by dataset
+    alone selects shared Central, which holds every synced source.
+    """
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    run_tool(server, "citadel_linear_search", "subscription credits missing", None)
+
+    post = client.posts[-1]
+    assert post["path"] == "/search"
+    assert post["payload"]["dataset"] == "masumi-network"
+    assert post["payload"]["source"] == "linear-issue"
+
+
+def test_linear_search_description_does_not_overclaim() -> None:
+    """The description is the contract an agent reads; it has to match the filter."""
+    server = create_mcp_server(FakeHttpClient())
+    all_tools = asyncio.run(server.list_tools())
+    tool = next(t for t in all_tools if t.name == "citadel_linear_search")
+    description = tool.description or ""
+
+    assert "linear-issue" in description.lower()
+    # The scope is derived from the header the syncer wrote into the body, and
+    # body text is author-controlled. Say so rather than implying attestation.
+    assert "header" in description.lower()
 
 
 def test_contribute_tool_rejects_empty_or_oversized_payloads(

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -254,6 +254,84 @@ def test_filter_hits_path_substring() -> None:
     assert "MIP-003" in (filtered[0]["path"] or "")
 
 
+def test_filter_hits_source_scopes_to_the_syncer_that_wrote_the_hit() -> None:
+    """``source=`` selects what a hit IS, not what its body talks about.
+
+    Measured on production: citadel_linear_search for a Linear-shaped query
+    returned four copies of a repo's ``docs/agents/issue-tracker.md`` above the
+    one real Linear issue, because the tool ran the general vault search with
+    no source filter. Both texts below are production shapes.
+    """
+    repo_doc_about_linear = {
+        "id": "repo-1",
+        "chunk_index": 0,
+        "text": (
+            "# masumi-network/sokosumi/docs/agents/issue-tracker.md\n"
+            "\n"
+            "Repository: masumi-network/sokosumi\n"
+            "Source: https://github.com/masumi-network/sokosumi/blob/1e03b94/docs/agents/issue-tracker.md\n"
+            "Commit: 1e03b94\n"
+            "Blob: 354a0ab\n"
+            "\n"
+            "---\n"
+            "\n"
+            "# Issue tracker: Linear\n"
+            "\n"
+            "Issues and PRDs for this repo live in **Linear**, team **Sokosumi**.\n"
+        ),
+    }
+    linear_issue = {
+        "id": "issue-1",
+        "chunk_index": 0,
+        "text": (
+            "# Linear DES-144: Subscription Credits missing\n"
+            "\n"
+            "- **State:** Backlog (backlog)\n"
+            "- **Team:** Design\n"
+            "- **URL:** https://linear.app/masumi/issue/DES-144/subscription-credits-missing\n"
+        ),
+    }
+
+    filtered = filter_hits([repo_doc_about_linear, linear_issue], source="linear-issue")
+
+    assert [hit["id"] for hit in filtered] == ["issue-1"]
+
+
+def test_filter_hits_source_reads_the_server_provenance_envelope() -> None:
+    """The server already resolved provenance; the filter reads it, never re-guesses."""
+    hits = [
+        {
+            "id": "repo-1",
+            "text": "prose that names Linear a lot",
+            "_citadel": {"provenance": {"source": "repo-content", "basis": "content-header"}},
+        },
+        {
+            "id": "issue-1",
+            "text": "body without a parseable header of its own",
+            "_citadel": {
+                "provenance": {
+                    "source": "linear-issue",
+                    "issue": "DES-144",
+                    "basis": "content-header",
+                }
+            },
+        },
+    ]
+
+    assert [hit["id"] for hit in filter_hits(hits, source="linear-issue")] == ["issue-1"]
+
+
+def test_filter_hits_source_refuses_a_forged_header_on_a_later_chunk() -> None:
+    """Chunk 1+ starts are author-controlled text, so a header there is forgeable."""
+    forged = {
+        "id": "forged",
+        "chunk_index": 3,
+        "text": "# Linear DES-999: not really an issue\n\n- **Team:** Design\n",
+    }
+
+    assert filter_hits([forged], source="linear-issue") == []
+
+
 def test_filter_hits_reads_server_citadel_envelope() -> None:
     hits = [
         {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3617,6 +3617,61 @@ def test_recent_contributions_lists_audit_events(tmp_path: Any) -> None:
     assert payload["contributions"][0]["detail"]["title"] == "WIP: MCP docs"
 
 
+def test_recent_contributions_lists_an_mcp_ingest(tmp_path: Any) -> None:
+    """A write through MCP is a contribution, and the feed must show it.
+
+    /ingest from the MCP surface records ONLY ``mcp.citadel_ingest`` (the
+    durable ``ingest`` row is suppressed for MCP requests), and the feed
+    selected the single action ``contribute`` — so a seat that ingested through
+    MCP saw an empty "recent contributions" list right after a write that was
+    independently proven to exist.
+    """
+    store = AccessStore(str(tmp_path / "access.json"))
+    app.state.access_store = store
+    writer = authed_client("test-writer")
+
+    ingested = writer.post(
+        "/ingest",
+        json={"data": "Runbook: rotate the sync token before minting seats.", "tags": ["runbook"]},
+        headers={"X-Citadel-MCP-Tool": "citadel_ingest"},
+    )
+    assert ingested.status_code == 200
+    assert ingested.json()["accepted"] is True
+
+    recent = writer.get("/api/contributions/recent?limit=10&mine=true")
+    assert recent.status_code == 200
+    payload = recent.json()
+    actions = [event["action"] for event in payload["contributions"]]
+    assert actions == ["mcp.citadel_ingest"], payload
+
+
+def test_recent_contributions_omits_rejected_writes(tmp_path: Any) -> None:
+    """The feed lists writes that landed, not writes that were attempted.
+
+    Widening the selection past ``contribute`` pulls in surfaces that audit
+    their failures too (a secret-blocked ingest records success=False), and a
+    rejected write listed as a contribution is the same dishonesty in the
+    other direction.
+    """
+    store = AccessStore(str(tmp_path / "access.json"))
+    app.state.access_store = store
+    writer = authed_client("test-writer")
+
+    # The row a secret-blocked MCP ingest writes (kb/server.py record_mcp_audit,
+    # success=bool(result.accepted)), recorded through the same store API.
+    store.record_event(
+        action="mcp.citadel_ingest",
+        actor=None,
+        success=False,
+        dataset="seat:test-writer",
+        detail={"surface": "mcp", "operation": "ingest", "blocked": "secret_content"},
+    )
+
+    recent = writer.get("/api/contributions/recent?limit=10")
+    assert recent.status_code == 200
+    assert recent.json()["contributions"] == []
+
+
 def test_contribute_routes_through_learning_process_and_audits(tmp_path: Any) -> None:
     client = authed_client("test-writer")
     store = AccessStore(str(tmp_path / "access.json"))


### PR DESCRIPTION
Three defects found by an end-to-end sweep against production. MCP is cross-cutting in every phase of the verification plan and is half the stated release exit, so these block the release rather than sitting beside it. All three were confirmed still present on current `main`; none was already fixed.

## 1. `citadel_recent_contributions` returned empty, always

**Root cause: two names for one act.** `/api/contributions/recent` selected the single audit action `"contribute"`, but an MCP ingest is never recorded under that name. `record_mcp_audit` writes `action="mcp.<tool>"`, and the durable `action="ingest"` row is deliberately skipped for MCP requests (`if result.accepted and not mcp_tool_name(request)`). So an MCP write produces exactly one row, `mcp.citadel_ingest`, and the feed selected a name it never has. CLI and HTTP ingests, and shared sessions, were invisible for the same reason.

Confirmed live before any change: `citadel_recent_contributions(limit=10)` returned `{"ok":true,"contributions":[]}` on production.

The endpoint now selects a set of contribution actions with `success=True`, and echoes both the action set and `accepted_only` in `filter` so a caller can see what was asked. The MCP twins of contribute and share_session are excluded because their non-MCP row is always written too, and listing both would double-count one write.

## 2. `citadel_ingest` reported a timeout on writes that landed

**Root cause:** `CitadelHttpClient._request` caught `HTTPError` and `URLError` but not `TimeoutError`, which is what a read timeout raises unwrapped out of `urlopen` — only the connect phase becomes a `URLError`. `_call` maps only `CitadelMcpError` to `ToolError`, so the timeout escaped raw.

A named `CitadelMcpTimeout` is now raised from both timeout shapes, and `citadel_ingest` returns an honest unconfirmed result: `ok:false`, `accepted:null`, `write_state:"unknown"`, the submitted note's first line, tags and dataset as a fingerprint, and a message naming the two tools that can check before re-ingesting. Fixing defect 1 is what makes that check work.

**What this does not fix, stated plainly:** the observed ~67s cut-off cannot have come from our client, whose budget is 180s. INFERRED, not verified: it comes from the MCP client's own tool timeout or an edge proxy, and while the shorter budget belongs to that layer, the honest payload never runs and the caller still gets an opaque error. `CITADEL_MCP_INGEST_TIMEOUT_SECONDS` exists so an operator can set ours below theirs. Cheapest measurement that would settle which layer cuts: time a deliberately slow `/ingest` from the CLI against the same call through MCP and compare where each stops.

## 3. `citadel_linear_search` did not scope to Linear

**Root cause:** the tool posted `/search` with `dataset: "masumi-network"` and nothing else. Dataset is not a scope — shared Central holds every synced source — so it ran the general vault search.

Confirmed live: a Linear-shaped query returned four chunks of a repo-content markdown file at ranks 1 to 4 and one actual Linear issue at rank 5.

## Tests

```
with the fixes:                    1400 passed, 1 skipped
source reverted, tests kept:         10 failed, 1375 passed, 1 skipped
```

One new test passes in both directions **by design** and is not counted as proof: it guards the contributions fix against over-widening rather than reproducing a defect. Saying so rather than quietly banking it.

## Rebased onto current main

This branch originally forked at `e9195d0`, before #236, #237 and #238 merged. Pushed as-is it would have deleted `kb/evolve_state.py`, stripped the `_serialized` write lock from `kb/access.py`, and removed both guard test files. `origin/main` is merged in, no conflicts, and all three shipped fixes verified present.

Refs #104