### PR TITLE
fix(http): back-port the read-timeout fix to every copy that drifted

### DIFF
--- a/kb/access_client.py
+++ b/kb/access_client.py
@@ -89,6 +89,15 @@ def _request(
         raise AccessClientError(str(detail or exc.reason), status=exc.code, body=parsed) from exc
     except urllib.error.URLError as exc:
         raise AccessClientError(str(exc.reason)) from exc
+    except TimeoutError as exc:
+        # A read-phase timeout surfaces as a bare TimeoutError from http.client's
+        # getresponse(), which urllib does NOT wrap in URLError — so it would
+        # otherwise escape as a raw traceback (#39).
+        raise AccessClientError(
+            f"Node request timed out after {timeout:.0f}s — retry or check the Node"
+        ) from exc
+    except OSError as exc:
+        raise AccessClientError(f"could not reach Node: {exc}") from exc
     return json.loads(body) if body else {}
 
 

--- a/scripts/run_backup_mirror.py
+++ b/scripts/run_backup_mirror.py
@@ -89,6 +89,10 @@ def _post_json(
         return exc.code, parsed
     except URLError as exc:
         return 599, {"detail": str(exc.reason)}
+    except TimeoutError as exc:
+        # A read-phase timeout is a bare TimeoutError, not a URLError, and
+        # would otherwise escape this handler as a raw traceback (#39/#116).
+        return 599, {"detail": f"timed out after {timeout}s: {exc}"}
 
 
 def _run_local(*, dry_run: bool) -> dict[str, Any]:

--- a/scripts/run_github_sync.py
+++ b/scripts/run_github_sync.py
@@ -100,6 +100,10 @@ def _post_json(
         return exc.code, parsed
     except URLError as exc:
         return 599, {"detail": str(exc.reason)}
+    except TimeoutError as exc:
+        # A read-phase timeout is a bare TimeoutError, not a URLError, and
+        # would otherwise escape this handler as a raw traceback (#39/#116).
+        return 599, {"detail": f"timed out after {timeout}s: {exc}"}
 
 
 def _github_result(result: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -201,6 +201,11 @@ def _cognify_via_api(url: str, *, force: bool) -> int:
     except URLError as exc:
         logger.error("Cognify API unreachable at %s: %s", endpoint, exc.reason)
         return 1
+    except TimeoutError as exc:
+        # A read-phase timeout is a bare TimeoutError, not a URLError, and
+        # would otherwise escape this handler as a raw traceback (#39/#116).
+        logger.error("Cognify API timed out after %ss: %s", _cognify_timeout(), exc)
+        return 1
 
     logger.info(
         "Cognify (API) finished: graph_before=%s graph_after=%s grew=%s",

--- a/scripts/run_self_improve.py
+++ b/scripts/run_self_improve.py
@@ -94,6 +94,10 @@ def _post_json(
         return exc.code, parsed
     except URLError as exc:
         return 599, {"detail": str(exc.reason)}
+    except TimeoutError as exc:
+        # A read-phase timeout is a bare TimeoutError, not a URLError, and
+        # would otherwise escape this handler as a raw traceback (#39/#116).
+        return 599, {"detail": f"timed out after {timeout}s: {exc}"}
 
 
 async def _run_local(*, dry_run: bool) -> dict[str, Any]:

--- a/tests/test_access_client.py
+++ b/tests/test_access_client.py
@@ -89,3 +89,28 @@ def test_http_error_maps_detail_and_status(monkeypatch) -> None:
         ac.create_seat(base_url="https://node.example", name="A", slug="a", key="owner-admin")
     assert excinfo.value.status == 422
     assert "already exists" in str(excinfo.value)
+
+
+def test_request_converts_read_timeout_to_client_error(monkeypatch) -> None:
+    # #116: a read-phase timeout is a bare TimeoutError (not a URLError) and
+    # escapes _request's HTTPError/URLError-only handling as a raw traceback
+    # instead of a clean AccessClientError — the same #39 bug, unbackported
+    # to this copy of the helper.
+    def boom(req: Any, timeout: float | None = None) -> None:
+        raise TimeoutError("the read operation timed out")
+
+    monkeypatch.setattr(ac._OPENER, "open", boom)
+    with pytest.raises(ac.AccessClientError) as excinfo:
+        ac.list_seats(base_url="https://node.example", key="owner-admin")
+    assert not isinstance(excinfo.value, TimeoutError)
+    assert "timed out" in str(excinfo.value).lower()
+
+
+def test_request_converts_oserror_to_client_error(monkeypatch) -> None:
+    def boom(req: Any, timeout: float | None = None) -> None:
+        raise OSError("connection reset by peer")
+
+    monkeypatch.setattr(ac._OPENER, "open", boom)
+    with pytest.raises(ac.AccessClientError) as excinfo:
+        ac.list_seats(base_url="https://node.example", key="owner-admin")
+    assert "connection reset by peer" in str(excinfo.value)

--- a/tests/test_backup_mirror_job.py
+++ b/tests/test_backup_mirror_job.py
@@ -115,3 +115,21 @@ def test_backup_mirror_job_fails_on_remote_http_error(monkeypatch: Any) -> None:
     monkeypatch.setattr(run_backup_mirror, "_post_json", post_json)
 
     assert run_backup_mirror.run() == 1
+
+
+def test_post_json_converts_read_timeout_to_clean_result(monkeypatch: Any) -> None:
+    # #116: a read-phase timeout is a bare TimeoutError, not a URLError, and
+    # would otherwise escape this helper's HTTPError/URLError-only handling
+    # as a raw traceback (the #39 bug, unbackported to this copy).
+    def boom(request: Any, timeout: int) -> None:
+        raise TimeoutError("the read operation timed out")
+
+    monkeypatch.setattr(run_backup_mirror, "urlopen", boom)
+    status, body = run_backup_mirror._post_json(
+        "https://citadel.example/api/backup-mirror/run",
+        payload={},
+        access_key="secret",
+        timeout=5,
+    )
+    assert status == 599
+    assert "timed out" in body["detail"].lower()

--- a/tests/test_github_sync_job.py
+++ b/tests/test_github_sync_job.py
@@ -190,3 +190,21 @@ def test_gateway_delivery_summary_falls_back_to_google_chat() -> None:
         run_github_sync._gateway_delivery_summary(result)
         == "google_chat:delivery_error"
     )
+
+
+def test_post_json_converts_read_timeout_to_clean_result(monkeypatch: Any) -> None:
+    # #116: a read-phase timeout is a bare TimeoutError, not a URLError, and
+    # would otherwise escape this helper's HTTPError/URLError-only handling
+    # as a raw traceback (the #39 bug, unbackported to this copy).
+    def boom(request: Any, timeout: int) -> None:
+        raise TimeoutError("the read operation timed out")
+
+    monkeypatch.setattr(run_github_sync, "urlopen", boom)
+    status, body = run_github_sync._post_json(
+        "https://citadel.example/api/learning-agent/run",
+        payload={},
+        access_key="secret",
+        timeout=5,
+    )
+    assert status == 599
+    assert "timed out" in body["detail"].lower()

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -513,3 +513,19 @@ def test_evolve_async_stages_are_all_coroutine_functions() -> None:
 
     for name, _, runner in run_railway.evolve_stages_async():
         assert inspect.iscoroutinefunction(runner), f"{name} is not awaitable"
+
+
+def test_cognify_via_api_converts_read_timeout_to_clean_failure(monkeypatch: Any) -> None:
+    # #116: a read-phase timeout is a bare TimeoutError, not a URLError, and
+    # would otherwise escape this helper's HTTPError/URLError-only handling
+    # as a raw traceback (the #39 bug, unbackported to this copy). The
+    # urlopen import is function-local, so patch the stdlib symbol itself.
+    import urllib.request
+
+    def boom(request: Any, timeout: int) -> None:
+        raise TimeoutError("the read operation timed out")
+
+    monkeypatch.setenv("CITADEL_ADMIN_KEY", "admin-key")
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+
+    assert run_railway._cognify_via_api("http://localhost:8080", force=False) == 1

--- a/tests/test_self_improve_job.py
+++ b/tests/test_self_improve_job.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts import run_self_improve
+
+
+def test_post_json_converts_read_timeout_to_clean_result(monkeypatch: Any) -> None:
+    # #116: a read-phase timeout is a bare TimeoutError, not a URLError, and
+    # would otherwise escape this helper's HTTPError/URLError-only handling
+    # as a raw traceback (the #39 bug, unbackported to this copy).
+    def boom(request: Any, timeout: int) -> None:
+        raise TimeoutError("the read operation timed out")
+
+    monkeypatch.setattr(run_self_improve, "urlopen", boom)
+    status, body = run_self_improve._post_json(
+        "https://citadel.example/api/learning-agent/optimize",
+        payload={},
+        access_key="secret",
+        timeout=5,
+    )
+    assert status == 599
+    assert "timed out" in body["detail"].lower()


### PR DESCRIPTION
## What

Back-port the #39 read-timeout handling to the remaining copies of the bare-`urllib` HTTP helper: `kb/access_client.py`, `scripts/run_backup_mirror.py`, `scripts/run_github_sync.py`, `scripts/run_self_improve.py`, and `scripts/run_railway.py`. A read-phase timeout raises a bare `TimeoutError` that `urllib` does not wrap in `URLError`; each copy now converts it into that helper's normal failure shape (an `AccessClientError`, a status-599 result, or a clean non-zero exit) instead of letting it escape as a raw traceback. Each copy gets a regression test.

## Why

Issue #116: the #39 timeout fix was never back-ported to these copies, so a read-phase timeout still surfaces as a raw traceback there. [The plan](docs/superpowers/specs/2026-08-04-citadel-execution-plan.md) puts it "before the end-to-end CLI run, which is half of this stage's exit. A CLI path still carrying the un-backported timeout will fail that run for a reason nobody is trying to test." This is the standalone back-port that issue's "What to do" section suggests landing first; the transport consolidation it proposes stays open, so this links rather than closes.

Refs #116

**Seven copies confirmed by inspection**, not taken on trust from the issue. Found by grepping for a `Request` carrying `Authorization: Bearer` handed to `urlopen`/`opener.open`, then checking each for the #39 bug shape: catching `HTTPError`/`URLError` but not the bare `TimeoutError` that a read-phase timeout raises unwrapped, since only the connect phase becomes a `URLError`.

**Look-alikes deliberately excluded**, with reasons rather than a blanket sweep: `kb/status.py`, `kb/capture.py`, `kb/webhook_gateway.py`, the three `kb/hooks/*.py`, and `scripts/bench/*.py` either wrap the call in a broad `except Exception` or have the caller catch `TimeoutError` one layer up. The server-side modules route through the shared `kb/secure_http.open_secure` and are not duplicated code at all.

That distinction matters: consolidating everything that merely *looks* like this helper would have been a much larger blast radius on the CLI path that half the release exit depends on.

## How it was verified

```
uv run pytest tests/ -q   -> 1415 passed, 1 skipped, 11 warnings in 40.33s
uv run ruff check .       -> All checks passed!
```

Proved in both directions: with the five source files reverted to the merge base and the tests kept, the suite fails with `6 failed, 1409 passed, 1 skipped`, and the six failures are by name exactly the six regression tests this PR adds. Restored, the suite is green again (`1415 passed, 1 skipped`).

## Checklist

- [x] Commits are signed off (`git commit -s`) — the DCO check enforces this
- [x] PR title follows Conventional Commits
- [x] Tests added or updated for the behaviour changed
- [x] `uv run pytest tests/ -q` passes locally
- [x] `uv run ruff check .` is clean
- [x] No secrets, tokens, `.env` contents or vault exports in the diff
- [x] Documentation updated if behaviour or interfaces changed (no doc describes these error paths; interfaces are unchanged)
