### PR TITLE
fix(learning-agent): carry the gateway skip reason into the audit trail

### DIFF
--- a/kb/server.py
+++ b/kb/server.py
@@ -5672,6 +5672,13 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
         and not body.dry_run
     ):
         await mesh_state.record_repo_content_sync(citadel.config, repo_content_result)
+    # The response body already carries WHY the gateway did or did not send
+    # (`notifications.google_chat.reason`: "google_chat_disabled",
+    # "no_meaningful_updates", "dry_run", "preview_only", or None on an actual
+    # send). Recording only `sent` here would collapse all of those distinct,
+    # legitimate states into one boolean in the one place — the audit trail —
+    # that survives after the response is gone (#149, #151).
+    google_chat_notification = (result.get("notifications") or {}).get("google_chat") or {}
     get_access_store().record_event(
         action="learning_agent.run",
         actor=actor,
@@ -5686,9 +5693,8 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
                 repo_content_result.get("files_ingested") if isinstance(repo_content_result, dict) else None
             ),
             "digest_meaningful": (result.get("organization_digest") or {}).get("meaningful"),
-            "google_chat_sent": (
-                (result.get("notifications") or {}).get("google_chat") or {}
-            ).get("sent"),
+            "google_chat_sent": google_chat_notification.get("sent"),
+            "google_chat_reason": google_chat_notification.get("reason"),
         },
     )
     record_mcp_audit(
@@ -5704,9 +5710,8 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
             "ingested": result.get("ingested"),
             "improved": result.get("improved"),
             "digest_meaningful": (result.get("organization_digest") or {}).get("meaningful"),
-            "google_chat_sent": (
-                (result.get("notifications") or {}).get("google_chat") or {}
-            ).get("sent"),
+            "google_chat_sent": google_chat_notification.get("sent"),
+            "google_chat_reason": google_chat_notification.get("reason"),
         },
     )
     return jsonable_encoder(result)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -951,6 +951,46 @@ def test_api_uses_configured_citadel_service() -> None:
     assert upgrade.status_code == 200
 
 
+def test_learning_agent_run_audit_records_gateway_skip_reason() -> None:
+    """A digest that posts nowhere must say why in the audit trail, not just that.
+
+    The response body from POST /api/learning-agent/run already carries a
+    ``reason`` on ``notifications.google_chat`` (e.g. "google_chat_disabled").
+    The audit record written for that same call is the only trace left once
+    nobody is watching the response — it must not collapse that reason down to
+    a bare ``sent: false`` with no explanation.
+    """
+    client = authed_client()
+
+    class SkippedGatewayAgent(FakeLearningAgent):
+        async def run(self, **kwargs: Any) -> dict[str, Any]:
+            result = await super().run(**kwargs)
+            result["notifications"] = {
+                "google_chat": {
+                    "enabled": False,
+                    "sent": False,
+                    "reason": "google_chat_disabled",
+                }
+            }
+            return result
+
+    server_module.app.state.learning_agent = SkippedGatewayAgent()
+
+    response = client.post("/api/learning-agent/run", json={"post_to_chat": True})
+    assert response.status_code == 200
+    assert response.json()["notifications"]["google_chat"]["reason"] == "google_chat_disabled"
+
+    events = server_module.app.state.access_store.snapshot()["audit_events"]
+    run_events = [event for event in events if event["action"] == "learning_agent.run"]
+    assert run_events, "expected a learning_agent.run audit event"
+    detail = run_events[-1]["detail"]
+    assert detail["google_chat_sent"] is False
+    assert detail["google_chat_reason"] == "google_chat_disabled", (
+        "the audit trail must carry why the gateway did not send, not just that "
+        f"it did not: {detail}"
+    )
+
+
 def test_linear_sync_api_endpoints() -> None:
     client = authed_client()
 


### PR DESCRIPTION
Issues #149 and #151, with the diagnosis corrected against what the code actually does.

## The issues are partly out of date

Both assume the "no gateway configured" success signal is silent or empty. It is not, and has not been since June: `_maybe_post_gateways` already returns an explicit `reason` on every skip path (`google_chat_disabled`, `no_meaningful_updates`, `dry_run`, `preview_only`), and both the API response and the dashboard already render it honestly. #151's own reproduction, `gateways=google_chat:google_chat_disabled`, is what the code already emits.

Verified by reading the current code rather than the issue text. `/contact`'s handling is likewise already honest: ADR-0013's amendment persists the enquiry before attempting delivery and returns 503 only when storage itself fails, not when a gateway is merely unconfigured.

## The real defect is one hop downstream

The audit record — the one thing that survives after the response is gone — carried only `"google_chat_sent": <bool>`. It read `.get("sent")` and dropped `.get("reason")`, so four distinct legitimate states (never configured, digest not meaningful, dry run, preview only) all collapsed into the same `google_chat_sent: false`.

That is exactly the class PR #232 fixed on the Knowledge Mesh surface: a field that discards the information needed to answer "why", reported as if a bare flag were the whole story.

Both the access-store audit and the MCP audit now carry `google_chat_reason` alongside `google_chat_sent`.

## Tests

```
with the fix:                  1390 passed, 1 skipped
source reverted, test kept:       1 failed  (KeyError: 'google_chat_reason')
```

Files deliberately not touched: `kb/learning_agent.py`, `kb/notification_gateways.py`, `kb/google_chat.py`, and the `/contact` handler. All were inspected and are already honest.

Rebased onto current `main`, which this branch predated; no conflicts, and #236, #237 and #238's changes are verified present.

Refs #149, #151