### PR TITLE
fix(deps): one cognee pin instead of two that disagree, and make body.force real

### DIFF
--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import json
 import logging
 from pathlib import Path
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 
 LINEAR_API = "https://api.linear.app/graphql"
 STATE_VERSION = 1
+
+# Tolerance for ordinary clock skew between Linear's clock and ours before an
+# updatedAt counts as future-dated and is excluded from cursor advancement.
+_CURSOR_SKEW_TOLERANCE = timedelta(minutes=5)
+# Consecutive incremental passes that wrote nothing before warning that the
+# sync may be stalled rather than the workspace merely quiet.
+_UNCHANGED_STREAK_WARN = 12
 
 
 def utc_now() -> str:
@@ -407,7 +414,21 @@ class LinearSyncer:
         # An issue absent from the prior state is always written (new issue, or
         # the max_issues window shifted onto it). force=True rewrites everything.
         prior_state = self._load_state()
+        # Anything past this horizon is future-dated, not merely skewed. A cursor
+        # ahead of real time makes `updated > prior_cursor` False for EVERY issue
+        # forever — a permanent stall that still reports ok:true with a fresh
+        # last_synced_at — so future-dated values are barred from the cursor on
+        # both the read side (below) and the write side (cursor advancement).
+        horizon = datetime.now(UTC) + _CURSOR_SKEW_TOLERANCE
         prior_cursor = None if force else _parse_iso(prior_state.get("last_seen_updated_at"))
+        if prior_cursor is not None and prior_cursor > horizon:
+            # Self-heal state poisoned before the clamp existed (or edited by
+            # hand): ignore the stored cursor and run this pass as a full sync.
+            logger.warning(
+                "Stored Linear sync cursor %s is future-dated; ignoring it and running a full pass",
+                prior_state.get("last_seen_updated_at"),
+            )
+            prior_cursor = None
         prior_issues = prior_state.get("issues")
         prior_ids = {
             str(item.get("id"))
@@ -547,19 +568,60 @@ class LinearSyncer:
                 self.citadel.cognee.schedule_cognify(cognify_datasets)
 
         # Advance the cursor to the newest updatedAt seen (keep the prior one
-        # when a pass sees nothing newer, e.g. an empty or truncated fetch).
-        new_cursor = prior_state.get("last_seen_updated_at")
-        best = _parse_iso(new_cursor)
+        # when a pass sees nothing newer, e.g. an empty or truncated fetch),
+        # clamped to the present: one future-dated updatedAt (Linear-side clock
+        # trouble, a bad import, a migration stamping the wrong year) must never
+        # pin the cursor ahead of real time and stall every later pass. The
+        # future-dated issue itself keeps being rewritten each pass (`updated >
+        # cursor` stays true — fail open, same rule as malformed timestamps)
+        # and is named in the warning, so the anomaly stays visible.
+        new_cursor = None
+        best: datetime | None = None
+        stored_raw = prior_state.get("last_seen_updated_at")
+        stored = _parse_iso(stored_raw)
+        if stored is not None and stored <= horizon:
+            best = stored
+            new_cursor = stored_raw
         for issue in issues:
             parsed = _parse_iso(issue.updated_at)
-            if parsed is not None and (best is None or parsed > best):
+            if parsed is None:
+                continue
+            if parsed > horizon:
+                logger.warning(
+                    "Linear issue %s has a future-dated updatedAt (%s); "
+                    "not advancing the sync cursor past it",
+                    issue.identifier,
+                    issue.updated_at,
+                )
+                continue
+            if best is None or parsed > best:
                 best = parsed
                 new_cursor = issue.updated_at
+
+        # A long run of write-less passes is either a genuinely quiet workspace
+        # or a stalled cursor — the logs are otherwise identical, so say so and
+        # name the disambiguator. A force=True pass writes (resetting the
+        # streak) and rebuilds the cursor from scratch.
+        streak_raw = prior_state.get("unchanged_pass_streak")
+        streak = (streak_raw if isinstance(streak_raw, int) and streak_raw >= 0 else 0) + 1
+        if touched_datasets:
+            streak = 0
+        elif streak >= _UNCHANGED_STREAK_WARN:
+            logger.warning(
+                "Linear sync has written nothing for %s consecutive passes "
+                "(%s issues fetched each time). Either the workspace is quiet or "
+                "the incremental cursor is stalled — a force=True run "
+                "(POST /api/linear-sync/run or CITADEL_RUN_MODE=linear-sync) "
+                "distinguishes the two.",
+                streak,
+                len(issues),
+            )
 
         payload = {
             "version": STATE_VERSION,
             "last_synced_at": utc_now(),
             "last_seen_updated_at": new_cursor,
+            "unchanged_pass_streak": streak,
             "last_error": None,  # clear any prior failure on a successful sync
             "last_attempt_at": utc_now(),
             "issues": [asdict(issue) for issue in issues],

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -33,6 +33,17 @@ def utc_now() -> str:
     return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse a Linear ISO-8601 timestamp; None when absent or malformed."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
 def _linear_state_path(configured: str | None) -> str:
     if configured:
         return configured
@@ -324,6 +335,15 @@ class LinearSyncer:
         return []
 
     async def run(self, *, force: bool = False, await_cognify: bool = False) -> dict[str, Any]:
+        """Sync Linear issues into Central (+ assignee seat mirrors).
+
+        Incremental by default (#90): an issue is rewritten only when its
+        ``updatedAt`` is newer than the stored cursor, when it is new to the
+        local state, or when its seat mirror has never recorded it (a seat
+        created after the issue last changed). ``force=True`` rewrites every
+        fetched issue regardless — the pre-#90 unconditional behaviour, and
+        what ``CITADEL_RUN_MODE=linear-sync`` uses.
+        """
         if not self.config.linear_api_key:
             return {"ok": False, "enabled": False, "reason": "linear_api_key_missing"}
 
@@ -379,51 +399,106 @@ class LinearSyncer:
         central_dataset = self.config.linear_sync_dataset or CENTRAL_DATASET
         session_id = self.config.linear_sync_session
 
+        # Incremental sync (#90): rewrite an issue only when Linear's updatedAt is
+        # newer than the cursor the previous run stored. The cursor is the max
+        # updatedAt SEEN — Linear's clock, not ours — so an issue updated while a
+        # sync is in flight still sorts after the cursor and is caught next pass;
+        # comparing against our own wall clock would skip exactly those writes.
+        # An issue absent from the prior state is always written (new issue, or
+        # the max_issues window shifted onto it). force=True rewrites everything.
+        prior_state = self._load_state()
+        prior_cursor = None if force else _parse_iso(prior_state.get("last_seen_updated_at"))
+        prior_issues = prior_state.get("issues")
+        prior_ids = {
+            str(item.get("id"))
+            for item in (prior_issues if isinstance(prior_issues, list) else [])
+            if isinstance(item, dict) and item.get("id")
+        }
+        prior_mirrors = (
+            prior_state.get("mirrors") if isinstance(prior_state.get("mirrors"), dict) else {}
+        )
+
+        def _changed(issue: LinearIssue) -> bool:
+            if prior_cursor is None or issue.id not in prior_ids:
+                return True
+            updated = _parse_iso(issue.updated_at)
+            # A malformed timestamp fails OPEN into a write: a redundant write is
+            # visible, a silently skipped issue is not.
+            return updated is None or updated > prior_cursor
+
+        changed_ids = {issue.id for issue in issues if _changed(issue)}
+        # A deletion changes the digest (the issue drops out of the listing)
+        # without moving any surviving issue's updatedAt, so it refreshes the
+        # digest too.
+        removed_ids = prior_ids - {issue.id for issue in issues}
+
         # Coalesce cognify (#46/#52): a full resync writes the digest + ~200 issues +
         # seat mirrors. Each write used to schedule its OWN background cognify, so
         # the on-demand POST /api/linear-sync/run fired ~200 Kuzu-writing cognifies
         # that stormed the writer lock and starved the request into a timeout. Write
         # ADD-ONLY here (defer_cognify=True) and schedule ONE cognify over every
         # dataset touched after the loop instead.
-        digest = format_workspace_digest(issues)
-        central_outcome = await learning.learn(
-            digest,
-            dataset=central_dataset,
-            tags=["linear-workspace", "linear-sync"],
-            session_id=session_id,
-            operation="linear_sync",
-            run_improve=self.config.linear_sync_run_improve,
-            tier="full",
-            defer_cognify=True,
-        )
-
-        mirrored = 0
-        mirrors: dict[str, list[str]] = {}
-        for issue in issues:
-            # Write each issue's full text (title + description) to Central so
-            # linear_search returns real issues org-wide — the digest only carried
-            # titles, leaving the 200 synced issues invisible to search (#52).
-            await learning.learn(
-                format_issue_note(issue),
+        central_outcome = None
+        if force or changed_ids or removed_ids:
+            digest = format_workspace_digest(issues)
+            central_outcome = await learning.learn(
+                digest,
                 dataset=central_dataset,
-                tags=[
-                    "linear-issue",
-                    "linear-sync",
-                    f"linear:{issue.identifier}",
-                    # Team as a structured, filterable metadata tag so Central issues
-                    # are discoverable by team (e.g. "what is the marketing team
-                    # working on?"). The human team NAME also rides in the note body
-                    # (format_issue_note) for semantic search.
-                    f"team:{issue.team_key}" if issue.team_key else "linear",
-                ],
+                tags=["linear-workspace", "linear-sync"],
                 session_id=session_id,
                 operation="linear_sync",
-                run_improve=False,
-                tier="light",
+                run_improve=self.config.linear_sync_run_improve,
+                tier="full",
                 defer_cognify=True,
             )
+
+        mirrored = 0
+        skipped_unchanged = 0
+        mirrors: dict[str, list[str]] = {}
+        written_mirror_datasets: list[str] = []
+        for issue in issues:
+            changed = issue.id in changed_ids
             mirror_dataset = resolve_mirror_dataset(issue, email_index, linear_user_map=user_map)
+            if mirror_dataset:
+                # The state mapping covers ALL fetched issues (issues_for_scope
+                # reads it), independent of whether this run rewrote the note.
+                mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
+            if changed:
+                # Write each issue's full text (title + description) to Central so
+                # linear_search returns real issues org-wide — the digest only carried
+                # titles, leaving the 200 synced issues invisible to search (#52).
+                await learning.learn(
+                    format_issue_note(issue),
+                    dataset=central_dataset,
+                    tags=[
+                        "linear-issue",
+                        "linear-sync",
+                        f"linear:{issue.identifier}",
+                        # Team as a structured, filterable metadata tag so Central issues
+                        # are discoverable by team (e.g. "what is the marketing team
+                        # working on?"). The human team NAME also rides in the note body
+                        # (format_issue_note) for semantic search.
+                        f"team:{issue.team_key}" if issue.team_key else "linear",
+                    ],
+                    session_id=session_id,
+                    operation="linear_sync",
+                    run_improve=False,
+                    tier="light",
+                    defer_cognify=True,
+                )
+            else:
+                skipped_unchanged += 1
             if not mirror_dataset:
+                continue
+            prior_mirror_ids = prior_mirrors.get(mirror_dataset)
+            mirror_has_note = isinstance(prior_mirror_ids, list) and issue.identifier in {
+                str(item) for item in prior_mirror_ids
+            }
+            # Backfill a mirror the state has never recorded this issue in even
+            # when the issue itself is unchanged — a seat created (or mapped)
+            # AFTER the issue last changed would otherwise never receive it
+            # until the issue next updates.
+            if not changed and mirror_has_note:
                 continue
             note = format_issue_note(issue)
             await learning.learn(
@@ -441,14 +516,20 @@ class LinearSyncer:
                 tier="light",
                 defer_cognify=True,
             )
-            mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
+            if mirror_dataset not in written_mirror_datasets:
+                written_mirror_datasets.append(mirror_dataset)
             mirrored += 1
 
         # One coalesced cognify over Central + every seat mirror we wrote — unless
-        # inline cognify is suppressed (the evolve Phase-1 subprocess is add-only and
-        # the web cognifies in Phase 2 as the sole Kuzu writer, #47).
-        if not _suppress_inline_cognify():
-            cognify_datasets = list(dict.fromkeys([central_dataset, *mirrors.keys()]))
+        # nothing was written (a fully-unchanged incremental pass has nothing to
+        # fold in) or inline cognify is suppressed (the evolve Phase-1 subprocess
+        # is add-only and the web cognifies in Phase 2 as the sole Kuzu writer, #47).
+        touched_datasets: list[str] = []
+        if central_outcome is not None:
+            touched_datasets.append(central_dataset)
+        touched_datasets.extend(written_mirror_datasets)
+        if touched_datasets and not _suppress_inline_cognify():
+            cognify_datasets = list(dict.fromkeys(touched_datasets))
             if await_cognify:
                 # Standalone CITADEL_RUN_MODE=linear-sync: AWAIT the single coalesced
                 # cognify so a manual forced run actually indexes the issues, instead
@@ -465,9 +546,20 @@ class LinearSyncer:
                 # without waiting on the graph write.
                 self.citadel.cognee.schedule_cognify(cognify_datasets)
 
+        # Advance the cursor to the newest updatedAt seen (keep the prior one
+        # when a pass sees nothing newer, e.g. an empty or truncated fetch).
+        new_cursor = prior_state.get("last_seen_updated_at")
+        best = _parse_iso(new_cursor)
+        for issue in issues:
+            parsed = _parse_iso(issue.updated_at)
+            if parsed is not None and (best is None or parsed > best):
+                best = parsed
+                new_cursor = issue.updated_at
+
         payload = {
             "version": STATE_VERSION,
             "last_synced_at": utc_now(),
+            "last_seen_updated_at": new_cursor,
             "last_error": None,  # clear any prior failure on a successful sync
             "last_attempt_at": utc_now(),
             "issues": [asdict(issue) for issue in issues],
@@ -479,12 +571,16 @@ class LinearSyncer:
             "ok": True,
             "enabled": True,
             "issue_count": len(issues),
+            # Incrementality diagnostics (#90): how many issues this pass actually
+            # rewrote vs skipped as unchanged since the stored cursor.
+            "written_count": len(changed_ids),
+            "skipped_unchanged": skipped_unchanged,
             "mirrored_count": mirrored,
             # Diagnostics for #46: how many assignees were auto-mapped to seats by
             # email. 0 with issues present usually means the Linear key cannot read
             # member emails — set CITADEL_LINEAR_USER_MAP explicitly in that case.
             "auto_mapped_assignees": auto_mapped,
-            "central_ingested": central_outcome.ingest.accepted,
+            "central_ingested": central_outcome.ingest.accepted if central_outcome else None,
             "mirrors": mirrors,
             "last_synced_at": payload["last_synced_at"],
         }

--- a/kb/server.py
+++ b/kb/server.py
@@ -902,6 +902,8 @@ class GitHubSyncBody(BaseModel):
 
 
 class LinearSyncBody(BaseModel):
+    # force=True rewrites every fetched issue; the default incremental pass skips
+    # issues unchanged since the stored updatedAt cursor (#90).
     force: bool = False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,15 @@ dependencies = []
 # `pip install citadel-archive[server]` — run the Node/MCP server + sync jobs.
 server = [
     "aiohttp>=3.14.1,<4.0.0",
-    "cognee[fastembed,postgres-binary]>=1.2.2,<2.0.0",
+    # Must match requirements.txt exactly (#150). The 1.2.x cap is load-bearing:
+    # ADR-0009 dataset attribution reads cognee PRIVATE internals
+    # (cognee.modules.data.models, get_default_user) that a 1.3.x could move,
+    # silently fail-closed, and blank every scoped caller's vault. Railway
+    # installs from requirements.txt, so a looser bound here is inert in
+    # production — but it bites any `pip install -e .`, and a dev env resolving
+    # a newer cognee against the production DATABASE_URL re-stamps the
+    # migration row forward (the 2026-07-13 cognee-1.3.0 incident).
+    "cognee[fastembed,postgres-binary]>=1.2.2,<1.3.0",
     "cryptography>=48.0.1,<49.0.0",
     "fastapi>=0.116.2,<1.0.0",
     "google-auth>=2.40.0,<3.0.0",

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -334,8 +334,10 @@ async def _linear_sync_stage_async() -> int:
 
     No-op (exit 0) when ``CITADEL_LINEAR_API_KEY`` is unset, so the stage is safe
     to leave enabled. The Central write lands in shared Postgres/pgvector; the
-    evolve cognify stage then folds it into the graph. Incremental (``force=False``)
-    — the explicit ``CITADEL_RUN_MODE=linear-sync`` job stays a forced full sync.
+    evolve cognify stage then folds it into the graph. Incremental
+    (``force=False``, #90): issues whose ``updatedAt`` predates the stored
+    cursor are skipped — the explicit ``CITADEL_RUN_MODE=linear-sync`` job
+    stays a forced full sync.
     """
     from kb.access import AccessStore
     from kb.linear_sync import LinearSyncer
@@ -358,8 +360,10 @@ async def _linear_sync_stage_async() -> int:
             )
             return 1
         logger.info(
-            "Linear sync stage finished: issues=%s mirrored=%s",
+            "Linear sync stage finished: issues=%s written=%s skipped_unchanged=%s mirrored=%s",
             result.get("issue_count"),
+            result.get("written_count"),
+            result.get("skipped_unchanged"),
             result.get("mirrored_count"),
         )
         return 0

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,32 @@
+"""#150: the cognee pin drifted between pyproject.toml (<2.0.0) and
+requirements.txt (<1.3.0). Railway installs from requirements.txt, so the
+looser pyproject bound was inert in production but resolved cognee 1.4.0 for
+any `pip install -e .` — and an uncapped side is what let production run
+cognee 1.3.0 for ~28h in 2026-07 and stamp a foreign migration revision.
+Keep both install paths on the same specifier so neither can drift alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cognee_requirement(lines: list[str]) -> str:
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("cognee"):
+            return stripped.rstrip(",").strip('"')
+    raise AssertionError("no cognee requirement found")
+
+
+def test_cognee_pin_matches_between_pyproject_and_requirements() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    server_deps = pyproject["project"]["optional-dependencies"]["server"]
+    pyproject_pin = _cognee_requirement([str(item) for item in server_deps])
+    requirements_pin = _cognee_requirement(
+        (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+    )
+    assert pyproject_pin == requirements_pin

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -384,3 +384,165 @@ def test_linear_sync_status_disabled(tmp_path: Any) -> None:
 
     status = asyncio.run(_status())
     assert status["enabled"] is False
+
+
+def _capture_learn(monkeypatch: Any, ingests: list[dict[str, Any]]) -> None:
+    async def fake_learn(
+        self: Any,
+        data: str,
+        *,
+        dataset: str | None = None,
+        tags: list[str] | None = None,
+        **_: Any,
+    ) -> Any:
+        ingests.append({"dataset": dataset, "tags": tags or [], "data": data})
+
+        class Outcome:
+            class ingest:
+                accepted = True
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+
+
+def _incremental_syncer(
+    tmp_path: Any,
+    sample_issues: list[dict[str, Any]],
+    monkeypatch: Any,
+    *,
+    with_seat: bool = True,
+) -> tuple[LinearSyncer, list[dict[str, Any]], list[list[str]]]:
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+        access_store_path=str(tmp_path / "access.json"),
+    )
+    citadel = Citadel(config)
+    store: AccessStore | None = None
+    if with_seat:
+        store = AccessStore(config.access_store_path)
+        store.create_seat(
+            name="John Doe", slug="john", email="john@example.com", issue_token=False
+        )
+    ingests: list[dict[str, Any]] = []
+    _capture_learn(monkeypatch, ingests)
+    scheduled: list[list[str]] = []
+    monkeypatch.setattr(
+        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+    )
+    syncer = LinearSyncer(
+        citadel, client=FakeLinearClient(sample_issues), access_store=store
+    )
+    return syncer, ingests, scheduled
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_incremental_skips_unchanged_issues(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #90: `force` was accepted but never read, so every pass (including the
+    # hourly evolve stage's force=False) was a full resync. A second pass over
+    # an unchanged workspace must write nothing and schedule no cognify.
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+
+    first = await syncer.run(force=False)  # no prior state: everything is new
+    assert first["ok"] is True
+    assert first["written_count"] == 2
+    assert first["skipped_unchanged"] == 0
+    ingests.clear()
+    scheduled.clear()
+
+    second = await syncer.run(force=False)
+    assert second["ok"] is True
+    assert ingests == []  # no digest, no issue notes, no mirror notes
+    assert scheduled == []  # nothing written, nothing to cognify
+    assert second["written_count"] == 0
+    assert second["skipped_unchanged"] == 2
+    assert second["mirrored_count"] == 0
+    assert second["central_ingested"] is None
+    # The pass still refreshes state: issues_for_scope stays complete.
+    assert second["last_synced_at"]
+    assert syncer.issues_for_scope(scope="my", seat_dataset_name=seat_dataset("john"))
+    assert len(syncer.issues_for_scope(scope="org", seat_dataset_name=None)) == 2
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_incremental_rewrites_only_updated_issue(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #90: only the issue whose updatedAt moved past the stored cursor is
+    # rewritten; the digest refreshes (its listing changed) and the coalesced
+    # cognify covers exactly Central + the one touched mirror.
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+    assert (await syncer.run(force=False))["ok"] is True
+    ingests.clear()
+    scheduled.clear()
+
+    sample_issues[0]["updatedAt"] = "2026-06-25T12:00:00Z"
+    sample_issues[0]["title"] = "Ship Linear sync v2"
+
+    second = await syncer.run(force=False)
+    assert second["ok"] is True
+    assert second["written_count"] == 1
+    assert second["skipped_unchanged"] == 1
+    issue_writes = [item for item in ingests if "linear-issue" in item["tags"]]
+    id_tags = {tag for item in issue_writes for tag in item["tags"] if tag.startswith("linear:")}
+    assert id_tags == {"linear:ENG-1"}  # ENG-2 untouched
+    assert any("linear-workspace" in item["tags"] for item in ingests)  # digest refreshed
+    assert scheduled == [["masumi-network", seat_dataset("john")]]
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_force_rewrites_unchanged_issues(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #90: force=True (POST body / CITADEL_RUN_MODE=linear-sync) must actually
+    # force — every issue is rewritten even when nothing changed.
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+    assert (await syncer.run(force=False))["ok"] is True
+    ingests.clear()
+    scheduled.clear()
+
+    second = await syncer.run(force=True)
+    assert second["ok"] is True
+    assert second["written_count"] == 2
+    assert second["skipped_unchanged"] == 0
+    assert second["mirrored_count"] == 1
+    central_issue_writes = [
+        item
+        for item in ingests
+        if item["dataset"] == "masumi-network" and "linear-issue" in item["tags"]
+    ]
+    id_tags = {
+        tag for item in central_issue_writes for tag in item["tags"] if tag.startswith("linear:")
+    }
+    assert id_tags == {"linear:ENG-1", "linear:ENG-2"}
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_backfills_mirror_for_seat_created_after_issue_update(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # #90: a seat created AFTER its issues last changed must still receive its
+    # mirror notes on the next incremental pass — the issues are unchanged, but
+    # the state has never recorded them in that mirror.
+    syncer, ingests, scheduled = _incremental_syncer(
+        tmp_path, sample_issues, monkeypatch, with_seat=False
+    )
+    first = await syncer.run(force=False)  # no seats yet: no mirrors resolve
+    assert first["ok"] is True
+    assert first["mirrored_count"] == 0
+    ingests.clear()
+    scheduled.clear()
+
+    store = AccessStore(str(tmp_path / "access.json"))
+    store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
+    syncer.access_store = store
+
+    second = await syncer.run(force=False)
+    assert second["ok"] is True
+    assert second["written_count"] == 0  # no Central rewrites
+    assert second["mirrored_count"] == 1  # ENG-1 backfilled into seat:john
+    assert [item["dataset"] for item in ingests] == [seat_dataset("john")]
+    assert scheduled == [[seat_dataset("john")]]  # Central untouched

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -546,3 +546,90 @@ async def test_linear_sync_backfills_mirror_for_seat_created_after_issue_update(
     assert second["mirrored_count"] == 1  # ENG-1 backfilled into seat:john
     assert [item["dataset"] for item in ingests] == [seat_dataset("john")]
     assert scheduled == [[seat_dataset("john")]]  # Central untouched
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_future_dated_updated_at_cannot_stall_cursor(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any, caplog: Any
+) -> None:
+    # Review of #90: one future-dated updatedAt (Linear clock trouble, a bad
+    # import) must not pin last_seen_updated_at ahead of real time — that would
+    # make _changed() False for every issue forever, a permanent silent stall
+    # that still reports ok:true with a fresh last_synced_at.
+    import json
+    import logging
+
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+    sample_issues[1]["updatedAt"] = "2099-01-01T00:00:00Z"  # poisoned
+
+    with caplog.at_level(logging.WARNING, logger="kb.linear_sync"):
+        first = await syncer.run(force=False)
+    assert first["ok"] is True
+    # The cursor stopped at the newest VALID timestamp, not 2099, and the
+    # future-dated issue was named in a warning.
+    state = json.loads((tmp_path / "linear_state.json").read_text(encoding="utf-8"))
+    assert state["last_seen_updated_at"] == "2026-06-25T10:00:00Z"
+    assert any("ENG-2" in record.getMessage() for record in caplog.records)
+    ingests.clear()
+
+    # The assertion that matters: a normal issue updated AFTER the poisoned pass
+    # is still written on the next incremental pass — the stall cannot happen.
+    from kb.linear_sync import utc_now
+
+    sample_issues[0]["updatedAt"] = utc_now()
+    second = await syncer.run(force=False)
+    assert second["ok"] is True
+    id_tags = {
+        tag
+        for item in ingests
+        if "linear-issue" in item["tags"]
+        for tag in item["tags"]
+        if tag.startswith("linear:")
+    }
+    assert "linear:ENG-1" in id_tags  # the real update landed
+    assert "linear:ENG-2" in id_tags  # the poisoned issue fails open into rewrites
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_recovers_from_future_dated_stored_cursor(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    # State persisted before the clamp existed (or edited by hand) can already
+    # hold a future cursor. It must be ignored (full pass) and replaced by the
+    # newest valid updatedAt, not preserved forever.
+    import json
+
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+    assert (await syncer.run(force=False))["ok"] is True
+    ingests.clear()
+
+    state_path = tmp_path / "linear_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["last_seen_updated_at"] = "2099-01-01T00:00:00Z"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    second = await syncer.run(force=False)
+    assert second["ok"] is True
+    assert second["written_count"] == 2  # full pass, nothing silently skipped
+    healed = json.loads(state_path.read_text(encoding="utf-8"))
+    assert healed["last_seen_updated_at"] == "2026-06-25T10:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_warns_after_prolonged_write_less_streak(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any, caplog: Any
+) -> None:
+    # A permanently-stalled incremental sync and a genuinely quiet workspace
+    # produce identical logs; after enough write-less passes, say so and name
+    # force=True as the disambiguator.
+    import logging
+
+    monkeypatch.setattr("kb.linear_sync._UNCHANGED_STREAK_WARN", 2)
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+    assert (await syncer.run(force=False))["ok"] is True  # writes; streak 0
+
+    with caplog.at_level(logging.WARNING, logger="kb.linear_sync"):
+        assert (await syncer.run(force=False))["ok"] is True  # streak 1: quiet
+        assert not any("written nothing" in record.message for record in caplog.records)
+        assert (await syncer.run(force=False))["ok"] is True  # streak 2: warn
+    assert any("written nothing" in record.message for record in caplog.records)


### PR DESCRIPTION
Stage one, section 2.3 of [the execution plan](docs/superpowers/specs/2026-08-04-citadel-execution-plan.md), which places it before any cognee upgrade "so there is one pin to move rather than two that disagree. Two declared ranges mean the deploy path and the packaged distribution can install different versions."

## The pin

`pyproject.toml` declared `cognee[fastembed,postgres-binary]>=1.2.2,<2.0.0`; `requirements.txt` declared `>=1.2.2,<1.3.0`. **Railway installs from `requirements.txt`**, so the deployed node and the packaged distribution could resolve to different cognee versions.

Both now read `<1.3.0`, the tighter of the two, with a comment recording why the 1.2.x cap is load-bearing: ADR-0009's dataset attribution reads cognee private internals that a 1.3.x could move, and it fails closed.

A new guard test parses both files and asserts the specifiers match, so this cannot drift again silently.

## The rider

#150: `body.force` was accepted by the linear-sync route and then ignored. The plan puts it here rather than later because "a parameter that is accepted and ignored is a lie an operator acts on." It is now passed through and gates incremental versus full rewrite, including a cursor clamp against future-dated timestamps.

## Rebased, and one near-miss worth recording

This carries PR #205's work rather than re-deriving it — the branch was stale, not wrong. Two checks were run before taking anything:

**Against `#205`'s merge-base:** `8d3bafe` had landed on main, bumping `aiohttp>=3.14.3` and `cryptography>=50.0.0`. Both survive; verified by grep on both files.

**Against current `main`:** this branch originally forked at `e9195d0`, before #236, #237 and #238 merged. Pushed as-is it would have deleted `kb/evolve_state.py`, stripped the `_serialized` write lock from `kb/access.py`, and removed two guard test files. That was caught by an independent verification pass, not by the original check, which only inspected six pin-related files. `origin/main` is now merged in with no conflicts and all three shipped fixes verified present.

## Tests

```
with the fix:                     1397 passed, 1 skipped
pin reverted in pyproject only:      1 failed  (specifiers disagree)
source reverted, tests kept:         8 failed, 12 passed
```

Supersedes #205. Refs #150