### PR TITLE
fix(linear): one blocked issue no longer aborts the whole sync pass

### DIFF
--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -529,7 +529,7 @@ class LinearSyncer:
                 # linear_search returns real issues org-wide — the digest only carried
                 # titles, leaving the 200 synced issues invisible to search (#52).
                 try:
-                    await learning.learn(
+                    issue_outcome = await learning.learn(
                         format_issue_note(issue),
                         dataset=central_dataset,
                         tags=[
@@ -548,7 +548,11 @@ class LinearSyncer:
                         tier="light",
                         defer_cognify=True,
                     )
-                    central_issue_written = True
+                    if issue_outcome.ingest.accepted:
+                        # Only an ACCEPTED add is a write; a filter rejection or
+                        # in-process duplicate returns accepted=False without
+                        # raising and stores nothing.
+                        central_issue_written = True
                 except SecretContentError as exc:
                     central_blocked = True
                     blocked.append(issue.identifier)
@@ -628,6 +632,11 @@ class LinearSyncer:
         if central_outcome is not None or central_issue_written:
             touched_datasets.append(central_dataset)
         touched_datasets.extend(written_mirror_datasets)
+        # What this pass OBSERVED about the coalesced graph write, reported as
+        # `central_ingested` below. Only the awaited branch sees the cognify
+        # finish (or fail); the scheduled branch has merely REQUESTED one, and
+        # must say so instead of implying completion.
+        cognify_observed: str | None = None
         if touched_datasets and not _suppress_inline_cognify():
             cognify_datasets = list(dict.fromkeys(touched_datasets))
             if await_cognify:
@@ -641,10 +650,18 @@ class LinearSyncer:
                     await self.citadel.cognee.cognify(datasets=cognify_datasets)
                 except Exception:  # noqa: BLE001 - writes succeeded; cognify is a follow-on
                     logger.exception("Linear sync coalesced cognify failed")
+                    cognify_observed = "cognify_failed"
+                else:
+                    cognify_observed = "cognified"
             else:
                 # On-demand endpoint / evolve: background it so the request returns
                 # without waiting on the graph write.
                 self.citadel.cognee.schedule_cognify(cognify_datasets)
+                cognify_observed = "queued_not_confirmed"
+        elif touched_datasets:
+            # Evolve Phase-1 subprocess (CITADEL_SUPPRESS_INLINE_COGNIFY): add-only
+            # by design; the web cognifies in Phase 2 as the sole Kuzu writer.
+            cognify_observed = "suppressed"
 
         # Advance the cursor to the newest updatedAt seen (keep the prior one
         # when a pass sees nothing newer, e.g. an empty or truncated fetch),
@@ -729,7 +746,25 @@ class LinearSyncer:
             # member fetch also leaves this at 0 (#148).
             "auto_mapped_assignees": auto_mapped,
             "auto_map_error": auto_map_error,
-            "central_ingested": central_outcome.ingest.accepted if central_outcome else None,
+            # Fate of this pass's Central writes as OBSERVED, never assumed.
+            # This used to report cognee.add() acceptance as True, but add()
+            # only QUEUES the graph write (cognify never runs synchronously),
+            # so a pass whose graph write later died was byte-identical to a
+            # working one. States a caller can branch on:
+            #   "cognified"             awaited coalesced cognify completed
+            #   "cognify_failed"        awaited coalesced cognify raised
+            #   "queued_not_confirmed"  background cognify scheduled; outcome
+            #                           not observed by this pass
+            #   "suppressed"            add-only mode; evolve Phase 2 cognifies
+            #   None                    no accepted Central write this pass
+            "central_ingested": (
+                cognify_observed
+                if (
+                    (central_outcome is not None and central_outcome.ingest.accepted)
+                    or central_issue_written
+                )
+                else None
+            ),
             "mirrors": mirrors,
             # Issues (or the workspace digest) the secret scanner refused this
             # pass (#117): identifiers only, never content. A blocked write is

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -21,6 +21,7 @@ from kb.secure_http import open_secure
 from kb.access import CENTRAL_DATASET, SEAT_DATASET_PREFIX, AccessStore, seat_dataset
 from kb.cognee_client import _suppress_inline_cognify
 from kb.learning import LearningProcess
+from kb.security_scan import SecretContentError
 from kb.service import Citadel
 from kb.state_io import StateFileError, load_state_file, save_state_file
 
@@ -473,19 +474,35 @@ class LinearSyncer:
         # that stormed the writer lock and starved the request into a timeout. Write
         # ADD-ONLY here (defer_cognify=True) and schedule ONE cognify over every
         # dataset touched after the loop instead.
+        # Secret-scan containment (#117): learning.learn scans every document
+        # (ADR-0005) and raises SecretContentError on a blocking finding. The
+        # sibling syncers (github_sync, repo_content_sync) record a block and
+        # keep going; here ONE poisoned issue used to kill the entire sync —
+        # one refused entry out of 200 zeroing the whole Linear surface.
+        # Blocked items are recorded by identifier only, never content, and
+        # simply retried whenever the issue next changes.
+        blocked: list[str] = []
+
         central_outcome = None
         if force or changed_ids or removed_ids:
             digest = format_workspace_digest(issues)
-            central_outcome = await learning.learn(
-                digest,
-                dataset=central_dataset,
-                tags=["linear-workspace", "linear-sync"],
-                session_id=session_id,
-                operation="linear_sync",
-                run_improve=self.config.linear_sync_run_improve,
-                tier="full",
-                defer_cognify=True,
-            )
+            try:
+                central_outcome = await learning.learn(
+                    digest,
+                    dataset=central_dataset,
+                    tags=["linear-workspace", "linear-sync"],
+                    session_id=session_id,
+                    operation="linear_sync",
+                    run_improve=self.config.linear_sync_run_improve,
+                    tier="full",
+                    defer_cognify=True,
+                )
+            except SecretContentError as exc:
+                blocked.append("workspace-digest")
+                logger.warning(
+                    "Linear workspace digest blocked by the secret scanner: %s",
+                    exc.public_message,
+                )
 
         mirrored = 0
         skipped_unchanged = 0
@@ -494,63 +511,104 @@ class LinearSyncer:
         for issue in issues:
             changed = issue.id in changed_ids
             mirror_dataset = resolve_mirror_dataset(issue, email_index, linear_user_map=user_map)
-            if mirror_dataset:
-                # The state mapping covers ALL fetched issues (issues_for_scope
-                # reads it), independent of whether this run rewrote the note.
-                mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
+            prior_mirror_ids = prior_mirrors.get(mirror_dataset) if mirror_dataset else None
+            mirror_has_note = mirror_dataset is not None and (
+                isinstance(prior_mirror_ids, list)
+                and issue.identifier in {str(item) for item in prior_mirror_ids}
+            )
+
+            central_blocked = False
             if changed:
                 # Write each issue's full text (title + description) to Central so
                 # linear_search returns real issues org-wide — the digest only carried
                 # titles, leaving the 200 synced issues invisible to search (#52).
-                await learning.learn(
-                    format_issue_note(issue),
-                    dataset=central_dataset,
-                    tags=[
-                        "linear-issue",
-                        "linear-sync",
-                        f"linear:{issue.identifier}",
-                        # Team as a structured, filterable metadata tag so Central issues
-                        # are discoverable by team (e.g. "what is the marketing team
-                        # working on?"). The human team NAME also rides in the note body
-                        # (format_issue_note) for semantic search.
-                        f"team:{issue.team_key}" if issue.team_key else "linear",
-                    ],
-                    session_id=session_id,
-                    operation="linear_sync",
-                    run_improve=False,
-                    tier="light",
-                    defer_cognify=True,
-                )
+                try:
+                    await learning.learn(
+                        format_issue_note(issue),
+                        dataset=central_dataset,
+                        tags=[
+                            "linear-issue",
+                            "linear-sync",
+                            f"linear:{issue.identifier}",
+                            # Team as a structured, filterable metadata tag so Central issues
+                            # are discoverable by team (e.g. "what is the marketing team
+                            # working on?"). The human team NAME also rides in the note body
+                            # (format_issue_note) for semantic search.
+                            f"team:{issue.team_key}" if issue.team_key else "linear",
+                        ],
+                        session_id=session_id,
+                        operation="linear_sync",
+                        run_improve=False,
+                        tier="light",
+                        defer_cognify=True,
+                    )
+                except SecretContentError as exc:
+                    central_blocked = True
+                    blocked.append(issue.identifier)
+                    logger.warning(
+                        "Linear issue %s blocked by the secret scanner; its Central "
+                        "write and mirror are withheld this pass (content not "
+                        "stored): %s",
+                        issue.identifier,
+                        exc.public_message,
+                    )
             else:
                 skipped_unchanged += 1
+
             if not mirror_dataset:
                 continue
-            prior_mirror_ids = prior_mirrors.get(mirror_dataset)
-            mirror_has_note = isinstance(prior_mirror_ids, list) and issue.identifier in {
-                str(item) for item in prior_mirror_ids
-            }
+
+            if central_blocked:
+                # Refused content must not reach a seat mirror either. A note
+                # that already landed on a PRIOR (unblocked) pass stays listed
+                # — it is not overwritten with the now-refused text, it just
+                # goes stale until the issue changes again and passes clean.
+                if mirror_has_note:
+                    mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
+                continue
+
             # Backfill a mirror the state has never recorded this issue in even
             # when the issue itself is unchanged — a seat created (or mapped)
             # AFTER the issue last changed would otherwise never receive it
             # until the issue next updates.
             if not changed and mirror_has_note:
+                mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
                 continue
+
             note = format_issue_note(issue)
-            await learning.learn(
-                note,
-                dataset=mirror_dataset,
-                tags=[
-                    "linear-assignee",
-                    "linear-issue",
-                    f"linear:{issue.identifier}",
-                    f"team:{issue.team_key}" if issue.team_key else "linear",
-                ],
-                session_id=f"linear-{mirror_dataset.removeprefix(SEAT_DATASET_PREFIX)}",
-                operation="linear_mirror",
-                run_improve=False,
-                tier="light",
-                defer_cognify=True,
-            )
+            try:
+                await learning.learn(
+                    note,
+                    dataset=mirror_dataset,
+                    tags=[
+                        "linear-assignee",
+                        "linear-issue",
+                        f"linear:{issue.identifier}",
+                        f"team:{issue.team_key}" if issue.team_key else "linear",
+                    ],
+                    session_id=f"linear-{mirror_dataset.removeprefix(SEAT_DATASET_PREFIX)}",
+                    operation="linear_mirror",
+                    run_improve=False,
+                    tier="light",
+                    defer_cognify=True,
+                )
+            except SecretContentError as exc:
+                blocked.append(issue.identifier)
+                logger.warning(
+                    "Linear issue %s mirror to %s blocked by the secret scanner "
+                    "(content not stored): %s",
+                    issue.identifier,
+                    mirror_dataset,
+                    exc.public_message,
+                )
+                if mirror_has_note:
+                    mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
+                continue
+
+            # The state mapping covers every fetched issue whose mirror note is
+            # actually present — this pass or a prior one — since
+            # issues_for_scope reads it directly.
+            mirrors.setdefault(mirror_dataset, []).append(issue.identifier)
             if mirror_dataset not in written_mirror_datasets:
                 written_mirror_datasets.append(mirror_dataset)
             mirrored += 1
@@ -661,5 +719,10 @@ class LinearSyncer:
             "auto_map_error": auto_map_error,
             "central_ingested": central_outcome.ingest.accepted if central_outcome else None,
             "mirrors": mirrors,
+            # Issues (or the workspace digest) the secret scanner refused this
+            # pass (#117): identifiers only, never content. A blocked write is
+            # contained, not silently dropped.
+            "blocked": blocked,
+            "blocked_count": len(blocked),
             "last_synced_at": payload["last_synced_at"],
         }

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -508,6 +508,12 @@ class LinearSyncer:
         skipped_unchanged = 0
         mirrors: dict[str, list[str]] = {}
         written_mirror_datasets: list[str] = []
+        # Tracked independently of central_outcome (the workspace digest's own
+        # result): the digest and each issue's Central note are separate
+        # learning.learn() calls, so the digest can be blocked while an
+        # unrelated issue's Central write still lands. touched_datasets must
+        # reflect that real write, not just the digest's fate.
+        central_issue_written = False
         for issue in issues:
             changed = issue.id in changed_ids
             mirror_dataset = resolve_mirror_dataset(issue, email_index, linear_user_map=user_map)
@@ -542,6 +548,7 @@ class LinearSyncer:
                         tier="light",
                         defer_cognify=True,
                     )
+                    central_issue_written = True
                 except SecretContentError as exc:
                     central_blocked = True
                     blocked.append(issue.identifier)
@@ -618,7 +625,7 @@ class LinearSyncer:
         # fold in) or inline cognify is suppressed (the evolve Phase-1 subprocess
         # is add-only and the web cognifies in Phase 2 as the sole Kuzu writer, #47).
         touched_datasets: list[str] = []
-        if central_outcome is not None:
+        if central_outcome is not None or central_issue_written:
             touched_datasets.append(central_dataset)
         touched_datasets.extend(written_mirror_datasets)
         if touched_datasets and not _suppress_inline_cognify():
@@ -697,7 +704,12 @@ class LinearSyncer:
             "last_error": None,  # clear any prior failure on a successful sync
             "last_attempt_at": utc_now(),
             "auto_map_error": auto_map_error,
-            "issues": [asdict(issue) for issue in issues],
+            # Scanner-blocked issues are excluded here, not just from Central/
+            # mirror writes: issues_for_scope() reads this list directly, so a
+            # blocked issue's title/description landing here would re-serve
+            # refused content through Linear search — identifier only (via
+            # `blocked` above), never content.
+            "issues": [asdict(issue) for issue in issues if issue.identifier not in blocked],
             "mirrors": mirrors,
         }
         self._save_state(payload)

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -698,6 +698,101 @@ async def test_linear_sync_recovers_from_future_dated_stored_cursor(
     assert healed["last_seen_updated_at"] == "2026-06-25T10:00:00Z"
 
 
+# --- #117: a scanner-blocked issue must not kill the rest of the pass -------
+
+
+class FakeCogneeForScanTest:
+    """Minimal real-scan-path fake: records every write so a blocked write's
+    text can be asserted absent, without touching a real Cognee backend."""
+
+    def __init__(self) -> None:
+        self.remember_calls: list[dict[str, Any]] = []
+
+    async def remember(self, data: Any, **kwargs: Any) -> dict[str, Any]:
+        self.remember_calls.append({"data": data, **kwargs})
+        return {"ok": True}
+
+    async def cognify(self, **kwargs: Any) -> dict[str, Any]:
+        return {"cognified": True}
+
+    def schedule_cognify(self, datasets: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_contains_scanner_blocked_issue(tmp_path: Any) -> None:
+    """#117: LinearSyncer must route through the same ingest gate as its
+    sibling syncers AND contain a block the way they do — a scanner-blocked
+    issue must be skipped (never stored), while the rest of the pass still
+    lands. Uses the REAL LearningProcess/security_scan (no monkeypatch of
+    .learn) so this proves the gate actually runs, not that a mock was called.
+    """
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+        access_store_path=str(tmp_path / "access.json"),
+    )
+    fake_cognee = FakeCogneeForScanTest()
+    citadel = Citadel(config, cognee=fake_cognee)
+    store = AccessStore(config.access_store_path)
+    store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
+
+    # AWS's own published example key (docs.aws.amazon.com) — shape-valid,
+    # never a real credential (memory: never use real credentials as fixtures).
+    planted_secret = "AKIAIOSFODNN7EXAMPLE"
+    issues = [
+        {
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            "title": "Ordinary issue",
+            "description": "Nothing sensitive here.",
+            "url": "https://linear.app/acme/issue/ENG-1",
+            "priority": 2,
+            "updatedAt": "2026-06-25T10:00:00Z",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "ENG", "name": "Engineering"},
+            "assignee": None,
+        },
+        {
+            "id": "issue-2",
+            "identifier": "ENG-2",
+            "title": "Leaked credential",
+            "description": f"AWS key {planted_secret} leaked in a log paste.",
+            "url": "https://linear.app/acme/issue/ENG-2",
+            "priority": 1,
+            "updatedAt": "2026-06-25T09:00:00Z",
+            "state": {"name": "Backlog", "type": "backlog"},
+            "team": {"key": "ENG", "name": "Engineering"},
+            "assignee": {"id": "user-john", "name": "John Doe", "email": "john@example.com"},
+        },
+    ]
+
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(issues), access_store=store)
+    result = await syncer.run(force=True)
+
+    # The pass as a whole must not abort: the unaffected issue still lands.
+    assert result["ok"] is True
+    assert "ENG-2" in result.get("blocked", [])
+    assert result.get("blocked_count", 0) >= 1
+
+    # The planted secret must never reach the store, in ANY write (digest,
+    # Central issue note, or seat mirror note).
+    stored_texts = [str(call.get("data", "")) for call in fake_cognee.remember_calls]
+    assert not any(planted_secret in text for text in stored_texts)
+
+    # The unaffected issue's Central write still happened.
+    central_datasets = [
+        call.get("dataset_name")
+        for call in fake_cognee.remember_calls
+        if "ENG-1" in str(call.get("data", ""))
+    ]
+    assert "masumi-network" in central_datasets
+
+    # The blocked issue must not be recorded as mirrored to john — the mirror
+    # note was never actually written for it.
+    assert "ENG-2" not in result["mirrors"].get(seat_dataset("john"), [])
+
+
 @pytest.mark.asyncio
 async def test_linear_sync_warns_after_prolonged_write_less_streak(
     tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any, caplog: Any

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -299,6 +299,9 @@ async def test_linear_sync_defers_coalesced_cognify_when_inline_suppressed(
     result = await syncer.run(force=True)
     assert result["ok"] is True
     assert scheduled == []  # suppressed: Phase 2 cognifies, not the subprocess
+    # And the pass says so: the graph write is deliberately deferred, so its
+    # outcome was not observed here.
+    assert result["central_ingested"] == "suppressed"
 
 
 @pytest.mark.asyncio
@@ -340,6 +343,71 @@ async def test_linear_sync_awaits_coalesced_cognify_when_requested(
     assert result["ok"] is True
     assert awaited == [["masumi-network"]]  # awaited inline over Central (no mirrors)
     assert scheduled == []  # awaited, not backgrounded
+
+
+# --- central_ingested reports an OBSERVED outcome, never a request -----------
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_reports_queued_not_confirmed_on_background_cognify(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    """central_ingested used to echo cognee.add() acceptance as True, but
+    add() only QUEUES the graph write (cognify never runs synchronously), so
+    a pass whose graph write later died silently was byte-identical to a
+    working one. On the scheduled path the pass observes nothing beyond the
+    request, and must report exactly that."""
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+
+    result = await syncer.run(force=True)
+    assert result["ok"] is True
+    assert scheduled  # the background cognify was requested...
+    # ...and the report claims no more than the request:
+    assert result["central_ingested"] == "queued_not_confirmed"
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_awaited_cognify_success_and_failure_report_differently(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    """The awaited path OBSERVES the coalesced cognify, so a completed graph
+    write and a failed one must produce different central_ingested values;
+    the two passes were previously indistinguishable."""
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+
+    async def fake_learn(self: Any, data: str, **_: Any) -> Any:
+        class Outcome:
+            class ingest:
+                accepted = True
+
+        return Outcome()
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
+
+    async def good_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setattr(citadel.cognee, "cognify", good_cognify)
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
+    healthy = await syncer.run(force=True, await_cognify=True)
+    assert healthy["ok"] is True
+    assert healthy["central_ingested"] == "cognified"
+
+    async def dead_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        raise RuntimeError("graph writer is down")
+
+    monkeypatch.setattr(citadel.cognee, "cognify", dead_cognify)
+    broken = await syncer.run(force=True, await_cognify=True)
+    # The pass still succeeds (the adds landed; cognify is a follow-on)...
+    assert broken["ok"] is True
+    # ...but the report now says what was actually observed.
+    assert broken["central_ingested"] == "cognify_failed"
+    assert broken["central_ingested"] != healthy["central_ingested"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -776,6 +776,7 @@ class FakeCogneeForScanTest:
 
     def __init__(self) -> None:
         self.remember_calls: list[dict[str, Any]] = []
+        self.scheduled_datasets: list[list[str]] = []
 
     async def remember(self, data: Any, **kwargs: Any) -> dict[str, Any]:
         self.remember_calls.append({"data": data, **kwargs})
@@ -785,7 +786,7 @@ class FakeCogneeForScanTest:
         return {"cognified": True}
 
     def schedule_cognify(self, datasets: Any) -> None:
-        return None
+        self.scheduled_datasets.append(list(datasets))
 
 
 @pytest.mark.asyncio
@@ -942,6 +943,7 @@ async def test_linear_sync_marks_central_touched_after_digest_rejection(
     # The bug: central_outcome (the digest's own result) is None, but a real
     # Central write happened via ENG-2. Central must still be scheduled for
     # cognify and must still reset the write-less streak.
+    assert any("masumi-network" in batch for batch in fake_cognee.scheduled_datasets)
     state_raw = (tmp_path / "linear_state.json").read_text()
     state = json.loads(state_raw)
     assert state["unchanged_pass_streak"] == 0

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -791,6 +792,141 @@ async def test_linear_sync_contains_scanner_blocked_issue(tmp_path: Any) -> None
     # The blocked issue must not be recorded as mirrored to john — the mirror
     # note was never actually written for it.
     assert "ENG-2" not in result["mirrors"].get(seat_dataset("john"), [])
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_marks_central_touched_after_digest_rejection(
+    tmp_path: Any,
+) -> None:
+    """#117 follow-up: format_workspace_digest() carries TITLES (not
+    descriptions), so a secret in an issue's title blocks the workspace
+    digest itself (not just that issue's own Central/mirror write). A
+    sibling, unrelated issue's clean Central write must still count as a
+    real Central write: it must be cognified and it must reset the
+    write-less streak, even though central_outcome (the digest's own
+    result) stayed None. This is the workspace-digest rejection branch
+    CodeRabbit flagged as uncovered, and the touched-Central-after-partial-
+    failure bug it flagged as likely broken, exercised together.
+    """
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+        access_store_path=str(tmp_path / "access.json"),
+    )
+    fake_cognee = FakeCogneeForScanTest()
+    citadel = Citadel(config, cognee=fake_cognee)
+    store = AccessStore(config.access_store_path)
+
+    # AWS's own published example key (docs.aws.amazon.com) — shape-valid,
+    # never a real credential (memory: never use real credentials as fixtures).
+    planted_secret = "AKIAIOSFODNN7EXAMPLE"
+    issues = [
+        {
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            # Secret lives in the TITLE: format_workspace_digest() includes
+            # titles, so this poisons the digest itself, not just this
+            # issue's own note.
+            "title": f"Rotate leaked key {planted_secret}",
+            "description": "Nothing sensitive in the body.",
+            "url": "https://linear.app/acme/issue/ENG-1",
+            "priority": 2,
+            "updatedAt": "2026-06-25T10:00:00Z",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "ENG", "name": "Engineering"},
+            "assignee": None,
+        },
+        {
+            "id": "issue-2",
+            "identifier": "ENG-2",
+            "title": "Ordinary, unrelated issue",
+            "description": "Nothing sensitive here either.",
+            "url": "https://linear.app/acme/issue/ENG-2",
+            "priority": 1,
+            "updatedAt": "2026-06-25T09:00:00Z",
+            "state": {"name": "Backlog", "type": "backlog"},
+            "team": {"key": "ENG", "name": "Engineering"},
+            "assignee": None,
+        },
+    ]
+
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(issues), access_store=store)
+    result = await syncer.run(force=True)
+
+    assert result["ok"] is True
+    # The digest itself was rejected (title-borne secret).
+    assert "workspace-digest" in result.get("blocked", [])
+    # The poisoned issue's own Central write was refused too.
+    assert "ENG-1" in result.get("blocked", [])
+
+    # The secret must never reach the store, in any write.
+    stored_texts = [str(call.get("data", "")) for call in fake_cognee.remember_calls]
+    assert not any(planted_secret in text for text in stored_texts)
+
+    # ENG-2's clean Central write landed.
+    central_datasets = [
+        call.get("dataset_name")
+        for call in fake_cognee.remember_calls
+        if "ENG-2" in str(call.get("data", ""))
+    ]
+    assert "masumi-network" in central_datasets
+
+    # The bug: central_outcome (the digest's own result) is None, but a real
+    # Central write happened via ENG-2. Central must still be scheduled for
+    # cognify and must still reset the write-less streak.
+    state_raw = (tmp_path / "linear_state.json").read_text()
+    state = json.loads(state_raw)
+    assert state["unchanged_pass_streak"] == 0
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_blocked_issue_content_not_in_persisted_state(
+    tmp_path: Any,
+) -> None:
+    """A scanner-blocked issue's title/description must never reach the
+    persisted sync state — issues_for_scope() reads that state directly and
+    would otherwise re-serve the refused content through Linear search,
+    bypassing the scanner gate entirely. Blocked items are tracked by
+    identifier only (see the `blocked` field), never by content.
+    """
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "linear_state.json"),
+        access_store_path=str(tmp_path / "access.json"),
+    )
+    fake_cognee = FakeCogneeForScanTest()
+    citadel = Citadel(config, cognee=fake_cognee)
+    store = AccessStore(config.access_store_path)
+
+    # AWS's own published example key (docs.aws.amazon.com) — shape-valid,
+    # never a real credential (memory: never use real credentials as fixtures).
+    planted_secret = "AKIAIOSFODNN7EXAMPLE"
+    issues = [
+        {
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            "title": f"Rotate leaked key {planted_secret}",
+            "description": "Nothing sensitive in the body.",
+            "url": "https://linear.app/acme/issue/ENG-1",
+            "priority": 2,
+            "updatedAt": "2026-06-25T10:00:00Z",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "ENG", "name": "Engineering"},
+            "assignee": None,
+        },
+    ]
+
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(issues), access_store=store)
+    result = await syncer.run(force=True)
+    assert "ENG-1" in result.get("blocked", [])
+
+    # Not in the raw persisted state file...
+    state_raw = (tmp_path / "linear_state.json").read_text()
+    assert planted_secret not in state_raw
+
+    # ...and not re-served through the org-scope read path either.
+    served = syncer.issues_for_scope(scope="org", seat_dataset_name=None)
+    assert not any(planted_secret in json.dumps(item) for item in served)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue **#117**, with the diagnosis corrected against what the code actually does.

## The plan's framing is imprecise, and saying so is the finding

The plan describes "a connector that bypasses the ingest gate". **It does not bypass it.** `LinearSyncer.run()` writes through `LearningProcess.learn()` for all three of its write paths — workspace digest, per-issue Central note, per-issue seat mirror — and that call scans via `scan_text_entries` and raises `SecretContentError` on a block, exactly like `citadel.ingest()`'s own backstop. Every byte written by the connector passes the real ADR-0005 gate.

## The real defect

`LinearSyncer` had **no `try`/`except`** around any of its three `learn()` calls, while its sibling `github_sync.py` does. One `SecretContentError` from a single issue, out of up to ~200, propagated unhandled out of `run()` and aborted the entire pass.

So the governance property holds and the availability property does not: a single blocked issue silently costs every other issue in that cycle.

## Why this branch and not the older one

A stale branch (`fix/linear-seat-mirror`, based ~27 merges behind current main) had diagnosed this under the same issue number, but its containment made refused content **persist and be served**. That is not reproduced here: refused content is still refused, and a refusal no longer kills the pass.

Its change-detection half has since landed separately.

Refs #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Linear synchronization now safely handles content blocked by security scans while continuing to process unaffected items.
  * Blocked issues are excluded from new seat mirrors and persisted issue state, while previously stored valid mirrors remain available.
  * Sync results now identify blocked items, report their counts, and accurately reflect Cognify processing status.
  * Central records remain updated when digest content is partially rejected.

* **Tests**
  * Added coverage for blocked content, partial processing, mirror preservation, and Cognify status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->