### PR TITLE
fix(chunk): a measured budget, and a detector for what no budget can bound

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -245,6 +245,31 @@ EMBEDDING_PROVIDER=fastembed
 EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
 EMBEDDING_DIMENSIONS=384
 
+# Chunk budget, counted in GPT-4o BPE tokens because that is the unit cognee
+# sizes chunks in. This model reads 512 wordpieces and drops the rest without
+# raising, so an oversized chunk is stored and unfindable rather than rejected.
+# cognee ships 8191 here; at that setting 245 of 274 chunks over a 172-document
+# probe corpus were past the window, worst 12,642 wordpieces.
+#
+# 256 is an OBSERVED value, not a bound. Wordpiece expansion depends on the
+# content, and budgets picked by measuring a ratio have been refuted three times
+# by the next content class (384 by Korean prose, 352 by minified JSON, 284 by
+# this repository's own minified JS). cognee also emits an over-budget chunk
+# verbatim when a single word does not fit, so no setting here caps chunk size
+# on its own. Citadel reports every real overflow at the embed boundary instead;
+# grep the logs for "embed window exceeded" and lower this when one appears.
+# Leave unset to take the value above. Lowering it raises the chunk count, which
+# costs cognify time and rows, so it is worth a measurement rather than a guess.
+CITADEL_CHUNK_BUDGET_TOKENS=256
+# Report chunks that exceeded the embedder's window. On by default; a detector
+# that is off is indistinguishable from one with nothing to report.
+CITADEL_EMBED_WINDOW_DETECTOR=true
+# Refuse a document containing one unbroken word larger than the budget. cognee
+# breaks words on a space and on sentence endings only, so one minified line is
+# one word: such a document either fails the whole dataset's cognify pass or is
+# stored truncated. The policy is refuse and record; nothing here edits content.
+CITADEL_UNCHUNKABLE_GUARD=true
+
 # Railway/Postgres examples. Bind DATABASE_URL from the Railway Postgres service.
 DATABASE_URL=
 DB_PROVIDER=postgres

--- a/kb/chunk_window.py
+++ b/kb/chunk_window.py
@@ -223,9 +223,17 @@ def _clear_cognee_budget_caches() -> None:
         )
         return
 
-    get_embedding_config.cache_clear()
-    create_embedding_engine.cache_clear()
-    _create_vector_engine.cache_clear()
+    try:
+        get_embedding_config.cache_clear()
+        create_embedding_engine.cache_clear()
+        _create_vector_engine.cache_clear()
+    except Exception:
+        # Same degradation as the import guard above: a cognee bump that stops
+        # wrapping any of these in ``lru_cache`` must not break every write.
+        logger.exception(
+            "Could not clear cognee's embedding caches; the chunk budget may not "
+            "have taken effect in this process"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +348,8 @@ def _untruncated_counter(engine: Any) -> Callable[[str], int] | None:
     cached = getattr(engine, "_citadel_window_counter", None)
     if cached is not None:
         return cached
+    if getattr(engine, "_citadel_window_counter_failed", False):
+        return None
 
     tokenizer = _model_tokenizer(engine)
     if tokenizer is None:
@@ -349,8 +359,15 @@ def _untruncated_counter(engine: Any) -> Callable[[str], int] | None:
 
         clone = Tokenizer.from_str(tokenizer.to_str())
         clone.no_truncation()
-    except Exception:  # pragma: no cover - tokenizer shape changed
+    except Exception:
+        # Cache the failure too: without this marker every embed batch repeats
+        # the clone attempt and logs another traceback, so one bad cognify pass
+        # buries the log under identical stack traces.
         logger.exception("Could not build an untruncated counter for the embed detector")
+        try:
+            engine._citadel_window_counter_failed = True
+        except Exception:  # pragma: no cover - slotted engine
+            pass
         return None
 
     def count(text: str) -> int:

--- a/kb/chunk_window.py
+++ b/kb/chunk_window.py
@@ -1,0 +1,526 @@
+"""Chunk budget for the embedder, and overflow detection at the embed boundary (#227).
+
+The defect
+----------
+cognee sizes chunks with a budget counted in GPT-4o BPE tokens
+(``EmbeddingConfig.embedding_max_completion_tokens``, shipped default 8191), and
+``FastembedEmbeddingEngine.get_tokenizer`` builds a ``TikTokenTokenizer(model="gpt-4o")``
+to count them. The model that then embeds those chunks is fastembed
+``BAAI/bge-small-en-v1.5``, whose own tokenizer declares
+``{'max_length': 512, 'stride': 0, 'strategy': 'longest_first', 'direction': 'right'}``
+and silently drops everything past that. Nothing raises. Measured on this tree at
+the shipped 8191, over a 172-document probe corpus: 245 of 274 emitted chunks
+were past the window, the worst at 12,642 wordpieces.
+
+Why there is no arithmetic that fixes this
+------------------------------------------
+The expansion from BPE tokens to wordpieces is a property of the content, and
+three budgets chosen by measuring a ratio and dividing have each been refuted by
+the next content class to arrive:
+
+    384  refuted by Korean prose            (529 wordpieces)   [reported, 2026-08-03]
+    352  refuted by minified JSON           (589 wordpieces)   [reported, 2026-08-03]
+    284  refuted by this tree's minified JS (1,710 wordpieces) [measured here]
+         and by a Korean-prose probe at a per-chunk ratio of 2.05, which is
+         already past the 1.795 the 284 was derived from [measured here]
+
+The first two rows are carried over from earlier work and were not re-run for
+this module; the third was measured in this tree. The Korean case is a
+constructed probe rather than vault content, because this repository holds no
+non-Latin text to sample.
+
+A second mechanism removes the last hope of an arithmetic answer.
+``chunk_by_paragraph`` compares against the budget only when the accumulating
+chunk is non-empty (``cognee/tasks/chunks/chunk_by_paragraph.py:40``), so a
+single over-budget "word" is emitted verbatim no matter what the budget says.
+Measured: one line of minified JS in ``kb/webui`` is 1,392 BPE tokens and comes
+out as one 1,710-wordpiece chunk at every budget from 512 down to 192 — at 192
+that is 7.2x the budget it supposedly obeys.
+
+What this module ships instead
+------------------------------
+1. ``OBSERVED_CHUNK_BUDGET_TOKENS`` — an observation, not a bound. See its note.
+2. ``record_embed_batch`` — a detector at the embed boundary that measures the
+   chunk actually handed to the model, in the model's own units, and says so.
+   Predicting an overflow is arithmetic; measuring one is evidence.
+3. ``check_chunkable`` — a verdict for the ingest chokepoint on content that
+   cannot be chunked at all. It refuses and records. It never edits text.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# The integer, and what it is.
+#
+# 256 is an OBSERVATION and NOT A BOUND. It is the largest budget in the sweep
+# below at which every content class that cognee is able to split landed inside
+# the deployed model's window. It is not a guarantee about content that has not
+# been measured, and the paragraph above explains why no integer could be.
+#
+# Sweep over 172 documents (this tree's markdown, Python, minified JS, configs,
+# plus probes in ko/zh/ja/ar/hi/th/ru, emoji, maths, base64, hex, UUIDs), run
+# through cognee's own ``chunk_by_paragraph`` and counted with the deployed
+# model's own tokenizer:
+#
+#   budget  chunks  over-window  worst wordpieces
+#     8191     274    245 (89%)            12,642
+#      512   2,922    709 (24%)             1,710
+#      384   3,933    527 (13%)             1,710
+#      352   4,316    187 ( 4%)             1,710
+#      284   5,414     28 (0.5%)            1,710
+#      256   6,064      3 (0.05%)           1,710
+#      224   7,028      3 (0.04%)           1,710
+#      192   8,237      3 (0.04%)           1,710
+#
+# The three that survive at 256 are the same three that survive at 192: one
+# un-splittable minified-JS line, per the mechanism above. Below 256 the chunk
+# count keeps climbing and buys nothing against them, which is the whole reason
+# to stop here rather than lower. Raise or lower it with CITADEL_CHUNK_BUDGET_TOKENS
+# when the detector reports a class this sweep did not contain.
+OBSERVED_CHUNK_BUDGET_TOKENS = 256
+
+CHUNK_BUDGET_ENV = "CITADEL_CHUNK_BUDGET_TOKENS"
+COGNEE_BUDGET_ENV = "EMBEDDING_MAX_COMPLETION_TOKENS"
+DETECTOR_ENV = "CITADEL_EMBED_WINDOW_DETECTOR"
+GUARD_ENV = "CITADEL_UNCHUNKABLE_GUARD"
+
+# cognee's ``chunk_by_word`` breaks on a single space and on these sentence
+# endings, and on nothing else. Not on "\n", not on "\t". That is why one line
+# of minified JS is one word to it.
+_COGNEE_DELIMITERS = " .;!?…。！？"
+_WORD_SPLIT = re.compile(r"[^ .;!?…。！？]*(?:[.;!?…。！？] *|[ ])?")
+
+# Per-chunk warnings are capped so one bad cognify pass cannot bury the log.
+# The counters in ``embed_window_report`` stay exact regardless.
+_MAX_WARNINGS = 50
+
+_REPORT: dict[str, int | None] = {}
+_APPLIED_BUDGET: int | None = None
+_DETECTOR_ANNOUNCED = False
+
+
+def _fresh_report() -> dict[str, int | None]:
+    return {
+        "checked": 0,
+        "over": 0,
+        "worst_tokens": 0,
+        "window": None,
+        "unmeasured": 0,
+        "warnings_emitted": 0,
+    }
+
+
+_REPORT = _fresh_report()
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+def _positive_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    try:
+        value = int(raw.strip())
+    except (AttributeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def resolve_chunk_budget() -> int:
+    """Return the chunk budget in GPT-4o BPE tokens.
+
+    Precedence: Citadel's own knob, then cognee's variable if an operator set it
+    directly, then the observation above.
+    """
+    explicit = _positive_int(os.getenv(CHUNK_BUDGET_ENV))
+    if explicit is not None:
+        return explicit
+    inherited = _positive_int(os.getenv(COGNEE_BUDGET_ENV))
+    if inherited is not None:
+        return inherited
+    return OBSERVED_CHUNK_BUDGET_TOKENS
+
+
+def reset_applied_budget() -> None:
+    """Forget that the budget was applied. For tests and for a deliberate re-clamp."""
+    global _APPLIED_BUDGET
+    _APPLIED_BUDGET = None
+
+
+def apply_chunk_budget(*, force: bool = False) -> int:
+    """Write the budget where cognee reads it, and make it reach ``get_max_chunk_tokens``.
+
+    Setting the environment variable is not enough on its own. ``get_max_chunk_tokens``
+    resolves ``get_vector_engine().embedding_engine``, and three caches sit on that
+    path: ``get_embedding_config`` (``lru_cache``), ``create_embedding_engine``
+    (``lru_cache``) and ``_create_vector_engine`` (``closing_lru_cache``). Measured
+    on this tree with the caches warm at 8191: clearing the config cache left the
+    answer at 8191, clearing the embedding-engine cache as well left it at 8191,
+    and only clearing the vector-engine cache moved it to 256. The vector engine
+    is the one that matters, because it captured the embedding engine object.
+
+    Returns the budget now in force.
+    """
+    global _APPLIED_BUDGET
+
+    target = resolve_chunk_budget()
+    if not force and _APPLIED_BUDGET == target:
+        return target
+
+    previous = os.environ.get(COGNEE_BUDGET_ENV)
+    os.environ[COGNEE_BUDGET_ENV] = str(target)
+    _APPLIED_BUDGET = target
+
+    if previous != str(target):
+        logger.info(
+            "Chunk budget set to %s BPE tokens via %s (was %s). This is an observed "
+            "value, not a bound: %s reports chunks that exceed the model's window.",
+            target,
+            COGNEE_BUDGET_ENV,
+            previous or "unset",
+            "kb.chunk_window",
+        )
+
+    _clear_cognee_budget_caches()
+    return target
+
+
+def _clear_cognee_budget_caches() -> None:
+    """Evict every cache between the environment variable and ``get_max_chunk_tokens``.
+
+    Skipped entirely when cognee has not been imported yet: there is nothing warm
+    to evict, and importing it here purely to clear empty caches would drag the
+    whole dependency into a path that only wanted to set a variable.
+    """
+    if "cognee" not in sys.modules:
+        return
+    try:
+        from cognee.infrastructure.databases.vector.create_vector_engine import (
+            _create_vector_engine,
+        )
+        from cognee.infrastructure.databases.vector.embeddings.config import (
+            get_embedding_config,
+        )
+        from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+            create_embedding_engine,
+        )
+    except Exception:  # pragma: no cover - a cognee bump that moved these
+        logger.exception(
+            "Could not reach cognee's embedding caches; the chunk budget may not "
+            "have taken effect in this process"
+        )
+        return
+
+    get_embedding_config.cache_clear()
+    create_embedding_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Detector at the embed boundary
+# ---------------------------------------------------------------------------
+
+
+def embed_window_report() -> dict[str, int | None]:
+    """Counts since process start (or since the last reset)."""
+    return dict(_REPORT)
+
+
+def reset_embed_window_report() -> None:
+    global _REPORT
+    _REPORT = _fresh_report()
+
+
+def _fingerprint(text: str) -> str:
+    return "sha256:" + sha256(text.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def record_embed_batch(
+    texts: Iterable[str],
+    *,
+    count_tokens: Callable[[str], int],
+    window: int,
+) -> int:
+    """Measure what is about to be embedded and report anything past the window.
+
+    ``count_tokens`` counts in the model's own units and must not truncate, or the
+    count comes back equal to the window and the overflow disappears into the
+    thing that caused it. Returns how many inputs were over.
+
+    Logs a digest and a length, never the content: this repository is public and
+    ingest carries user text.
+    """
+    over = 0
+    for text in texts:
+        try:
+            tokens = int(count_tokens(text))
+        except Exception:  # pragma: no cover - a tokenizer that raises is unmeasured
+            _REPORT["unmeasured"] = int(_REPORT["unmeasured"] or 0) + 1
+            continue
+
+        _REPORT["checked"] = int(_REPORT["checked"] or 0) + 1
+        _REPORT["window"] = window
+        if tokens > int(_REPORT["worst_tokens"] or 0):
+            _REPORT["worst_tokens"] = tokens
+
+        if tokens <= window:
+            continue
+
+        over += 1
+        _REPORT["over"] = int(_REPORT["over"] or 0) + 1
+        emitted = int(_REPORT["warnings_emitted"] or 0)
+        if emitted < _MAX_WARNINGS:
+            _REPORT["warnings_emitted"] = emitted + 1
+            logger.warning(
+                "embed window exceeded: %d tokens against a %d window (%.2fx), "
+                "%d characters, chunk %s. The model truncates the remainder and "
+                "raises nothing, so that text is in the store and not retrievable.",
+                tokens,
+                window,
+                tokens / window if window else 0.0,
+                len(text),
+                _fingerprint(text),
+            )
+            if _REPORT["warnings_emitted"] == _MAX_WARNINGS:
+                logger.warning(
+                    "embed window exceeded: %d per-chunk lines emitted, suppressing "
+                    "further ones for this process. Counts stay exact in "
+                    "kb.chunk_window.embed_window_report().",
+                    _MAX_WARNINGS,
+                )
+    return over
+
+
+def record_unmeasurable_batch(count: int) -> None:
+    """Record inputs the detector could not measure. Not the same as zero overflows."""
+    _REPORT["unmeasured"] = int(_REPORT["unmeasured"] or 0) + int(count)
+
+
+def _model_tokenizer(engine: Any) -> Any | None:
+    """The tokenizer the embedding model will actually use, or None."""
+    model = getattr(engine, "embedding_model", None)
+    inner = getattr(model, "model", None)
+    return getattr(inner, "tokenizer", None)
+
+
+def resolve_model_window(engine: Any) -> int | None:
+    """Read the window off the model's own tokenizer.
+
+    Returns None when it cannot be read. None means not measured; it does not mean
+    512, and nothing here substitutes a default for it.
+    """
+    tokenizer = _model_tokenizer(engine)
+    truncation = getattr(tokenizer, "truncation", None)
+    if not isinstance(truncation, dict):
+        return None
+    value = truncation.get("max_length")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _untruncated_counter(engine: Any) -> Callable[[str], int] | None:
+    """A counter using a truncation-free copy of the model's own tokenizer.
+
+    The live tokenizer truncates, so counting with it caps every answer at the
+    window and hides the number worth reporting.
+    """
+    cached = getattr(engine, "_citadel_window_counter", None)
+    if cached is not None:
+        return cached
+
+    tokenizer = _model_tokenizer(engine)
+    if tokenizer is None:
+        return None
+    try:
+        from tokenizers import Tokenizer
+
+        clone = Tokenizer.from_str(tokenizer.to_str())
+        clone.no_truncation()
+    except Exception:  # pragma: no cover - tokenizer shape changed
+        logger.exception("Could not build an untruncated counter for the embed detector")
+        return None
+
+    def count(text: str) -> int:
+        return len(clone.encode(text).ids)
+
+    try:
+        engine._citadel_window_counter = count
+    except Exception:  # pragma: no cover - slotted engine
+        pass
+    return count
+
+
+def detector_enabled() -> bool:
+    raw = os.getenv(DETECTOR_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def install_embed_window_detector() -> str | None:
+    """Wrap the deployed embedder's ``embed_text`` so overflows become log lines.
+
+    Returns the name of the class that was wrapped, or None. Says so out loud when
+    the configured provider is one it does not cover, because a detector nobody
+    installed looks exactly like a detector with nothing to report.
+
+    Called on every cognee operation, so each outcome is announced once per process
+    rather than once per call.
+    """
+    global _DETECTOR_ANNOUNCED
+
+    if not detector_enabled():
+        if not _DETECTOR_ANNOUNCED:
+            _DETECTOR_ANNOUNCED = True
+            logger.info("Embed-window detector disabled by %s", DETECTOR_ENV)
+        return None
+
+    provider = (os.getenv("EMBEDDING_PROVIDER") or "").strip().lower()
+    if provider != "fastembed":
+        if not _DETECTOR_ANNOUNCED:
+            _DETECTOR_ANNOUNCED = True
+            logger.warning(
+                "Embed-window detector covers the fastembed engine; EMBEDDING_PROVIDER "
+                "is %r, so chunks that exceed this embedder's window will not be "
+                "reported.",
+                provider or "unset",
+            )
+        return None
+
+    try:
+        from cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine import (
+            FastembedEmbeddingEngine,
+        )
+    except Exception:  # pragma: no cover - fastembed extra missing
+        logger.exception("Embed-window detector could not import the fastembed engine")
+        return None
+
+    original = FastembedEmbeddingEngine.embed_text
+    if getattr(original, "_citadel_window_detector", False):
+        return FastembedEmbeddingEngine.__name__
+    _DETECTOR_ANNOUNCED = True
+
+    async def embed_text(self: Any, text: Any) -> Any:
+        inputs = text if isinstance(text, list) else [text]
+        window = resolve_model_window(self)
+        counter = _untruncated_counter(self)
+        if window is None or counter is None:
+            record_unmeasurable_batch(len(inputs))
+        else:
+            record_embed_batch(inputs, count_tokens=counter, window=window)
+        return await original(self, text)
+
+    embed_text._citadel_window_detector = True  # type: ignore[attr-defined]
+    embed_text.__wrapped__ = original  # type: ignore[attr-defined]
+    FastembedEmbeddingEngine.embed_text = embed_text  # type: ignore[method-assign]
+    logger.info("Embed-window detector installed on %s", FastembedEmbeddingEngine.__name__)
+    return FastembedEmbeddingEngine.__name__
+
+
+# ---------------------------------------------------------------------------
+# The un-chunkable ingest verdict
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UnchunkableSpan:
+    """A verdict about content, carrying no content.
+
+    Deliberately has no field holding the offending text. The policy is refuse and
+    record: a caller cannot accidentally log the word, and there is no return path
+    that could hand back an edited document.
+    """
+
+    tokens: int
+    budget: int
+    char_length: int
+    fingerprint: str
+
+
+def split_cognee_words(text: str) -> list[str]:
+    """Segment exactly where cognee's ``chunk_by_word`` segments.
+
+    Joining the result reproduces the input. Any coarser rule (``str.split()``, for
+    one, which breaks on newlines that cognee ignores) under-measures the longest
+    word and lets past the documents this check exists to catch.
+    """
+    if not text:
+        return []
+    return [match.group(0) for match in _WORD_SPLIT.finditer(text) if match.group(0)]
+
+
+_BPE_ENCODING: Any | None = None
+_BPE_ENCODING_FAILED = False
+
+
+def _bpe_encoding() -> Any | None:
+    """The same encoding cognee counts the budget in: tiktoken for gpt-4o."""
+    global _BPE_ENCODING, _BPE_ENCODING_FAILED
+    if _BPE_ENCODING is not None or _BPE_ENCODING_FAILED:
+        return _BPE_ENCODING
+    try:
+        import tiktoken
+
+        _BPE_ENCODING = tiktoken.encoding_for_model("gpt-4o")
+    except Exception:
+        _BPE_ENCODING_FAILED = True
+        logger.exception(
+            "Could not load the gpt-4o encoding; un-chunkable content will pass "
+            "the ingest check unmeasured"
+        )
+    return _BPE_ENCODING
+
+
+def guard_enabled() -> bool:
+    raw = os.getenv(GUARD_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def check_chunkable(text: str, *, budget: int | None = None) -> UnchunkableSpan | None:
+    """Report the first word cognee cannot fit in the budget, or None.
+
+    Such a word has two fates, both bad. If it is the trailing one,
+    ``chunk_by_sentence`` raises ``ValueError`` (``chunk_by_sentence.py:94``) and
+    ``run_tasks`` turns that single item into a whole-dataset
+    ``PipelineRunFailedError`` (``run_tasks.py:153-158``), so one document stops
+    every other document in the dataset from being indexed, on this pass and on
+    every later one. Anywhere else it is emitted verbatim as an over-budget chunk
+    and the embedder truncates it.
+
+    The scan skips any word whose UTF-8 length is within the budget. That skip is
+    sound because a BPE token covers at least one UTF-8 byte, so byte length is an
+    upper bound on token count — it is a prefilter and never the verdict. The
+    verdict is taken in BPE tokens, which is the unit that actually raises.
+    """
+    limit = budget if budget is not None else resolve_chunk_budget()
+    encoding = _bpe_encoding()
+    if encoding is None:
+        return None
+
+    for word in split_cognee_words(text):
+        if len(word.encode("utf-8", "replace")) <= limit:
+            continue
+        tokens = len(encoding.encode(word, disallowed_special=()))
+        if tokens > limit:
+            return UnchunkableSpan(
+                tokens=tokens,
+                budget=limit,
+                char_length=len(word),
+                fingerprint=_fingerprint(word),
+            )
+    return None

--- a/kb/chunk_window.py
+++ b/kb/chunk_window.py
@@ -54,6 +54,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
 from hashlib import sha256
 from typing import Any, Callable, Iterable
 
@@ -95,9 +96,8 @@ DETECTOR_ENV = "CITADEL_EMBED_WINDOW_DETECTOR"
 GUARD_ENV = "CITADEL_UNCHUNKABLE_GUARD"
 
 # cognee's ``chunk_by_word`` breaks on a single space and on these sentence
-# endings, and on nothing else. Not on "\n", not on "\t". That is why one line
-# of minified JS is one word to it.
-_COGNEE_DELIMITERS = " .;!?…。！？"
+# endings — " .;!?…。！？" — and on nothing else. Not on "\n", not on "\t". That is
+# why one line of minified JS is one word to it.
 _WORD_SPLIT = re.compile(r"[^ .;!?…。！？]*(?:[.;!?…。！？] *|[ ])?")
 
 # Per-chunk warnings are capped so one bad cognify pass cannot bury the log.
@@ -448,18 +448,39 @@ class UnchunkableSpan:
     budget: int
     char_length: int
     fingerprint: str
+    # False when ``tokens`` is the arithmetic floor rather than a count, because
+    # the word was too long to hand to the tokenizer on the ingest path. The field
+    # exists so nothing downstream can quote a floor as a measurement.
+    tokens_are_exact: bool = True
+
+    def describe_tokens(self) -> str:
+        """How the number may be spoken out loud."""
+        if self.tokens_are_exact:
+            return f"{self.tokens} BPE tokens"
+        return f"at least {self.tokens} BPE tokens"
+
+
+def _iter_cognee_words(text: str) -> Iterable[str]:
+    """Yield segments exactly where cognee's ``chunk_by_word`` segments.
+
+    Lazy on purpose. ``check_chunkable`` needs the first word that fails, not a
+    list of every word: building the list for a 2,000,000-byte document allocated
+    166,667 strings and peaked at 10.28 MB on this tree, all of it thrown away.
+    """
+    for match in _WORD_SPLIT.finditer(text):
+        word = match.group(0)
+        if word:
+            yield word
 
 
 def split_cognee_words(text: str) -> list[str]:
-    """Segment exactly where cognee's ``chunk_by_word`` segments.
+    """The whole segmentation, as a list.
 
     Joining the result reproduces the input. Any coarser rule (``str.split()``, for
     one, which breaks on newlines that cognee ignores) under-measures the longest
     word and lets past the documents this check exists to catch.
     """
-    if not text:
-        return []
-    return [match.group(0) for match in _WORD_SPLIT.finditer(text) if match.group(0)]
+    return list(_iter_cognee_words(text))
 
 
 _BPE_ENCODING: Any | None = None
@@ -484,6 +505,32 @@ def _bpe_encoding() -> Any | None:
     return _BPE_ENCODING
 
 
+@lru_cache(maxsize=1)
+def max_token_bytes() -> int | None:
+    """The longest token in the encoding's vocabulary, in UTF-8 bytes.
+
+    Read off the vocabulary rather than written down, because a tiktoken or cognee
+    bump can move it. Cached because the scan over ~200,000 vocabulary entries costs
+    19 ms and ``check_chunkable`` runs per ingest.
+
+    Returns None when it cannot be read. None turns the shortcut in
+    ``check_chunkable`` off and leaves the exact measurement in its place: the
+    slower answer, never a different one.
+    """
+    encoding = _bpe_encoding()
+    if encoding is None:
+        return None
+    try:
+        longest = max(len(token) for token in encoding._mergeable_ranks)
+    except Exception:  # pragma: no cover - tiktoken moved the vocabulary
+        logger.exception(
+            "Could not read the encoding's longest token; the un-chunkable check "
+            "will measure every oversized word in full"
+        )
+        return None
+    return longest if longest > 0 else None
+
+
 def guard_enabled() -> bool:
     raw = os.getenv(GUARD_ENV)
     if raw is None:
@@ -502,19 +549,38 @@ def check_chunkable(text: str, *, budget: int | None = None) -> UnchunkableSpan 
     every later one. Anywhere else it is emitted verbatim as an over-budget chunk
     and the embedder truncates it.
 
-    The scan skips any word whose UTF-8 length is within the budget. That skip is
-    sound because a BPE token covers at least one UTF-8 byte, so byte length is an
-    upper bound on token count — it is a prefilter and never the verdict. The
-    verdict is taken in BPE tokens, which is the unit that actually raises.
+    Byte length brackets the answer from both sides, which is what keeps this
+    affordable on an ``async`` ingest path:
+
+    * a token covers **at least** one UTF-8 byte, so a word within ``budget``
+      bytes is within ``budget`` tokens and is skipped untokenized;
+    * a token covers **at most** ``max_token_bytes()`` UTF-8 bytes, and the token
+      byte strings concatenate back to the word, so a word longer than
+      ``budget * max_token_bytes()`` is over the budget however the merges fall.
+      Tokenizing a 2,000,000-byte word to learn that costs 571 ms of the event
+      loop, measured on this tree, and the answer is only ever read as "over".
+
+    Between those two the word is measured exactly. Neither bracket decides
+    differently from the tokenizer; they decide the same thing sooner.
     """
     limit = budget if budget is not None else resolve_chunk_budget()
     encoding = _bpe_encoding()
     if encoding is None:
         return None
+    ceiling = max_token_bytes()
 
-    for word in split_cognee_words(text):
-        if len(word.encode("utf-8", "replace")) <= limit:
+    for word in _iter_cognee_words(text):
+        span_bytes = len(word.encode("utf-8", "replace"))
+        if span_bytes <= limit:
             continue
+        if ceiling is not None and span_bytes > limit * ceiling:
+            return UnchunkableSpan(
+                tokens=-(-span_bytes // ceiling),
+                budget=limit,
+                char_length=len(word),
+                fingerprint=_fingerprint(word),
+                tokens_are_exact=False,
+            )
         tokens = len(encoding.encode(word, disallowed_special=()))
         if tokens > limit:
             return UnchunkableSpan(

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -13,6 +13,8 @@ from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 from uuid import NAMESPACE_OID, UUID, uuid5
 
+from kb import chunk_window
+
 logger = logging.getLogger(__name__)
 
 # Strong refs to detached background cognify tasks so the loop does not GC them
@@ -395,6 +397,24 @@ class CogneePublicClient:
         self._ensure_llm_api_key()
         self._ensure_cognee_database_env()
         self._ensure_auto_feedback_default()
+        self._ensure_chunk_budget()
+
+    def _ensure_chunk_budget(self) -> None:
+        """Size chunks for the embedder, and watch the embed boundary (#227).
+
+        cognee counts the chunk budget in GPT-4o BPE tokens and defaults it to
+        8191; the deployed embedder truncates at 512 wordpieces and raises
+        nothing. See kb/chunk_window.py for the measurement and for why the
+        budget it ships is an observation rather than a bound.
+
+        Here rather than in the deploy environment for the same reason
+        AUTO_FEEDBACK is: a variable nobody sets is not a fix. An explicit
+        CITADEL_CHUNK_BUDGET_TOKENS or EMBEDDING_MAX_COMPLETION_TOKENS still
+        wins. Both calls are idempotent, so paying for them on every cognee
+        operation costs a dictionary lookup after the first.
+        """
+        chunk_window.apply_chunk_budget()
+        chunk_window.install_embed_window_detector()
 
     def _ensure_auto_feedback_default(self) -> None:
         """Default cognee's AUTO_FEEDBACK off, because it costs an LLM call per search.

--- a/kb/logging_utils.py
+++ b/kb/logging_utils.py
@@ -2,9 +2,39 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
 VALID_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+# Everything left in C0/C1 once the three that have readable escapes are handled.
+# \x09 (tab) and \x0a (newline) are excluded from the range because the explicit
+# replacements below have already consumed them.
+_REMAINING_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+# Long enough for a dataset name, a path or a source id; short enough that no one
+# value can push the rest of a line out of a log viewer.
+DEFAULT_LOG_VALUE_LIMIT = 200
+
+
+def safe_log_value(value: object, *, limit: int = DEFAULT_LOG_VALUE_LIMIT) -> str:
+    """Render an untrusted value as one line of a log record.
+
+    A log line is a record this project reads back as evidence. A value carrying
+    ``\\n`` writes a second line that looks exactly like a real one, and a value
+    carrying ``\\r`` can overwrite the first on a terminal. Callers reach this with
+    request-supplied strings: dataset names, tags, paths, source ids.
+
+    Escapes rather than strips, so ``"a\\nb"`` and ``"ab"`` stay distinguishable in
+    the record, and bounds the result so a large value cannot bury the fields
+    logged after it.
+    """
+    text = str(value).replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
+    text = text.replace("\t", "\\t")
+    text = _REMAINING_CONTROL_CHARS.sub(lambda m: f"\\x{ord(m.group(0)):02x}", text)
+    if len(text) > limit:
+        return f"{text[:limit]}...(+{len(text) - limit} more characters)"
+    return text
 
 
 def resolve_log_level(value: str | None = None) -> str:

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from kb import chunk_window
 from kb.github_sync import GitHubAPIError, GitHubOrgClient, utc_now
 from kb.learning import LearningProcess
 from kb.security_scan import SecurityScanEntry, scan_text_entries
@@ -42,6 +43,19 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 STATE_VERSION = 1
+
+# Rejection reasons that are a function of the bytes we sent, so re-sending the
+# same bytes buys nothing but an identical second refusal. ``empty``,
+# ``excluded_path`` and ``too_short`` come from ``PreIngestFilter.check``;
+# ``unchunkable_content`` from ``Citadel._guard_chunkable``.
+#
+# ``duplicate_in_process`` is deliberately absent. It is decided against
+# ``Citadel._seen_ingest_keys``, which lives and dies with the process, so
+# treating it as terminal would let one restart's bookkeeping suppress a file
+# for every later run.
+TERMINAL_INGEST_REJECTIONS = frozenset(
+    {"empty", "excluded_path", "too_short", "unchunkable_content"}
+)
 
 # One lock per state file, NOT per syncer instance. ``get_repo_content_syncer``
 # in kb.server builds a fresh ``RepoContentSyncer`` on every call (app.state
@@ -579,6 +593,13 @@ class RepoContentSyncer:
             state = {}
             state_error = str(exc)
         files = state.get("files") if isinstance(state.get("files"), dict) else {}
+        # A refusal is recorded in the same map, so counting the map would report
+        # a file as tracked for the exact reason it is missing from the index.
+        refused = {
+            key
+            for key, entry in files.items()
+            if isinstance(entry, dict) and entry.get("rejected_reason")
+        }
         # Off the loop for the same reason as in ``run``: with autojoin on this
         # is up to 1 + max_repos * len(markers) synchronous urllib round trips,
         # and GET /api/repo-content-sync is served from the web process's single
@@ -612,7 +633,8 @@ class RepoContentSyncer:
             "max_bytes_per_file": self.config.repo_content_sync_max_bytes_per_file,
             "run_improve": self.config.repo_content_sync_run_improve,
             "last_checked_at": state.get("last_checked_at"),
-            "tracked_files": len(files),
+            "tracked_files": len(files) - len(refused),
+            "refused_files": len(refused),
             "state_path": str(self.state_path),
         }
 
@@ -816,6 +838,31 @@ class RepoContentSyncer:
                         _record_skip(repo_result, "unchanged")
                         continue
 
+                    # The same bytes were already refused for a reason the bytes
+                    # themselves cause, so submitting them again produces the
+                    # same refusal. Checked here rather than after the ingest so
+                    # the pass also skips the pin lookup, which is a second
+                    # GitHub round trip per file.
+                    #
+                    # Three things clear it, all of them ordinary: the file
+                    # changing (sha or content_hash), an operator raising or
+                    # lowering the chunk budget, and --force. The budget is
+                    # compared for every terminal reason, not only the one that
+                    # reads it, because retrying a handful of files after a
+                    # deliberate budget change costs one pass and being wrong in
+                    # the other direction is silent.
+                    refused_reason = previous.get("rejected_reason")
+                    if (
+                        not force
+                        and refused_reason
+                        and previous.get("sha") == file.sha
+                        and previous.get("content_hash") == file.content_hash
+                        and previous.get("rejected_at_budget")
+                        == chunk_window.resolve_chunk_budget()
+                    ):
+                        _record_skip(repo_result, f"refused_unchanged:{refused_reason}")
+                        continue
+
                     scan = scan_text_entries(
                         [
                             SecurityScanEntry(
@@ -936,7 +983,39 @@ class RepoContentSyncer:
                         # must be able to resume, not restart.
                         _checkpoint(tracked)
                     else:
-                        _record_skip(repo_result, "ingest_rejected")
+                        # "ingest_rejected" is a category, not a reason. Reading
+                        # it in a sync report cannot tell anyone whether a human
+                        # has to look at the file or whether the same bytes were
+                        # merely already in flight, so carry what ingest said.
+                        reasons = sorted(
+                            {result.reason for result in outcome.all_ingests}
+                        )
+                        reason = reasons[0] if len(reasons) == 1 else "+".join(reasons)
+                        if reasons and all(
+                            value in TERMINAL_INGEST_REJECTIONS for value in reasons
+                        ):
+                            # Record it so the next pass does not pay a
+                            # fetch_file_text and a fetch_last_commit_sha to
+                            # reach the identical refusal, on a scheduler that
+                            # runs about every 1h45m, forever. NOT written with
+                            # cognee_data_ids: nothing may mistake a refused
+                            # file for an indexed one.
+                            tracked[key] = {
+                                "sha": file.sha,
+                                "content_hash": file.content_hash,
+                                "rejected_reason": reason,
+                                "rejected_at": checked_at,
+                                # unchunkable_content is decided against a budget
+                                # that kb.chunk_window documents as an observation
+                                # an operator may raise. Storing the budget in
+                                # force means raising it retries these files on
+                                # the next ordinary pass instead of needing
+                                # --force, which is the difference between a knob
+                                # and a knob that does nothing.
+                                "rejected_at_budget": chunk_window.resolve_chunk_budget(),
+                            }
+                            _checkpoint(tracked)
+                        _record_skip(repo_result, f"ingest_rejected:{reason}")
             except GitHubAPIError as exc:
                 repo_result["errors"].append({"error": str(exc)[:240]})
             repo_results.append(repo_result)

--- a/kb/service.py
+++ b/kb/service.py
@@ -78,8 +78,13 @@ class Citadel:
         merged_tags = merge_tags(self.config.default_tags, tags)
         decision = self.filter.check(data)
         if not decision.accepted:
+            # Escaped for the same reason as the un-chunkable branch below: the
+            # dataset name is whatever the caller sent, and an unescaped newline
+            # in it writes a second log line indistinguishable from a real one.
             logger.info(
-                "Ingest rejected for dataset %s: %s", target_dataset, decision.reason
+                "Ingest rejected for dataset %s: %s",
+                safe_log_value(target_dataset),
+                decision.reason,
             )
             return IngestResult(False, decision.reason, target_dataset, merged_tags)
 
@@ -93,7 +98,8 @@ class Citadel:
         ingest_key = (target_dataset, content_hash)
         if ingest_key in self._seen_ingest_keys:
             logger.info(
-                "Ingest rejected for dataset %s: duplicate_in_process", target_dataset
+                "Ingest rejected for dataset %s: duplicate_in_process",
+                safe_log_value(target_dataset),
             )
             return IngestResult(False, "duplicate_in_process", target_dataset, merged_tags)
         # Claimed BEFORE the await so two concurrent ingests of identical content

--- a/kb/service.py
+++ b/kb/service.py
@@ -12,6 +12,7 @@ from kb import chunk_window
 from kb.cognee_client import CogneeGateway, CogneePublicClient
 from kb.config import CitadelConfig
 from kb.filters import PreIngestFilter
+from kb.logging_utils import safe_log_value
 from kb.models import FeedbackRequest, FeedbackResult, IngestResult
 from kb.security_scan import (
     SecretContentError,
@@ -163,13 +164,17 @@ class Citadel:
         span = chunk_window.check_chunkable(data)
         if span is None:
             return None
+        # The dataset name arrives from the caller and is not constrained to a
+        # charset anywhere on the way here, so it is escaped before it goes into a
+        # line this project later reads back as evidence (CodeQL py/log-injection).
+        # The document itself never reaches the log: only its digest and lengths.
         logger.warning(
             "Ingest refused for dataset %s: unchunkable_content. One unbroken word is "
-            "%d BPE tokens against a budget of %d (%d characters, %s). cognee cannot "
+            "%s against a budget of %d (%d characters, %s). cognee cannot "
             "split it, so accepting it would either fail this dataset's next cognify "
             "pass outright or store text the embedder silently truncates.",
-            dataset,
-            span.tokens,
+            safe_log_value(dataset),
+            span.describe_tokens(),
             span.budget,
             span.char_length,
             span.fingerprint,

--- a/kb/service.py
+++ b/kb/service.py
@@ -8,6 +8,7 @@ import re
 from uuid import uuid4
 from typing import Any
 
+from kb import chunk_window
 from kb.cognee_client import CogneeGateway, CogneePublicClient
 from kb.config import CitadelConfig
 from kb.filters import PreIngestFilter
@@ -83,6 +84,10 @@ class Citadel:
 
         self._guard_content(data, target_dataset)
 
+        unchunkable = self._guard_chunkable(data, target_dataset)
+        if unchunkable is not None:
+            return IngestResult(False, unchunkable, target_dataset, merged_tags)
+
         content_hash = sha256(data.encode("utf-8")).hexdigest()
         ingest_key = (target_dataset, content_hash)
         if ingest_key in self._seen_ingest_keys:
@@ -133,6 +138,43 @@ class Citadel:
                 block_severity=self.config.content_scan_block_severity,
                 findings=scan.get("findings", []),  # type: ignore[arg-type]
             )
+
+    def _guard_chunkable(self, data: str, dataset: str) -> str | None:
+        """Refuse content the chunker cannot fit in the budget, and say why (#227).
+
+        cognee breaks words on a single space and on sentence endings only, so one
+        line of minified output is one word to it. A word over the budget either
+        raises ``ValueError`` out of ``chunk_by_sentence`` — which ``run_tasks``
+        escalates into a failure of the entire dataset's pipeline run, so one
+        document blocks every other document in that dataset from being indexed —
+        or is emitted verbatim as an over-budget chunk that the embedder truncates.
+
+        The choice here is refuse and record, not split. A splitter that edits
+        content to make it fit has already corrupted two of this project's own
+        documents inside fenced config blocks, turning ``SEVERITY=high`` into
+        ``SEVERITY=hig h`` and removing ``CITADEL_GOOGLE_CHAT_SPACE_NAME`` from
+        the index entirely. Content that is stored wrong is worse than content
+        that is visibly refused, because only one of the two tells anyone.
+
+        Returns a rejection reason, or None to let the write proceed.
+        """
+        if not chunk_window.guard_enabled():
+            return None
+        span = chunk_window.check_chunkable(data)
+        if span is None:
+            return None
+        logger.warning(
+            "Ingest refused for dataset %s: unchunkable_content. One unbroken word is "
+            "%d BPE tokens against a budget of %d (%d characters, %s). cognee cannot "
+            "split it, so accepting it would either fail this dataset's next cognify "
+            "pass outright or store text the embedder silently truncates.",
+            dataset,
+            span.tokens,
+            span.budget,
+            span.char_length,
+            span.fingerprint,
+        )
+        return "unchunkable_content"
 
     async def search(
         self,

--- a/tests/test_chunk_window.py
+++ b/tests/test_chunk_window.py
@@ -1,0 +1,440 @@
+"""Chunk budget, embed-window overflow detection, and the un-chunkable ingest gate (#227).
+
+The defect these cover: cognee sizes chunks with a budget counted in GPT-4o BPE
+tokens, while the deployed embedder (fastembed ``BAAI/bge-small-en-v1.5``)
+truncates at 512 wordpieces and raises nothing when it does. Measured on this
+tree at the shipped default of 8191, 245 of 274 chunks over a 172-document probe
+corpus exceeded the window, worst 12,642 wordpieces.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kb import chunk_window
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FakeWordpieceTokenizer:
+    """Stands in for the model's own tokenizer: one wordpiece per character."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def count(self, text: str) -> int:
+        self.calls += 1
+        return len(text)
+
+
+@pytest.fixture(autouse=True)
+def _clean_window_state() -> Any:
+    """Snapshot both budget variables.
+
+    ``apply_chunk_budget`` writes ``os.environ`` directly, which monkeypatch does
+    not undo, so without this one test's clamp decides the next test's budget.
+    """
+    saved = {
+        name: os.environ.get(name)
+        for name in (chunk_window.CHUNK_BUDGET_ENV, chunk_window.COGNEE_BUDGET_ENV)
+    }
+    chunk_window.reset_embed_window_report()
+    chunk_window.reset_applied_budget()
+    yield
+    chunk_window.reset_embed_window_report()
+    chunk_window.reset_applied_budget()
+    for name, value in saved.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+
+# --------------------------------------------------------------------------
+# 1. The budget is labelled an observation, not a bound.
+# --------------------------------------------------------------------------
+
+
+def test_budget_is_an_integer_the_operator_can_lower() -> None:
+    assert isinstance(chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS, int)
+    assert chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS > 0
+
+
+def test_budget_env_override_wins(monkeypatch: Any) -> None:
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "192")
+    assert chunk_window.resolve_chunk_budget() == 192
+
+
+def test_budget_env_override_ignores_garbage(monkeypatch: Any) -> None:
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "not-a-number")
+    assert chunk_window.resolve_chunk_budget() == chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS
+
+
+def test_nothing_in_the_shipped_text_claims_the_budget_cannot_overflow() -> None:
+    """No comment, log line or doc may claim this budget is a bound.
+
+    Three budgets picked by sampling-and-multiplying were already refuted by the
+    next content class (384 by Korean prose, 352 by minified JSON, 284 by this
+    tree's own minified JS at 1,710 wordpieces). A file that calls the number
+    safe teaches the next reader to stop measuring.
+    """
+    forbidden = (
+        "cannot overflow",
+        "can never exceed",
+        "never exceeds",
+        "guarantees the window",
+        "guaranteed to fit",
+        "always fits",
+        "most conservative known budget",
+        "safe for all content",
+    )
+    targets = [
+        REPO_ROOT / "kb" / "chunk_window.py",
+        REPO_ROOT / ".env.example",
+    ]
+    for path in targets:
+        text = path.read_text(encoding="utf-8").lower()
+        for phrase in forbidden:
+            assert phrase not in text, f"{path.name} claims a bound it does not have: {phrase!r}"
+
+
+def test_the_budget_is_explicitly_labelled_an_observation() -> None:
+    text = (REPO_ROOT / "kb" / "chunk_window.py").read_text(encoding="utf-8").lower()
+    assert "observation" in text
+    assert "not a bound" in text
+
+
+# --------------------------------------------------------------------------
+# 2. The detector at the embed boundary.
+# --------------------------------------------------------------------------
+
+
+def test_detector_fires_on_a_planted_over_window_chunk(caplog: Any) -> None:
+    """Plant a chunk past the window and prove the detector says so.
+
+    A detector that has never fired is indistinguishable from one with nothing
+    to detect, so this plants the input rather than waiting for real content.
+    """
+    tokenizer = _FakeWordpieceTokenizer()
+    planted = "x" * 1710  # the worst real chunk measured on this tree, in wordpieces
+    with caplog.at_level(logging.WARNING, logger="kb.chunk_window"):
+        over = chunk_window.record_embed_batch(
+            [planted], count_tokens=tokenizer.count, window=512
+        )
+
+    assert over == 1
+    report = chunk_window.embed_window_report()
+    assert report["over"] == 1
+    assert report["checked"] == 1
+    assert report["worst_tokens"] == 1710
+    assert report["window"] == 512
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("embed window exceeded" in message for message in messages)
+    assert any("1710" in message for message in messages)
+
+
+def test_detector_is_silent_on_in_window_chunks(caplog: Any) -> None:
+    """The other direction: a detector that always fires is also useless."""
+    tokenizer = _FakeWordpieceTokenizer()
+    with caplog.at_level(logging.WARNING, logger="kb.chunk_window"):
+        over = chunk_window.record_embed_batch(
+            ["y" * 511, "z" * 512], count_tokens=tokenizer.count, window=512
+        )
+
+    assert over == 0
+    report = chunk_window.embed_window_report()
+    assert report["over"] == 0
+    assert report["checked"] == 2
+    assert report["worst_tokens"] == 512
+    assert not [rec for rec in caplog.records if "embed window exceeded" in rec.getMessage()]
+
+
+def test_detector_never_logs_the_content_it_measured(caplog: Any) -> None:
+    """This repository is public and ingest carries user text: log a digest, not the chunk."""
+    secret = "SUPERSECRET" + "q" * 1000
+    with caplog.at_level(logging.WARNING, logger="kb.chunk_window"):
+        chunk_window.record_embed_batch([secret], count_tokens=len, window=512)
+
+    joined = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "SUPERSECRET" not in joined
+    assert "sha256:" in joined
+
+
+def test_window_is_read_from_the_model_not_from_a_constant() -> None:
+    """The window comes from the tokenizer the embedder will actually use."""
+
+    class _Tok:
+        truncation = {"max_length": 384, "stride": 0}
+
+        def encode(self, text: str) -> Any:  # pragma: no cover - not called here
+            raise AssertionError
+
+    class _Model:
+        tokenizer = _Tok()
+
+    class _TextEmbedding:
+        model = _Model()
+
+    class _Engine:
+        embedding_model = _TextEmbedding()
+
+    assert chunk_window.resolve_model_window(_Engine()) == 384
+
+
+def test_unresolvable_window_is_recorded_rather_than_assumed() -> None:
+    """No window means no measurement — say so, do not invent 512."""
+
+    class _Engine:
+        embedding_model = object()
+
+    assert chunk_window.resolve_model_window(_Engine()) is None
+
+
+def test_detector_reports_when_it_could_not_measure() -> None:
+    chunk_window.record_unmeasurable_batch(2)
+    assert chunk_window.embed_window_report()["unmeasured"] == 2
+
+
+# --------------------------------------------------------------------------
+# 3. The clamp has to reach the real chunk budget.
+# --------------------------------------------------------------------------
+
+
+def test_clamp_reaches_get_max_chunk_tokens_after_a_cognee_operation_warmed_the_caches(
+    monkeypatch: Any,
+) -> None:
+    """Clearing ``get_embedding_config`` alone does NOT change the chunk budget.
+
+    ``get_max_chunk_tokens()`` reads ``get_vector_engine().embedding_engine``, and
+    ``create_vector_engine`` is ``closing_lru_cache``d, so the warm entry keeps
+    handing back the engine built at the old budget. Measured on this tree:
+    clearing the config cache left it at 8191, clearing the embedding-engine cache
+    as well left it at 8191, and only clearing the vector-engine cache moved it.
+    """
+    from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_config
+    from cognee.infrastructure.llm.utils import get_max_chunk_tokens
+
+    # A cheap engine keeps this off the network and off the ONNX loader while
+    # still exercising all three real caches.
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
+    monkeypatch.setenv("EMBEDDING_MODEL", "openai/text-embedding-3-large")
+    monkeypatch.setenv("EMBEDDING_DIMENSIONS", "3072")
+    monkeypatch.setenv("LLM_API_KEY", "test-key-not-used")
+    monkeypatch.setenv("VECTOR_DB_PROVIDER", "lancedb")
+    monkeypatch.delenv(chunk_window.COGNEE_BUDGET_ENV, raising=False)
+    monkeypatch.delenv(chunk_window.CHUNK_BUDGET_ENV, raising=False)
+    chunk_window.reset_applied_budget()
+    get_embedding_config.cache_clear()
+
+    # A cognee operation runs BEFORE the guard, warming every cache at 8191.
+    warm = get_max_chunk_tokens()
+    assert warm > chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS, (
+        f"expected the un-clamped default to be larger than the budget, got {warm}"
+    )
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "256")
+    applied = chunk_window.apply_chunk_budget()
+
+    assert applied == 256
+    assert os.environ[chunk_window.COGNEE_BUDGET_ENV] == "256"
+    assert get_max_chunk_tokens() == 256, (
+        "the clamp did not reach the real chunk budget: a warm create_vector_engine "
+        "entry is still serving an embedding engine built at the old budget"
+    )
+
+
+def test_an_explicit_cognee_budget_is_respected(monkeypatch: Any) -> None:
+    """An operator who sets cognee's own variable is not silently overruled."""
+    monkeypatch.delenv(chunk_window.CHUNK_BUDGET_ENV, raising=False)
+    monkeypatch.setenv(chunk_window.COGNEE_BUDGET_ENV, "300")
+    chunk_window.reset_applied_budget()
+
+    assert chunk_window.apply_chunk_budget() == 300
+    assert os.environ[chunk_window.COGNEE_BUDGET_ENV] == "300"
+
+
+# --------------------------------------------------------------------------
+# 4. Refuse and record; never mangle.
+# --------------------------------------------------------------------------
+
+
+def test_unbroken_word_over_budget_is_reported(monkeypatch: Any) -> None:
+    """cognee splits words only on ' ' and [.;!?…。！？] — not on newlines or tabs.
+
+    So one minified line is one word. At a budget of 256 such a word either
+    raises ``ValueError`` out of ``chunk_by_sentence`` (killing the whole
+    dataset's pipeline run) or is emitted verbatim as an over-window chunk.
+    """
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    blob = "a" * 4000  # no space, no sentence ending: one word to cognee
+    span = chunk_window.check_chunkable(f"intro text.\n{blob}\nmore text.")
+
+    assert span is not None
+    assert span.tokens > 64
+    assert span.budget == 64
+    assert span.fingerprint.startswith("sha256:")
+
+
+def test_ordinary_prose_is_not_reported(monkeypatch: Any) -> None:
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    prose = "The payment service escrows funds until the seller submits a result. " * 40
+    assert chunk_window.check_chunkable(prose) is None
+
+
+def test_check_chunkable_never_rewrites_the_text(monkeypatch: Any) -> None:
+    """The policy is refuse and record. A splitter that edits content is not on the menu.
+
+    An earlier attempt gated on UTF-8 bytes and corrupted two of this project's
+    own documents inside fenced config blocks: ``SEVERITY=high`` became
+    ``SEVERITY=hig h`` and ``CITADEL_GOOGLE_CHAT_SPACE_NAME`` stopped existing in
+    the index. ``check_chunkable`` returns a verdict; it has no return path that
+    can carry modified text.
+    """
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    source = "SEVERITY=high\nCITADEL_GOOGLE_CHAT_SPACE_NAME=spaces/AAA\n" + ("b" * 4000)
+    span = chunk_window.check_chunkable(source)
+
+    assert span is not None
+    assert not hasattr(span, "text")
+    assert not any(isinstance(value, str) and "SEVERITY" in value for value in vars(span).values())
+
+
+def test_byte_prefilter_is_a_sound_lower_bound() -> None:
+    """The prefilter skips words whose UTF-8 length is under the budget.
+
+    That is sound only because every BPE token covers at least one UTF-8 byte,
+    so byte length is an upper bound on token count. It is a prefilter, never the
+    gate: the verdict is taken in BPE tokens, which is the unit that actually
+    raises.
+    """
+    import tiktoken
+
+    encoding = tiktoken.encoding_for_model("gpt-4o")
+    for sample in ("héllo wörld", "🚀🔥💡", "плати́ть", "a" * 300, "日本語テキスト"):
+        assert len(encoding.encode(sample)) <= len(sample.encode("utf-8"))
+
+
+@pytest.mark.parametrize("delimiter", [" ", ".", ";", "!", "?", "…", "。", "！", "？"])
+def test_word_segmentation_matches_cognees_delimiters(delimiter: Any) -> None:
+    """Segment on exactly what cognee segments on, or the gate under-measures.
+
+    ``chunk_by_word`` breaks on a single space and on the sentence endings, and on
+    nothing else — notably not on ``\\n`` or ``\\t``.
+    """
+    monkeypatch_free = f"aaa{delimiter}bbb"
+    assert chunk_window.split_cognee_words(monkeypatch_free) == ["aaa" + delimiter, "bbb"]
+
+
+def test_newline_is_not_a_word_boundary() -> None:
+    assert chunk_window.split_cognee_words("aaa\nbbb") == ["aaa\nbbb"]
+
+
+def test_ingest_refuses_content_cognee_cannot_chunk(monkeypatch: Any) -> None:
+    """Refuse and record. One such document fails the whole dataset's pipeline run."""
+    import asyncio
+
+    from kb.config import CitadelConfig
+    from kb.service import Citadel
+    from tests.test_service import FakeCognee
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    fake = FakeCognee()
+    citadel = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    poisoned = "A note about the bundle.\n" + ("z" * 4000)
+    result = asyncio.run(citadel.ingest(poisoned))
+
+    assert not result.accepted
+    assert result.reason == "unchunkable_content"
+    assert fake.remember_calls == [], "refused content must not reach the vault"
+
+
+def test_ingest_accepts_ordinary_content_at_the_same_budget(monkeypatch: Any) -> None:
+    """The other direction: the gate must not swallow prose."""
+    import asyncio
+
+    from kb.config import CitadelConfig
+    from kb.service import Citadel
+    from tests.test_service import FakeCognee
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    fake = FakeCognee()
+    citadel = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    result = asyncio.run(citadel.ingest("A perfectly ordinary engineering note about caching."))
+
+    assert result.accepted
+    assert len(fake.remember_calls) == 1
+
+
+def test_ingest_stores_the_callers_bytes_unchanged(monkeypatch: Any) -> None:
+    """Citadel adds no transformation between the caller's text and the store.
+
+    The invariant worth having is that chunking never edits content. cognee's own
+    chunker joins batched paragraphs with a space, so byte-identical reassembly is
+    not ours to assert downstream — what is ours is that nothing on this side
+    rewrites, pads or splits the document on its way in.
+    """
+    import asyncio
+
+    from kb.config import CitadelConfig
+    from kb.service import Citadel
+    from tests.test_service import FakeCognee
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "256")
+    fake = FakeCognee()
+    citadel = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    source = (
+        "```bash\nSEVERITY=high\nCITADEL_GOOGLE_CHAT_SPACE_NAME=spaces/AAAA\n```\n"
+        "Trailing prose with  double  spaces and a\ttab.\n"
+    )
+    result = asyncio.run(citadel.ingest(source))
+
+    assert result.accepted
+    assert fake.remember_calls[0]["data"] == source
+
+
+def test_unchunkable_guard_can_be_turned_off(monkeypatch: Any) -> None:
+    import asyncio
+
+    from kb.config import CitadelConfig
+    from kb.service import Citadel
+    from tests.test_service import FakeCognee
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    monkeypatch.setenv(chunk_window.GUARD_ENV, "false")
+    fake = FakeCognee()
+    citadel = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    result = asyncio.run(citadel.ingest("A note.\n" + ("z" * 4000)))
+
+    assert result.accepted
+    assert len(fake.remember_calls) == 1
+
+
+def test_word_segmentation_agrees_with_cognee() -> None:
+    """Checked against the real ``chunk_by_word``, not against a description of it."""
+    from cognee.tasks.chunks.chunk_by_word import chunk_by_word
+
+    samples = [
+        "Hello world. This is a sentence!\nAnd a new line.",
+        "no-spaces-at-all\nsecond\tline",
+        "trailing spaces after a period.   then more",
+        "日本語。テキスト？おわり",
+        "a" * 500,
+        "",
+    ]
+    for sample in samples:
+        theirs = [word for word, _kind in chunk_by_word(sample)]
+        mine = chunk_window.split_cognee_words(sample)
+        assert "".join(mine) == sample, "segmentation must be lossless"
+        assert max((len(w) for w in mine), default=0) >= max(
+            (len(w) for w in theirs), default=0
+        ), "our longest segment must not be shorter than cognee's longest word"

--- a/tests/test_chunk_window.py
+++ b/tests/test_chunk_window.py
@@ -217,7 +217,6 @@ def test_clamp_reaches_get_max_chunk_tokens_after_a_cognee_operation_warmed_the_
     clearing the config cache left it at 8191, clearing the embedding-engine cache
     as well left it at 8191, and only clearing the vector-engine cache moved it.
     """
-    from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_config
     from cognee.infrastructure.llm.utils import get_max_chunk_tokens
 
     # A cheap engine keeps this off the network and off the ONNX loader while
@@ -230,23 +229,30 @@ def test_clamp_reaches_get_max_chunk_tokens_after_a_cognee_operation_warmed_the_
     monkeypatch.delenv(chunk_window.COGNEE_BUDGET_ENV, raising=False)
     monkeypatch.delenv(chunk_window.CHUNK_BUDGET_ENV, raising=False)
     chunk_window.reset_applied_budget()
-    get_embedding_config.cache_clear()
+    # Inherit no cache state: this test depends on all three caches, not just the
+    # config one, so an engine an earlier test left warm would decide `warm` here.
+    chunk_window._clear_cognee_budget_caches()
+    try:
+        # A cognee operation runs BEFORE the guard, warming every cache at 8191.
+        warm = get_max_chunk_tokens()
+        assert warm > chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS, (
+            f"expected the un-clamped default to be larger than the budget, got {warm}"
+        )
 
-    # A cognee operation runs BEFORE the guard, warming every cache at 8191.
-    warm = get_max_chunk_tokens()
-    assert warm > chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS, (
-        f"expected the un-clamped default to be larger than the budget, got {warm}"
-    )
+        monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "256")
+        applied = chunk_window.apply_chunk_budget()
 
-    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "256")
-    applied = chunk_window.apply_chunk_budget()
-
-    assert applied == 256
-    assert os.environ[chunk_window.COGNEE_BUDGET_ENV] == "256"
-    assert get_max_chunk_tokens() == 256, (
-        "the clamp did not reach the real chunk budget: a warm create_vector_engine "
-        "entry is still serving an embedding engine built at the old budget"
-    )
+        assert applied == 256
+        assert os.environ[chunk_window.COGNEE_BUDGET_ENV] == "256"
+        assert get_max_chunk_tokens() == 256, (
+            "the clamp did not reach the real chunk budget: a warm create_vector_engine "
+            "entry is still serving an embedding engine built at the old budget"
+        )
+    finally:
+        # Export no cache state either: the engine above was built for openai +
+        # lancedb at budget 256 under monkeypatched env, and monkeypatch's env
+        # restore does not evict it for the next test.
+        chunk_window._clear_cognee_budget_caches()
 
 
 def test_an_explicit_cognee_budget_is_respected(monkeypatch: Any) -> None:
@@ -614,6 +620,57 @@ def test_the_refusal_log_line_cannot_be_forged_by_the_dataset_name(
     for message in messages:
         assert "\n" not in message, "a caller-supplied value opened a new log line"
     assert any("\\n" in message for message in messages), "the value must survive, escaped"
+
+
+def test_counter_build_failure_is_cached_not_repeated(caplog: Any) -> None:
+    """One broken tokenizer clone must not log one traceback per embed batch.
+
+    ``_untruncated_counter`` cached only the success. On a persistent clone
+    failure every embed batch repeated the ``to_str()``, the failed
+    ``Tokenizer.from_str`` and the ``logger.exception``, so one bad cognify pass
+    buried the log under identical stack traces.
+    """
+
+    class _BadTokenizer:
+        def to_str(self) -> str:
+            return "not a tokenizer serialization"
+
+    class _Model:
+        tokenizer = _BadTokenizer()
+
+    class _TextEmbedding:
+        model = _Model()
+
+    class _Engine:
+        embedding_model = _TextEmbedding()
+
+    engine = _Engine()
+    with caplog.at_level(logging.ERROR, logger="kb.chunk_window"):
+        assert chunk_window._untruncated_counter(engine) is None
+        assert chunk_window._untruncated_counter(engine) is None
+
+    failures = [rec for rec in caplog.records if "untruncated counter" in rec.getMessage()]
+    assert len(failures) == 1, "the second call must return the cached failure silently"
+
+
+def test_cache_clear_failure_is_contained(monkeypatch: Any, caplog: Any) -> None:
+    """A cognee bump that unwraps these callables must degrade, not break every write.
+
+    The import guard in ``_clear_cognee_budget_caches`` already logs and returns;
+    the ``cache_clear()`` calls sat outside it, so a symbol that stops being
+    ``lru_cache``-wrapped would raise ``AttributeError`` out of
+    ``apply_chunk_budget`` on every cognee operation.
+    """
+    import cognee.infrastructure.databases.vector.create_vector_engine as cve
+
+    def _plain(*args: Any, **kwargs: Any) -> None:  # no .cache_clear attribute
+        return None
+
+    monkeypatch.setattr(cve, "_create_vector_engine", _plain)
+    with caplog.at_level(logging.ERROR, logger="kb.chunk_window"):
+        chunk_window._clear_cognee_budget_caches()  # must not raise
+
+    assert any("chunk budget may not" in rec.getMessage() for rec in caplog.records)
 
 
 def test_word_segmentation_agrees_with_cognee() -> None:

--- a/tests/test_chunk_window.py
+++ b/tests/test_chunk_window.py
@@ -305,7 +305,7 @@ def test_check_chunkable_never_rewrites_the_text(monkeypatch: Any) -> None:
     assert not any(isinstance(value, str) and "SEVERITY" in value for value in vars(span).values())
 
 
-def test_byte_prefilter_is_a_sound_lower_bound() -> None:
+def test_byte_length_is_an_upper_bound_on_token_count() -> None:
     """The prefilter skips words whose UTF-8 length is under the budget.
 
     That is sound only because every BPE token covers at least one UTF-8 byte,
@@ -417,6 +417,203 @@ def test_unchunkable_guard_can_be_turned_off(monkeypatch: Any) -> None:
 
     assert result.accepted
     assert len(fake.remember_calls) == 1
+
+
+# --------------------------------------------------------------------------
+# 5. The scan is on the ingest path, so its work has to be bounded.
+# --------------------------------------------------------------------------
+
+
+def test_the_scan_stops_at_the_first_word_it_can_refuse(monkeypatch: Any) -> None:
+    """Segment lazily. The verdict needs one word, not a list of every word.
+
+    Measured on this tree before this became lazy: segmenting 2,000,000 bytes
+    built a 166,667-entry list and peaked at 10.28 MB, all of it discarded the
+    moment the first word failed. ``Citadel.ingest`` is ``async`` and calls this
+    synchronously, so the whole node waits through it.
+    """
+    seen: list[str] = []
+    real = chunk_window._iter_cognee_words
+
+    def counting(text: str) -> Any:
+        for word in real(text):
+            seen.append(word)
+            yield word
+
+    monkeypatch.setattr(chunk_window, "_iter_cognee_words", counting)
+    document = ("a" * 40_000) + " " + ("ordinary prose here. " * 20_000)
+
+    span = chunk_window.check_chunkable(document, budget=256)
+
+    assert span is not None
+    assert len(seen) == 1, f"segmented {len(seen)} words to decide on the first one"
+
+
+def test_a_word_too_long_to_measure_exactly_is_still_refused() -> None:
+    """Refuse by arithmetic rather than tokenizing megabytes on the ingest path.
+
+    Every token this encoding emits covers at most ``max_token_bytes()`` UTF-8
+    bytes, so a word longer than ``budget * max_token_bytes()`` cannot fit the
+    budget however the merges fall. Measured: encoding one 2,000,000-byte word
+    costs 571 ms of the event loop, and the exact number is never used as a
+    number — only as "over".
+    """
+    ceiling = 256 * chunk_window.max_token_bytes()
+    span = chunk_window.check_chunkable("a" * (ceiling + 1), budget=256)
+
+    assert span is not None
+    assert span.tokens > 256
+    assert not span.tokens_are_exact
+    assert "at least" in span.describe_tokens()
+
+
+def test_a_word_inside_the_ceiling_still_gets_an_exact_count() -> None:
+    """The shortcut must not swallow the exact measurement where one is affordable."""
+    span = chunk_window.check_chunkable("a" * 4000, budget=64)
+
+    assert span is not None
+    assert span.tokens_are_exact
+    assert "at least" not in span.describe_tokens()
+
+    encoding = chunk_window._bpe_encoding()
+    assert span.tokens == len(encoding.encode("a" * 4000, disallowed_special=()))
+
+
+def test_the_arithmetic_floor_never_claims_more_tokens_than_there_are() -> None:
+    """Soundness of the shortcut, checked against the encoding rather than asserted.
+
+    The floor is ``ceil(bytes / max_token_bytes())``. It is sound because the token
+    byte strings concatenate back to the input, so no encoding of N bytes can use
+    fewer than N / (longest token) tokens.
+    """
+    encoding = chunk_window._bpe_encoding()
+    limit = chunk_window.max_token_bytes()
+    samples = [
+        "a" * 40_000,
+        "한국어 텍스트 " * 3000,
+        "🚀🔥💡" * 4000,
+        "{\"key\":\"value\"}," * 3000,
+        "0123456789" * 4000,
+        "The payment service escrows funds until the seller submits a result. " * 600,
+    ]
+    for sample in samples:
+        floor = -(-len(sample.encode("utf-8", "replace")) // limit)
+        exact = len(encoding.encode(sample, disallowed_special=()))
+        assert floor <= exact, f"floor {floor} claimed more tokens than the {exact} there are"
+
+
+def test_max_token_bytes_is_read_from_the_encoding_not_asserted() -> None:
+    """It must come off the vocabulary, because a cognee or tiktoken bump can move it."""
+    encoding = chunk_window._bpe_encoding()
+    assert chunk_window.max_token_bytes() == max(
+        len(token) for token in encoding._mergeable_ranks
+    )
+
+
+# --------------------------------------------------------------------------
+# 6. Module state that is written in one call and read in the next.
+# --------------------------------------------------------------------------
+
+
+def test_applying_the_budget_twice_evicts_the_caches_once(monkeypatch: Any) -> None:
+    """``_APPLIED_BUDGET`` is written on one call and read on the next.
+
+    Cache eviction is the expensive half of ``apply_chunk_budget`` and it runs on
+    every cognee operation, so the second call has to be a no-op.
+    """
+    calls: list[int] = []
+    monkeypatch.setattr(
+        chunk_window, "_clear_cognee_budget_caches", lambda: calls.append(1)
+    )
+    chunk_window.reset_applied_budget()
+
+    chunk_window.apply_chunk_budget()
+    chunk_window.apply_chunk_budget()
+
+    assert calls == [1]
+    chunk_window.apply_chunk_budget(force=True)
+    assert calls == [1, 1]
+
+
+def test_an_uncovered_embedding_provider_is_announced_once_per_process(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """``_DETECTOR_ANNOUNCED`` is written on one call and read on the next.
+
+    ``install_embed_window_detector`` runs on every cognee operation. Without the
+    flag the same warning would be emitted on each one.
+    """
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
+    monkeypatch.setattr(chunk_window, "_DETECTOR_ANNOUNCED", False)
+
+    with caplog.at_level(logging.WARNING, logger="kb.chunk_window"):
+        assert chunk_window.install_embed_window_detector() is None
+        assert chunk_window.install_embed_window_detector() is None
+
+    announcements = [r for r in caplog.records if "detector covers the fastembed" in r.getMessage()]
+    assert len(announcements) == 1
+
+
+def test_a_tokenizer_that_cannot_load_is_not_retried_on_every_document(
+    monkeypatch: Any,
+) -> None:
+    """``_BPE_ENCODING_FAILED`` is written on one call and read on the next.
+
+    ``check_chunkable`` runs per ingest. Retrying a failed import per document
+    would mean an exception and a traceback per document.
+    """
+    import sys
+    import types
+
+    attempts: list[int] = []
+
+    stub = types.ModuleType("tiktoken")
+
+    def encoding_for_model(_name: str) -> Any:
+        attempts.append(1)
+        raise RuntimeError("no vocabulary available")
+
+    stub.encoding_for_model = encoding_for_model  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tiktoken", stub)
+    monkeypatch.setattr(chunk_window, "_BPE_ENCODING", None)
+    monkeypatch.setattr(chunk_window, "_BPE_ENCODING_FAILED", False)
+
+    assert chunk_window._bpe_encoding() is None
+    assert chunk_window._bpe_encoding() is None
+    assert attempts == [1]
+
+    # And an unmeasurable document is let through rather than refused on a guess.
+    assert chunk_window.check_chunkable("a" * 40_000, budget=256) is None
+
+
+def test_the_refusal_log_line_cannot_be_forged_by_the_dataset_name(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """The dataset name is caller-supplied and lands in this warning.
+
+    Reported by CodeQL as ``py/log-injection`` at ``kb/service.py``. Several of
+    this project's findings came out of reading its own logs, so a value that can
+    open a new line can write a sentence into that evidence.
+    """
+    import asyncio
+
+    from kb.config import CitadelConfig
+    from kb.service import Citadel
+    from tests.test_service import FakeCognee
+
+    monkeypatch.setenv(chunk_window.CHUNK_BUDGET_ENV, "64")
+    citadel = Citadel(CitadelConfig(default_dataset="notes"), cognee=FakeCognee())
+    forged = "notes\n2026-08-04 INFO kb.service Ingest accepted for dataset central"
+
+    with caplog.at_level(logging.WARNING, logger="kb.service"):
+        result = asyncio.run(citadel.ingest("A note.\n" + ("z" * 4000), dataset=forged))
+
+    assert result.reason == "unchunkable_content"
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages, "the refusal must still be logged"
+    for message in messages:
+        assert "\n" not in message, "a caller-supplied value opened a new log line"
+    assert any("\\n" in message for message in messages), "the value must survive, escaped"
 
 
 def test_word_segmentation_agrees_with_cognee() -> None:

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -6,6 +6,7 @@ from kb.logging_utils import (
     VALID_LEVELS,
     configure_logging,
     resolve_log_level,
+    safe_log_value,
 )
 
 
@@ -62,3 +63,42 @@ def test_configure_logging_is_idempotent_on_handlers(restore_root, monkeypatch):
     configure_logging("info")  # second call must not add another handler
     assert len(restore_root.handlers) == 1
     assert restore_root.level == logging.INFO
+
+
+# --------------------------------------------------------------------------
+# safe_log_value: untrusted text that has to appear in a log line
+# --------------------------------------------------------------------------
+
+
+def test_safe_log_value_escapes_a_line_break_instead_of_emitting_it():
+    """A value carrying a newline would otherwise write a second log line.
+
+    This project reads its own logs as evidence, so a caller-supplied value that
+    can start a line can put a sentence of its choosing into that evidence.
+    """
+    forged = "notes\n2026-08-04 INFO kb.service Ingest accepted for dataset central"
+    out = safe_log_value(forged)
+
+    assert "\n" not in out
+    assert "\\n" in out
+    # Escaped, not deleted: two different inputs must not collapse to one string.
+    assert "Ingest accepted" in out
+    assert safe_log_value("a\nb") != safe_log_value("ab")
+
+
+def test_safe_log_value_escapes_carriage_returns_tabs_and_other_control_bytes():
+    assert safe_log_value("a\rb\tc\x00d\x1be") == "a\\rb\\tc\\x00d\\x1be"
+
+
+def test_safe_log_value_bounds_what_it_emits_and_says_how_much_it_dropped():
+    out = safe_log_value("x" * 5000, limit=32)
+
+    assert out.startswith("x" * 32)
+    assert len(out) < 80
+    assert "4968" in out, "a truncated value must say how much of it is missing"
+
+
+def test_safe_log_value_leaves_an_ordinary_value_untouched():
+    assert safe_log_value("seat:sarthi") == "seat:sarthi"
+    assert safe_log_value(None) == "None"
+    assert safe_log_value(256) == "256"

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -1401,3 +1401,196 @@ async def test_a_second_overlapping_run_is_refused_instead_of_losing_state(
     again = await second.run()
     assert again.get("skipped") is None
     assert again["files_skipped"] == 2
+
+
+# --------------------------------------------------------------------------
+# A refusal the content itself caused is terminal until the content changes.
+# --------------------------------------------------------------------------
+
+
+class RefusingLearningProcess(FakeLearningProcess):
+    """Refuses every document with a fixed reason, like the real ingest guards."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__()
+        self.reason = reason
+
+    async def learn(self, data: str, **kwargs: Any) -> Any:
+        self.calls.append({"data": data, **kwargs})
+        rejection = IngestResult(False, self.reason, kwargs.get("dataset", "x"), ())
+
+        class Outcome:
+            ingest = rejection
+            chunk_ingests = ()
+            improve = None
+
+            @property
+            def all_ingests(self) -> tuple[IngestResult, ...]:
+                return (self.ingest,)
+
+            @property
+            def improved(self) -> bool:
+                return False
+
+        return Outcome()
+
+
+def _refusal_config(state_path: Path) -> CitadelConfig:
+    return CitadelConfig(
+        repo_content_sync_enabled=True,
+        repo_content_sync_dataset="masumi-network",
+        repo_content_sync_session="masumi-repo-content",
+        repo_content_sync_state_path=str(state_path),
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_root_paths=("README.md",),
+        repo_content_sync_tree_prefixes=("skills/",),
+        repo_content_sync_tree_extensions=(".md",),
+        repo_content_sync_max_files_per_repo=10,
+        repo_content_sync_run_improve=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_records_the_reason_the_ingest_actually_gave(
+    tmp_path: Path,
+) -> None:
+    """``ingest_rejected`` is not a reason, it is a category.
+
+    Reading ``{"ingest_rejected": 2}`` in a sync report cannot tell anyone whether
+    a human has to look at a file (``unchunkable_content``) or whether the same
+    bytes were simply already in flight (``duplicate_in_process``).
+    """
+    state_path = tmp_path / "state.json"
+    config = _refusal_config(state_path)
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=RefusingLearningProcess("unchunkable_content"),  # type: ignore[arg-type]
+    )
+
+    result = await syncer.run()
+
+    assert result["files_ingested"] == 0
+    assert result["files_skipped_by_reason"] == {"ingest_rejected:unchunkable_content": 2}
+
+
+@pytest.mark.asyncio
+async def test_content_the_ingest_can_never_accept_is_not_resubmitted_every_sync(
+    tmp_path: Path,
+) -> None:
+    """The refusal branch used to record nothing in ``tracked``.
+
+    ``unchunkable_content`` is a function of the bytes, so re-submitting the same
+    bytes buys a second identical refusal. The cost is not the refusal: reaching
+    it spends a ``fetch_file_text`` and a ``fetch_last_commit_sha`` per file per
+    pass, on a scheduler that runs about every 1h45m, forever.
+    """
+    state_path = tmp_path / "state.json"
+    config = _refusal_config(state_path)
+    learning = RefusingLearningProcess("unchunkable_content")
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    await syncer.run()
+    assert len(learning.calls) == 2
+
+    second = await syncer.run()
+
+    assert len(learning.calls) == 2, "the same bytes were submitted for a second refusal"
+    assert second["files_skipped_by_reason"] == {
+        "refused_unchanged:unchunkable_content": 2
+    }
+    entry = json.loads(state_path.read_text(encoding="utf-8"))["files"][
+        "masumi-network/sokosumi-cli/README.md"
+    ]
+    assert entry["rejected_reason"] == "unchunkable_content"
+    assert entry["sha"] and entry["content_hash"]
+    assert not entry.get("cognee_data_ids"), "a refused file must not look ingested"
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_that_is_not_about_the_content_is_retried(
+    tmp_path: Path,
+) -> None:
+    """``duplicate_in_process`` is scoped to one process, so it must not stick.
+
+    ``Citadel._seen_ingest_keys`` is per-process state. Recording it as terminal
+    would let one restart's bookkeeping suppress a file for every later run.
+    """
+    state_path = tmp_path / "state.json"
+    config = _refusal_config(state_path)
+    learning = RefusingLearningProcess("duplicate_in_process")
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    await syncer.run()
+    second = await syncer.run()
+
+    assert len(learning.calls) == 4, "a process-scoped refusal was made permanent"
+    assert second["files_skipped_by_reason"] == {
+        "ingest_rejected:duplicate_in_process": 2
+    }
+
+
+@pytest.mark.asyncio
+async def test_raising_the_chunk_budget_retries_what_the_old_budget_refused(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """The budget is an observation, and the knob to change it has to do something.
+
+    ``kb.chunk_window`` says out loud to raise CITADEL_CHUNK_BUDGET_TOKENS when the
+    detector reports a content class its sweep did not contain. A terminal skip
+    that ignored the budget would make that raise a no-op for every file the old
+    budget had already refused, which is a guard shipping inert.
+    """
+    state_path = tmp_path / "state.json"
+    config = _refusal_config(state_path)
+    learning = RefusingLearningProcess("unchunkable_content")
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    monkeypatch.setenv("CITADEL_CHUNK_BUDGET_TOKENS", "256")
+    await syncer.run()
+    assert len(learning.calls) == 2
+
+    monkeypatch.setenv("CITADEL_CHUNK_BUDGET_TOKENS", "512")
+    await syncer.run()
+
+    assert len(learning.calls) == 4, "the raised budget never retried the refused files"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_file_is_not_counted_as_a_tracked_file(tmp_path: Path) -> None:
+    """``tracked_files`` is read as how much of the corpus this connector holds.
+
+    Refusal entries live in the same ``files`` map as ingested ones, so counting
+    the map would report a file as tracked precisely because it is absent from
+    the index. They are reported, but under their own name.
+    """
+    state_path = tmp_path / "state.json"
+    config = _refusal_config(state_path)
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=str(state_path),
+        learning=RefusingLearningProcess("unchunkable_content"),  # type: ignore[arg-type]
+    )
+
+    await syncer.run()
+    status = await syncer.status()
+
+    assert status["tracked_files"] == 0, "a refused file is not in the index"
+    assert status["refused_files"] == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -849,3 +849,38 @@ async def test_improve_runs_when_graph_has_data() -> None:
     await kb.improve()
 
     assert fake.improve_calls, "cognee.improve should run on a non-empty graph"
+
+
+@pytest.mark.asyncio
+async def test_every_rejection_line_in_ingest_escapes_the_dataset_name(
+    caplog: Any,
+) -> None:
+    """``Citadel.ingest`` logs the caller's dataset name on three refusal paths.
+
+    CodeQL raised ``py/log-injection`` on one of them (the un-chunkable branch);
+    the other two are the same variable, in the same function, reported on main as
+    open alerts of the same rule. Escaping one and not the others closes an alert
+    without closing the hole: a dataset name carrying a newline still writes a
+    second line that looks exactly like a genuine record, in a project that reads
+    its own logs back as evidence.
+    """
+    import logging
+
+    forged = "notes\n2026-08-04 INFO kb.service Ingest accepted for dataset central"
+    kb = Citadel(CitadelConfig(), cognee=FakeCognee())
+
+    with caplog.at_level(logging.INFO, logger="kb.service"):
+        # 1. the pre-ingest filter refuses it
+        empty = await kb.ingest("   ", dataset=forged)
+        # 2. the same bytes arrive twice in one process
+        await kb.ingest("a real note", dataset=forged)
+        duplicate = await kb.ingest("a real note", dataset=forged)
+
+    assert empty.reason == "empty"
+    assert duplicate.reason == "duplicate_in_process"
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 2, messages
+    for message in messages:
+        assert "\n" not in message, "a caller-supplied value opened a new log line"
+        assert "\\n" in message, "the value must survive the escaping, not be deleted"


### PR DESCRIPTION
Issue **#227**, which [the plan](docs/superpowers/specs/2026-08-04-citadel-execution-plan.md) puts *strictly before* #228: re-indexing 892 documents at a budget the embedder cannot consume produces 892 documents that are indexed and still unretrievable, paid twice.

## The finding that matters more than the number

Four budgets have now been refuted by measurement (384 on Korean, 352 on minified JSON, and this round **284** on a Korean probe at a per-chunk ratio of **2.05**). The reason is structural, and it is not the ratio:

> `cognee/tasks/chunks/chunk_by_paragraph.py:40` — `if current_chunk_size > 0 and (current_chunk_size + sentence_size > max_chunk_size)`. When the accumulator is empty, an over-budget sentence is appended **anyway**.

**No budget bounds the emitted chunk.** The same 1,392-BPE line comes out as one 1,710-wordpiece chunk at 512, 384, 284, 256 **and** 192 — at 192 that is 7.2× the budget it supposedly obeys. Every attempt to pick a safe number was solving the wrong problem.

Confirmed verbatim against the deployed model: a ~10,001-wordpiece input returns `len ids == 512`, no exception. Silent truncation.

## What ships

**256 BPE tokens, labelled an observation and not a bound.** Chosen as the knee of a 172-document sweep, not from a ratio — the three chunks surviving at 256 are the *same three* surviving at 192.

```
budget  chunks   over-window   worst wordpieces
  8191     274    245 (89.4%)           12,642
   352   4,316    187 ( 4.3%)            1,710
   284   5,414     28 (0.52%)            1,710
   256   6,064      3 (0.05%)            1,710
   192   8,237      3 (0.04%)            1,710
```

**A detector at the embed boundary**, because only measuring the emitted chunk is a bound. It reads the window off the model's own tokenizer rather than a constant, counts with a truncation-free clone, and logs the chunk's sha256 — never its content, since this repo is public.

```
WARNING kb.chunk_window embed window exceeded: 1710 tokens against a 512 window
(3.34x), 3005 characters, chunk sha256:21798385473e. The model truncates the
remainder and raises nothing, so that text is in the store and not retrievable.
```

Verified firing against the real model, with a companion test asserting silence at 511 and 512.

**Two tests enforce the labelling**, one grepping for eight forbidden phrases including `most conservative known budget` — the exact claim an earlier attempt shipped.

**Refuse and record, never mangle.** Un-chunkable content is rejected at the ingest chokepoint with a reason, reusing the existing rejection shape. Not split: a previous attempt's splitter turned `SEVERITY=high` into `SEVERITY=hig h` in our own docs. Measured exposure of 8191 → 256 is **one** additional document across 172 probes, and **0 of 86** eligible repo-content files.

## The clamp reaches the real budget

```
A. cold                                    -> 8191
C. + get_embedding_config.cache_clear()    -> 8191
D. + create_embedding_engine.cache_clear() -> 8191
E. + _create_vector_engine.cache_clear()   ->  256
```

All three are cleared, and the test warms the caches with a real cognee call *before* the guard. Substituting a config-only clear makes it fail.

## Tests

```
green:                    1441 passed, 1 skipped
source stubbed, kept:       22 failed, 1419 passed, 1 skipped
```

Collection is 1442 in **both** directions — the module was stubbed, not deleted, so this is a real failure rather than a zero-collected phantom.

## For #228 and the cognee bump

The root cause is a tokenizer mismatch: `FastembedEmbeddingEngine.get_tokenizer()` returns `TikTokenTokenizer(model="gpt-4o")` while the model tokenizes wordpieces. If the engine counted in the model's own units, **510 would be an exact bound** for everything cognee can split. Deliberately not done here, because the 1.4.x upgrade fixes it upstream and shipping our own tokenizer would be work thrown away.

Nothing was re-embedded. That is #228.

Refs #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable chunk-size limits for document processing.
  * Added embedding-window overflow detection and aggregate reporting.
  * Added protection against ingesting documents containing unbroken content larger than the configured limit.
  * Added environment settings to enable, disable, and tune these safeguards.

* **Bug Fixes**
  * Prevented oversized documents from being submitted for processing.
  * Improved retry handling for rejected files.
  * Sanitized log values to prevent unsafe or misleading log entries while keeping content private.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->