### PR TITLE
fix: report the outcome a surface observed, not the one it requested

### DIFF
--- a/kb/agent_workflows.py
+++ b/kb/agent_workflows.py
@@ -291,10 +291,45 @@ def shape_prepare_pr_context(
     }
 
 
-def normalize_local_search_results(results: Any) -> dict[str, Any]:
-    """Wrap local Citadel.search list into a payload shape_search_payload understands."""
+def _with_local_provenance(results: list[Any], dataset: str | None) -> list[Any]:
+    """Stamp each raw hit with the dataset it was actually read out of.
+
+    ``Citadel.search`` returns cognee's dicts untouched, so nothing downstream
+    could tell which dataset a local hit came from. ``infer_trust_tier`` /
+    ``infer_doc_type`` read exactly that field, so every local hit — including a
+    genuine session trace — came back ``unattested`` / ``other``, indistinguishable
+    from a hit that really has no provenance. The HTTP route has always passed the
+    dataset it read (``with_result_metadata``); this gives the local path the same
+    observed signal instead of a silent default.
+
+    Only a MISSING envelope is filled in: a hit that already carries provenance
+    keeps it, and no field beyond the dataset is invented here.
+    """
+    if not dataset:
+        return results
+    stamped: list[Any] = []
+    for item in results:
+        if isinstance(item, dict) and not isinstance(item.get("_citadel"), dict):
+            stamped.append({**item, "_citadel": {"dataset": dataset}})
+        else:
+            stamped.append(item)
+    return stamped
+
+
+def normalize_local_search_results(results: Any, *, dataset: str | None = None) -> dict[str, Any]:
+    """Wrap local Citadel.search list into a payload shape_search_payload understands.
+
+    ``dataset`` is the dataset ``Citadel.search`` actually searched. Pass it: it
+    is the only attested provenance signal the local path has, and without it
+    every hit is reported as unattested regardless of what it is.
+    """
     if isinstance(results, dict) and "results" in results:
         return results
     if isinstance(results, list):
-        return {"results": results, "timed_out": False, "truncated": False}
-    return {"results": [], "note": "unexpected local search payload"}
+        return {
+            "results": _with_local_provenance(results, dataset),
+            "dataset": dataset,
+            "timed_out": False,
+            "truncated": False,
+        }
+    return {"results": [], "dataset": dataset, "note": "unexpected local search payload"}

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -689,7 +689,12 @@ async def _search_local(args: argparse.Namespace) -> int:
     except TimeoutError as exc:
         return _emit_search_timeout(args, note=str(exc) or "local search timed out")
 
-    payload = normalize_local_search_results(results)
+    # Report the dataset that was READ, not the one that was asked for: with no
+    # dataset the hits carry no provenance and every one of them — session traces
+    # included — is labelled `unattested`, which the HTTP route never does.
+    payload = normalize_local_search_results(
+        results, dataset=kb.resolve_search_dataset(args.dataset)
+    )
     shaped = shape_search_payload(payload, **_shape_kwargs(args))
     _print_json(shaped)
     return 0 if shaped.get("ok") else 1

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -6,18 +6,50 @@ import contextvars
 import json
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from datetime import datetime, timezone
 from time import monotonic, perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 from uuid import NAMESPACE_OID, UUID, uuid5
 
+from kb.models import INDEX_STATE_NOT_SCHEDULED, INDEX_STATE_PENDING
+
 logger = logging.getLogger(__name__)
 
 # Strong refs to detached background cognify tasks so the loop does not GC them
 # mid-flight (and so they can be awaited/observed in tests).
 _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
+
+
+def _observed_data_ids(added: Any) -> tuple[str, ...]:
+    """Pull the data ids cognee assigned out of what ``cognee.add()`` returned.
+
+    ``add`` returns a ``PipelineRunInfo`` pydantic model (concretely a
+    ``PipelineRunCompleted``) on which ``data_ingestion_info`` is an ATTRIBUTE,
+    not a dict key. An earlier reader gated on ``isinstance(added, dict)``, so
+    the gate was always taken and it extracted nothing for every file ever
+    ingested. Read the attribute first and fall back to a mapping, so a future
+    cognee that returns a plain dict still works, and never gate on the
+    container type alone.
+
+    An empty result means "no ids readable here", NOT "the write failed": a
+    stub client returns a shape with no ids at all. Callers must treat it as
+    absence of evidence.
+    """
+    if added is None:
+        return ()
+    info_list = getattr(added, "data_ingestion_info", None)
+    if info_list is None and isinstance(added, Mapping):
+        info_list = added.get("data_ingestion_info")
+    ids: list[str] = []
+    for info in info_list or ():
+        data_id = (
+            info.get("data_id") if isinstance(info, Mapping) else getattr(info, "data_id", None)
+        )
+        if data_id:
+            ids.append(str(data_id))
+    return tuple(dict.fromkeys(ids))
 
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -268,7 +300,10 @@ class CogneeGateway(Protocol):
     ) -> Any:
         ...
 
-    def schedule_cognify(self, datasets: list[str]) -> None:
+    def schedule_cognify(self, datasets: list[str]) -> bool:
+        ...
+
+    def cognify_status(self, dataset: str) -> str | None:
         ...
 
     async def recall(
@@ -341,6 +376,12 @@ class CogneePublicClient:
         # single-flight lock so a burst of dashboard opens shares one Kuzu read.
         self._graph_data_cache: tuple[float, tuple[list[Any], list[Any]]] | None = None
         self._graph_data_lock = asyncio.Lock()
+        # Last OBSERVED cognify outcome per dataset: "ok" / "failed" /
+        # "not_scheduled". A background cognify finishes long after the write
+        # that scheduled it has already been reported, so its outcome has
+        # nowhere to be recorded — it was logged and lost. This is where the
+        # next pass looks to find out whether the promised graph write happened.
+        self._cognify_outcomes: dict[str, str] = {}
 
     def _copy_env_if_missing(self, target: str, *sources: str) -> None:
         if os.getenv(target):
@@ -523,28 +564,67 @@ class CogneePublicClient:
         # 2) Otherwise we schedule our OWN background cognify that serializes on the
         #    writer lock (kept non-blocking for the caller, #56), so concurrent
         #    in-process ingests and the evolve scheduler never collide.
+        #
+        # Every one of those three branches returns BEFORE the graph write, so
+        # none of them may report this write as indexed. ``index_state`` says
+        # which of them ran, in terms a caller can branch on: "pending_cognify"
+        # for a graph write that is genuinely owed, "cognify_not_scheduled" for
+        # one that nothing will ever perform. Those two used to be the same
+        # ``{"background_cognify": True}``, which is how a sync whose cognify
+        # silently died reported byte-identical success to one that indexed
+        # everything.
+        data_ids = _observed_data_ids(added)
         if _suppress_inline_cognify():
-            return {"added": added, "cognify": "suppressed"}
+            return {
+                "added": added,
+                "cognify": "suppressed",
+                "data_ids": data_ids,
+                "index_state": INDEX_STATE_PENDING,
+            }
         if defer_cognify:
             # The caller (e.g. a bulk Linear resync) coalesces ONE cognify over every
             # dataset it touched at the end, instead of scheduling one-per-write — a
             # 200-issue resync otherwise fires 200 background cognifies that storm the
             # writer lock and starve the request (#46/#52). Add-only here; the caller
             # calls schedule_cognify() once when the batch is done.
-            return {"added": added, "cognify": "deferred"}
-        self._schedule_background_cognify(dataset_name)
-        return {"added": added, "background_cognify": True}
+            return {
+                "added": added,
+                "cognify": "deferred",
+                "data_ids": data_ids,
+                "index_state": INDEX_STATE_PENDING,
+            }
+        scheduled = self._schedule_background_cognify(dataset_name)
+        return {
+            "added": added,
+            "background_cognify": scheduled,
+            "data_ids": data_ids,
+            "index_state": INDEX_STATE_PENDING if scheduled else INDEX_STATE_NOT_SCHEDULED,
+        }
 
-    def _schedule_background_cognify(self, dataset_name: str) -> None:
+    def _schedule_background_cognify(self, dataset_name: str) -> bool:
         """Schedule a tracked, writer-lock-guarded cognify so ingest stays fast.
 
         Replaces cognee's fire-and-forget run_in_background cognify with one that
         acquires our writer lock (via cognify()) — serializing the Kuzu write and
         surfacing failures instead of swallowing them (#47/#56).
-        """
-        self.schedule_cognify([dataset_name])
 
-    def schedule_cognify(self, datasets: list[str]) -> None:
+        Returns whether a cognify was actually scheduled, so the caller reports
+        the outcome it observed rather than the one it asked for.
+        """
+        return self.schedule_cognify([dataset_name])
+
+    def cognify_status(self, dataset: str) -> str | None:
+        """Last OBSERVED cognify outcome for ``dataset``: ok / failed / not_scheduled.
+
+        ``None`` means this process has not watched a cognify for that dataset,
+        which is not evidence either way. A background cognify finishes long
+        after the write that scheduled it has been reported, so this is where a
+        later pass looks to find out whether the graph write it was promised
+        ever happened.
+        """
+        return self._cognify_outcomes.get(dataset)
+
+    def schedule_cognify(self, datasets: list[str]) -> bool:
         """Schedule ONE tracked, writer-lock-guarded background cognify.
 
         Lets a bulk writer (the Linear resync) coalesce a single cognify over every
@@ -552,10 +632,14 @@ class CogneePublicClient:
         a storm of per-issue cognifies (#46/#52). The single cognify still serializes
         on the writer lock (single Kuzu writer, #47) and logs — never crashes — on
         failure. No-op with no running loop (sync caller) or no datasets.
+
+        Returns True only when a task was actually created. The caller reports
+        an outcome it observed, so "I declined to schedule" must be a value it
+        can read, not something buried in a log line.
         """
         wanted = list(dict.fromkeys(datasets))  # de-dup, preserve order
         if not wanted:
-            return
+            return False
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -569,13 +653,15 @@ class CogneePublicClient:
                 "is stored but will not be searchable until a cognify runs.",
                 wanted,
             )
-            return
+            self._record_cognify_outcome(wanted, "not_scheduled")
+            return False
 
         async def _run() -> None:
             try:
                 await self.cognify(datasets=wanted)
             except Exception:  # noqa: BLE001 - background task: log, never crash the loop
                 logger.exception("background cognify for datasets %s failed", wanted)
+                self._record_cognify_outcome(wanted, "failed")
             else:
                 # Log SUCCESS too. Previously only failures were logged, so a
                 # cognify that never ran — because the process exited before this
@@ -583,10 +669,16 @@ class CogneePublicClient:
                 # from one that completed. That is how a whole repository stayed
                 # missing from the index while every surface reported it synced.
                 logger.info("background cognify finished for datasets %s", wanted)
+                self._record_cognify_outcome(wanted, "ok")
 
         task = loop.create_task(_run())
         _BACKGROUND_COGNIFY_TASKS.add(task)
         task.add_done_callback(_BACKGROUND_COGNIFY_TASKS.discard)
+        return True
+
+    def _record_cognify_outcome(self, datasets: list[str], status: str) -> None:
+        for dataset in datasets:
+            self._cognify_outcomes[dataset] = status
 
     async def recall(
         self,

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -6,7 +6,7 @@ import contextvars
 import json
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from datetime import datetime, timezone
 from time import monotonic, perf_counter
 from typing import Any, Protocol
@@ -18,6 +18,93 @@ logger = logging.getLogger(__name__)
 # Strong refs to detached background cognify tasks so the loop does not GC them
 # mid-flight (and so they can be awaited/observed in tests).
 _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
+
+# OBSERVED outcomes of the detached background cognifies (process-lifetime).
+# remember() returns before the graph write in every branch, so an ingest-time
+# surface can only ever report that a cognify was REQUESTED. These counters are
+# where the request and its outcome stop being the same number: on a working
+# node runs_completed tracks runs_scheduled; on a node whose detached tasks die
+# (or never get a loop) the two diverge. Surfaced via /readyz so the divergence
+# is visible on the wire instead of only in a log line.
+_BACKGROUND_COGNIFY_STATS: dict[str, Any] = {
+    "runs_scheduled": 0,
+    "runs_completed": 0,
+    "runs_failed": 0,
+    # The no-running-loop branch of schedule_cognify: data stored, cognify
+    # never even scheduled. Previously a single error log was the only trace.
+    "runs_not_scheduled": 0,
+    "last_scheduled_at": None,
+    "last_completed_at": None,
+    "last_failed_at": None,
+    "last_error": None,
+}
+
+
+def background_cognify_stats() -> dict[str, Any]:
+    """Snapshot of observed background-cognify outcomes.
+
+    Counts what actually happened (completed/failed), next to what was merely
+    requested (scheduled), so a reader can tell a node that indexes from one
+    that only queues.
+    """
+    return dict(_BACKGROUND_COGNIFY_STATS)
+
+
+def _stamp_cognify_stat(event: str, *, error: str | None = None) -> None:
+    _BACKGROUND_COGNIFY_STATS[f"runs_{event}"] += 1
+    now = datetime.now(timezone.utc).isoformat()
+    if event == "scheduled":
+        _BACKGROUND_COGNIFY_STATS["last_scheduled_at"] = now
+    elif event == "completed":
+        _BACKGROUND_COGNIFY_STATS["last_completed_at"] = now
+    elif event in {"failed", "not_scheduled"}:
+        _BACKGROUND_COGNIFY_STATS["last_failed_at"] = now
+        _BACKGROUND_COGNIFY_STATS["last_error"] = error
+
+
+def ingest_indexing_state(cognee_result: Any) -> str:
+    """Disposition of the graph-indexing request behind an accepted ingest.
+
+    ``"scheduled"`` / ``"deferred"`` / ``"suppressed"`` describe what happened
+    to the cognify REQUEST — none of them mean the content is searchable yet,
+    because remember() returns before the graph write in every branch.
+    ``"unknown"`` is the explicit fallback when the outcome payload carries no
+    observation at all (older writers, fakes, results stripped in transport):
+    callers must surface it rather than defaulting to the optimistic value.
+    """
+    if isinstance(cognee_result, Mapping):
+        disposition = cognee_result.get("cognify")
+        if isinstance(disposition, str) and disposition:
+            return disposition
+        if cognee_result.get("background_cognify"):
+            return "scheduled"
+    return "unknown"
+
+
+def _remember_result(
+    added: Any, *, cognify: str, background_cognify: bool = False
+) -> dict[str, Any]:
+    """Uniform remember() outcome: what was observed vs what was requested.
+
+    Every branch of remember() returns BEFORE the graph write happens
+    (suppressed: another process cognifies later; deferred: the caller
+    schedules one; scheduled: a detached background task runs later), so
+    ``indexed`` is always False here and ``cognify`` records only the
+    disposition of the indexing request. A caller that needs the real outcome
+    must observe it (the repo-sync cognee_data_ids guard, the census chunk
+    count, :func:`background_cognify_stats`) instead of reading acceptance as
+    "in the index" — which is how 892 accepted documents sat unfindable at
+    chunk_count 0 while every counter reported success.
+    """
+    result: dict[str, Any] = {
+        "added": added,
+        "cognify": cognify,
+        "indexed": False,
+        "status": f"indexing_{cognify}",
+    }
+    if background_cognify:
+        result["background_cognify"] = True
+    return result
 
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -524,16 +611,16 @@ class CogneePublicClient:
         #    writer lock (kept non-blocking for the caller, #56), so concurrent
         #    in-process ingests and the evolve scheduler never collide.
         if _suppress_inline_cognify():
-            return {"added": added, "cognify": "suppressed"}
+            return _remember_result(added, cognify="suppressed")
         if defer_cognify:
             # The caller (e.g. a bulk Linear resync) coalesces ONE cognify over every
             # dataset it touched at the end, instead of scheduling one-per-write — a
             # 200-issue resync otherwise fires 200 background cognifies that storm the
             # writer lock and starve the request (#46/#52). Add-only here; the caller
             # calls schedule_cognify() once when the batch is done.
-            return {"added": added, "cognify": "deferred"}
+            return _remember_result(added, cognify="deferred")
         self._schedule_background_cognify(dataset_name)
-        return {"added": added, "background_cognify": True}
+        return _remember_result(added, cognify="scheduled", background_cognify=True)
 
     def _schedule_background_cognify(self, dataset_name: str) -> None:
         """Schedule a tracked, writer-lock-guarded cognify so ingest stays fast.
@@ -569,13 +656,15 @@ class CogneePublicClient:
                 "is stored but will not be searchable until a cognify runs.",
                 wanted,
             )
+            _stamp_cognify_stat("not_scheduled", error="no_running_event_loop")
             return
 
         async def _run() -> None:
             try:
                 await self.cognify(datasets=wanted)
-            except Exception:  # noqa: BLE001 - background task: log, never crash the loop
+            except Exception as exc:  # noqa: BLE001 - background task: log, never crash the loop
                 logger.exception("background cognify for datasets %s failed", wanted)
+                _stamp_cognify_stat("failed", error=exc.__class__.__name__)
             else:
                 # Log SUCCESS too. Previously only failures were logged, so a
                 # cognify that never ran — because the process exited before this
@@ -583,8 +672,14 @@ class CogneePublicClient:
                 # from one that completed. That is how a whole repository stayed
                 # missing from the index while every surface reported it synced.
                 logger.info("background cognify finished for datasets %s", wanted)
+                _stamp_cognify_stat("completed")
 
         task = loop.create_task(_run())
+        # Observed request/outcome ledger: `scheduled` is stamped here, and only
+        # _run() itself can stamp `completed`/`failed` — so a task that dies
+        # unrun leaves a visible scheduled-minus-completed gap instead of
+        # nothing.
+        _stamp_cognify_stat("scheduled")
         _BACKGROUND_COGNIFY_TASKS.add(task)
         task.add_done_callback(_BACKGROUND_COGNIFY_TASKS.discard)
 

--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -21,6 +21,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request
 
+from kb.cognee_client import ingest_indexing_state
 from kb.secure_http import open_secure
 
 from kb.learning import LearningProcess
@@ -406,15 +407,24 @@ class GitHubOrgSyncer:
             }
             self._save_state(state)
 
+        # `ingested` reports that the store ACCEPTED the digest (the add). The
+        # graph write that makes it searchable is asynchronous, so this run can
+        # only observe the disposition of that request — never its outcome.
+        indexing_state = (
+            ingest_indexing_state(ingest_result.cognee_result)
+            if ingest_result is not None and ingest_result.accepted
+            else None
+        )
         logger.info(
             "GitHub sync finished for org %s: %d repos scanned, %d changed, %d events, "
-            "%d commits, ingested=%s",
+            "%d commits, ingested=%s indexing=%s",
             self.org,
             len(repos),
             len(update.changed_repos),
             len(update.new_events),
             len(update.new_commits),
             bool(ingest_result and ingest_result.accepted),
+            indexing_state,
         )
         return {
             "ok": True,
@@ -443,6 +453,11 @@ class GitHubOrgSyncer:
             "active_repositories": update.active_repositories[:20],
             "recent_events": [event.summary_dict() for event in update.new_events[:20]],
             "ingested": bool(ingest_result and ingest_result.accepted),
+            # What happened to the graph-indexing request for that add
+            # ("scheduled"/"deferred"/"suppressed", or "unknown" when the
+            # outcome payload carries no observation). None when nothing was
+            # accepted. Not a confirmation: the index write happens later.
+            "indexing": indexing_state,
             "ingest_reason": (
                 "blocked_by_security_scan"
                 if security_blocked

--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -24,6 +24,7 @@ from urllib.request import Request
 from kb.secure_http import open_secure
 
 from kb.learning import LearningProcess
+from kb.models import INDEX_STATE_UNKNOWN
 from kb.repository_update import (
     SOURCE_URL_TEMPLATE,
     GitHubCommit,
@@ -397,6 +398,20 @@ class GitHubOrgSyncer:
             if should_ingest:
                 state["last_digest_at"] = checked_at
                 state["last_digest"] = update.digest
+                # What was OBSERVED about the graph write, plus the ids cognee
+                # assigned. ``last_digest_at`` only ever recorded that a write
+                # was requested; with the digest reported as ingested the
+                # moment cognee.add() returned, a pass whose cognify silently
+                # never ran left a state file identical to a pass that indexed
+                # everything. Persisting the ids is what lets a later pass (or
+                # an operator) check this claim against the index instead of
+                # taking the connector's word for it — the same repair
+                # repo_content_sync already made for its skip decision.
+                state["last_digest_index"] = {
+                    "checked_at": checked_at,
+                    "index_state": getattr(ingest_result, "index_state", INDEX_STATE_UNKNOWN),
+                    "cognee_data_ids": list(getattr(ingest_result, "cognee_data_ids", ()) or ()),
+                }
             state["last_security_scan"] = {
                 "checked_at": checked_at,
                 "ok": security_scan.get("ok"),
@@ -442,7 +457,20 @@ class GitHubOrgSyncer:
             ],
             "active_repositories": update.active_repositories[:20],
             "recent_events": [event.summary_dict() for event in update.new_events[:20]],
+            # `ingested` describes the REQUEST: it is True the instant
+            # cognee.add() returned. `indexed` describes the OUTCOME, and is
+            # deliberately tri-state — null while the graph write is still owed,
+            # false when nothing will ever perform it. Reading `ingested` as
+            # "retrievable" is the mistake this pair exists to prevent, so the
+            # two are reported side by side rather than one replacing the other.
             "ingested": bool(ingest_result and ingest_result.accepted),
+            "index_state": (
+                ingest_result.index_state if ingest_result is not None else INDEX_STATE_UNKNOWN
+            ),
+            "indexed": (ingest_result.indexed if ingest_result is not None else None),
+            "cognee_data_ids": list(
+                getattr(ingest_result, "cognee_data_ids", ()) or ()
+            ),
             "ingest_reason": (
                 "blocked_by_security_scan"
                 if security_blocked

--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -133,22 +133,23 @@ def _norm_path(value: str) -> str:
     return os.path.realpath(os.path.abspath(expanded))
 
 
-def load_capture_roots() -> list[dict[str, Any]]:
-    """Approved Capture Roots from the local config.
+def capture_roots_state() -> tuple[list[dict[str, Any]], str]:
+    """(Approved Capture Roots, why the list may be empty).
 
-    Always fail-closed: missing, empty, or corrupt ``capture.json`` returns
-    ``[]`` (approve nothing). Global capture without an explicit allowlist is
-    never enabled — run ``citadel onboard`` or ``citadel setup`` first.
+    The state names what was OBSERVED about ``capture.json`` — ``ok`` /
+    ``missing`` / ``invalid`` (unreadable or malformed) / ``empty`` — so a
+    receipt can distinguish "never onboarded" from "the config broke", which an
+    empty list alone collapses into one silence.
     """
     path = capture_config_path()
     if not path.exists():
-        return []
+        return [], "missing"
     try:
         data = json.loads(path.read_text())
     except Exception:
-        return []
+        return [], "invalid"
     if not isinstance(data, dict):
-        return []
+        return [], "invalid"
     roots: list[dict[str, Any]] = []
     for item in data.get("roots") or []:
         if not isinstance(item, dict):
@@ -166,7 +167,19 @@ def load_capture_roots() -> list[dict[str, Any]]:
                 ],
             }
         )
-    return roots
+    if not roots:
+        return [], "empty"
+    return roots, "ok"
+
+
+def load_capture_roots() -> list[dict[str, Any]]:
+    """Approved Capture Roots from the local config.
+
+    Always fail-closed: missing, empty, or corrupt ``capture.json`` returns
+    ``[]`` (approve nothing). Global capture without an explicit allowlist is
+    never enabled — run ``citadel onboard`` or ``citadel setup`` first.
+    """
+    return capture_roots_state()[0]
 
 
 def matched_root(repo_root: str, roots: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -359,13 +372,25 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[s
 
 
 def receipt_summary(response: dict[str, Any] | None, *, short_sha: str, branch: str) -> str:
-    """Receipt line for a completed POST, mirroring the server's decision."""
+    """Receipt line for a completed POST, mirroring the server's decision.
+
+    "captured" is claimed only on an explicit ``accepted: true`` — an
+    observation the server actually stated. A body that omits the field (or
+    carries a non-boolean) states no decision, and the receipt says storage is
+    unconfirmed rather than defaulting to the optimistic verdict.
+    """
     if response is None:
         return f"commit {short_sha} sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    accepted = response.get("accepted")
+    if accepted is True:
         return f"captured commit {short_sha} on {branch} → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    if accepted is False:
+        reason = response.get("reason") or "rejected"
+        return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    return (
+        f"commit {short_sha} sent: server reply had no accepted field; "
+        "storage not confirmed"
+    )
 
 
 def _send_failure_summary(exc: BaseException, *, short_sha: str) -> str:
@@ -409,6 +434,9 @@ def _sync_one(
         remote_ref=remote_ref,
     )
     if not note.strip():
+        # `git show` gave us nothing to snapshot — say so instead of leaving a
+        # silence identical to a successful capture's absence.
+        _write_receipt(f"commit {sha[:7]} skipped: could not read commit metadata; nothing sent")
         return
     note = _truncate_utf8(note, _max_ingest_bytes())
     branch = ref_branch_name(local_ref) if local_ref else _git_branch(cwd)
@@ -429,29 +457,48 @@ def _sync_one(
 
 
 def run(stdin: Any, remote_name: str = "") -> int:
-    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking.
+
+    Fail-silent means "never block the push", not "leave no trace": every exit
+    path below writes a receipt naming what was observed, so ``citadel activity
+    --local`` can distinguish a clean skip from a broken config from a crash.
+    Absent that, all of them look identical to a capture that worked.
+    """
     try:
         token = os.getenv(TOKEN_ENV)
         if not token:
+            _write_receipt(
+                f"push skipped: no capture token in the environment ({TOKEN_ENV} unset); "
+                "nothing sent"
+            )
             return 0
 
         cwd = git_toplevel()
 
         # ADR-0007 P4.3 (fail-closed): only push from an Approved Capture Root.
         # Missing/empty/corrupt ~/.citadel/capture.json → capture nothing.
-        roots = load_capture_roots()
+        roots, roots_state = capture_roots_state()
         capture_tags: list[str] = []
         if not roots:
             sys.stderr.write(
                 "citadel: no Approved Capture Roots configured; skipping "
                 "capture (run `citadel onboard` or `citadel setup`).\n"
             )
+            detail = {
+                "missing": "capture.json missing (run `citadel onboard` or `citadel setup`)",
+                "invalid": "capture.json unreadable or malformed",
+                "empty": "capture.json lists no approved roots",
+            }.get(roots_state, roots_state)
+            _write_receipt(f"push skipped: {detail}; nothing sent")
             return 0
         match = matched_root(cwd, roots)
         if match is None:
             sys.stderr.write(
                 f"citadel: {cwd} is not an Approved Capture Root; skipping "
                 "capture (run `citadel setup` to approve it).\n"
+            )
+            _write_receipt(
+                f"push skipped: {cwd} is not an Approved Capture Root; nothing sent"
             )
             return 0
         capture_tags = list(match["tags"])
@@ -479,10 +526,9 @@ def run(stdin: Any, remote_name: str = "") -> int:
 
         # Manual invocation (no pre-push stdin): snapshot HEAD once.
         head = _git_run(cwd, "rev-parse", "HEAD")
-        if head.returncode != 0:
-            return 0
-        sha = head.stdout.strip()
+        sha = head.stdout.strip() if head.returncode == 0 else ""
         if not sha:
+            _write_receipt("push skipped: could not resolve HEAD to snapshot; nothing sent")
             return 0
         _sync_one(
             cwd,
@@ -493,7 +539,11 @@ def run(stdin: Any, remote_name: str = "") -> int:
             token=token,
             capture_tags=capture_tags,
         )
-    except Exception:
+    except Exception as exc:
+        # Class name only — a message could echo repo content or the token.
+        _write_receipt(
+            f"push hook crashed: {exc.__class__.__name__}; capture state unknown"
+        )
         return 0
     return 0
 

--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -359,13 +359,26 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[s
 
 
 def receipt_summary(response: dict[str, Any] | None, *, short_sha: str, branch: str) -> str:
-    """Receipt line for a completed POST, mirroring the server's decision."""
+    """Receipt line for a completed POST, mirroring the server's decision.
+
+    Only an explicit ``accepted: true`` is reported as a capture. The test used
+    to be ``is not False``, which reads a MISSING key as success — so an older
+    Node, a proxy, or any response-shape change would have written "captured"
+    for a write nobody ever confirmed. A verdict we did not observe is unknown,
+    and unknown is not the optimistic value.
+    """
     if response is None:
         return f"commit {short_sha} sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    accepted = response.get("accepted")
+    if accepted is True:
         return f"captured commit {short_sha} on {branch} → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    if accepted is False:
+        reason = response.get("reason") or "rejected"
+        return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    return (
+        f"commit {short_sha} capture unconfirmed: the server's 2xx response did not "
+        "state whether the write was accepted"
+    )
 
 
 def _send_failure_summary(exc: BaseException, *, short_sha: str) -> str:
@@ -381,12 +394,21 @@ def _send_failure_summary(exc: BaseException, *, short_sha: str) -> str:
     return f"commit {short_sha} not captured: send failed ({exc.__class__.__name__})"
 
 
-def _write_receipt(summary: str) -> None:
+# Receipt kinds. A capture attempt, a deliberate skip, and a crash are three
+# different events; they shared one kind (or, for skips and crashes, produced no
+# line at all), so `citadel activity --local` could not tell "ran and had nothing
+# to send" from "the token got unset" or "it blew up".
+RECEIPT_KIND = "push"
+RECEIPT_KIND_SKIP = "push-skip"
+RECEIPT_KIND_ERROR = "push-error"
+
+
+def _write_receipt(summary: str, kind: str = RECEIPT_KIND) -> None:
     """Best-effort DX-5 receipt (never raises, never surfaces the token)."""
     try:
         from kb.hooks.receipt import write_receipt
 
-        write_receipt("push", summary)
+        write_receipt(kind, summary)
     except Exception:
         pass
 
@@ -409,6 +431,10 @@ def _sync_one(
         remote_ref=remote_ref,
     )
     if not note.strip():
+        _write_receipt(
+            f"commit {sha[:7]} skipped: no snapshot could be built from git metadata",
+            kind=RECEIPT_KIND_SKIP,
+        )
         return
     note = _truncate_utf8(note, _max_ingest_bytes())
     branch = ref_branch_name(local_ref) if local_ref else _git_branch(cwd)
@@ -429,10 +455,22 @@ def _sync_one(
 
 
 def run(stdin: Any, remote_name: str = "") -> int:
-    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking.
+
+    Fail-silent means never blocking the push, not leaving no trace. Every exit
+    below writes a receipt, because exit 0 with no output was the same observable
+    outcome for "ran and legitimately had nothing to send", "the token env var is
+    unset", "capture.json is corrupt", and "it crashed" — and the product's
+    "capture runs without you" promise rests on being able to tell those apart.
+    """
     try:
         token = os.getenv(TOKEN_ENV)
         if not token:
+            _write_receipt(
+                f"push skipped: {TOKEN_ENV} is not set in this environment "
+                "(run `citadel onboard`)",
+                kind=RECEIPT_KIND_SKIP,
+            )
             return 0
 
         cwd = git_toplevel()
@@ -446,12 +484,24 @@ def run(stdin: Any, remote_name: str = "") -> int:
                 "citadel: no Approved Capture Roots configured; skipping "
                 "capture (run `citadel onboard` or `citadel setup`).\n"
             )
+            _write_receipt(
+                "push skipped: no Approved Capture Roots configured "
+                "(run `citadel onboard` or `citadel setup`)",
+                kind=RECEIPT_KIND_SKIP,
+            )
             return 0
         match = matched_root(cwd, roots)
         if match is None:
             sys.stderr.write(
                 f"citadel: {cwd} is not an Approved Capture Root; skipping "
                 "capture (run `citadel setup` to approve it).\n"
+            )
+            # Basename only: stderr is ephemeral, the receipt log is not, and the
+            # full path adds nothing a dev running in the repo cannot already see.
+            _write_receipt(
+                f"push skipped: {os.path.basename(cwd.rstrip(os.sep)) or cwd} is not an "
+                "Approved Capture Root (run `citadel setup` to approve it)",
+                kind=RECEIPT_KIND_SKIP,
             )
             return 0
         capture_tags = list(match["tags"])
@@ -479,10 +529,12 @@ def run(stdin: Any, remote_name: str = "") -> int:
 
         # Manual invocation (no pre-push stdin): snapshot HEAD once.
         head = _git_run(cwd, "rev-parse", "HEAD")
-        if head.returncode != 0:
-            return 0
-        sha = head.stdout.strip()
+        sha = head.stdout.strip() if head.returncode == 0 else ""
         if not sha:
+            _write_receipt(
+                "push skipped: git could not resolve HEAD, so there is nothing to snapshot",
+                kind=RECEIPT_KIND_SKIP,
+            )
             return 0
         _sync_one(
             cwd,
@@ -493,7 +545,13 @@ def run(stdin: Any, remote_name: str = "") -> int:
             token=token,
             capture_tags=capture_tags,
         )
-    except Exception:
+    except Exception as exc:
+        # Class name only: an exception message can echo local paths or request
+        # details, and this line lands in a file that outlives the push.
+        _write_receipt(
+            f"push not run: the hook failed before sending ({exc.__class__.__name__})",
+            kind=RECEIPT_KIND_ERROR,
+        )
         return 0
     return 0
 

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -250,13 +250,22 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[s
 
 
 def receipt_summary(response: dict[str, Any] | None) -> str:
-    """Receipt line for a completed POST, mirroring the server's decision."""
+    """Receipt line for a completed POST, mirroring the server's decision.
+
+    "captured" is claimed only on an explicit ``accepted: true`` — an
+    observation the server actually stated. A body that omits the field (or
+    carries a non-boolean) states no decision, and the receipt says storage is
+    unconfirmed rather than defaulting to the optimistic verdict.
+    """
     if response is None:
         return "session sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    accepted = response.get("accepted")
+    if accepted is True:
         return "session captured → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"session not stored: server rejected the write ({reason})"
+    if accepted is False:
+        reason = response.get("reason") or "rejected"
+        return f"session not stored: server rejected the write ({reason})"
+    return "session sent: server reply had no accepted field; storage not confirmed"
 
 
 def _send_failure_summary(exc: BaseException) -> str:
@@ -283,21 +292,38 @@ def _write_receipt(summary: str) -> None:
 
 
 def run(stream_in: Any) -> int:
-    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking.
+
+    Fail-silent means "never block session close", not "leave no trace": every
+    exit path below writes a receipt naming what was observed, so ``citadel
+    activity --local`` can distinguish a clean skip from a broken config from a
+    crash. Absent that, all of them look identical to a capture that worked.
+    """
     try:
         payload = read_hook_payload(stream_in)
         token = os.getenv(TOKEN_ENV)
         if not token:
-            # No token configured -> nothing to sync. Clean no-op exit.
+            # No token configured -> nothing to sync, but say so: an unset env
+            # var is otherwise indistinguishable from a session with nothing in it.
+            _write_receipt(
+                f"session skipped: no capture token in the environment ({TOKEN_ENV} unset); "
+                "nothing sent"
+            )
             return 0
 
         transcript_path = payload.get("transcript_path")
         cwd = payload.get("cwd") or os.getcwd()
-        entries = (
-            _iter_transcript(transcript_path)
-            if isinstance(transcript_path, str) and transcript_path
-            else []
-        )
+        entries: list[dict[str, Any]] = []
+        if isinstance(transcript_path, str) and transcript_path:
+            if not transcript_path_allowed(transcript_path):
+                # Refused, not read. Without its own receipt this looked
+                # identical to "session had nothing worth sending".
+                _write_receipt(
+                    "session skipped: transcript path not under an allowed agent "
+                    "directory; nothing read or sent"
+                )
+                return 0
+            entries = _iter_transcript(transcript_path)
 
         note = distill_transcript(entries)
         if not note.strip():
@@ -319,8 +345,13 @@ def run(stream_in: Any) -> int:
             _write_receipt(_send_failure_summary(exc))
             return 0
         _write_receipt(receipt_summary(response))
-    except Exception:
-        # Fail-silent: never block session close, never surface the token.
+    except Exception as exc:
+        # Fail-silent: never block session close, never surface the token —
+        # but a crash still leaves a receipt (class name only: a message could
+        # echo transcript content or request details).
+        _write_receipt(
+            f"session hook crashed: {exc.__class__.__name__}; capture state unknown"
+        )
         return 0
     return 0
 

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -250,13 +250,26 @@ def post_ingest(base_url: str, token: str, data: str, tags: list[str]) -> dict[s
 
 
 def receipt_summary(response: dict[str, Any] | None) -> str:
-    """Receipt line for a completed POST, mirroring the server's decision."""
+    """Receipt line for a completed POST, mirroring the server's decision.
+
+    Only an explicit ``accepted: true`` is reported as a capture. The test used
+    to be ``is not False``, which reads a MISSING key as success — so an older
+    Node, a proxy, or any response-shape change would have written "captured"
+    for a write nobody ever confirmed. A verdict we did not observe is unknown,
+    and unknown is not the optimistic value.
+    """
     if response is None:
         return "session sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    accepted = response.get("accepted")
+    if accepted is True:
         return "session captured → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"session not stored: server rejected the write ({reason})"
+    if accepted is False:
+        reason = response.get("reason") or "rejected"
+        return f"session not stored: server rejected the write ({reason})"
+    return (
+        "session capture unconfirmed: the server's 2xx response did not state "
+        "whether the write was accepted"
+    )
 
 
 def _send_failure_summary(exc: BaseException) -> str:
@@ -272,23 +285,44 @@ def _send_failure_summary(exc: BaseException) -> str:
     return f"session not captured: send failed ({exc.__class__.__name__})"
 
 
-def _write_receipt(summary: str) -> None:
+# Receipt kinds. A capture attempt, a deliberate skip, and a crash are three
+# different events; they shared one kind (or, for the token and crash paths,
+# produced no line at all), so `citadel activity --local` could not tell "ran and
+# had nothing to send" from "the token got unset" or "it blew up".
+RECEIPT_KIND = "session"
+RECEIPT_KIND_SKIP = "session-skip"
+RECEIPT_KIND_ERROR = "session-error"
+
+
+def _write_receipt(summary: str, kind: str = RECEIPT_KIND) -> None:
     """Best-effort DX-5 receipt (never raises, never surfaces the token)."""
     try:
         from kb.hooks.receipt import write_receipt
 
-        write_receipt("session", summary)
+        write_receipt(kind, summary)
     except Exception:
         pass
 
 
 def run(stream_in: Any) -> int:
-    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
+    """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking.
+
+    Fail-silent means never blocking session close, not leaving no trace. Every
+    exit below writes a receipt, because exit 0 with no output was the same
+    observable outcome for "ran and legitimately had nothing to send", "the token
+    env var is unset", and "it crashed".
+    """
     try:
         payload = read_hook_payload(stream_in)
         token = os.getenv(TOKEN_ENV)
         if not token:
-            # No token configured -> nothing to sync. Clean no-op exit.
+            # No token configured -> nothing to sync, but say so: a hook that was
+            # installed and then lost its token is not the same as a quiet session.
+            _write_receipt(
+                f"session skipped: {TOKEN_ENV} is not set in this environment "
+                "(run `citadel onboard`)",
+                kind=RECEIPT_KIND_SKIP,
+            )
             return 0
 
         transcript_path = payload.get("transcript_path")
@@ -304,7 +338,10 @@ def run(stream_in: Any) -> int:
             # Nothing extractable, so nothing is sent. A constant placeholder
             # note carries zero session content; the receipt still records that
             # the hook ran and chose to skip.
-            _write_receipt("session skipped: no extractable session content (nothing sent)")
+            _write_receipt(
+                "session skipped: no extractable session content (nothing sent)",
+                kind=RECEIPT_KIND_SKIP,
+            )
             return 0
 
         note = _truncate_utf8(note, _max_ingest_bytes())
@@ -319,8 +356,14 @@ def run(stream_in: Any) -> int:
             _write_receipt(_send_failure_summary(exc))
             return 0
         _write_receipt(receipt_summary(response))
-    except Exception:
-        # Fail-silent: never block session close, never surface the token.
+    except Exception as exc:
+        # Fail-silent: never block session close, never surface the token. Class
+        # name only — an exception message can echo transcript paths or content,
+        # and this line lands in a file that outlives the session.
+        _write_receipt(
+            f"session not run: the hook failed before sending ({exc.__class__.__name__})",
+            kind=RECEIPT_KIND_ERROR,
+        )
         return 0
     return 0
 

--- a/kb/hooks/sync_start.py
+++ b/kb/hooks/sync_start.py
@@ -37,6 +37,11 @@ from typing import Any
 
 DEFAULT_BASE_URL = "https://citadel-archive-production.up.railway.app"
 TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
+# Deliberately shorter than the 10s the capture hooks use (sync_push /
+# sync_session): those run at push and session close and their payload is lost if
+# the send is abandoned, whereas this one runs in front of the developer at every
+# session start and its payload is a nice-to-have digest. A slow Node must delay
+# startup by seconds, not by ten.
 HTTP_TIMEOUT_SECONDS = 5
 RECENT_LIMIT = 8
 # Static agent policy — no cross-seat content; always injected (digest is optional).
@@ -127,6 +132,19 @@ def format_digest(items: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+RECEIPT_KIND_ERROR = "start-error"
+
+
+def _write_receipt(summary: str) -> None:
+    """Best-effort receipt (never raises, never surfaces the token)."""
+    try:
+        from kb.hooks.receipt import write_receipt
+
+        write_receipt(RECEIPT_KIND_ERROR, summary)
+    except Exception:
+        pass
+
+
 def run(stream_in: Any) -> int:
     """Hook entrypoint. ALWAYS returns 0 — fail-silent, non-blocking."""
     try:
@@ -139,8 +157,16 @@ def run(stream_in: Any) -> int:
             items = fetch_recent(_base_url(), token)
             if items:
                 sys.stdout.write(format_digest(items) + "\n\n")
-        except Exception:
-            pass  # digest optional; policy still injected below
+        except Exception as exc:
+            # The digest stays optional — the policy below still prints — but a
+            # swallowed failure looked exactly like a quiet vault, so a dev whose
+            # warm-start context stopped arriving had nothing to find. Only real
+            # failures get a line; this hook runs at every session start and an
+            # empty vault is not an event. Class name only: the message can carry
+            # the node URL.
+            _write_receipt(
+                f"warm-start digest unavailable: fetch failed ({exc.__class__.__name__})"
+            )
     sys.stdout.write(AGENT_POLICY_REMINDER + "\n")
     return 0
 

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -21,6 +21,7 @@ from kb.secure_http import open_secure
 from kb.access import CENTRAL_DATASET, SEAT_DATASET_PREFIX, AccessStore, seat_dataset
 from kb.cognee_client import _suppress_inline_cognify
 from kb.learning import LearningProcess
+from kb.models import INDEX_STATE_UNKNOWN, index_flag, resolve_index_state
 from kb.service import Citadel
 from kb.state_io import StateFileError, load_state_file, save_state_file
 
@@ -563,6 +564,12 @@ class LinearSyncer:
         if central_outcome is not None:
             touched_datasets.append(central_dataset)
         touched_datasets.extend(written_mirror_datasets)
+        # What this run OBSERVED happen to the graph write, in the vocabulary
+        # kb.models.resolve_index_state understands: ok / failed / not_scheduled
+        # / None for "did not look". Everything the writes land in is a
+        # relational + vector row until a cognify runs, so this is the only
+        # thing that turns "we wrote 200 issues" into "200 issues are findable".
+        cognify_status: str | None = None
         if touched_datasets and not _suppress_inline_cognify():
             cognify_datasets = list(dict.fromkeys(touched_datasets))
             if await_cognify:
@@ -572,14 +579,26 @@ class LinearSyncer:
                 # — the writes already landed in Postgres, so a cognify failure (e.g. a
                 # cross-process Kuzu lock if the web is writing, #47) is logged, not
                 # raised; the next evolve pass folds the data into the graph.
+                #
+                # Swallowing the exception is right. Reporting central_ingested:true
+                # afterwards and nothing else was not: this run WATCHED the graph
+                # write fail and then discarded the observation, so the payload was
+                # identical to a run that indexed everything.
                 try:
                     await self.citadel.cognee.cognify(datasets=cognify_datasets)
                 except Exception:  # noqa: BLE001 - writes succeeded; cognify is a follow-on
                     logger.exception("Linear sync coalesced cognify failed")
+                    cognify_status = "failed"
+                else:
+                    cognify_status = "ok"
             else:
                 # On-demand endpoint / evolve: background it so the request returns
-                # without waiting on the graph write.
-                self.citadel.cognee.schedule_cognify(cognify_datasets)
+                # without waiting on the graph write. Scheduling can DECLINE (no
+                # running loop), which leaves the writes permanently unindexed —
+                # a distinct outcome from one still in flight, so it gets a
+                # distinct status rather than sharing "we backgrounded it".
+                scheduled = self.citadel.cognee.schedule_cognify(cognify_datasets)
+                cognify_status = None if scheduled else "not_scheduled"
 
         # Advance the cursor to the newest updatedAt seen (keep the prior one
         # when a pass sees nothing newer, e.g. an empty or truncated fetch),
@@ -631,9 +650,29 @@ class LinearSyncer:
                 len(issues),
             )
 
+        # Refine the write's own state with the cognify outcome this run
+        # observed. `resolve_index_state` only promotes to "indexed" when
+        # something was actually watched; "I did not look" leaves it pending.
+        central_index_state = INDEX_STATE_UNKNOWN
+        central_data_ids: tuple[str, ...] = ()
+        if central_outcome is not None:
+            central_index_state = resolve_index_state(
+                central_outcome.ingest.index_state, cognify_status
+            )
+            central_data_ids = tuple(central_outcome.ingest.cognee_data_ids)
+
         payload = {
             "version": STATE_VERSION,
             "last_synced_at": utc_now(),
+            # The ids cognee assigned plus what was observed about the graph
+            # write, so the next pass can check this run's claim against the
+            # index rather than trusting `last_synced_at` — which records the
+            # decision to sync, not a successful one.
+            "last_central_index": {
+                "index_state": central_index_state,
+                "cognee_data_ids": list(central_data_ids),
+                "cognify_status": cognify_status,
+            },
             "last_seen_updated_at": new_cursor,
             "unchanged_pass_streak": streak,
             "last_error": None,  # clear any prior failure on a successful sync
@@ -659,7 +698,16 @@ class LinearSyncer:
             # member fetch also leaves this at 0 (#148).
             "auto_mapped_assignees": auto_mapped,
             "auto_map_error": auto_map_error,
+            # `central_ingested` describes the REQUEST (cognee.add() returned).
+            # `central_indexed` describes the OUTCOME and stays null until a
+            # cognify was watched, false when one was watched to fail. Both are
+            # reported, because collapsing them is exactly how a sync whose
+            # graph write died looked identical to one that worked.
             "central_ingested": central_outcome.ingest.accepted if central_outcome else None,
+            "central_index_state": central_index_state,
+            "central_indexed": index_flag(central_index_state),
+            "cognify_status": cognify_status,
+            "cognee_data_ids": list(central_data_ids),
             "mirrors": mirrors,
             "last_synced_at": payload["last_synced_at"],
         }

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -782,6 +782,66 @@ def _unconfirmed_ingest(
     }
 
 
+# The user-approval signal travels with every guarded write so the request, the
+# tool result, and (for promotion decisions) the audit trail all state whether
+# the calling agent presented a user confirmation. The quote is clamped well
+# under the node's 400-char decision-note bound (PromotionDecisionBody.note) so
+# composing it with the caller's own note never turns a valid call into a 422.
+MAX_USER_APPROVAL_CHARS = 160
+MAX_DECISION_NOTE_CHARS = 400
+APPROVAL_NOT_STATED = "not stated by calling agent"
+_MISSING_APPROVAL_WARNING = (
+    "This call carried no user_approval, so it is recorded as having no stated "
+    "user confirmation. Ask the user before writing durable context and pass "
+    "their approving reply (a short quote) as user_approval."
+)
+
+
+def _normalized_approval(user_approval: str | None) -> str | None:
+    """One bounded line of the user's approving reply, or None when not stated."""
+    if user_approval is None:
+        return None
+    collapsed = " ".join(str(user_approval).split())
+    return collapsed[:MAX_USER_APPROVAL_CHARS] or None
+
+
+def _with_approval_signal(payload: Any, signal: str | None) -> Any:
+    """Mirror the approval observation into the tool result.
+
+    The MCP layer attests only what it observed: the argument it was handed.
+    A call made with a stated approval and one made without must not produce
+    identical results, so the block is present either way and a missing signal
+    additionally raises a warning the operator can see. Non-dict payloads pass
+    through untouched.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    reported: dict[str, Any] = {
+        **payload,
+        "user_approval": {"provided": signal is not None, "signal": signal},
+    }
+    if signal is None:
+        warnings = [w for w in (payload.get("warnings") or []) if w]
+        warnings.append(_MISSING_APPROVAL_WARNING)
+        reported["warnings"] = warnings
+    return reported
+
+
+def _decision_note(signal: str | None, note: str | None) -> str:
+    """Compose a promotion decision note that leads with the approval signal.
+
+    The decision endpoints write the note into the node's audit trail, which
+    makes the note the channel that records the signal durably today. The lead
+    line states the caller's quote or the explicit "not stated" marker; the
+    caller's own note follows, and the whole string is clamped to the server's
+    note bound.
+    """
+    lead = f"user approval: {signal or APPROVAL_NOT_STATED}"
+    trimmed = " ".join(note.split()) if isinstance(note, str) else ""
+    combined = f"{lead} | note: {trimmed}" if trimmed else lead
+    return combined[:MAX_DECISION_NOTE_CHARS]
+
+
 class CitadelHttpClient:
     def __init__(
         self,
@@ -1228,10 +1288,15 @@ def create_mcp_server(
         tags: list[str] | None = None,
         session_id: str | None = None,
         cognify: bool = True,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
         """Stage durable context in the caller's personal seat node. Requires writer access.
 
-        **Always ask the user for explicit approval before calling this tool.**
+        **Always ask the user for explicit approval before calling this tool,
+        then pass their approving reply (a short quote, e.g. "yes, save that")
+        as `user_approval` so the confirmation is recorded with the request.**
+        A call without `user_approval` is reported in the result as carrying no
+        stated user confirmation.
 
         Seat-writer tokens: writes go to your personal node only (seat:{slug}). Do not
         pass `dataset` or Central/org tags — the server rejects them for seat MCP.
@@ -1249,18 +1314,23 @@ def create_mcp_server(
         def post_ingest() -> dict[str, Any]:
             normalized_data = _require_non_empty(data, "data")
             _validate_ingest_size(normalized_data)
+            approval = _normalized_approval(user_approval)
             try:
-                return resolve_client(ctx).post(
-                    "/ingest",
-                    {
-                        "data": normalized_data,
-                        "dataset": dataset,
-                        "tags": tags or [],
-                        "session_id": session_id,
-                        "cognify": cognify,
-                    },
-                    tool_name="citadel_ingest",
-                    timeout=_ingest_cognify_timeout() if cognify else None,
+                return _with_approval_signal(
+                    resolve_client(ctx).post(
+                        "/ingest",
+                        {
+                            "data": normalized_data,
+                            "dataset": dataset,
+                            "tags": tags or [],
+                            "session_id": session_id,
+                            "cognify": cognify,
+                            "user_approval": approval,
+                        },
+                        tool_name="citadel_ingest",
+                        timeout=_ingest_cognify_timeout() if cognify else None,
+                    ),
+                    approval,
                 )
             except CitadelMcpTimeout as exc:
                 # An expired budget proves only that no response arrived. The
@@ -1270,8 +1340,11 @@ def create_mcp_server(
                 # retry a write that had landed, duplicating it. Report what is
                 # known instead: submitted, outcome unconfirmed, here is how to
                 # settle it.
-                return _unconfirmed_ingest(
-                    normalized_data, tags or [], dataset, exc.timeout_s
+                return _with_approval_signal(
+                    _unconfirmed_ingest(
+                        normalized_data, tags or [], dataset, exc.timeout_s
+                    ),
+                    approval,
                 )
 
         return await _call_async(
@@ -1287,10 +1360,15 @@ def create_mcp_server(
         transcript_path: str | None = None,
         capture_roots: list[str] | None = None,
         has_tool_errors: bool = False,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
         """Volunteer a Shared Session Trace for teammates to find via search.
 
-        **Always ask the user for explicit approval before calling this tool.**
+        **Always ask the user for explicit approval before calling this tool,
+        then pass their approving reply (a short quote) as `user_approval` so
+        the confirmation is recorded with the request.** A call without
+        `user_approval` is reported in the result as carrying no stated user
+        confirmation.
 
         Provide either ``data`` (Compact Session Context markdown) or a local
         ``transcript_path`` to distill on this machine. Pass ``capture_roots``
@@ -1326,15 +1404,20 @@ def create_mcp_server(
                 raise ToolError("Provide data or a readable transcript_path.")
 
             _validate_ingest_size(payload_data)
-            return resolve_client(ctx).post(
-                "/api/share-session",
-                {
-                    "data": payload_data,
-                    "cwd": normalized_cwd,
-                    "capture_roots": roots,
-                    "has_tool_errors": tool_errors,
-                },
-                tool_name="citadel_share_session",
+            approval = _normalized_approval(user_approval)
+            return _with_approval_signal(
+                resolve_client(ctx).post(
+                    "/api/share-session",
+                    {
+                        "data": payload_data,
+                        "cwd": normalized_cwd,
+                        "capture_roots": roots,
+                        "has_tool_errors": tool_errors,
+                        "user_approval": approval,
+                    },
+                    tool_name="citadel_share_session",
+                ),
+                approval,
             )
 
         return await _call_async("citadel_share_session", post_share)
@@ -1347,10 +1430,15 @@ def create_mcp_server(
         tags: list[str] | None = None,
         source_url: str | None = None,
         dataset: str | None = None,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
         """Add a titled Vault Contribution through the Learning Process.
 
-        **Always ask the user for explicit approval before calling this tool.**
+        **Always ask the user for explicit approval before calling this tool,
+        then pass their approving reply (a short quote) as `user_approval` so
+        the confirmation is recorded with the request.** A call without
+        `user_approval` is reported in the result as carrying no stated user
+        confirmation.
 
         Not available to seat-writer MCP tokens (403). Seat devs use `citadel_ingest`
         for personal notes after user approval. Central contributions use this path
@@ -1361,16 +1449,21 @@ def create_mcp_server(
             normalized_title = _require_non_empty(title, "title")
             normalized_content = _require_non_empty(content, "content")
             _validate_ingest_size(normalized_content)
-            return resolve_client(ctx).post(
-                "/api/contribute",
-                {
-                    "title": normalized_title,
-                    "content": normalized_content,
-                    "tags": tags or [],
-                    "source_url": source_url,
-                    "dataset": dataset,
-                },
-                tool_name="citadel_contribute",
+            approval = _normalized_approval(user_approval)
+            return _with_approval_signal(
+                resolve_client(ctx).post(
+                    "/api/contribute",
+                    {
+                        "title": normalized_title,
+                        "content": normalized_content,
+                        "tags": tags or [],
+                        "source_url": source_url,
+                        "dataset": dataset,
+                        "user_approval": approval,
+                    },
+                    tool_name="citadel_contribute",
+                ),
+                approval,
             )
 
         return await _call_async("citadel_contribute", post_contribute)
@@ -1541,16 +1634,30 @@ def create_mcp_server(
         item_id: str,
         ctx: Context,
         note: str | None = None,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
-        """Approve a pending promotion item. Requires explicit user confirmation first."""
+        """Approve a pending promotion item. Requires explicit user confirmation first.
+
+        Ask the user, then pass their approving reply (a short quote, e.g.
+        "yes, promote it") as `user_approval`. The decision note written to the
+        node's audit trail leads with that signal, and reads "user approval:
+        not stated by calling agent" when the call omits it.
+        """
         normalized_id = _require_non_empty(item_id, "item_id")
+        approval = _normalized_approval(user_approval)
 
         def approve() -> dict[str, Any]:
-            payload = {"note": note} if note else {}
-            return resolve_client(ctx).post(
-                f"/api/promotion/pending/{quote(normalized_id, safe='')}/approve",
-                payload,
-                tool_name="citadel_promotion_approve",
+            payload = {
+                "note": _decision_note(approval, note),
+                "user_approval": approval,
+            }
+            return _with_approval_signal(
+                resolve_client(ctx).post(
+                    f"/api/promotion/pending/{quote(normalized_id, safe='')}/approve",
+                    payload,
+                    tool_name="citadel_promotion_approve",
+                ),
+                approval,
             )
 
         return await _call_async("citadel_promotion_approve", approve)
@@ -1560,16 +1667,30 @@ def create_mcp_server(
         item_id: str,
         ctx: Context,
         note: str | None = None,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
-        """Reject a pending promotion item. Requires explicit user confirmation first."""
+        """Reject a pending promotion item. Requires explicit user confirmation first.
+
+        Ask the user, then pass their approving reply (a short quote) as
+        `user_approval`. The decision note written to the node's audit trail
+        leads with that signal, and reads "user approval: not stated by calling
+        agent" when the call omits it.
+        """
         normalized_id = _require_non_empty(item_id, "item_id")
+        approval = _normalized_approval(user_approval)
 
         def reject() -> dict[str, Any]:
-            payload = {"note": note} if note else {}
-            return resolve_client(ctx).post(
-                f"/api/promotion/pending/{quote(normalized_id, safe='')}/reject",
-                payload,
-                tool_name="citadel_promotion_reject",
+            payload = {
+                "note": _decision_note(approval, note),
+                "user_approval": approval,
+            }
+            return _with_approval_signal(
+                resolve_client(ctx).post(
+                    f"/api/promotion/pending/{quote(normalized_id, safe='')}/reject",
+                    payload,
+                    tool_name="citadel_promotion_reject",
+                ),
+                approval,
             )
 
         return await _call_async("citadel_promotion_reject", reject)

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -152,12 +152,25 @@ class CitadelMcpTimeout(CitadelMcpError):
         self.timeout_s = timeout_s
 
 
+# Carries the caller's answer to the tool's "ask the user first" instruction.
+# The node records it in the audit trail; it is never treated as authorization.
+USER_CONFIRMED_HEADER = "X-Citadel-User-Confirmed"
+
+
 @dataclass(frozen=True)
 class ToolPolicy:
     role: str
     scope: str
     risk: str
     annotations: ToolAnnotations
+    # True for tools whose docstring instructs the agent to obtain the user's
+    # explicit approval first. That instruction is prose handed to a model, so
+    # the node cannot observe whether it was followed, but it can record the
+    # answer the caller reports. Declaring it here rather than inferring it from
+    # the docstring keeps the two from drifting: a new tool that asks for
+    # approval and forgets this flag writes audit rows that cannot answer
+    # "was this confirmed?".
+    requires_user_approval: bool = False
 
 
 TOOL_POLICIES: dict[str, ToolPolicy] = {
@@ -259,6 +272,7 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             idempotentHint=False,
             openWorldHint=False,
         ),
+        requires_user_approval=True,
     ),
     "citadel_share_session": ToolPolicy(
         role="writer",
@@ -270,6 +284,7 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             idempotentHint=False,
             openWorldHint=False,
         ),
+        requires_user_approval=True,
     ),
     "citadel_contribute": ToolPolicy(
         role="writer",
@@ -281,6 +296,7 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             idempotentHint=False,
             openWorldHint=False,
         ),
+        requires_user_approval=True,
     ),
     "citadel_record_feedback": ToolPolicy(
         role="writer",
@@ -393,6 +409,7 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             idempotentHint=False,
             openWorldHint=False,
         ),
+        requires_user_approval=True,
     ),
     "citadel_promotion_reject": ToolPolicy(
         role="admin",
@@ -404,6 +421,7 @@ TOOL_POLICIES: dict[str, ToolPolicy] = {
             idempotentHint=False,
             openWorldHint=False,
         ),
+        requires_user_approval=True,
     ),
 }
 
@@ -826,8 +844,16 @@ class CitadelHttpClient:
         *,
         tool_name: str | None = None,
         timeout: float | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
-        return self._request("POST", path, payload, tool_name=tool_name, timeout=timeout)
+        return self._request(
+            "POST",
+            path,
+            payload,
+            tool_name=tool_name,
+            timeout=timeout,
+            user_confirmed=user_confirmed,
+        )
 
     def _request(
         self,
@@ -839,6 +865,7 @@ class CitadelHttpClient:
         require_token: bool = True,
         extra_headers: dict[str, str] | None = None,
         timeout: float | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
         if require_token and not self.access_token:
             raise CitadelMcpError("Set CITADEL_MCP_ACCESS_TOKEN to a Citadel access token.")
@@ -851,6 +878,11 @@ class CitadelHttpClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         if tool_name:
             headers["X-Citadel-MCP-Tool"] = tool_name
+        # Omitted when the tool did not report an answer, so the node records
+        # "unknown" rather than inheriting a stale or optimistic value. Sending
+        # "false" and sending nothing are different facts and stay different.
+        if user_confirmed is not None:
+            headers[USER_CONFIRMED_HEADER] = "true" if user_confirmed else "false"
         if extra_headers:
             headers.update(extra_headers)
         request = Request(
@@ -1228,10 +1260,14 @@ def create_mcp_server(
         tags: list[str] | None = None,
         session_id: str | None = None,
         cognify: bool = True,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
         """Stage durable context in the caller's personal seat node. Requires writer access.
 
         **Always ask the user for explicit approval before calling this tool.**
+        Report the answer in ``user_confirmed`` (true when they said yes, false
+        when you proceeded without asking or they declined). It is written to
+        the audit trail; leaving it unset records "unknown", not consent.
 
         Seat-writer tokens: writes go to your personal node only (seat:{slug}). Do not
         pass `dataset` or Central/org tags — the server rejects them for seat MCP.
@@ -1261,6 +1297,7 @@ def create_mcp_server(
                     },
                     tool_name="citadel_ingest",
                     timeout=_ingest_cognify_timeout() if cognify else None,
+                    user_confirmed=user_confirmed,
                 )
             except CitadelMcpTimeout as exc:
                 # An expired budget proves only that no response arrived. The
@@ -1287,10 +1324,13 @@ def create_mcp_server(
         transcript_path: str | None = None,
         capture_roots: list[str] | None = None,
         has_tool_errors: bool = False,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
         """Volunteer a Shared Session Trace for teammates to find via search.
 
         **Always ask the user for explicit approval before calling this tool.**
+        Report the answer in ``user_confirmed``; it is written to the audit
+        trail, and leaving it unset records "unknown", not consent.
 
         Provide either ``data`` (Compact Session Context markdown) or a local
         ``transcript_path`` to distill on this machine. Pass ``capture_roots``
@@ -1335,6 +1375,7 @@ def create_mcp_server(
                     "has_tool_errors": tool_errors,
                 },
                 tool_name="citadel_share_session",
+                user_confirmed=user_confirmed,
             )
 
         return await _call_async("citadel_share_session", post_share)
@@ -1347,10 +1388,13 @@ def create_mcp_server(
         tags: list[str] | None = None,
         source_url: str | None = None,
         dataset: str | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
         """Add a titled Vault Contribution through the Learning Process.
 
         **Always ask the user for explicit approval before calling this tool.**
+        Report the answer in ``user_confirmed``; it is written to the audit
+        trail, and leaving it unset records "unknown", not consent.
 
         Not available to seat-writer MCP tokens (403). Seat devs use `citadel_ingest`
         for personal notes after user approval. Central contributions use this path
@@ -1371,6 +1415,7 @@ def create_mcp_server(
                     "dataset": dataset,
                 },
                 tool_name="citadel_contribute",
+                user_confirmed=user_confirmed,
             )
 
         return await _call_async("citadel_contribute", post_contribute)
@@ -1541,8 +1586,13 @@ def create_mcp_server(
         item_id: str,
         ctx: Context,
         note: str | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
-        """Approve a pending promotion item. Requires explicit user confirmation first."""
+        """Approve a pending promotion item. Requires explicit user confirmation first.
+
+        Report the answer in ``user_confirmed``; it is written to the audit
+        trail, and leaving it unset records "unknown", not consent.
+        """
         normalized_id = _require_non_empty(item_id, "item_id")
 
         def approve() -> dict[str, Any]:
@@ -1551,6 +1601,7 @@ def create_mcp_server(
                 f"/api/promotion/pending/{quote(normalized_id, safe='')}/approve",
                 payload,
                 tool_name="citadel_promotion_approve",
+                user_confirmed=user_confirmed,
             )
 
         return await _call_async("citadel_promotion_approve", approve)
@@ -1560,8 +1611,13 @@ def create_mcp_server(
         item_id: str,
         ctx: Context,
         note: str | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
-        """Reject a pending promotion item. Requires explicit user confirmation first."""
+        """Reject a pending promotion item. Requires explicit user confirmation first.
+
+        Report the answer in ``user_confirmed``; it is written to the audit
+        trail, and leaving it unset records "unknown", not consent.
+        """
         normalized_id = _require_non_empty(item_id, "item_id")
 
         def reject() -> dict[str, Any]:
@@ -1570,6 +1626,7 @@ def create_mcp_server(
                 f"/api/promotion/pending/{quote(normalized_id, safe='')}/reject",
                 payload,
                 tool_name="citadel_promotion_reject",
+                user_confirmed=user_confirmed,
             )
 
         return await _call_async("citadel_promotion_reject", reject)

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -364,31 +364,44 @@ class MeshState:
             if result.accepted:
                 document_id = stable_id("document", f"{dataset}:{data}")
                 label = data.strip().splitlines()[0][:80] or "Untitled memory"
+                # The badge and the index:graph edge are both claims about the
+                # Kuzu write, and cognee.add() does not perform it. Drawing
+                # every accepted write as "indexed" and linked drew a picture of
+                # a graph write that had not happened yet — and, for the
+                # documents whose cognify silently never ran, never would.
+                indexed = result.indexed
                 self.nodes[document_id] = {
                     "id": document_id,
                     "label": label,
                     "type": "document",
-                    "status": "indexed",
+                    "status": (
+                        "indexed" if indexed else ("unindexed" if indexed is False else "pending")
+                    ),
                     "size": min(20 + len(data) // 40, 64),
                     "metadata": {
                         "dataset": dataset,
                         "tags": list(result.tags),
                         "characters": len(data),
+                        "index_state": result.index_state,
                     },
                 }
                 self._edge(dataset_id, document_id, "contains")
                 for tag in result.tags or tuple(tags):
                     tag_id = self._tag_node(tag)
                     self._edge(document_id, tag_id, "tagged")
+                # The vector write IS what add() performs, so that edge stands
+                # on its own. The graph edge waits for an observed cognify.
                 self._edge(document_id, "index:vector", "embedded")
-                self._edge(document_id, "index:graph", "linked")
+                if indexed:
+                    self._edge(document_id, "index:graph", "linked")
                 self.documents += 1
                 await self._record_event(
                     "ingest",
-                    "Memory indexed",
+                    "Memory indexed" if indexed else "Memory stored",
                     {
                         "dataset": dataset,
                         "reason": result.reason,
+                        "index_state": result.index_state,
                         "tags": list(result.tags),
                         "chunks": 1,
                     },

--- a/kb/models.py
+++ b/kb/models.py
@@ -18,6 +18,75 @@ class IngestRequest:
     session_id: str | None = None
 
 
+# How far a write got, reported from what was OBSERVED rather than requested.
+#
+# ``accepted`` describes a REQUEST: it is True as soon as ``cognee.add()``
+# returns. ``add`` writes the relational and vector stores; only ``cognify``
+# writes the Kuzu graph, and that is what makes a document retrievable. Cognify
+# never runs synchronously inside a write, so no write can report "indexed" at
+# the moment it returns. Saying so out loud is the point of this field: a caller
+# gets a state it can branch on instead of reading ``accepted`` as "landed".
+INDEX_STATE_UNKNOWN = "unknown"
+"""Nothing was observed. Never a success claim; the safe default."""
+
+INDEX_STATE_REJECTED = "rejected"
+"""The write never happened (filtered, duplicate, blocked)."""
+
+INDEX_STATE_PENDING = "pending_cognify"
+"""Stored, and a graph write is owed. NOT yet retrievable, and not a failure."""
+
+INDEX_STATE_NOT_SCHEDULED = "cognify_not_scheduled"
+"""Observed: no cognify was scheduled, so nothing will index this write."""
+
+INDEX_STATE_FAILED = "cognify_failed"
+"""Observed: the cognify covering this write ran and failed."""
+
+INDEX_STATE_INDEXED = "indexed"
+"""Observed: a cognify covering this write completed successfully."""
+
+# States that positively answer "is this write NOT in the graph?". Everything
+# outside these and INDEX_STATE_INDEXED is genuinely undetermined.
+_INDEX_STATES_NOT_INDEXED = frozenset(
+    {INDEX_STATE_REJECTED, INDEX_STATE_NOT_SCHEDULED, INDEX_STATE_FAILED}
+)
+
+
+def index_flag(index_state: str) -> bool | None:
+    """Tri-state view of an index state: True / False / None for "not observed".
+
+    ``None`` is deliberate and load-bearing. A caller that forgets to branch and
+    writes ``bool(flag)`` gets ``False`` for an unobserved write, so the failure
+    mode of forgetting is pessimism, not a fabricated success.
+    """
+    if index_state == INDEX_STATE_INDEXED:
+        return True
+    if index_state in _INDEX_STATES_NOT_INDEXED:
+        return False
+    return None
+
+
+def resolve_index_state(index_state: str, cognify_status: str | None) -> str:
+    """Refine a write's index state with an OBSERVED cognify outcome.
+
+    ``cognify_status`` is what the caller watched happen to the cognify covering
+    this write: ``"ok"``, ``"failed"``, ``"not_scheduled"``, or ``None`` when it
+    watched nothing. Only a status promotes the state; ``None`` leaves it where
+    it was, because "I did not look" is not evidence of success.
+
+    A write that never landed cannot be rescued by a later cognify, so a
+    rejected or unstored write keeps its state whatever the cognify did.
+    """
+    if index_state in {INDEX_STATE_REJECTED, INDEX_STATE_UNKNOWN} and cognify_status != "failed":
+        return index_state
+    if cognify_status == "ok":
+        return INDEX_STATE_INDEXED
+    if cognify_status == "failed":
+        return INDEX_STATE_FAILED
+    if cognify_status == "not_scheduled":
+        return INDEX_STATE_NOT_SCHEDULED
+    return index_state
+
+
 @dataclass(frozen=True)
 class IngestResult:
     accepted: bool
@@ -25,6 +94,21 @@ class IngestResult:
     dataset: str
     tags: tuple[str, ...]
     cognee_result: Any = None
+    # What was OBSERVED about the graph write, as opposed to what was requested.
+    index_state: str = INDEX_STATE_UNKNOWN
+    # The ids cognee assigned, so a later pass can check this claim against the
+    # index instead of trusting its own bookkeeping. Empty is not proof of
+    # failure — some clients return a shape we cannot read ids from.
+    cognee_data_ids: tuple[str, ...] = ()
+
+    @property
+    def indexed(self) -> bool | None:
+        """True only when a cognify covering this write was observed to finish.
+
+        ``None`` means not yet observed. Read :func:`index_flag` for why that
+        matters more than it looks.
+        """
+        return index_flag(self.index_state)
 
 
 @dataclass(frozen=True)

--- a/kb/models.py
+++ b/kb/models.py
@@ -73,10 +73,16 @@ def resolve_index_state(index_state: str, cognify_status: str | None) -> str:
     watched nothing. Only a status promotes the state; ``None`` leaves it where
     it was, because "I did not look" is not evidence of success.
 
-    A write that never landed cannot be rescued by a later cognify, so a
-    rejected or unstored write keeps its state whatever the cognify did.
+    A write that never happened is neither indexed nor a cognify failure, so a
+    rejected one keeps its state whatever the cognify did. An ``unknown`` write
+    can still be moved in the pessimistic direction — a cognify observed to
+    fail means nothing landed in the graph either way — but never to
+    ``indexed``, because there is no evidence the write itself reached the
+    store.
     """
-    if index_state in {INDEX_STATE_REJECTED, INDEX_STATE_UNKNOWN} and cognify_status != "failed":
+    if index_state == INDEX_STATE_REJECTED:
+        return index_state
+    if index_state == INDEX_STATE_UNKNOWN and cognify_status == "ok":
         return index_state
     if cognify_status == "ok":
         return INDEX_STATE_INDEXED

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -815,7 +815,16 @@ class PromotionEngine:
         actor: AccessIdentity,
         *,
         delegate: bool = False,
+        user_confirmation: str = "unknown",
     ) -> dict[str, Any]:
+        """Promote a queued candidate into Central.
+
+        ``user_confirmation`` is what the caller reports about the user's
+        explicit approval ("confirmed" / "not_confirmed" / "unknown"). It is
+        recorded, not enforced: the value is asserted by the caller, so it
+        documents what was claimed and never stands in for authorization.
+        Role and seat checks still decide who may call this.
+        """
         item = self.access_store.get_promotion_pending(item_id)
         if item is None:
             raise ValueError(f"Promotion item not found: {item_id}")
@@ -852,6 +861,7 @@ class PromotionEngine:
                 "delegate": delegate,
                 "promoted": promoted,
                 "reference_status": item.reference_status,
+                "user_confirmation": user_confirmation,
             },
         )
         return {
@@ -871,7 +881,10 @@ class PromotionEngine:
         actor: AccessIdentity,
         *,
         delegate: bool = False,
+        user_confirmation: str = "unknown",
     ) -> dict[str, Any]:
+        """Decline a queued candidate. See ``approve_pending`` for
+        ``user_confirmation``: recorded, never enforced."""
         item = self.access_store.get_promotion_pending(item_id)
         if item is None:
             raise ValueError(f"Promotion item not found: {item_id}")
@@ -893,6 +906,7 @@ class PromotionEngine:
                 "item_id": item_id,
                 "seat_slug": item.seat_slug,
                 "delegate": delegate,
+                "user_confirmation": user_confirmation,
             },
         )
         return {"ok": True, "item": decided.to_dict()}

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -52,6 +52,12 @@ PERSONAL_CAPTURE_TAG = "personal"
 ORG_WORK_CAPTURE_TAG = "org-work"
 CAPTURE_SUMMARY_MARKER = "# capture summary:"
 
+# Explicit unknown for the decision audit trail: the caller handed this engine
+# no user-approval signal. Recorded as its own value, never by omitting the
+# field, so a reader can branch on recorded-vs-not instead of inferring from
+# absence (which also looks like an event written before the field existed).
+USER_APPROVAL_NOT_RECORDED = "not_recorded"
+
 # Broad seed queries used to enumerate a seat node. cognee.recall is semantic,
 # not an exhaustive listing, so a few complementary seeds widen coverage; the
 # results are deduped and capped. This is best-effort top-N by design.
@@ -815,6 +821,7 @@ class PromotionEngine:
         actor: AccessIdentity,
         *,
         delegate: bool = False,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
         item = self.access_store.get_promotion_pending(item_id)
         if item is None:
@@ -852,6 +859,10 @@ class PromotionEngine:
                 "delegate": delegate,
                 "promoted": promoted,
                 "reference_status": item.reference_status,
+                # The trail records what the engine was handed about user
+                # approval: the caller's stated signal, or the explicit
+                # not_recorded marker when none arrived with the decision.
+                "user_approval": user_approval or USER_APPROVAL_NOT_RECORDED,
             },
         )
         return {
@@ -871,6 +882,7 @@ class PromotionEngine:
         actor: AccessIdentity,
         *,
         delegate: bool = False,
+        user_approval: str | None = None,
     ) -> dict[str, Any]:
         item = self.access_store.get_promotion_pending(item_id)
         if item is None:
@@ -893,6 +905,9 @@ class PromotionEngine:
                 "item_id": item_id,
                 "seat_slug": item.seat_slug,
                 "delegate": delegate,
+                # Same recording rule as approve: state the signal or state
+                # that none was handed over, never leave the field out.
+                "user_approval": user_approval or USER_APPROVAL_NOT_RECORDED,
             },
         )
         return {"ok": True, "item": decided.to_dict()}

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from kb.cognee_client import ingest_indexing_state
 from kb.github_sync import GitHubAPIError, GitHubOrgClient, utc_now
 from kb.learning import LearningProcess
 from kb.security_scan import SecurityScanEntry, scan_text_entries
@@ -690,6 +691,14 @@ class RepoContentSyncer:
 
         repo_results: list[dict[str, Any]] = []
         ingested_files = 0
+        # Split of ingested_files by what this run OBSERVED about the add:
+        # cognee assigned data ids (confirmed) or it did not (unconfirmed — the
+        # cognee_data_ids guard makes the next pass re-ingest those).
+        add_confirmed_files = 0
+        add_unconfirmed_files = 0
+        # Disposition(s) of the graph-indexing requests behind the accepted
+        # adds. Normally one value; a set so a mixed run cannot misreport.
+        indexing_states: set[str] = set()
         skipped_files = 0
         blocked_files = 0
         improved = False
@@ -919,6 +928,21 @@ class RepoContentSyncer:
                     if any(result.accepted for result in outcome.all_ingests):
                         ingested_files += 1
                         repo_result["ingested"] += 1
+                        data_ids = _cognee_data_ids(outcome)
+                        # Count from the observation, not the request:
+                        # `accepted` only says cognee.add() returned. Data ids
+                        # in the outcome are the store's own receipt for the
+                        # add; their absence is reported as unconfirmed instead
+                        # of being folded into the success counter.
+                        if data_ids:
+                            add_confirmed_files += 1
+                        else:
+                            add_unconfirmed_files += 1
+                        for result in outcome.all_ingests:
+                            if result.accepted:
+                                indexing_states.add(
+                                    ingest_indexing_state(result.cognee_result)
+                                )
                         tracked[key] = {
                             "sha": file.sha,
                             "content_hash": file.content_hash,
@@ -927,7 +951,7 @@ class RepoContentSyncer:
                             # run can check its own claim against the index; a
                             # state file holding only sha and content_hash can
                             # never verify what it asserted.
-                            "cognee_data_ids": _cognee_data_ids(outcome),
+                            "cognee_data_ids": data_ids,
                         }
                         # Checkpoint immediately. State used to be written only
                         # after every repo finished, so a run killed part-way
@@ -989,6 +1013,15 @@ class RepoContentSyncer:
             "repos_scanned": len(repo_results),
             "repos_errored": len(repos_errored),
             "files_ingested": ingested_files,
+            # files_ingested counts adds the store ACCEPTED; it does not
+            # observe that anything became searchable. The split below is what
+            # this run actually saw: cognee returned data ids for the add
+            # (confirmed) or it did not (unconfirmed → re-ingested next pass
+            # via the cognee_data_ids guard). `indexing` is the disposition of
+            # the asynchronous graph-write request(s), never their outcome.
+            "files_add_confirmed": add_confirmed_files,
+            "files_add_unconfirmed": add_unconfirmed_files,
+            "indexing": sorted(indexing_states),
             "files_skipped": skipped_files,
             "files_skipped_by_reason": skip_totals,
             "files_blocked": blocked_files,

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -22,6 +22,7 @@ from urllib.parse import quote
 
 from kb.github_sync import GitHubAPIError, GitHubOrgClient, utc_now
 from kb.learning import LearningProcess
+from kb.models import INDEX_STATE_UNKNOWN, index_flag
 from kb.security_scan import SecurityScanEntry, scan_text_entries
 from kb.service import Citadel
 from kb.state_io import StateFileError, load_state_file, save_state_file
@@ -151,6 +152,24 @@ def _cognee_data_ids(outcome: Any) -> list[str]:
             if data_id:
                 ids.append(str(data_id))
     return list(dict.fromkeys(ids))
+
+
+def _worst_index_state(outcome: Any) -> str:
+    """The least-indexed state across every chunk this file was written as.
+
+    A document can be chunked into several ingests. It is findable only if all
+    of them are, so the file's state is the worst of them, never the best — the
+    opposite choice would let one indexed chunk vouch for a document whose rest
+    never reached the graph.
+    """
+    states = [
+        getattr(result, "index_state", INDEX_STATE_UNKNOWN)
+        for result in getattr(outcome, "all_ingests", ()) or ()
+    ]
+    if not states:
+        return INDEX_STATE_UNKNOWN
+    # False (observed not indexed) beats None (unobserved) beats True.
+    return min(states, key=lambda state: {False: 0, None: 1, True: 2}[index_flag(state)])
 
 
 def format_repo_content_document(file: RepoContentFile) -> str:
@@ -690,6 +709,13 @@ class RepoContentSyncer:
 
         repo_results: list[dict[str, Any]] = []
         ingested_files = 0
+        # ingested_files counts WRITES REQUESTED — it increments when
+        # cognee.add() returned, which is before the graph write that makes a
+        # file findable. These two count what was OBSERVED about that graph
+        # write, so a pass that stored 40 files and indexed none stops
+        # reporting the same number as a pass that indexed all 40.
+        indexed_files = 0
+        index_failed_files = 0
         skipped_files = 0
         blocked_files = 0
         improved = False
@@ -733,6 +759,8 @@ class RepoContentSyncer:
                 "repo": full_name,
                 "paths_discovered": 0,
                 "ingested": 0,
+                "indexed": 0,
+                "index_failed": 0,
                 "skipped": 0,
                 "skipped_reasons": {},
                 "blocked": 0,
@@ -919,6 +947,14 @@ class RepoContentSyncer:
                     if any(result.accepted for result in outcome.all_ingests):
                         ingested_files += 1
                         repo_result["ingested"] += 1
+                        file_index_state = _worst_index_state(outcome)
+                        file_indexed = index_flag(file_index_state)
+                        if file_indexed is True:
+                            indexed_files += 1
+                            repo_result["indexed"] += 1
+                        elif file_indexed is False:
+                            index_failed_files += 1
+                            repo_result["index_failed"] += 1
                         tracked[key] = {
                             "sha": file.sha,
                             "content_hash": file.content_hash,
@@ -928,6 +964,10 @@ class RepoContentSyncer:
                             # state file holding only sha and content_hash can
                             # never verify what it asserted.
                             "cognee_data_ids": _cognee_data_ids(outcome),
+                            # And what was observed about the graph write, which
+                            # the ids alone do not say: an id exists as soon as
+                            # the row does.
+                            "index_state": file_index_state,
                         }
                         # Checkpoint immediately. State used to be written only
                         # after every repo finished, so a run killed part-way
@@ -988,7 +1028,13 @@ class RepoContentSyncer:
             "checked_at": checked_at,
             "repos_scanned": len(repo_results),
             "repos_errored": len(repos_errored),
+            # files_ingested counts writes REQUESTED; the two below count what
+            # was observed about the graph write that makes them findable.
+            # files_ingested - files_indexed - files_index_failed is the number
+            # still in flight, and that is a real state, not a rounding error.
             "files_ingested": ingested_files,
+            "files_indexed": indexed_files,
+            "files_index_failed": index_failed_files,
             "files_skipped": skipped_files,
             "files_skipped_by_reason": skip_totals,
             "files_blocked": blocked_files,

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -182,6 +182,14 @@ DOC_TYPE_OTHER = "other"
 # ``content_hint``, which makes no authority claim.
 TRUST_REFERENCE = "reference-only"
 TRUST_UNATTESTED = "unattested"
+# The attestation channel itself was absent. ``unattested`` states the server
+# envelope was consulted and attested nothing; ``unknown`` states no envelope
+# existed to consult (hits handed straight to this module by the in-process
+# ``--local`` search stack, or degraded payloads). The two must not share a
+# value: a genuine session-trace hit read without an envelope used to come back
+# ``unattested`` — byte-identical to an honestly unattested hit — so a reader
+# could not tell "checked, nothing attested" from "nothing could be checked".
+TRUST_UNKNOWN = "unknown"
 
 # Retained so older parsers and stored telemetry keep resolving; never assigned.
 TRUST_CANONICAL = "canonical"
@@ -427,10 +435,20 @@ def infer_trust_tier(item: dict[str, Any], doc_type: str | None = None) -> str:
 
     ``reference-only`` is the one tier the server can actually attest today: it
     comes from the dataset a hit was read out of (session traces), not from the
-    hit's content. Everything else is ``unattested`` — the vault stores no
-    per-document provenance yet, so no hit can honestly claim more.
+    hit's content. Everything else the envelope covers is ``unattested`` — the
+    vault stores no per-document provenance yet, so no hit can honestly claim
+    more.
+
+    A hit with no ``_citadel`` envelope at all is ``unknown``, never
+    ``unattested``: this function derives the tier from the envelope, so when
+    the envelope is absent the tier was not derived from anything. Reporting
+    ``unattested`` there would state an observation nothing made — the CLI
+    ``--local`` path hands cognee payloads straight here, and its session-trace
+    hits came back indistinguishable from honestly unattested ones.
     """
-    envelope = item.get("_citadel") if isinstance(item.get("_citadel"), dict) else {}
+    envelope = item.get("_citadel") if isinstance(item.get("_citadel"), dict) else None
+    if envelope is None:
+        return TRUST_UNKNOWN
     if envelope.get("trust") == TRUST_REFERENCE:
         return TRUST_REFERENCE
     if str(envelope.get("dataset") or "") == "session-traces":
@@ -644,7 +662,8 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
             "score": None,
             "snippet": text[:SNIPPET_CHARS],
             "content_hint": HINT_UNCLASSIFIED,
-            "trust_tier": TRUST_UNATTESTED,
+            # A bare string carries no envelope, so no attestation was consulted.
+            "trust_tier": TRUST_UNKNOWN,
             "rank": index + 1,
         }
 
@@ -1002,6 +1021,15 @@ def shape_search_payload(
         warnings.append("search timed out; results may be incomplete")
     if relevance["no_lexical_match"]:
         warnings.append(NO_LEXICAL_MATCH_WARNING)
+    # Say at page level when tiers could not be derived, so a caller does not
+    # have to notice the per-hit ``unknown`` values one by one.
+    unknown_tier = sum(1 for h in hits if h.get("trust_tier") == TRUST_UNKNOWN)
+    if unknown_tier:
+        warnings.append(
+            f"trust_tier is 'unknown' for {unknown_tier} of {len(hits)} hits: they "
+            "carried no server envelope, so attested provenance was never consulted "
+            "(expected for --local searches)"
+        )
     authority = token_asset_authority_warning(query)
     if authority:
         warnings.append(authority)

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -183,6 +183,16 @@ DOC_TYPE_OTHER = "other"
 TRUST_REFERENCE = "reference-only"
 TRUST_UNATTESTED = "unattested"
 
+# WHICH AUTHORITY produced ``trust_tier`` — reported next to it because the two
+# possible reasons for ``unattested`` are not the same fact. ``dataset-attested``
+# means a reading authority named the dataset the hit came out of, so the tier
+# reports an observation. ``unknown`` means no envelope reached this hit at all:
+# ``unattested`` is then the fallback value and a caller must NOT read it as
+# "this hit was checked and has no provenance". Without the distinction a path
+# that never wired the envelope up is byte-identical to one that checked.
+TRUST_BASIS_ATTESTED = "dataset-attested"
+TRUST_BASIS_UNKNOWN = "unknown"
+
 # Retained so older parsers and stored telemetry keep resolving; never assigned.
 TRUST_CANONICAL = "canonical"
 TRUST_VERIFIED = "verified"
@@ -440,6 +450,22 @@ def infer_trust_tier(item: dict[str, Any], doc_type: str | None = None) -> str:
     return TRUST_UNATTESTED
 
 
+def trust_tier_basis(item: dict[str, Any]) -> str:
+    """Whether ``infer_trust_tier`` OBSERVED anything, or fell back to a default.
+
+    ``infer_trust_tier`` reads only ``item["_citadel"]``. A hit that reaches it
+    without an envelope therefore always returns ``unattested``, whatever it
+    actually is — which is exactly what the CLI ``--local`` path did to genuine
+    session traces. Reporting the basis alongside the tier is what lets a caller
+    tell "checked, no provenance attested" (``dataset-attested``) from "the
+    attesting authority was never consulted" (``unknown``).
+    """
+    envelope = item.get("_citadel") if isinstance(item.get("_citadel"), dict) else {}
+    if envelope.get("trust") or envelope.get("dataset"):
+        return TRUST_BASIS_ATTESTED
+    return TRUST_BASIS_UNKNOWN
+
+
 def spec_mode_boost(item: dict[str, Any]) -> float:
     """Higher is better — used to re-order hits for API/spec verification queries."""
     kind = infer_doc_type(item)
@@ -645,6 +671,7 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
             "snippet": text[:SNIPPET_CHARS],
             "content_hint": HINT_UNCLASSIFIED,
             "trust_tier": TRUST_UNATTESTED,
+            "trust_tier_basis": TRUST_BASIS_UNKNOWN,
             "rank": index + 1,
         }
 
@@ -730,6 +757,9 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
         "text": snippet,
         "content_hint": infer_content_hint(item, doc_type),
         "trust_tier": trust_tier,
+        # Say which authority produced the tier, so a path that never attached
+        # an envelope stops looking identical to one that checked and found none.
+        "trust_tier_basis": trust_tier_basis(item),
         "rank": envelope.get("rank") or (index + 1),
         "dataset": envelope.get("dataset"),
         "_citadel": envelope or None,

--- a/kb/server.py
+++ b/kb/server.py
@@ -42,6 +42,7 @@ from kb.access import (
     default_scopes,
     hash_api_token,
     is_seat_dataset,
+    now_iso,
     seat_dataset,
     validate_seat_slug,
 )
@@ -145,7 +146,9 @@ def _forget_background_task(task: "asyncio.Task[Any]") -> None:
 # Most recent evolve-scheduler cognify canary verdict (verify=True), surfaced via
 # /readyz so an always-on health probe goes RED when end-to-end ingest+cognify+
 # search stops working — not only when node/auth are down (#27). None until the
-# first scheduled pass runs.
+# first scheduled pass runs, and that is the common case: the scheduler is off
+# by default, so most nodes never produce one. /readyz therefore reports
+# "never_ran" explicitly instead of folding it into a pass.
 _LAST_CANARY: dict[str, Any] | None = None
 # Corpus-volume gate: if at least this many sources are tracked but the graph holds
 # fewer than the floor of indexed nodes, the data plane is broken (green dashboards
@@ -355,6 +358,10 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
                 "search_hit": verification.get("search_hit"),
                 "graph_grew": result.get("graph_grew"),
                 "marker": verification.get("marker"),
+                # A pass with no timestamp is nearly as unactionable as none at
+                # all: one that succeeded nine days ago reads identically to one
+                # from six minutes ago. Stamp it so a consumer can judge staleness.
+                "checked_at": now_iso(),
             }
             logger.info(
                 "Evolve scheduler: cognify finished (graph_after=%s grew=%s canary_ok=%s)",
@@ -600,6 +607,11 @@ async def mcp_trailing_slash_redirect() -> RedirectResponse:
 app.mount("/mcp", _McpAcceptShim(mcp_app))
 ADMIN_COOKIE = "citadel_admin"
 MCP_TOOL_HEADER = "x-citadel-mcp-tool"
+# The caller's answer to a tool's "ask the user first" instruction. Recorded in
+# the audit trail, never consulted for authorization: the value is asserted by
+# the calling agent, so it says what was REPORTED, not what the node observed.
+MCP_USER_CONFIRMED_HEADER = "x-citadel-user-confirmed"
+USER_CONFIRMATION_UNKNOWN = "unknown"
 AUDIT_VIEWS = frozenset({"all", "mcp", "access", "failures"})
 AUDIT_LIMIT_MAX = 500
 PUBLIC_CACHE_HEADERS = {"Cache-Control": "public, max-age=300"}
@@ -2263,6 +2275,28 @@ def mcp_tool_name(request: Request) -> str | None:
     return tool_name
 
 
+def user_confirmation(request: Request) -> str:
+    """What the caller reports about the user's approval for this write.
+
+    ``confirmed`` / ``not_confirmed`` / ``unknown``. Five MCP tools instruct the
+    agent to obtain explicit approval before writing, but that instruction is
+    prose handed to a model: nothing carried the answer back, so an approved
+    write and an unattended one produced identical audit rows and the trail
+    could not answer "was this confirmed?" for any of them.
+
+    The absent header is ``unknown``, never the optimistic value. An older
+    client that cannot report, and a user who said yes, are different facts.
+    Anything other than the two known values is also ``unknown``: a header this
+    function cannot read is not evidence of consent.
+    """
+    raw = (request.headers.get(MCP_USER_CONFIRMED_HEADER) or "").strip().lower()
+    if raw == "true":
+        return "confirmed"
+    if raw == "false":
+        return "not_confirmed"
+    return USER_CONFIRMATION_UNKNOWN
+
+
 async def capture_search_feedback(
     *,
     mesh_state: MeshState,
@@ -2355,6 +2389,10 @@ def record_mcp_audit(
         "required_scope": policy.scope,
         "risk": policy.risk,
     }
+    # Only tools that ask for approval carry the field. A search has nothing to
+    # confirm, so stamping one on its row would answer a question nobody asked.
+    if policy.requires_user_approval:
+        event_detail["user_confirmation"] = user_confirmation(request)
     if detail:
         event_detail.update(detail)
     get_access_store().record_event(
@@ -4425,14 +4463,57 @@ async def _corpus_health() -> dict[str, Any]:
         }
 
 
+def _canary_health(config: CitadelConfig) -> dict[str, Any]:
+    """The end-to-end canary's state, as three distinguishable outcomes.
+
+    The old payload sent ``"canary": null`` for a node that never ran one and
+    folded it into ``ok`` with ``canary is None or bool(canary.get("ok", True))``.
+    Both defaults were optimistic, and the scheduler that sets ``_LAST_CANARY``
+    is off unless ``CITADEL_EVOLVE_SCHEDULER_ENABLED`` is set, so on a
+    default-config node the never-ran branch fired on every request and a node
+    that never checked was indistinguishable on the wire from one that passed.
+
+    Now: ``state`` is ``passed`` / ``failed`` / ``never_ran`` and ``ok`` is
+    True / False / None, so a monitoring consumer can branch. ``never_ran``
+    does not force RED (that would 503 every node running the default
+    configuration), but it can no longer be mistaken for a pass, and
+    ``scheduler_enabled`` says whether one was ever going to run.
+    """
+    scheduler_enabled = bool(config.evolve_scheduler_enabled)
+    canary = _LAST_CANARY
+    if canary is None:
+        return {
+            "state": "never_ran",
+            "ok": None,
+            "scheduler_enabled": scheduler_enabled,
+            "checked_at": None,
+            "reason": (
+                "evolve scheduler disabled: no end-to-end canary will run on this node"
+                if not scheduler_enabled
+                else "evolve scheduler enabled; no pass has completed yet"
+            ),
+        }
+    # `is True` rather than `.get("ok", True)`: a recorded verdict that does not
+    # say it passed has not observed a pass, and must not be read as one.
+    passed = canary.get("ok") is True
+    return {
+        **canary,
+        "state": "passed" if passed else "failed",
+        "ok": passed,
+        "scheduler_enabled": scheduler_enabled,
+        "checked_at": canary.get("checked_at"),
+    }
+
+
 @app.get("/readyz")
 async def readyz(request: Request) -> Any:
     require_access(request, "reader", "kb:read")
     config = get_citadel().config
     corpus = await _corpus_health()
-    canary = _LAST_CANARY
-    # RED when the corpus gate trips or the last end-to-end canary failed.
-    ok = corpus["ok"] and (canary is None or bool(canary.get("ok", True)))
+    canary = _canary_health(config)
+    # RED when the corpus gate trips or the last end-to-end canary failed. A
+    # canary that never ran is reported, not gated on.
+    ok = corpus["ok"] and canary["state"] != "failed"
     payload = {
         "ok": ok,
         "service": "citadel",
@@ -5546,6 +5627,23 @@ async def run_promotion(body: PromoteRunBody, request: Request) -> Any:
                 "highest_severity": exc.highest_severity,
             },
         )
+        # Parity with /ingest. The generic middleware backstop already wrote an
+        # mcp.* row for this request, but it carried only status_code=422, so
+        # the MCP view of the trail could not say the run was stopped by the
+        # secret gate, nor how severe the finding was. Record the reason here so the
+        # row states what happened rather than only that something did.
+        record_mcp_audit(
+            request,
+            actor=actor,
+            success=False,
+            dataset=body.dataset,
+            detail={
+                "operation": "promotion.run",
+                "dry_run": body.dry_run,
+                "blocked": "secret_content",
+                "highest_severity": exc.highest_severity,
+            },
+        )
         raise HTTPException(status_code=422, detail=exc.public_message) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -5617,6 +5715,7 @@ async def approve_promotion_pending(
             item_id,
             identity,
             delegate=delegate,
+            user_confirmation=user_confirmation(request),
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
@@ -5651,6 +5750,7 @@ async def reject_promotion_pending(
             item_id,
             identity,
             delegate=delegate,
+            user_confirmation=user_confirmation(request),
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/kb/server.py
+++ b/kb/server.py
@@ -68,7 +68,7 @@ from kb.mcp_server import (
     set_tools_list_session_resolver,
 )
 from kb.mesh import MeshState
-from kb.models import FeedbackRequest
+from kb.models import FeedbackRequest, index_flag, resolve_index_state
 from kb.obsidian_sync import ObsidianSyncStore, SyncPushDocument, normalize_path
 from kb.promotion import PromotionEngine
 from kb.promotion_queue import (
@@ -5237,7 +5237,15 @@ async def push_obsidian_sync(body: ObsidianPushBody, request: Request) -> Any:
         ingest_results.append(
             {
                 "document_id": accepted["document_id"],
+                # `accepted` is the REQUEST: cognee.add() returned. The graph
+                # write that makes the note findable happens later and can fail
+                # with nothing reported, so the vault client gets the observed
+                # state and the ids cognee assigned rather than a flag that
+                # reads as "your note is in the vault".
                 "accepted": ingest_result.accepted,
+                "index_state": ingest_result.index_state,
+                "indexed": ingest_result.indexed,
+                "cognee_data_ids": list(ingest_result.cognee_data_ids),
                 "reason": ingest_result.reason,
                 "dataset": ingest_result.dataset,
                 "tags": list(ingest_result.tags),
@@ -6059,15 +6067,24 @@ async def ingest(body: IngestBody, request: Request) -> Any:
         },
     )
     payload = jsonable_encoder(result)
+    # `indexed` is a property, so it is not a dataclass field jsonable_encoder
+    # would pick up. It is the field a client should read: `accepted` only says
+    # the write was requested.
+    payload["indexed"] = result.indexed
     # Inline cognify (opt-in) so the just-written data is immediately searchable.
     # The write already succeeded; a cognify failure must NOT fail the ingest.
     if body.cognify and result.accepted:
         try:
             await citadel.cognify_dataset(dataset=outcome.dataset)
             payload["cognified"] = True
+            # This request WATCHED the graph write happen, which is the one
+            # situation where a write surface may report the note as indexed.
+            payload["index_state"] = resolve_index_state(result.index_state, "ok")
         except Exception as exc:  # pragma: no cover - depends on runtime Cognee state
             logger.error("inline cognify after ingest failed: %s", exc.__class__.__name__)
             payload["cognified"] = False
+            payload["index_state"] = resolve_index_state(result.index_state, "failed")
+        payload["indexed"] = index_flag(str(payload["index_state"]))
     return payload
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -50,7 +50,11 @@ from kb.capture_config import MAX_APPROVED_CAPTURE_ROOTS, matched_capture_root
 from kb.backup_mirror import BackupMirror, BackupMirrorDisabled, BackupMirrorPublishError
 from kb.conflicts import KnowledgeConflictStore, obsidian_push_conflict_candidate
 from kb.tags import normalize_tags
-from kb.cognee_client import assert_cognee_dataset_api
+from kb.cognee_client import (
+    assert_cognee_dataset_api,
+    background_cognify_stats,
+    ingest_indexing_state,
+)
 from kb.config import CitadelConfig
 from kb.contact_store import ContactStore
 from kb.github_sync import GitHubOrgSyncer
@@ -4431,8 +4435,22 @@ async def readyz(request: Request) -> Any:
     config = get_citadel().config
     corpus = await _corpus_health()
     canary = _LAST_CANARY
+    # Three distinct canary states, because "never ran" and "passed" used to
+    # answer identically: _LAST_CANARY is written only by the evolve scheduler,
+    # which is off by default, so a node that never exercised the end-to-end
+    # ingest+cognify+search check reported the same green as one that proved
+    # it. "never_ran" is reported, not failed — readiness gates rotation, and
+    # 503ing every default-config node would take healthy nodes out of service,
+    # which is worse than the gap. A probe that wants the stronger guarantee
+    # must branch on canary_state, which now exists for exactly that.
+    if canary is None:
+        canary_state = "never_ran"
+    elif canary.get("ok"):
+        canary_state = "passed"
+    else:
+        canary_state = "failed"
     # RED when the corpus gate trips or the last end-to-end canary failed.
-    ok = corpus["ok"] and (canary is None or bool(canary.get("ok", True)))
+    ok = corpus["ok"] and canary_state != "failed"
     payload = {
         "ok": ok,
         "service": "citadel",
@@ -4442,6 +4460,12 @@ async def readyz(request: Request) -> Any:
         "build_global_context_index": config.build_global_context_index,
         "corpus": corpus,
         "canary": canary,
+        "canary_state": canary_state,
+        # Observed outcomes of the detached post-ingest graph writes. A node
+        # whose scheduled cognifies never complete shows runs_scheduled
+        # climbing while runs_completed stays flat — previously that node and
+        # a healthy one were indistinguishable on every HTTP surface.
+        "background_cognify": background_cognify_stats(),
     }
     return JSONResponse(payload, status_code=200 if ok else 503)
 
@@ -5239,6 +5263,15 @@ async def push_obsidian_sync(body: ObsidianPushBody, request: Request) -> Any:
                 "document_id": accepted["document_id"],
                 "accepted": ingest_result.accepted,
                 "reason": ingest_result.reason,
+                # `accepted` says the store took the add; the graph write that
+                # makes the note searchable is asynchronous. This is the
+                # disposition of that request ("scheduled"/"deferred"/
+                # "suppressed"/"unknown"), never a confirmation.
+                "indexing": (
+                    ingest_indexing_state(ingest_result.cognee_result)
+                    if ingest_result.accepted
+                    else None
+                ),
                 "dataset": ingest_result.dataset,
                 "tags": list(ingest_result.tags),
             }
@@ -6059,15 +6092,23 @@ async def ingest(body: IngestBody, request: Request) -> Any:
         },
     )
     payload = jsonable_encoder(result)
+    # `accepted` describes the add request; the graph write that makes the
+    # data searchable is asynchronous. Report the disposition of that request
+    # explicitly so no caller reads acceptance as "indexed". Only the inline
+    # cognify below OBSERVES an outcome and may overwrite this.
+    if result.accepted:
+        payload["indexing"] = ingest_indexing_state(result.cognee_result)
     # Inline cognify (opt-in) so the just-written data is immediately searchable.
     # The write already succeeded; a cognify failure must NOT fail the ingest.
     if body.cognify and result.accepted:
         try:
             await citadel.cognify_dataset(dataset=outcome.dataset)
             payload["cognified"] = True
+            payload["indexing"] = "completed"
         except Exception as exc:  # pragma: no cover - depends on runtime Cognee state
             logger.error("inline cognify after ingest failed: %s", exc.__class__.__name__)
             payload["cognified"] = False
+            payload["indexing"] = "failed"
     return payload
 
 
@@ -6405,6 +6446,25 @@ async def contribute(body: ContributeBody, request: Request) -> Any:
         {
             "ok": True,
             "accepted": accepted,
+            # Disposition of the asynchronous graph-indexing request behind
+            # the accepted add(s) — never a confirmation that anything became
+            # searchable. None when nothing was accepted. Read from an
+            # ACCEPTED ingest because `accepted` is any-of-chunks and a
+            # rejected primary carries no outcome to observe.
+            "indexing": (
+                ingest_indexing_state(
+                    next(
+                        (
+                            result.cognee_result
+                            for result in outcome.all_ingests
+                            if result.accepted
+                        ),
+                        None,
+                    )
+                )
+                if accepted
+                else None
+            ),
             "chunks": outcome.accepted_chunks,
             "conflict": outcome.conflict,
             "dataset": outcome.dataset,

--- a/kb/service.py
+++ b/kb/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from hashlib import sha256
 import logging
 import re
@@ -11,7 +11,13 @@ from typing import Any
 from kb.cognee_client import CogneeGateway, CogneePublicClient
 from kb.config import CitadelConfig
 from kb.filters import PreIngestFilter
-from kb.models import FeedbackRequest, FeedbackResult, IngestResult
+from kb.models import (
+    INDEX_STATE_REJECTED,
+    INDEX_STATE_UNKNOWN,
+    FeedbackRequest,
+    FeedbackResult,
+    IngestResult,
+)
 from kb.security_scan import (
     SecretContentError,
     SecurityScanEntry,
@@ -79,7 +85,13 @@ class Citadel:
             logger.info(
                 "Ingest rejected for dataset %s: %s", target_dataset, decision.reason
             )
-            return IngestResult(False, decision.reason, target_dataset, merged_tags)
+            return IngestResult(
+                False,
+                decision.reason,
+                target_dataset,
+                merged_tags,
+                index_state=INDEX_STATE_REJECTED,
+            )
 
         self._guard_content(data, target_dataset)
 
@@ -89,7 +101,13 @@ class Citadel:
             logger.info(
                 "Ingest rejected for dataset %s: duplicate_in_process", target_dataset
             )
-            return IngestResult(False, "duplicate_in_process", target_dataset, merged_tags)
+            return IngestResult(
+                False,
+                "duplicate_in_process",
+                target_dataset,
+                merged_tags,
+                index_state=INDEX_STATE_REJECTED,
+            )
         # Claimed BEFORE the await so two concurrent ingests of identical content
         # cannot both pass the check, and released again if the write fails. It
         # used to be added and never removed, so one failed remember() marked that
@@ -108,7 +126,26 @@ class Citadel:
         except BaseException:
             self._seen_ingest_keys.discard(ingest_key)
             raise
-        return IngestResult(True, "accepted", target_dataset, merged_tags, result)
+        # ``accepted`` says the WRITE was requested and cognee.add() returned.
+        # It says nothing about the graph write that makes the document
+        # retrievable, and cognify never runs synchronously here. Carry through
+        # what the client observed instead of letting every connector read
+        # ``accepted`` as "indexed" — an unreadable client result stays
+        # ``unknown``, never the optimistic value.
+        index_state = INDEX_STATE_UNKNOWN
+        data_ids: tuple[str, ...] = ()
+        if isinstance(result, Mapping):
+            index_state = str(result.get("index_state") or INDEX_STATE_UNKNOWN)
+            data_ids = tuple(str(item) for item in (result.get("data_ids") or ()))
+        return IngestResult(
+            True,
+            "accepted",
+            target_dataset,
+            merged_tags,
+            result,
+            index_state=index_state,
+            cognee_data_ids=data_ids,
+        )
 
     def _guard_content(self, data: str, dataset: str) -> None:
         """Block storing content that carries a blocking-severity secret.

--- a/kb/service.py
+++ b/kb/service.py
@@ -134,6 +134,16 @@ class Citadel:
                 findings=scan.get("findings", []),  # type: ignore[arg-type]
             )
 
+    def resolve_search_dataset(self, dataset: str | None) -> str:
+        """The dataset ``search`` will actually read from.
+
+        Exposed because callers have to report which dataset a hit came out of
+        (it is the only attested provenance signal a local hit carries), and a
+        caller re-deriving ``dataset or default_dataset`` on its own drifts the
+        moment this rule changes.
+        """
+        return dataset or self.config.default_dataset
+
     async def search(
         self,
         query: str,
@@ -143,7 +153,7 @@ class Citadel:
         top_k: int = 10,
     ) -> list[Any]:
         top_k = min(max(int(top_k), 1), MAX_SEARCH_TOP_K)
-        target_dataset = dataset or self.config.default_dataset
+        target_dataset = self.resolve_search_dataset(dataset)
         results = await self.cognee.recall(
             query,
             dataset=target_dataset,

--- a/kb/status.py
+++ b/kb/status.py
@@ -319,8 +319,23 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
     canary = data.get("canary")
     indexed = corpus.get("indexed_docs")
     tracked = corpus.get("tracked_sources")
-    ok = bool(corpus.get("ok", True)) and (canary is None or bool(canary.get("ok", True)))
+    # /readyz now names the canary's state: passed / failed / never_ran. Only
+    # "failed" is a RED signal. A node that never ran one has observed nothing,
+    # which is not a failure and is emphatically not a pass, so say which it is
+    # in the detail line rather than printing a bare "ok" over an unchecked
+    # data plane. Older nodes still send a bare verdict dict or null; the
+    # fallback keeps `citadel status` working against them.
+    state = canary.get("state") if isinstance(canary, dict) else None
+    if state is not None:
+        canary_ok = state != "failed"
+    else:
+        canary_ok = canary is None or bool(canary.get("ok", True))
+    ok = bool(corpus.get("ok", True)) and canary_ok
     detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
+    if state == "never_ran":
+        detail = f"{detail} (canary: never ran)"
+    elif state == "failed":
+        detail = f"{detail} (canary: failed)"
     return Check("corpus", ok=ok, detail=detail, latency_ms=latency, data={"canary": canary})
 
 

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -29,6 +29,23 @@ def test_normalize_local_search_results() -> None:
     assert wrapped["timed_out"] is True
 
 
+def test_local_search_pipeline_reports_unknown_trust() -> None:
+    """The --local pipeline (normalize_local_search_results → shape_search_payload).
+
+    It hands cognee payloads to the shaper with no ``_citadel`` envelope, so no
+    attested provenance is ever consulted; the shaped hits must say so
+    ("unknown") instead of reading exactly like honestly unattested HTTP hits.
+    """
+    from kb.search_format import shape_search_payload
+
+    payload = normalize_local_search_results(
+        [{"id": "c1", "text": "# Dead-end route\n\nsession trace body"}]
+    )
+    shaped = shape_search_payload(payload, query="dead-end route")
+    assert shaped["results"][0]["trust_tier"] == "unknown"
+    assert any("trust_tier is 'unknown'" in w for w in shaped["warnings"])
+
+
 def test_shape_verify_and_prepare() -> None:
     path = Path("payment.md")
     payload = {
@@ -45,7 +62,9 @@ def test_shape_verify_and_prepare() -> None:
     report = shape_verify_report(
         path=path, file_text="MIP-003 purchase endpoint", search_payload=payload, query="MIP-003"
     )
-    assert report["doc_shaped_sources"][0]["trust_tier"] == "unattested"
+    # This fixture's hits carry no _citadel envelope, so no attested provenance
+    # was consulted: the tier says "unknown", not "unattested".
+    assert report["doc_shaped_sources"][0]["trust_tier"] == "unknown"
     assert report["doc_shaped_sources"][0]["content_hint"] == "looks-like-spec"
     assert report["known_overlaps"]
     brief = shape_prepare_pr_context(repo="cardano-dev-skills", topic="masumi", search_payload=payload)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -526,7 +526,9 @@ def test_verify_and_prepare_pr_context(monkeypatch, tmp_path, capsys) -> None:
     verify_out = json.loads(capsys.readouterr().out)
     assert verify_out["ok"] is True
     assert verify_out["doc_shaped_sources"]
-    assert verify_out["doc_shaped_sources"][0]["trust_tier"] == "unattested"
+    # This fixture's hits carry no _citadel envelope, so no attested provenance
+    # was consulted: the tier says "unknown", not "unattested".
+    assert verify_out["doc_shaped_sources"][0]["trust_tier"] == "unknown"
     assert "agent_instruction" in verify_out
 
     p_args = argparse.Namespace(

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -998,7 +998,14 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
     assert isinstance(captured["data"], DataItem)
     assert captured["data"].data == "real digest"
     assert captured["data"].external_metadata == {"citadel_tags": ["github"]}
-    assert result == {"added": {"ok": True}, "cognify": "suppressed"}
+    # "suppressed" names WHICH branch ran; index_state says what that means for
+    # the caller — stored, graph write still owed, and never "indexed".
+    assert result == {
+        "added": {"ok": True},
+        "cognify": "suppressed",
+        "data_ids": (),
+        "index_state": "pending_cognify",
+    }
 
 
 @pytest.mark.asyncio
@@ -1031,7 +1038,12 @@ async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: A
     client = CogneePublicClient()
 
     result = await client.remember("note", dataset_name="seat:sarthi", tags=())
-    assert result == {"added": {"ok": True}, "background_cognify": True}
+    assert result == {
+        "added": {"ok": True},
+        "background_cognify": True,
+        "data_ids": (),
+        "index_state": "pending_cognify",
+    }
     # Drain the scheduled background cognify and confirm it ran via cognify().
     await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == [["seat:sarthi"]]

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -998,7 +998,12 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
     assert isinstance(captured["data"], DataItem)
     assert captured["data"].data == "real digest"
     assert captured["data"].external_metadata == {"citadel_tags": ["github"]}
-    assert result == {"added": {"ok": True}, "cognify": "suppressed"}
+    assert result == {
+        "added": {"ok": True},
+        "cognify": "suppressed",
+        "indexed": False,
+        "status": "indexing_suppressed",
+    }
 
 
 @pytest.mark.asyncio
@@ -1031,7 +1036,13 @@ async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: A
     client = CogneePublicClient()
 
     result = await client.remember("note", dataset_name="seat:sarthi", tags=())
-    assert result == {"added": {"ok": True}, "background_cognify": True}
+    assert result == {
+        "added": {"ok": True},
+        "cognify": "scheduled",
+        "indexed": False,
+        "status": "indexing_scheduled",
+        "background_cognify": True,
+    }
     # Drain the scheduled background cognify and confirm it ran via cognify().
     await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == [["seat:sarthi"]]

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -190,6 +190,9 @@ async def test_github_sync_ingests_daily_digest_and_persists_state(tmp_path: Any
     assert result["event_count"] == 1
     assert result["commit_count"] == 1
     assert result["ingested"] is True
+    # FakeCitadel returns no cognee outcome payload, so the indexing
+    # disposition must be the explicit "unknown" — never an implied success.
+    assert result["indexing"] == "unknown"
     assert result["improved"] is True
     assert "masumi-network/agent" in citadel.ingest_calls[0]["data"]
     assert "teach the archive about commits" in citadel.ingest_calls[0]["data"]

--- a/tests/test_ingest_index_state.py
+++ b/tests/test_ingest_index_state.py
@@ -537,3 +537,40 @@ async def test_repo_content_sync_counts_unindexed_files_separately(
     assert result["files_ingested"] == 2  # stored
     assert result["files_indexed"] == 0  # and retrievable: none of them
     assert result["files_index_failed"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("index_state", "expected_status", "expects_graph_edge"),
+    [
+        (INDEX_STATE_INDEXED, "indexed", True),
+        (INDEX_STATE_PENDING, "pending", False),
+        (INDEX_STATE_NOT_SCHEDULED, "unindexed", False),
+        (INDEX_STATE_UNKNOWN, "pending", False),
+    ],
+)
+async def test_mesh_document_status_follows_the_observed_index_state(
+    index_state: str, expected_status: str, expects_graph_edge: bool
+) -> None:
+    # The mesh drew every accepted write as status "indexed" with an edge to
+    # index:graph — a picture of a graph write that had not happened, and in
+    # the 892-document case would never happen. The badge and the edge are
+    # claims about the graph, so both wait for the observation.
+    from kb.mesh import MeshState
+
+    config = CitadelConfig(tenant_id="test", default_dataset="notes")
+    mesh = MeshState()
+    result = IngestResult(True, "accepted", "notes", ("ops",), index_state=index_state)
+
+    await mesh.record_ingest(config, result, data="Runbook", dataset="notes", tags=["ops"])
+    snapshot = await mesh.snapshot(config)
+
+    document = next(node for node in snapshot["nodes"] if node["type"] == "document")
+    assert document["status"] == expected_status
+    graph_edges = [
+        edge
+        for edge in snapshot["edges"]
+        if edge["target"] == "index:graph" and edge["source"] == document["id"]
+    ]
+    assert bool(graph_edges) is expects_graph_edge
+    assert snapshot["events"][0]["details"]["index_state"] == index_state

--- a/tests/test_ingest_index_state.py
+++ b/tests/test_ingest_index_state.py
@@ -75,8 +75,15 @@ def test_resolve_index_state_only_promotes_on_an_observed_cognify() -> None:
     assert resolve_index_state(INDEX_STATE_PENDING, "not_scheduled") == INDEX_STATE_NOT_SCHEDULED
     # Nothing observed leaves the state where it was — never promoted.
     assert resolve_index_state(INDEX_STATE_PENDING, None) == INDEX_STATE_PENDING
-    # A successful cognify cannot rescue a write that never landed.
+    # A write that never happened stays rejected whatever the cognify did: it is
+    # neither indexed nor a cognify failure.
     assert resolve_index_state(INDEX_STATE_REJECTED, "ok") == INDEX_STATE_REJECTED
+    assert resolve_index_state(INDEX_STATE_REJECTED, "failed") == INDEX_STATE_REJECTED
+    # An unknown write moves in the pessimistic direction only. A failed cognify
+    # means nothing reached the graph either way; a successful one is no
+    # evidence the write itself ever landed in the store.
+    assert resolve_index_state(INDEX_STATE_UNKNOWN, "failed") == "cognify_failed"
+    assert resolve_index_state(INDEX_STATE_UNKNOWN, "ok") == INDEX_STATE_UNKNOWN
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_ingest_index_state.py
+++ b/tests/test_ingest_index_state.py
@@ -1,0 +1,539 @@
+"""A write may only report an outcome it OBSERVED.
+
+``IngestResult.accepted`` describes a REQUEST: it is True the instant
+``cognee.add()`` returns. The graph write that makes a document retrievable is
+``cognify``, and ``remember`` never runs it synchronously — every branch either
+suppresses it, defers it to the caller, or hands it to a background task. So a
+sync whose cognify silently never ran and a sync that indexed everything used to
+emit byte-identical ``{"ok": true, "ingested": true}``.
+
+These tests exist to make those two cases distinguishable. Each one simulates a
+cognify that does not land and asserts the reported counter does not claim
+success. Every one of them passes with cognify entirely broken if the
+``index_state`` plumbing is removed, which is the defect stated as a test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kb.cognee_client import CogneePublicClient
+from kb.config import CitadelConfig
+from kb.models import (
+    INDEX_STATE_INDEXED,
+    INDEX_STATE_NOT_SCHEDULED,
+    INDEX_STATE_PENDING,
+    INDEX_STATE_REJECTED,
+    INDEX_STATE_UNKNOWN,
+    IngestResult,
+    resolve_index_state,
+)
+
+
+# --------------------------------------------------------------------------
+# The tri-state itself. `indexed` must never be True on an unobserved write,
+# and `bool(...)` on the pending value must be falsy so a caller that forgets
+# to branch fails closed instead of inheriting the optimistic answer.
+# --------------------------------------------------------------------------
+
+
+def test_pending_write_is_not_reported_as_indexed() -> None:
+    result = IngestResult(True, "accepted", "ds", (), None, index_state=INDEX_STATE_PENDING)
+    assert result.accepted is True  # the request was accepted
+    assert result.indexed is None  # the outcome was NOT observed
+    assert bool(result.indexed) is False  # a forgetful caller fails closed
+
+
+def test_unknown_index_state_is_not_reported_as_indexed() -> None:
+    # The default. A construction site that never learned about index_state
+    # must not silently claim its writes are retrievable.
+    result = IngestResult(True, "accepted", "ds", ())
+    assert result.index_state == INDEX_STATE_UNKNOWN
+    assert result.indexed is None
+
+
+def test_rejected_write_is_reported_as_not_indexed() -> None:
+    result = IngestResult(False, "duplicate_in_process", "ds", (), index_state=INDEX_STATE_REJECTED)
+    assert result.indexed is False
+
+
+def test_unscheduled_cognify_is_reported_as_not_indexed() -> None:
+    # The silent death: the data is stored and nothing will ever index it.
+    result = IngestResult(True, "accepted", "ds", (), index_state=INDEX_STATE_NOT_SCHEDULED)
+    assert result.accepted is True
+    assert result.indexed is False
+
+
+def test_resolve_index_state_only_promotes_on_an_observed_cognify() -> None:
+    assert resolve_index_state(INDEX_STATE_PENDING, "ok") == INDEX_STATE_INDEXED
+    assert resolve_index_state(INDEX_STATE_PENDING, "failed") == "cognify_failed"
+    assert resolve_index_state(INDEX_STATE_PENDING, "not_scheduled") == INDEX_STATE_NOT_SCHEDULED
+    # Nothing observed leaves the state where it was — never promoted.
+    assert resolve_index_state(INDEX_STATE_PENDING, None) == INDEX_STATE_PENDING
+    # A successful cognify cannot rescue a write that never landed.
+    assert resolve_index_state(INDEX_STATE_REJECTED, "ok") == INDEX_STATE_REJECTED
+
+
+# --------------------------------------------------------------------------
+# The one fix, in cognee_client.remember, that all four connectors inherit.
+# --------------------------------------------------------------------------
+
+
+def _fake_cognee(
+    *,
+    add_result: Any,
+    cognify: Any = None,
+) -> SimpleNamespace:
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def add(data: Any, **kwargs: Any) -> Any:
+        return add_result
+
+    async def default_cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        return {"ok": True}
+
+    return SimpleNamespace(
+        run_startup_migrations=run_startup_migrations,
+        add=add,
+        cognify=cognify or default_cognify,
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_reports_pending_never_indexed_for_a_backgrounded_cognify(
+    monkeypatch: Any,
+) -> None:
+    # The normal production path. cognee.add() has returned; the Kuzu write has
+    # NOT happened yet. "pending_cognify" is the whole point: it is the state a
+    # caller can branch on instead of reading `accepted` as "retrievable".
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setitem(sys.modules, "cognee", _fake_cognee(add_result={"ok": True}))
+
+    client = CogneePublicClient()
+    result = await client.remember("note", dataset_name="seat:sarthi", tags=())
+
+    assert result["index_state"] == INDEX_STATE_PENDING
+    assert result["index_state"] != INDEX_STATE_INDEXED
+    import kb.cognee_client as cc
+
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_remember_reports_not_scheduled_when_the_cognify_is_never_scheduled(
+    monkeypatch: Any,
+) -> None:
+    # THE LOAD-BEARING CASE at the client. schedule_cognify can decline to
+    # schedule (no running loop). Before index_state, remember returned
+    # {"added": ..., "background_cognify": True} either way, so a write nothing
+    # would ever index was indistinguishable from one that got indexed.
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setitem(sys.modules, "cognee", _fake_cognee(add_result={"ok": True}))
+
+    client = CogneePublicClient()
+    monkeypatch.setattr(client, "schedule_cognify", lambda datasets: False)
+
+    result = await client.remember("note", dataset_name="seat:sarthi", tags=())
+    assert result["index_state"] == INDEX_STATE_NOT_SCHEDULED
+
+
+@pytest.mark.asyncio
+async def test_remember_reports_pending_when_cognify_is_suppressed(monkeypatch: Any) -> None:
+    # Evolve Phase 1 is add-only by design; Phase 2 owes the graph write. That
+    # is still "not yet indexed", not "indexed".
+    monkeypatch.setenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "true")
+    monkeypatch.setitem(sys.modules, "cognee", _fake_cognee(add_result={"ok": True}))
+
+    client = CogneePublicClient()
+    result = await client.remember("note", dataset_name="ds", tags=())
+    assert result["cognify"] == "suppressed"
+    assert result["index_state"] == INDEX_STATE_PENDING
+
+
+@pytest.mark.asyncio
+async def test_remember_reports_pending_when_cognify_is_deferred(monkeypatch: Any) -> None:
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setitem(sys.modules, "cognee", _fake_cognee(add_result={"ok": True}))
+
+    client = CogneePublicClient()
+    result = await client.remember("note", dataset_name="ds", tags=(), defer_cognify=True)
+    assert result["cognify"] == "deferred"
+    assert result["index_state"] == INDEX_STATE_PENDING
+
+
+@pytest.mark.asyncio
+async def test_remember_surfaces_the_data_ids_cognee_assigned(monkeypatch: Any) -> None:
+    # The real cognee return type, imported rather than hand-rolled: a fake that
+    # invents a third party's shape only proves the parser parses the fake.
+    from uuid import NAMESPACE_URL, uuid5
+
+    from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted
+
+    data_id = str(uuid5(NAMESPACE_URL, "data:note"))
+    added = PipelineRunCompleted(
+        pipeline_run_id=uuid5(NAMESPACE_URL, "run:note"),
+        dataset_id=uuid5(NAMESPACE_URL, "ds"),
+        dataset_name="ds",
+        payload=None,
+        data_ingestion_info=[{"data_id": data_id}],
+    )
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setitem(sys.modules, "cognee", _fake_cognee(add_result=added))
+
+    client = CogneePublicClient()
+    result = await client.remember("note", dataset_name="ds", tags=(), defer_cognify=True)
+    assert result["data_ids"] == (data_id,)
+
+
+@pytest.mark.asyncio
+async def test_schedule_cognify_reports_whether_it_scheduled_anything() -> None:
+    client = CogneePublicClient()
+    scheduled: list[list[str]] = []
+
+    async def fake_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        scheduled.append(list(datasets))
+        return {"ok": True}
+
+    setattr(client, "cognify", fake_cognify)
+    assert client.schedule_cognify([]) is False  # nothing to do is not a success
+    assert client.schedule_cognify(["ds"]) is True
+
+    import kb.cognee_client as cc
+
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    assert scheduled == [["ds"]]
+    assert client.cognify_status("ds") == "ok"
+
+
+@pytest.mark.asyncio
+async def test_background_cognify_failure_is_recorded_for_the_next_pass() -> None:
+    # A background cognify that raises is logged and dropped; the write that
+    # scheduled it has already been reported. Recording the outcome per dataset
+    # is what makes the silent drop detectable on the NEXT pass.
+    client = CogneePublicClient()
+
+    async def failing_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        raise RuntimeError("kuzu lock held")
+
+    setattr(client, "cognify", failing_cognify)
+    assert client.schedule_cognify(["ds"]) is True
+
+    import kb.cognee_client as cc
+
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    assert client.cognify_status("ds") == "failed"
+
+
+# --------------------------------------------------------------------------
+# Citadel.ingest carries the observed state through to every connector.
+# --------------------------------------------------------------------------
+
+
+class _StubCognee:
+    """Minimal CogneeClient stand-in that returns whatever remember() should."""
+
+    def __init__(self, remember_result: Any) -> None:
+        self._remember_result = remember_result
+        self.scheduled: list[list[str]] = []
+
+    async def remember(self, data: Any, **kwargs: Any) -> Any:
+        return self._remember_result
+
+    def schedule_cognify(self, datasets: list[str]) -> bool:
+        self.scheduled.append(list(datasets))
+        return True
+
+    def cognify_status(self, dataset: str) -> str | None:
+        return None
+
+
+def _citadel(remember_result: Any, tmp_path: Any) -> Any:
+    from kb.service import Citadel
+
+    config = CitadelConfig(
+        access_store_path=str(tmp_path / "a.json"),
+        content_scan_enabled=False,
+    )
+    citadel = Citadel(config)
+    citadel.cognee = _StubCognee(remember_result)  # type: ignore[assignment]
+    return citadel
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_the_observed_index_state(tmp_path: Any) -> None:
+    citadel = _citadel(
+        {"added": {"ok": True}, "index_state": INDEX_STATE_NOT_SCHEDULED, "data_ids": ()},
+        tmp_path,
+    )
+    result = await citadel.ingest("some durable note")
+    assert result.accepted is True  # the request landed in the store
+    assert result.index_state == INDEX_STATE_NOT_SCHEDULED
+    assert result.indexed is False  # and nothing will ever index it
+
+
+@pytest.mark.asyncio
+async def test_ingest_propagates_data_ids(tmp_path: Any) -> None:
+    citadel = _citadel(
+        {"added": {"ok": True}, "index_state": INDEX_STATE_PENDING, "data_ids": ("d1", "d2")},
+        tmp_path,
+    )
+    result = await citadel.ingest("another durable note")
+    assert result.cognee_data_ids == ("d1", "d2")
+    assert result.indexed is None
+
+
+@pytest.mark.asyncio
+async def test_ingest_of_an_unreadable_cognee_result_is_unknown_not_indexed(
+    tmp_path: Any,
+) -> None:
+    # A client whose return value we cannot read is an absence of evidence, and
+    # absence of evidence must never resolve to the optimistic value.
+    citadel = _citadel(object(), tmp_path)
+    result = await citadel.ingest("a third durable note")
+    assert result.index_state == INDEX_STATE_UNKNOWN
+    assert result.indexed is None
+
+
+@pytest.mark.asyncio
+async def test_rejected_ingest_reports_rejected_index_state(tmp_path: Any) -> None:
+    citadel = _citadel({"index_state": INDEX_STATE_PENDING}, tmp_path)
+    first = await citadel.ingest("duplicate note body")
+    assert first.accepted is True
+    second = await citadel.ingest("duplicate note body")
+    assert second.accepted is False
+    assert second.index_state == INDEX_STATE_REJECTED
+    assert second.indexed is False
+
+
+# --------------------------------------------------------------------------
+# The connectors. Each one published `accepted` as its headline success, so a
+# sync whose cognify silently died emitted the same {"ok": true,
+# "ingested": true} as one that indexed everything. These are the counters.
+# --------------------------------------------------------------------------
+
+
+class _IndexStateCitadel:
+    """A Citadel whose writes land in the store and are never indexed."""
+
+    def __init__(self, config: CitadelConfig, index_state: str) -> None:
+        self.config = config
+        self._index_state = index_state
+        self.ingest_calls: list[dict[str, Any]] = []
+
+    async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
+        self.ingest_calls.append({"data": data, **kwargs})
+        return IngestResult(
+            True,
+            "accepted",
+            kwargs["dataset"],
+            tuple(kwargs.get("tags") or ()),
+            index_state=self._index_state,
+            cognee_data_ids=("data-id-1",),
+        )
+
+    async def improve(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("index_state", "expected_indexed"),
+    [
+        (INDEX_STATE_NOT_SCHEDULED, False),  # cognify silently never scheduled
+        (INDEX_STATE_PENDING, None),  # queued, outcome not yet observed
+    ],
+)
+async def test_github_sync_never_claims_an_unobserved_index(
+    tmp_path: Any, index_state: str, expected_indexed: bool | None
+) -> None:
+    # THE LOAD-BEARING TEST for the GitHub connector. Before index_state both
+    # rows produced {"ingested": true} and nothing else, so a digest that never
+    # became retrievable was indistinguishable from one that did. That is very
+    # likely the mechanism behind "a pass ran and its content never became
+    # retrievable".
+    import json
+
+    from kb.github_sync import GitHubOrgSyncer
+    from tests.test_github_sync import FakeGitHubClient
+
+    config = CitadelConfig(
+        github_sync_dataset="masumi-network",
+        github_sync_session="masumi-github-daily",
+        github_sync_state_path=str(tmp_path / "github_state.json"),
+        content_scan_enabled=False,
+    )
+    citadel = _IndexStateCitadel(config, index_state)
+    syncer = GitHubOrgSyncer(citadel, client=FakeGitHubClient(), org="masumi-network")  # type: ignore[arg-type]
+
+    result = await syncer.run()
+
+    assert result["ingested"] is True  # the write was accepted, and that is all
+    assert result["index_state"] == index_state
+    assert result["indexed"] is expected_indexed
+    assert result["indexed"] is not True
+
+    # And the ids cognee assigned are persisted, so the NEXT pass can check this
+    # claim against the index instead of trusting its own bookkeeping.
+    state = json.loads((tmp_path / "github_state.json").read_text())
+    assert state["last_digest_index"]["index_state"] == index_state
+    assert state["last_digest_index"]["cognee_data_ids"] == ["data-id-1"]
+
+
+def _one_issue() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "issue-1",
+            "identifier": "ENG-1",
+            "title": "Ship it",
+            "description": "body",
+            "url": "https://linear.app/acme/issue/ENG-1",
+            "priority": 2,
+            "updatedAt": "2026-06-25T10:00:00Z",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "ENG", "name": "Engineering"},
+        }
+    ]
+
+
+def _pending_learn() -> Any:
+    async def fake_learn(self: Any, data: str, **kwargs: Any) -> Any:
+        class Outcome:
+            ingest = IngestResult(
+                True,
+                "accepted",
+                str(kwargs.get("dataset") or "masumi-network"),
+                (),
+                index_state=INDEX_STATE_PENDING,
+                cognee_data_ids=("data-id-1",),
+            )
+
+        return Outcome()
+
+    return fake_learn
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_reports_a_failed_coalesced_cognify(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    # THE LOAD-BEARING TEST for Linear. The standalone run AWAITS its one
+    # coalesced cognify and swallows the exception, because the rows already
+    # landed. Swallowing it is fine; reporting central_ingested:true afterwards
+    # and nothing else is not — the failure was observed and then discarded.
+    from kb.linear_sync import LinearSyncer
+    from kb.service import Citadel
+    from tests.test_linear_sync import FakeLinearClient
+
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+
+    async def failing_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        raise RuntimeError("kuzu lock held by another process")
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", _pending_learn())
+    monkeypatch.setattr(citadel.cognee, "cognify", failing_cognify)
+
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(_one_issue()))
+    result = await syncer.run(force=True, await_cognify=True)
+
+    assert result["ok"] is True
+    assert result["central_ingested"] is True  # the rows landed
+    assert result["central_index_state"] == "cognify_failed"
+    assert result["central_indexed"] is False  # and none of it is retrievable
+    assert result["cognify_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_reports_indexed_only_after_an_observed_cognify(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    # The other direction: a cognify this run WATCHED succeed is the one case
+    # where "indexed" is a claim about something observed.
+    from kb.linear_sync import LinearSyncer
+    from kb.service import Citadel
+    from tests.test_linear_sync import FakeLinearClient
+
+    config = CitadelConfig(
+        linear_api_key="lin_test",
+        linear_sync_state_path=str(tmp_path / "s.json"),
+        access_store_path=str(tmp_path / "a.json"),
+    )
+    citadel = Citadel(config)
+
+    async def ok_cognify(*, datasets: Any, force: bool = False) -> dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", _pending_learn())
+    monkeypatch.setattr(citadel.cognee, "cognify", ok_cognify)
+
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(_one_issue()))
+    result = await syncer.run(force=True, await_cognify=True)
+
+    assert result["cognify_status"] == "ok"
+    assert result["central_index_state"] == INDEX_STATE_INDEXED
+    assert result["central_indexed"] is True
+
+
+@pytest.mark.asyncio
+async def test_repo_content_sync_counts_unindexed_files_separately(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    # repo_content_sync already refuses to treat a file as `unchanged` without
+    # the ids cognee assigned, which repairs the SKIP decision. Its own
+    # files_ingested counter still counted a request. Split the counters so a
+    # pass that stored two files and indexed none says so.
+    from kb.repo_content_sync import RepoContentSyncer
+    from tests.test_repo_content_sync import (
+        FakeCitadel,
+        FakeLearningProcess,
+        FakeRepoContentClient,
+    )
+
+    config = CitadelConfig(
+        github_org="masumi-network",
+        repo_content_sync_repos=("sokosumi-cli",),
+        repo_content_sync_state_path=str(tmp_path / "repo_state.json"),
+        repo_content_sync_dataset="masumi-network",
+    )
+    learning = FakeLearningProcess()
+    original_learn = learning.learn
+
+    async def learn_without_index(data: str, **kwargs: Any) -> Any:
+        outcome = await original_learn(data, **kwargs)
+        ingest = outcome.ingest
+        outcome.ingest = IngestResult(  # type: ignore[misc]
+            ingest.accepted,
+            ingest.reason,
+            ingest.dataset,
+            ingest.tags,
+            ingest.cognee_result,
+            index_state=INDEX_STATE_NOT_SCHEDULED,
+            cognee_data_ids=ingest.cognee_data_ids,
+        )
+        return outcome
+
+    monkeypatch.setattr(learning, "learn", learn_without_index)
+    syncer = RepoContentSyncer(
+        FakeCitadel(config),
+        client=FakeRepoContentClient(),
+        state_path=config.repo_content_sync_state_path,
+        learning=learning,  # type: ignore[arg-type]
+    )
+
+    result = await syncer.run()
+
+    assert result["files_ingested"] == 2  # stored
+    assert result["files_indexed"] == 0  # and retrievable: none of them
+    assert result["files_index_failed"] == 2

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -15,6 +15,7 @@ from kb.linear_sync import (
     resolve_mirror_dataset,
     seat_email_index,
 )
+from kb.models import INDEX_STATE_PENDING, IngestResult
 from kb.service import Citadel
 
 
@@ -134,11 +135,16 @@ async def test_linear_sync_ingests_central_and_mirror(
             }
         )
 
-        class FakeResult:
-            accepted = True
-
         class Outcome:
-            ingest = FakeResult()
+            # The real IngestResult: `accepted` alone cannot express the state
+            # the caller now branches on (stored vs actually indexed).
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -189,8 +195,17 @@ async def test_linear_sync_writes_each_issue_to_central(
         ingests.append({"dataset": dataset, "tags": tags or [], "data": data})
 
         class Outcome:
-            class ingest:
-                accepted = True
+            # The real IngestResult, not a bare stub with `accepted = True`.
+            # Every write here is deferred, so its honest state is "stored, the
+            # graph write is still owed" — a fake that only carries `accepted`
+            # cannot express the difference the caller now has to branch on.
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -248,8 +263,17 @@ async def test_linear_sync_auto_maps_assignee_by_member_email(
 
     async def fake_learn(self: Any, data: str, **_: Any) -> Any:
         class Outcome:
-            class ingest:
-                accepted = True
+            # The real IngestResult, not a bare stub with `accepted = True`.
+            # Every write here is deferred, so its honest state is "stored, the
+            # graph write is still owed" — a fake that only carries `accepted`
+            # cannot express the difference the caller now has to branch on.
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -283,8 +307,17 @@ async def test_linear_sync_defers_coalesced_cognify_when_inline_suppressed(
 
     async def fake_learn(self: Any, data: str, **_: Any) -> Any:
         class Outcome:
-            class ingest:
-                accepted = True
+            # The real IngestResult, not a bare stub with `accepted = True`.
+            # Every write here is deferred, so its honest state is "stored, the
+            # graph write is still owed" — a fake that only carries `accepted`
+            # cannot express the difference the caller now has to branch on.
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -316,8 +349,17 @@ async def test_linear_sync_awaits_coalesced_cognify_when_requested(
 
     async def fake_learn(self: Any, data: str, **_: Any) -> Any:
         class Outcome:
-            class ingest:
-                accepted = True
+            # The real IngestResult, not a bare stub with `accepted = True`.
+            # Every write here is deferred, so its honest state is "stored, the
+            # graph write is still owed" — a fake that only carries `accepted`
+            # cannot express the difference the caller now has to branch on.
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -433,11 +475,16 @@ async def test_member_fetch_failure_is_carried_not_a_neutral_zero(
     store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
 
     async def fake_learn(self: Any, data: str, **kwargs: Any) -> Any:
-        class FakeResult:
-            accepted = True
-
         class Outcome:
-            ingest = FakeResult()
+            # The real IngestResult: `accepted` alone cannot express the state
+            # the caller now branches on (stored vs actually indexed).
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 
@@ -481,8 +528,17 @@ def _capture_learn(monkeypatch: Any, ingests: list[dict[str, Any]]) -> None:
         ingests.append({"dataset": dataset, "tags": tags or [], "data": data})
 
         class Outcome:
-            class ingest:
-                accepted = True
+            # The real IngestResult, not a bare stub with `accepted = True`.
+            # Every write here is deferred, so its honest state is "stored, the
+            # graph write is still owed" — a fake that only carries `accepted`
+            # cannot express the difference the caller now has to branch on.
+            ingest = IngestResult(
+                True,
+                "accepted",
+                "masumi-network",
+                (),
+                index_state=INDEX_STATE_PENDING,
+            )
 
         return Outcome()
 

--- a/tests/test_local_search_provenance.py
+++ b/tests/test_local_search_provenance.py
@@ -1,0 +1,203 @@
+"""The CLI ``--local`` search path must attest provenance from what it read.
+
+Two implementations answer "what is this hit's doc_type / trust_tier":
+``kb.server.with_result_metadata`` for the HTTP route, and
+``kb.search_format.normalize_search_hit`` for CLI ``--json`` output. The second
+re-derives from scratch, and its only attested signal is
+``item["_citadel"]["dataset"]``.
+
+Nothing on the local path ever attached that envelope, so a genuine
+session-trace hit came back ``trust_tier: "unattested"`` — byte-identical to an
+honestly unattested hit. These tests pin the two paths to the same answer for
+the same bytes, and pin the marker that says whether the tier was OBSERVED or
+merely defaulted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from kb.agent_workflows import normalize_local_search_results
+from kb.search_format import (
+    DOC_TYPE_TRACE,
+    TRUST_BASIS_ATTESTED,
+    TRUST_BASIS_UNKNOWN,
+    TRUST_REFERENCE,
+    TRUST_UNATTESTED,
+    normalize_search_hit,
+    shape_search_payload,
+)
+
+SESSION_TRACES = "session-traces"
+QUERY = "kupo retry policy"
+
+# What cognee hands back on the local path: no `_citadel` envelope at all.
+RAW_TRACE_HIT: dict[str, Any] = {
+    "id": "trace-abc-123",
+    "text": "# Session trace\nAuthor-Seat: seat:probe\nWe changed the kupo retry policy.",
+}
+
+
+def _local_hits(raw: list[dict[str, Any]], *, dataset: str | None) -> list[dict[str, Any]]:
+    """Run hits through the exact seam ``kb.cli._search_local`` uses."""
+    payload = normalize_local_search_results(raw, dataset=dataset)
+    return shape_search_payload(payload, query=QUERY)["results"]
+
+
+def _http_hit(raw: dict[str, Any], *, dataset: str) -> dict[str, Any]:
+    """Run one hit through the seam the live HTTP route uses."""
+    from kb.server import with_result_metadata
+
+    served = with_result_metadata(dict(raw), 0, dataset, query=QUERY)
+    return normalize_search_hit(served, index=0, query=QUERY)
+
+
+def test_local_and_http_paths_agree_on_a_session_trace() -> None:
+    """Same bytes, same dataset, two implementations — one answer.
+
+    Before the fix the local path returned ``other`` / ``unattested`` for a hit
+    the HTTP route labels ``session-trace`` / ``reference-only``.
+    """
+    local = _local_hits([RAW_TRACE_HIT], dataset=SESSION_TRACES)[0]
+    served = _http_hit(RAW_TRACE_HIT, dataset=SESSION_TRACES)
+
+    assert local["trust_tier"] == TRUST_REFERENCE
+    assert local["doc_type"] == DOC_TYPE_TRACE
+    assert (local["doc_type"], local["trust_tier"]) == (served["doc_type"], served["trust_tier"])
+
+
+def test_local_hit_reports_the_dataset_it_was_read_out_of() -> None:
+    """The dataset is the attesting signal; a hit that drops it cannot be checked."""
+    hit = _local_hits([RAW_TRACE_HIT], dataset=SESSION_TRACES)[0]
+    assert hit["dataset"] == SESSION_TRACES
+    assert hit["_citadel"]["dataset"] == SESSION_TRACES
+
+
+def test_local_seat_hit_stays_unattested_but_says_so_from_an_observation() -> None:
+    """Attaching the envelope must not hand every local hit a trust upgrade."""
+    hit = _local_hits([RAW_TRACE_HIT], dataset="seat:probe")[0]
+    assert hit["trust_tier"] == TRUST_UNATTESTED
+    assert hit["trust_tier_basis"] == TRUST_BASIS_ATTESTED
+
+
+def test_a_defaulted_trust_tier_is_marked_unknown_not_unattested() -> None:
+    """No envelope means the authority was never consulted.
+
+    ``unattested`` alone cannot distinguish "checked, no provenance" from
+    "never checked", so the basis is emitted alongside it for a caller to
+    branch on.
+    """
+    hit = _local_hits([RAW_TRACE_HIT], dataset=None)[0]
+    assert hit["trust_tier"] == TRUST_UNATTESTED
+    assert hit["trust_tier_basis"] == TRUST_BASIS_UNKNOWN
+
+
+def test_http_hits_report_an_attested_basis() -> None:
+    served = _http_hit(RAW_TRACE_HIT, dataset=SESSION_TRACES)
+    assert served["trust_tier_basis"] == TRUST_BASIS_ATTESTED
+
+
+def test_non_dict_hit_reports_an_unknown_basis() -> None:
+    assert normalize_search_hit("a bare string")["trust_tier_basis"] == TRUST_BASIS_UNKNOWN
+
+
+def test_normalize_local_search_results_does_not_overwrite_a_real_envelope() -> None:
+    """A hit that already carries provenance keeps it; we only fill a gap."""
+    already = {"id": "x", "text": "note", "_citadel": {"dataset": "central", "trust": "x"}}
+    out = normalize_local_search_results([already], dataset=SESSION_TRACES)
+    assert out["results"][0]["_citadel"] == {"dataset": "central", "trust": "x"}
+
+
+def test_normalize_local_search_results_keeps_its_old_shape() -> None:
+    """Existing callers pass no dataset and must be unaffected."""
+    assert normalize_local_search_results([{"text": "a"}])["results"][0]["text"] == "a"
+    wrapped = normalize_local_search_results({"results": [{"text": "b"}], "timed_out": True})
+    assert wrapped["timed_out"] is True
+
+
+# --- the CLI end to end: tests/test_cli_commands.py monkeypatches _search_local
+# --- away entirely, so nothing exercised the real handler.
+
+
+class _FakeConfig:
+    default_dataset = "central"
+    github_sync_dataset = "github-sync"
+    github_sync_session = "gh"
+    default_session = "default"
+
+
+class _FakeCitadel:
+    """Stands in for the in-process server stack; records the dataset asked for."""
+
+    def __init__(self) -> None:
+        self.config = _FakeConfig()
+        self.asked_for: str | None = None
+
+    @classmethod
+    def from_env(cls) -> "_FakeCitadel":
+        return cls()
+
+    def resolve_search_dataset(self, dataset: str | None) -> str:
+        return dataset or self.config.default_dataset
+
+    async def search(
+        self,
+        query: str,
+        *,
+        dataset: str | None = None,
+        session_id: str | None = None,
+        top_k: int = 10,
+    ) -> list[Any]:
+        self.asked_for = dataset
+        return [dict(RAW_TRACE_HIT)]
+
+
+def _search_args(dataset: str | None) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="search",
+        query=QUERY,
+        local=True,
+        dataset=dataset,
+        session=None,
+        top_k=5,
+        json=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("dataset", "expected_tier"),
+    [(SESSION_TRACES, TRUST_REFERENCE), ("seat:probe", TRUST_UNATTESTED)],
+)
+def test_search_local_json_carries_the_attested_tier(
+    monkeypatch: Any, capsys: Any, dataset: str, expected_tier: str
+) -> None:
+    import kb.cli as cli
+    import kb.service as service
+
+    monkeypatch.setattr(service, "Citadel", _FakeCitadel)
+    assert asyncio.run(cli._search_local(_search_args(dataset))) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    hit = payload["results"][0]
+    assert hit["trust_tier"] == expected_tier
+    assert hit["trust_tier_basis"] == TRUST_BASIS_ATTESTED
+    assert hit["dataset"] == dataset
+
+
+def test_search_local_falls_back_to_the_configured_default_dataset(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    """``--local`` without ``--dataset`` still knows which dataset it read."""
+    import kb.cli as cli
+    import kb.service as service
+
+    monkeypatch.setattr(service, "Citadel", _FakeCitadel)
+    assert asyncio.run(cli._search_local(_search_args(None))) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["dataset"] == _FakeConfig.default_dataset

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -853,6 +853,135 @@ def test_promotion_decision_tools_require_admin_in_policy() -> None:
         assert policy.scope == "sources:sync", name
 
 
+_APPROVAL_GUARDED_TOOLS = (
+    "citadel_ingest",
+    "citadel_share_session",
+    "citadel_contribute",
+    "citadel_promotion_approve",
+    "citadel_promotion_reject",
+)
+
+
+def test_user_approval_stays_optional_in_every_guarded_tool_schema() -> None:
+    """The signal is recorded, not enforced: a required parameter would fail
+    every existing client at schema validation, so user_approval must stay
+    optional on all five guarded write tools."""
+    server = create_mcp_server(FakeHttpClient())
+
+    for name in _APPROVAL_GUARDED_TOOLS:
+        schema = server._tool_manager.get_tool(name).parameters
+        assert "user_approval" in schema["properties"], name
+        assert "user_approval" not in (schema.get("required") or []), name
+
+
+def test_ingest_forwards_and_reports_the_user_approval_signal() -> None:
+    """A write made with a stated user approval and one made without must not
+    produce identical requests or results: the signal rides the payload and is
+    mirrored into the tool result."""
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    approved = run_tool(
+        server,
+        "citadel_ingest",
+        "a durable note",
+        None,
+        user_approval="  yes,   save that  ",
+    )
+
+    assert client.posts[0]["payload"]["user_approval"] == "yes, save that"
+    assert approved["user_approval"] == {"provided": True, "signal": "yes, save that"}
+    assert not any("user_approval" in w for w in approved.get("warnings") or [])
+
+
+def test_ingest_without_user_approval_is_marked_not_confirmed() -> None:
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    result = run_tool(server, "citadel_ingest", "a durable note", None)
+
+    assert client.posts[0]["payload"]["user_approval"] is None
+    assert result["user_approval"] == {"provided": False, "signal": None}
+    assert any("user_approval" in w for w in result["warnings"])
+
+
+def test_contribute_and_share_session_carry_the_approval_signal() -> None:
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    contributed = run_tool(
+        server,
+        "citadel_contribute",
+        "Title",
+        "Body",
+        None,
+        user_approval="yes, contribute it",
+    )
+    shared = run_tool(
+        server,
+        "citadel_share_session",
+        None,
+        "/repo",
+        data="# Compact Session Context",
+        capture_roots=["/repo"],
+    )
+
+    contribute_post = next(p for p in client.posts if p["path"] == "/api/contribute")
+    share_post = next(p for p in client.posts if p["path"] == "/api/share-session")
+    assert contribute_post["payload"]["user_approval"] == "yes, contribute it"
+    assert contributed["user_approval"]["provided"] is True
+    assert share_post["payload"]["user_approval"] is None
+    assert shared["user_approval"] == {"provided": False, "signal": None}
+    assert any("user_approval" in w for w in shared["warnings"])
+
+
+def test_promotion_decisions_lead_the_audit_note_with_the_approval_signal() -> None:
+    """The decision note is what the node writes to its audit trail, so it must
+    state the signal either way: the user's quote, or the explicit "not
+    stated" marker. An asked-first approval and a skipped-ask approval then
+    stop looking identical in the trail."""
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    run_tool(
+        server,
+        "citadel_promotion_approve",
+        "item-1",
+        None,
+        note="checked for duplicates",
+        user_approval="yes, promote it",
+    )
+    run_tool(server, "citadel_promotion_reject", "item-2", None)
+
+    approve_post = next(p for p in client.posts if p["path"].endswith("/approve"))
+    reject_post = next(p for p in client.posts if p["path"].endswith("/reject"))
+    assert approve_post["payload"]["note"] == (
+        "user approval: yes, promote it | note: checked for duplicates"
+    )
+    assert approve_post["payload"]["user_approval"] == "yes, promote it"
+    assert reject_post["payload"]["note"] == (
+        f"user approval: {mcp_server.APPROVAL_NOT_STATED}"
+    )
+    assert reject_post["payload"]["user_approval"] is None
+
+
+def test_decision_note_never_exceeds_the_server_note_bound() -> None:
+    # PromotionDecisionBody caps note at 400 chars server-side; an oversized
+    # composition would turn a valid decision into a 422, so the composed note
+    # clamps the quote first (160) and the total second (400).
+    signal = mcp_server._normalized_approval("y" * 500)
+    assert signal == "y" * mcp_server.MAX_USER_APPROVAL_CHARS
+
+    composed = mcp_server._decision_note(signal, "n" * 500)
+    assert len(composed) == mcp_server.MAX_DECISION_NOTE_CHARS
+    assert composed.startswith(f"user approval: {signal}")
+
+    assert mcp_server._normalized_approval("   ") is None
+    assert mcp_server._decision_note(None, None) == (
+        f"user approval: {mcp_server.APPROVAL_NOT_STATED}"
+    )
+
+
 def test_tools_list_protocol_handler_applies_role_filter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -62,6 +62,9 @@ class FakeHttpClient:
         self.public_gets.append({"path": path, "extra_headers": extra_headers or {}})
         return {"ok": True, "path": path, "public": True}
 
+    # Mirrors CitadelHttpClient.post exactly, user_confirmed included: a fake
+    # narrower than the real client turns a wiring change into a TypeError in
+    # unrelated tests instead of a finding.
     def post(
         self,
         path: str,
@@ -69,9 +72,16 @@ class FakeHttpClient:
         *,
         tool_name: str | None = None,
         timeout: float | None = None,
+        user_confirmed: bool | None = None,
     ) -> dict[str, Any]:
         self.posts.append(
-            {"path": path, "payload": payload, "tool_name": tool_name, "timeout": timeout}
+            {
+                "path": path,
+                "payload": payload,
+                "tool_name": tool_name,
+                "timeout": timeout,
+                "user_confirmed": user_confirmed,
+            }
         )
         return {"ok": True, "path": path, "payload": payload, "tool_name": tool_name}
 

--- a/tests/test_observable_approval_and_readiness.py
+++ b/tests/test_observable_approval_and_readiness.py
@@ -1,0 +1,541 @@
+"""A surface must report what it OBSERVED, not what it REQUESTED.
+
+Two families of the same defect live here.
+
+**The approval signal.** Five MCP tools tell the calling agent to obtain the
+user's explicit approval before writing. That instruction existed only as
+prose in a docstring: nothing carried the answer back to the node, so the
+audit trail could not tell a write the user confirmed from one the agent made
+on its own. Both produced byte-identical rows. The fix records a tri-state
+(``confirmed`` / ``not_confirmed`` / ``unknown``) the caller sets, and the
+absent case is ``unknown``, never the optimistic value.
+
+**The readiness canary.** ``/readyz`` reported a node with no canary and a
+node whose canary passed identically, because ``canary is None`` was folded
+into the ok expression and the payload carried a bare ``null``. A monitoring
+consumer could not branch on the difference.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import kb.server as server_module
+from kb.access import AccessStore
+from kb.mcp_server import TOOL_POLICIES, CitadelHttpClient
+from kb.promotion_queue import ReferenceAssessment, build_pending_item
+from kb.security_scan import SecretContentError
+from kb.server import app
+
+MCP_TOOL_HEADER = "X-Citadel-MCP-Tool"
+CONFIRM_HEADER = "X-Citadel-User-Confirmed"
+
+# The tools whose docstrings instruct the agent to get the user's approval.
+APPROVAL_REQUIRED_TOOLS = {
+    "citadel_ingest",
+    "citadel_share_session",
+    "citadel_contribute",
+    "citadel_promotion_approve",
+    "citadel_promotion_reject",
+}
+
+_APPROVAL_PROSE = re.compile(
+    r"(explicit user (approval|confirmation)"
+    r"|user for explicit approval"
+    r"|requires explicit user confirmation)",
+    re.IGNORECASE,
+)
+
+
+def _audit_events() -> list[dict[str, Any]]:
+    return app.state.access_store.snapshot()["audit_events"]
+
+
+def _last_mcp_event() -> dict[str, Any]:
+    events = [e for e in _audit_events() if str(e["action"]).startswith("mcp.")]
+    assert events, f"no mcp.* audit event was recorded: {_audit_events()}"
+    return events[-1]
+
+
+# --------------------------------------------------------------------------
+# A. The approval signal reaches the audit trail
+# --------------------------------------------------------------------------
+
+
+def test_mcp_ingest_records_an_explicit_user_confirmation(tmp_path: Path) -> None:
+    from test_server import authed_client
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    writer = authed_client("test-writer")
+
+    response = writer.post(
+        "/ingest",
+        json={"data": "Runbook: rotate the sync token before minting seats."},
+        headers={MCP_TOOL_HEADER: "citadel_ingest", CONFIRM_HEADER: "true"},
+    )
+
+    assert response.status_code == 200
+    assert _last_mcp_event()["detail"]["user_confirmation"] == "confirmed"
+
+
+def test_mcp_ingest_without_the_header_records_unknown_not_confirmed(
+    tmp_path: Path,
+) -> None:
+    """The absent case must not read as approval.
+
+    This is the whole point: an older client that never sends the field, and a
+    client whose user said yes, must not produce the same audit row.
+    """
+    from test_server import authed_client
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    writer = authed_client("test-writer")
+
+    response = writer.post(
+        "/ingest",
+        json={"data": "Runbook: rotate the sync token before minting seats."},
+        headers={MCP_TOOL_HEADER: "citadel_ingest"},
+    )
+
+    assert response.status_code == 200
+    detail = _last_mcp_event()["detail"]
+    assert detail["user_confirmation"] == "unknown"
+    assert detail["user_confirmation"] != "confirmed"
+
+
+def test_a_declined_confirmation_is_recorded_and_the_write_still_runs(
+    tmp_path: Path,
+) -> None:
+    """Recorded, not enforced.
+
+    The signal is asserted by the calling agent, so the node cannot verify it.
+    Rejecting on it would teach every client to hardcode ``true`` and destroy
+    the observability the field exists to provide, and would 422 every client
+    built before the field existed. So the row says ``not_confirmed`` and the
+    write proceeds, and the trail can answer the question later.
+    """
+    from test_server import authed_client
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    writer = authed_client("test-writer")
+
+    response = writer.post(
+        "/ingest",
+        json={"data": "Runbook: rotate the sync token before minting seats."},
+        headers={MCP_TOOL_HEADER: "citadel_ingest", CONFIRM_HEADER: "false"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["accepted"] is True
+    assert _last_mcp_event()["detail"]["user_confirmation"] == "not_confirmed"
+
+
+def test_a_read_only_tool_does_not_claim_a_confirmation(tmp_path: Path) -> None:
+    """Only tools that ask for approval carry the field.
+
+    A search has nothing to confirm, so a ``user_confirmation`` on its row
+    would be a claim about a question nobody asked.
+    """
+    from test_server import authed_client
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    reader = authed_client("test-reader")
+
+    response = reader.post(
+        "/search",
+        json={"query": "runbook"},
+        headers={MCP_TOOL_HEADER: "citadel_search", CONFIRM_HEADER: "true"},
+    )
+
+    assert response.status_code == 200
+    assert "user_confirmation" not in _last_mcp_event()["detail"]
+
+
+def test_every_approval_instructing_tool_declares_the_signal() -> None:
+    """The docstring and the policy cannot drift apart.
+
+    The defect was a tool that *tells* the model to get approval while nothing
+    downstream records the answer. Parsing the source keeps that from coming
+    back through a newly added tool: prose demanding approval without
+    ``requires_user_approval=True`` fails here.
+    """
+    source = Path(server_module.__file__).with_name("mcp_server.py").read_text()
+    tree = ast.parse(source)
+
+    instructing: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        doc = ast.get_docstring(node) or ""
+        if not _APPROVAL_PROSE.search(doc):
+            continue
+        for decorator in node.decorator_list:
+            for sub in ast.walk(decorator):
+                if (
+                    isinstance(sub, ast.Subscript)
+                    and isinstance(sub.value, ast.Name)
+                    and sub.value.id == "TOOL_POLICIES"
+                    and isinstance(sub.slice, ast.Constant)
+                ):
+                    instructing.add(str(sub.slice.value))
+
+    assert instructing == APPROVAL_REQUIRED_TOOLS, (
+        "tools whose docstring instructs user approval changed; update "
+        "APPROVAL_REQUIRED_TOOLS and the policy table together"
+    )
+    declared = {
+        name for name, policy in TOOL_POLICIES.items() if policy.requires_user_approval
+    }
+    assert declared == APPROVAL_REQUIRED_TOOLS
+
+
+def test_the_mcp_client_puts_the_confirmation_on_the_wire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A signal the tool accepts but never transmits is the same defect again."""
+    seen: list[dict[str, str]] = []
+
+    class _Response:
+        def read(self) -> bytes:
+            return b"{}"
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    def fake_urlopen(request: Any, timeout: float | None = None) -> _Response:
+        seen.append(dict(request.headers))
+        return _Response()
+
+    monkeypatch.setattr("kb.mcp_server.urlopen", fake_urlopen)
+    client = CitadelHttpClient(base_url="https://node.example", access_token="t")
+
+    client.post("/ingest", {"data": "x"}, tool_name="citadel_ingest", user_confirmed=True)
+    client.post("/ingest", {"data": "x"}, tool_name="citadel_ingest", user_confirmed=False)
+    client.post("/ingest", {"data": "x"}, tool_name="citadel_ingest")
+
+    # urllib title-cases header names.
+    assert seen[0]["X-citadel-user-confirmed"] == "true"
+    assert seen[1]["X-citadel-user-confirmed"] == "false"
+    assert "X-citadel-user-confirmed" not in seen[2]
+
+
+@pytest.mark.asyncio
+async def test_promotion_approve_records_the_confirmation_in_its_audit_detail(
+    tmp_path: Path,
+) -> None:
+    """The Central-bound decision is the one that most needs the answer."""
+    from test_promotion import CENTRAL, SEAT, FakeCitadel, FakeLearning, _config
+
+    from kb.access import AccessIdentity
+    from kb.promotion import PromotionEngine
+
+    store = AccessStore(tmp_path / "access.json")
+    config = _config(promotion_enabled=True)
+    learning = FakeLearning()
+    engine = PromotionEngine(FakeCitadel(config, []), learning, store, config)
+
+    item = build_pending_item(
+        seat_slug="alice",
+        seat_dataset=SEAT,
+        candidate_text="Central-worthy note about the release process.",
+        assessment=ReferenceAssessment(status="new_org_project", reason="new"),
+        created_at="2026-08-04T00:00:00+00:00",
+    )
+    store.add_promotion_pending(item)
+    actor = AccessIdentity(
+        role="admin",
+        actor_id="admin",
+        actor_kind="user",
+        actor_name="Admin",
+        source="token",
+        default_dataset=CENTRAL,
+        seat_slug=None,
+    )
+
+    await engine.approve_pending(item.id, actor, user_confirmation="confirmed")
+
+    approvals = [
+        e for e in store.snapshot()["audit_events"] if e["action"] == "promotion.approve"
+    ]
+    assert approvals and approvals[-1]["detail"]["user_confirmation"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_promotion_reject_defaults_to_unknown_not_confirmed(
+    tmp_path: Path,
+) -> None:
+    from test_promotion import CENTRAL, SEAT, FakeCitadel, FakeLearning, _config
+
+    from kb.access import AccessIdentity
+    from kb.promotion import PromotionEngine
+
+    store = AccessStore(tmp_path / "access.json")
+    config = _config(promotion_enabled=True)
+    engine = PromotionEngine(FakeCitadel(config, []), FakeLearning(), store, config)
+
+    item = build_pending_item(
+        seat_slug="alice",
+        seat_dataset=SEAT,
+        candidate_text="A candidate a reviewer will decline.",
+        assessment=ReferenceAssessment(status="new_org_project", reason="new"),
+        created_at="2026-08-04T00:00:00+00:00",
+    )
+    store.add_promotion_pending(item)
+    actor = AccessIdentity(
+        role="admin",
+        actor_id="admin",
+        actor_kind="user",
+        actor_name="Admin",
+        source="token",
+        default_dataset=CENTRAL,
+        seat_slug=None,
+    )
+
+    await engine.reject_pending(item.id, actor)
+
+    rejects = [
+        e for e in store.snapshot()["audit_events"] if e["action"] == "promotion.reject"
+    ]
+    assert rejects and rejects[-1]["detail"]["user_confirmation"] == "unknown"
+
+
+def test_the_approve_endpoint_forwards_the_header_to_the_engine(
+    tmp_path: Path,
+) -> None:
+    """The header has to survive the HTTP hop, not just exist at both ends."""
+    from test_server import authed_client
+
+    store = AccessStore(tmp_path / "access.json")
+    app.state.access_store = store
+    client = authed_client()
+
+    item = build_pending_item(
+        seat_slug="alice",
+        seat_dataset="seat:alice",
+        candidate_text="Central-worthy note about the release process.",
+        assessment=ReferenceAssessment(status="new_org_project", reason="new"),
+        created_at="2026-08-04T00:00:00+00:00",
+    )
+    store.add_promotion_pending(item)
+
+    captured: dict[str, Any] = {}
+
+    class _Engine:
+        async def approve_pending(
+            self, item_id: str, actor: Any, *, delegate: bool = False, **kwargs: Any
+        ) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"ok": True, "promoted": True}
+
+    server_module.app.dependency_overrides = {}
+    original = server_module.get_promotion_engine
+    server_module.get_promotion_engine = lambda: _Engine()  # type: ignore[assignment]
+    try:
+        response = client.post(
+            f"/api/promotion/pending/{item.id}/approve",
+            json={},
+            headers={
+                MCP_TOOL_HEADER: "citadel_promotion_approve",
+                CONFIRM_HEADER: "true",
+            },
+        )
+    finally:
+        server_module.get_promotion_engine = original  # type: ignore[assignment]
+
+    assert response.status_code == 200
+    assert captured.get("user_confirmation") == "confirmed"
+
+
+# --------------------------------------------------------------------------
+# B. /readyz tells "never ran" from "passed" from "failed"
+# --------------------------------------------------------------------------
+
+
+def _populated_client() -> TestClient:
+    from test_server import FakeCitadel, authed_client
+
+    class PopulatedCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            return {"nodes": 280, "edges": 514}
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    client = authed_client("test-reader")
+    app.state.citadel = PopulatedCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+    return client
+
+
+def test_readyz_says_never_ran_when_no_canary_has_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    client = _populated_client()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 200
+    canary = ready.json()["canary"]
+    assert canary["state"] == "never_ran"
+    # None, not True: nothing observed a pass.
+    assert canary["ok"] is None
+    # The scheduler is off by default, which is *why* nothing ran.
+    assert canary["scheduler_enabled"] is False
+
+
+def test_readyz_never_ran_and_passed_are_not_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect in one assertion.
+
+    Before the fix both nodes answered ``"canary": null`` with ``ok: true``.
+    """
+    client = _populated_client()
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    never_ran = client.get("/readyz").json()["canary"]
+
+    monkeypatch.setattr(
+        server_module,
+        "_LAST_CANARY",
+        {"ok": True, "search_hit": True, "graph_grew": True, "marker": "m"},
+    )
+    passed = client.get("/readyz").json()["canary"]
+
+    assert never_ran != passed
+    assert never_ran["state"] == "never_ran"
+    assert passed["state"] == "passed"
+    assert passed["ok"] is True
+
+
+def test_readyz_is_red_when_the_canary_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        server_module,
+        "_LAST_CANARY",
+        {"ok": False, "search_hit": False, "graph_grew": False, "marker": "m"},
+    )
+    client = _populated_client()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+    assert ready.json()["canary"]["state"] == "failed"
+
+
+def test_readyz_does_not_assume_a_pass_when_the_verdict_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded canary with no verdict has not observed a pass."""
+    monkeypatch.setattr(server_module, "_LAST_CANARY", {"marker": "m"})
+    client = _populated_client()
+
+    ready = client.get("/readyz")
+
+    assert ready.json()["canary"]["state"] == "failed"
+    assert ready.status_code == 503
+
+
+def test_check_corpus_reports_the_canary_state_to_the_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`citadel status` carried the same optimistic default as /readyz."""
+    import kb.status as status_module
+
+    payload = {
+        "ok": True,
+        "corpus": {"ok": True, "tracked_sources": 50, "indexed_docs": 280},
+        "canary": {"state": "never_ran", "ok": None, "scheduler_enabled": False},
+    }
+    monkeypatch.setattr(status_module, "_request", lambda *a, **k: payload)
+
+    check = status_module.check_corpus("https://node.example", "token")
+
+    assert check is not None
+    # Never-ran is not a failure, but it is not a pass either. Say which.
+    assert check.ok is True
+    assert "never ran" in check.detail
+    assert check.data["canary"]["state"] == "never_ran"
+
+
+def test_check_corpus_is_red_when_the_canary_state_is_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kb.status as status_module
+
+    payload = {
+        "ok": False,
+        "corpus": {"ok": True, "tracked_sources": 50, "indexed_docs": 280},
+        "canary": {"state": "failed", "ok": False, "scheduler_enabled": True},
+    }
+    monkeypatch.setattr(status_module, "_request", lambda *a, **k: payload)
+
+    check = status_module.check_corpus("https://node.example", "token")
+
+    assert check is not None
+    assert check.ok is False
+
+
+# --------------------------------------------------------------------------
+# C. /api/promote/run's secret block reaches the MCP audit with its reason
+# --------------------------------------------------------------------------
+
+
+def test_promote_run_secret_block_records_the_reason_in_the_mcp_audit(
+    tmp_path: Path,
+) -> None:
+    """Parity with /ingest.
+
+    The generic middleware backstop already wrote an ``mcp.*`` row for this
+    request, but it carried only ``status_code: 422``, so the row could not say
+    the write was stopped by the secret gate, or how severe the finding was.
+    /ingest records both facts on the same failure.
+    """
+    from test_server import authed_client
+
+    store = AccessStore(tmp_path / "access.json")
+    app.state.access_store = store
+    client = authed_client()
+
+    class _Engine:
+        async def run(self, dataset: str, **kwargs: Any) -> dict[str, Any]:
+            raise SecretContentError(
+                dataset=dataset,
+                highest_severity="critical",
+                block_severity="high",
+                findings=[{"rule_id": "aws-access-key", "severity": "critical"}],
+            )
+
+    original = server_module.get_promotion_engine
+    server_module.get_promotion_engine = lambda: _Engine()  # type: ignore[assignment]
+    try:
+        response = client.post(
+            "/api/promote/run",
+            json={"dataset": "seat:alice", "dry_run": True},
+            headers={MCP_TOOL_HEADER: "citadel_ingest"},
+        )
+    finally:
+        server_module.get_promotion_engine = original  # type: ignore[assignment]
+
+    assert response.status_code == 422
+    mcp_rows = [e for e in store.snapshot()["audit_events"] if str(e["action"]).startswith("mcp.")]
+    assert mcp_rows, "the MCP surface recorded nothing for a blocked promotion run"
+    detail = mcp_rows[-1]["detail"]
+    assert detail["blocked"] == "secret_content"
+    assert detail["highest_severity"] == "critical"
+    assert mcp_rows[-1]["success"] is False

--- a/tests/test_observable_approval_and_readiness.py
+++ b/tests/test_observable_approval_and_readiness.py
@@ -228,6 +228,41 @@ def test_the_mcp_client_puts_the_confirmation_on_the_wire(
     assert "X-citadel-user-confirmed" not in seen[2]
 
 
+@pytest.mark.parametrize(
+    ("tool", "args", "kwargs"),
+    [
+        ("citadel_ingest", ("a durable note", None), {}),
+        ("citadel_contribute", ("A title", "Some content", None), {}),
+        ("citadel_promotion_approve", ("promo_1", None), {}),
+        ("citadel_promotion_reject", ("promo_1", None), {}),
+        (
+            "citadel_share_session",
+            (None, "/repo"),
+            {"data": "# Compact Session Context", "capture_roots": ["/repo"]},
+        ),
+    ],
+)
+def test_each_tool_hands_its_confirmation_to_the_client(
+    tool: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> None:
+    """The connective tissue between "the tool accepts it" and "the wire carries it".
+
+    A tool that takes ``user_confirmed`` and drops it on the floor satisfies
+    both of the tests either side of this one.
+    """
+    from test_mcp_server import FakeHttpClient, run_tool
+
+    from kb.mcp_server import create_mcp_server
+
+    http = FakeHttpClient()
+    server = create_mcp_server(http)
+
+    run_tool(server, tool, *args, user_confirmed=True, **kwargs)
+
+    assert http.posts, f"{tool} made no POST"
+    assert http.posts[-1]["user_confirmed"] is True
+
+
 @pytest.mark.asyncio
 async def test_promotion_approve_records_the_confirmation_in_its_audit_detail(
     tmp_path: Path,

--- a/tests/test_observable_ingest_outcome.py
+++ b/tests/test_observable_ingest_outcome.py
@@ -1,0 +1,172 @@
+"""Ingest surfaces report what they OBSERVED, not what they REQUESTED.
+
+`remember()` returns before the graph write in every branch (suppressed /
+deferred / scheduled), so for years `accepted` doubled as "indexed" on every
+connector surface while 892 of 2867 documents sat at chunk_count 0 — accepted
+and never cognified — and a working node and a silently broken one emitted
+byte-identical output. These tests pin the two halves of the fix:
+
+1. remember() states the indexing outcome explicitly (`indexed: False` plus a
+   request disposition), and `ingest_indexing_state` maps any outcome payload
+   to a disposition with an explicit "unknown" fallback — never an implied
+   success.
+2. The detached background cognify stamps its OBSERVED outcome into a
+   module-level ledger (`background_cognify_stats`), so scheduled-but-never-
+   completed runs become visible instead of leaving no trace.
+
+The modules are imported as modules (not names) on purpose: reverting the
+source must FAIL these tests, not error collection.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import kb.cognee_client as cc
+
+
+def _fresh_stats() -> dict[str, Any]:
+    return {
+        "runs_scheduled": 0,
+        "runs_completed": 0,
+        "runs_failed": 0,
+        "runs_not_scheduled": 0,
+        "last_scheduled_at": None,
+        "last_completed_at": None,
+        "last_failed_at": None,
+        "last_error": None,
+    }
+
+
+def _install_fake_cognee(monkeypatch: Any, *, cognify: Any = None) -> None:
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def add(data: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def default_cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            run_startup_migrations=run_startup_migrations,
+            add=add,
+            cognify=cognify or default_cognify,
+        ),
+    )
+
+
+def test_ingest_indexing_state_never_defaults_to_success() -> None:
+    # The three request dispositions pass through verbatim.
+    assert cc.ingest_indexing_state({"cognify": "scheduled"}) == "scheduled"
+    assert cc.ingest_indexing_state({"cognify": "deferred"}) == "deferred"
+    assert cc.ingest_indexing_state({"cognify": "suppressed"}) == "suppressed"
+    # Legacy scheduled-branch payloads carried only the background_cognify flag.
+    assert cc.ingest_indexing_state({"background_cognify": True}) == "scheduled"
+    # No observation → the explicit unknown state, never an optimistic value.
+    assert cc.ingest_indexing_state(None) == "unknown"
+    assert cc.ingest_indexing_state({}) == "unknown"
+    assert cc.ingest_indexing_state({"added": {"ok": True}}) == "unknown"
+    assert cc.ingest_indexing_state("accepted") == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_remember_deferred_states_indexing_outcome_explicitly(
+    monkeypatch: Any,
+) -> None:
+    # defer_cognify=True is add-only; the caller cognifies later. The return
+    # must say the graph write has NOT happened rather than leaving the caller
+    # to read the add as indexed.
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    _install_fake_cognee(monkeypatch)
+    client = cc.CogneePublicClient()
+
+    result = await client.remember(
+        "note", dataset_name="seat:sarthi", tags=(), defer_cognify=True
+    )
+
+    assert result == {
+        "added": {"ok": True},
+        "cognify": "deferred",
+        "indexed": False,
+        "status": "indexing_deferred",
+    }
+
+
+@pytest.mark.asyncio
+async def test_background_cognify_completion_is_observed(monkeypatch: Any) -> None:
+    # A scheduled cognify stamps `scheduled`; only the task body itself can
+    # stamp `completed`. On a working node the two counters track each other.
+    import asyncio
+
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    _install_fake_cognee(monkeypatch)
+    monkeypatch.setattr(cc, "_BACKGROUND_COGNIFY_STATS", _fresh_stats())
+    client = cc.CogneePublicClient()
+
+    result = await client.remember("note", dataset_name="seat:sarthi", tags=())
+    assert result["indexed"] is False
+    assert result["status"] == "indexing_scheduled"
+
+    stats = cc.background_cognify_stats()
+    assert stats["runs_scheduled"] == 1
+    # Nothing has completed yet: the request and the outcome are not the same
+    # number, which is the entire point of the ledger.
+    assert stats["runs_completed"] == 0
+
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    stats = cc.background_cognify_stats()
+    assert stats["runs_completed"] == 1
+    assert stats["runs_failed"] == 0
+    assert stats["last_completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_background_cognify_failure_is_observed(monkeypatch: Any) -> None:
+    # A cognify that dies must leave a failed stamp, not silence: previously a
+    # dead task and a completed one looked identical to every reader.
+    import asyncio
+
+    monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+
+    async def broken_cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        raise RuntimeError("kuzu lock held")
+
+    _install_fake_cognee(monkeypatch, cognify=broken_cognify)
+    monkeypatch.setattr(cc, "_BACKGROUND_COGNIFY_STATS", _fresh_stats())
+    client = cc.CogneePublicClient()
+
+    await client.remember("note", dataset_name="seat:sarthi", tags=())
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+
+    stats = cc.background_cognify_stats()
+    assert stats["runs_scheduled"] == 1
+    assert stats["runs_completed"] == 0
+    assert stats["runs_failed"] == 1
+    assert stats["last_error"] == "RuntimeError"
+    assert stats["last_failed_at"] is not None
+
+
+def test_schedule_cognify_without_loop_is_observed(monkeypatch: Any) -> None:
+    # The no-running-loop branch stores data that will never be searchable in
+    # this process. That used to be one error log; now it is a counted state.
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setattr(cc, "_BACKGROUND_COGNIFY_STATS", _fresh_stats())
+    client = cc.CogneePublicClient()
+
+    client.schedule_cognify(["seat:sarthi"])  # sync context: no running loop
+
+    stats = cc.background_cognify_stats()
+    assert stats["runs_scheduled"] == 0
+    assert stats["runs_not_scheduled"] == 1
+    assert stats["last_error"] == "no_running_event_loop"

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -732,3 +732,49 @@ async def test_approve_pending_surfaces_the_write_reason(
     assert result["write_reason"] == "duplicate_in_process"
     # The item is consumed regardless, matching the contract on main.
     assert store.get_promotion_pending(item.id).status != "pending"
+
+
+async def test_decision_audit_states_the_user_approval_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """promotion.approve / promotion.reject events must state what the engine
+    was handed about user approval: the caller's signal, or the explicit
+    not_recorded marker. Never silence, because an absent field reads the same
+    as an event from before the field existed."""
+    summary_a = (
+        "# Capture summary: side project\n"
+        "- Remote: `https://github.com/other-org/new-app.git`\n"
+        "- Capture Root Tags: org-work\n"
+    )
+    summary_b = (
+        "# Capture summary: second project\n"
+        "- Remote: `https://github.com/other-org/second-app.git`\n"
+        "- Capture Root Tags: org-work\n"
+    )
+    engine, _learning, store = _engine(
+        tmp_path,
+        [summary_a, summary_b],
+        _github_state(tmp_path),
+    )
+    _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.95)
+
+    queued = await engine.run(SEAT, dry_run=False)
+    assert queued["queued"] == 2
+    items = store.list_promotion_pending(seat_slug="alice")
+    actor = AccessIdentity(
+        role="admin",
+        actor_id="root",
+        actor_kind="user",
+        actor_name="Root",
+        source="token",
+        default_dataset=CENTRAL,
+        seat_slug=None,
+    )
+
+    await engine.approve_pending(items[0].id, actor, user_approval="yes, promote it")
+    await engine.reject_pending(items[1].id, actor)
+
+    approve_event = store.recent_audit_events(action="promotion.approve")[0]
+    reject_event = store.recent_audit_events(action="promotion.reject")[0]
+    assert approve_event["detail"]["user_approval"] == "yes, promote it"
+    assert reject_event["detail"]["user_approval"] == promotion.USER_APPROVAL_NOT_RECORDED

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -252,6 +252,12 @@ async def test_repo_content_syncer_ingests_changed_files(tmp_path: Path) -> None
 
     first = await syncer.run()
     assert first["files_ingested"] == 2
+    # The run reports what it OBSERVED about those adds, next to the request
+    # counter: cognee returned data ids for both (confirmed), and the graph
+    # write is only a scheduled request, never claimed as done.
+    assert first["files_add_confirmed"] == 2
+    assert first["files_add_unconfirmed"] == 0
+    assert first["indexing"] == ["scheduled"]
     assert len(learning.calls) == 2
     assert learning.calls[0]["tags"] == [
         "github",

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -99,14 +99,23 @@ def test_infer_doc_type_and_trust() -> None:
         "url": "https://github.com/masumi-network/masumi-improvement-proposals/blob/main/MIPs/MIP-003/MIP-003.md",
     }
     assert infer_doc_type(spec) == "spec"
-    # Shaped like a spec, but the vault stores no provenance for it, so it may
-    # not claim authority — only that it looks like one.
-    assert infer_trust_tier(spec) == "unattested"
+    # Shaped like a spec, but carrying no server envelope: no attested
+    # provenance was ever consulted, and the tier says exactly that instead of
+    # implying a check happened ("unattested" is reserved for consulted-and-
+    # nothing-attested).
+    assert infer_trust_tier(spec) == "unknown"
     assert infer_content_hint(spec) == "looks-like-spec"
+    # With an envelope the channel WAS consulted; a non-trace dataset attests
+    # nothing, which is what "unattested" states.
+    assert infer_trust_tier({**spec, "_citadel": {"dataset": "masumi-network"}}) == "unattested"
 
     activity = {"text": "GitHub org daily digest for masumi-network"}
     assert infer_doc_type(activity) == "activity"
-    assert infer_trust_tier(activity) == "unattested"
+    assert infer_trust_tier(activity) == "unknown"
+    assert (
+        infer_trust_tier({**activity, "_citadel": {"dataset": "masumi-network"}})
+        == "unattested"
+    )
 
     trace = {"_citadel": {"dataset": "session-traces", "trust": "reference-only"}}
     assert infer_doc_type(trace) == "session-trace"
@@ -128,8 +137,57 @@ def test_body_text_cannot_mint_a_trust_claim() -> None:
         {"title": "guess", "text": "the openapi file probably allows it"},
     ]
     for item in forgeries:
-        assert infer_trust_tier(item) == "unattested", item
-        assert normalize_search_hit(item)["trust_tier"] == "unattested", item
+        # Without an envelope nothing was consulted — and the body still buys
+        # nothing: the tier is "unknown", never "reference-only".
+        assert infer_trust_tier(item) == "unknown", item
+        assert normalize_search_hit(item)["trust_tier"] == "unknown", item
+        # With an envelope the channel was consulted and attests nothing.
+        enveloped = {**item, "_citadel": {"dataset": "masumi-network"}}
+        assert infer_trust_tier(enveloped) == "unattested", item
+        assert normalize_search_hit(enveloped)["trust_tier"] == "unattested", item
+
+
+def test_envelope_less_trace_hit_is_distinguishable_from_unattested() -> None:
+    """The in-process --local search stack attaches no ``_citadel`` envelope.
+
+    A genuine session-trace hit read without an envelope used to normalize to
+    trust_tier "unattested" — byte-identical to an honestly unattested HTTP
+    hit — so a reader could not tell "checked, nothing attested" from "nothing
+    could be checked". The two states must not share a value.
+    """
+    trace_text = "# Dead-end route\n\nNested HTTP to /api/session deadlocked tools/list"
+    local_hit = normalize_search_hit({"id": "t1", "text": trace_text})
+    http_unattested = normalize_search_hit(
+        {"id": "t2", "text": "a plain central note", "_citadel": {"dataset": "masumi-network"}}
+    )
+    http_trace = normalize_search_hit(
+        {
+            "id": "t3",
+            "text": trace_text,
+            "_citadel": {"dataset": "session-traces", "trust": "reference-only"},
+        }
+    )
+    assert http_trace["trust_tier"] == "reference-only"
+    assert http_unattested["trust_tier"] == "unattested"
+    # The envelope-less hit states that no attestation channel existed…
+    assert local_hit["trust_tier"] == "unknown"
+    # …so it is no longer byte-identical to the honestly unattested one.
+    assert local_hit["trust_tier"] != http_unattested["trust_tier"]
+
+
+def test_shape_search_payload_warns_when_tiers_unknown() -> None:
+    """The page-level warning names how many tiers could not be derived."""
+    shaped = shape_search_payload(
+        {"results": [{"id": "1", "text": "local cognee payload"}]}, query="payload"
+    )
+    assert shaped["results"][0]["trust_tier"] == "unknown"
+    assert any("trust_tier is 'unknown'" in w for w in shaped["warnings"])
+
+    enveloped = shape_search_payload(
+        {"results": [{"id": "1", "text": "note text", "_citadel": {"dataset": "d"}}]},
+        query="note",
+    )
+    assert all("trust_tier is 'unknown'" not in w for w in enveloped["warnings"])
 
 
 def test_digest_cannot_relabel_itself_as_documentation() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2526,6 +2526,59 @@ def test_readyz_ok_when_graph_populated() -> None:
     assert ready.json()["corpus"]["ok"] is True
 
 
+def test_readyz_reports_canary_never_ran_as_distinct_state() -> None:
+    # A node that never ran the end-to-end canary and one that passed it used
+    # to answer with the same ok bit: _LAST_CANARY is written only by the
+    # evolve scheduler, which is off by default. "never_ran" is now an
+    # explicit, branchable state. It is reported, NOT failed — 503ing every
+    # default-config node would evict healthy nodes from rotation, which is
+    # worse than the gap.
+    import kb.server as server_module
+
+    class PopulatedCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            return {"nodes": 280, "edges": 514}
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    client = authed_client("test-reader")
+    app.state.citadel = PopulatedCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+
+    original = server_module._LAST_CANARY
+    try:
+        server_module._LAST_CANARY = None
+        ready = client.get("/readyz")
+        assert ready.status_code == 200
+        body = ready.json()
+        assert body["ok"] is True
+        assert body["canary"] is None
+        assert body["canary_state"] == "never_ran"
+        # The observed background-cognify ledger rides along, so a node whose
+        # scheduled graph writes never complete is visible on the wire.
+        assert "background_cognify" in body
+        assert "runs_scheduled" in body["background_cognify"]
+        assert "runs_completed" in body["background_cognify"]
+
+        server_module._LAST_CANARY = {"ok": True, "search_hit": True}
+        body = client.get("/readyz").json()
+        assert body["ok"] is True
+        assert body["canary_state"] == "passed"
+
+        server_module._LAST_CANARY = {"ok": False, "search_hit": False}
+        ready = client.get("/readyz")
+        assert ready.status_code == 503
+        body = ready.json()
+        assert body["ok"] is False
+        assert body["canary_state"] == "failed"
+    finally:
+        server_module._LAST_CANARY = original
+
+
 def test_search_across_datasets_runs_concurrently() -> None:
     # #50: per-dataset recalls run concurrently, not serially.
     import asyncio as aio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,7 +22,7 @@ from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
 from kb.knowledge_mesh import KnowledgeMesh
 from kb.mesh import MeshState
-from kb.models import FeedbackResult, IngestResult
+from kb.models import INDEX_STATE_PENDING, FeedbackResult, IngestResult
 from kb.obsidian_sync import ObsidianSyncStore
 from kb.server import app
 
@@ -39,7 +39,17 @@ class FakeCitadel:
     )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
-        return IngestResult(True, "accepted", kwargs["dataset"] or "notes", tuple(kwargs["tags"]))
+        # What the real Citadel.ingest returns for an ordinary write: stored,
+        # with the graph write still owed. A fake that left index_state at the
+        # default would let every /ingest response look unobservable rather
+        # than merely not-yet-observed.
+        return IngestResult(
+            True,
+            "accepted",
+            kwargs["dataset"] or "notes",
+            tuple(kwargs["tags"]),
+            index_state=INDEX_STATE_PENDING,
+        )
 
     async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
         return [{"query": query, "dataset": kwargs["dataset"], "top_k": kwargs["top_k"]}]
@@ -1153,10 +1163,17 @@ def test_ingest_inline_cognify_flag() -> None:
     plain = client.post("/ingest", json={"data": "note one", "tags": []})
     assert plain.status_code == 200
     assert "cognified" not in plain.json()
+    # Without an inline cognify nothing has watched the graph write, so the
+    # write may not be reported as indexed — `accepted` covers the request only.
+    assert plain.json()["accepted"] is True
+    assert plain.json()["indexed"] is not True
     # cognify=True → the Node cognifies inline (server-side) and reports it.
     with_cognify = client.post("/ingest", json={"data": "note two", "tags": [], "cognify": True})
     assert with_cognify.status_code == 200
     assert with_cognify.json()["cognified"] is True
+    # And only THAT run may claim the note is indexed, because it observed it.
+    assert with_cognify.json()["index_state"] == "indexed"
+    assert with_cognify.json()["indexed"] is True
 
 
 def test_ingest_and_contribute_reject_oversized_payloads(monkeypatch: Any) -> None:

--- a/tests/test_sync_push.py
+++ b/tests/test_sync_push.py
@@ -412,3 +412,111 @@ def test_unreachable_node_still_exits_zero(monkeypatch: Any, tmp_path: Path) -> 
     receipt = _receipt_text()
     assert "not captured" in receipt
     assert "captured commit" not in receipt
+
+
+# --- a receipt reports what the server said, not what we hoped it said -------
+
+
+def test_receipt_treats_a_missing_accepted_key_as_unconfirmed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A 2xx body that never states a verdict is not a capture.
+
+    ``accepted`` describes the server's decision. Reading "not False" made an
+    ABSENT key report success, so a proxy, an older Node, or any response shape
+    change would have printed "captured" for a write nobody confirmed.
+    """
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"reason": "stored"}).encode())
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "unconfirmed" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_receipt_summary_is_unconfirmed_for_a_non_boolean_accepted() -> None:
+    summary = sync_push.receipt_summary({"accepted": "yes"}, short_sha="abc1234", branch="main")
+    assert "unconfirmed" in summary
+    assert "captured commit" not in summary
+
+
+# --- an early exit is still a run, and must leave a trace --------------------
+
+
+def _receipt_kinds() -> list[str]:
+    """The ``kind`` column of every receipt line."""
+    return [line.split()[1] for line in _receipt_text().splitlines() if line.split()]
+
+
+def test_receipt_records_a_run_with_no_token(monkeypatch: Any, tmp_path: Path) -> None:
+    """"Nothing to send" and "the token env var got unset" must not look alike."""
+    monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "CITADEL_MCP_ACCESS_TOKEN" in receipt
+    assert _receipt_kinds() == ["push-skip"]
+
+
+def test_receipt_records_an_empty_capture_allowlist(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(tmp_path / "absent.json"))
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/some-repo")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    assert "Approved Capture Roots" in _receipt_text()
+    assert _receipt_kinds() == ["push-skip"]
+
+
+def test_receipt_records_a_repo_outside_the_allowlist(monkeypatch: Any, tmp_path: Path) -> None:
+    config = tmp_path / "capture.json"
+    _write_capture_config(config, [{"path": "/some/approved", "tags": []}])
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(config))
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/other-repo")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "not an Approved Capture Root" in receipt
+    assert "other-repo" in receipt
+    assert _receipt_kinds() == ["push-skip"]
+
+
+def test_receipt_records_a_crash_and_the_hook_still_exits_zero(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The outer ``except Exception: return 0`` used to erase the whole event."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+
+    def boom() -> None:
+        raise ValueError("capture.json is a directory with sensitive detail")
+
+    monkeypatch.setattr(sync_push, "load_capture_roots", boom)
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/some-repo")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "ValueError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "captured commit" not in receipt
+    assert _receipt_kinds() == ["push-error"]
+
+
+def test_receipt_records_a_head_that_cannot_be_resolved(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Manual invocation with no pre-push stdin and no resolvable HEAD."""
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+
+    class _Failed:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(sync_push, "_git_run", lambda cwd, *args: _Failed())
+    assert sync_push.run(io.StringIO(""), remote_name="origin") == 0
+    assert _receipt_kinds() == ["push-skip"]
+    assert "captured commit" not in _receipt_text()
+
+
+def test_a_real_capture_keeps_the_plain_push_kind(monkeypatch: Any, tmp_path: Path) -> None:
+    """Skips are a distinct kind; an actual capture must not be relabelled."""
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"accepted": True}).encode())
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    assert _receipt_kinds() == ["push"]

--- a/tests/test_sync_push.py
+++ b/tests/test_sync_push.py
@@ -412,3 +412,91 @@ def test_unreachable_node_still_exits_zero(monkeypatch: Any, tmp_path: Path) -> 
     receipt = _receipt_text()
     assert "not captured" in receipt
     assert "captured commit" not in receipt
+
+
+def test_receipt_when_server_states_no_decision(monkeypatch: Any, tmp_path: Path) -> None:
+    """A 2xx body that OMITS `accepted` states no decision — never "captured".
+
+    The receipt used to read `accepted is not False`, so a response missing the
+    key reported capture from nothing the server ever said.
+    """
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"ok": True}).encode())
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "storage not confirmed" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_receipt_when_accepted_is_not_a_boolean(monkeypatch: Any, tmp_path: Path) -> None:
+    _approve_repo_for_real_sync(monkeypatch, tmp_path)
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"accepted": "yes"}).encode())
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "storage not confirmed" in receipt
+    assert "captured commit" not in receipt
+
+
+# --- every exit path leaves a distinguishable receipt ------------------------
+
+
+def test_missing_token_leaves_receipt(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(tmp_path / "capture.json"))
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "push skipped" in receipt
+    assert "CITADEL_MCP_ACCESS_TOKEN" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_missing_vs_malformed_config_leave_distinct_receipts(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """"Never onboarded" and "the config broke" are different silences."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/repo")
+    config = tmp_path / "capture.json"
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(config))
+
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0  # missing
+    config.write_text("{ not json")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0  # malformed
+
+    receipt = _receipt_text()
+    assert "capture.json missing" in receipt
+    assert "unreadable or malformed" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_unapproved_repo_leaves_receipt(monkeypatch: Any, tmp_path: Path) -> None:
+    config = tmp_path / "capture.json"
+    _write_capture_config(config, [{"path": "/some/approved", "tags": []}])
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(config))
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/other-repo")
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "not an Approved Capture Root" in receipt
+    assert "nothing sent" in receipt
+    assert "captured commit" not in receipt
+
+
+def test_crash_inside_run_leaves_receipt(monkeypatch: Any, tmp_path: Path) -> None:
+    """The outer except used to swallow the crash with no trace at all."""
+    config = tmp_path / "capture.json"
+    _write_capture_config(config, [{"path": "/tmp/repo", "tags": []}])
+    monkeypatch.setenv("CITADEL_CAPTURE_CONFIG_PATH", str(config))
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_push, "git_toplevel", lambda cwd="": "/tmp/repo")
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("crash with sensitive detail")
+
+    monkeypatch.setattr(sync_push, "_sync_one", boom)
+    assert sync_push.run(io.StringIO(_PUSH_STDIN), remote_name="origin") == 0
+    receipt = _receipt_text()
+    assert "push hook crashed" in receipt
+    assert "RuntimeError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "captured commit" not in receipt

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -395,3 +395,81 @@ def test_empty_session_is_not_sent(monkeypatch: Any, tmp_path: Path) -> None:
     receipt = _receipt_text()
     assert "skipped" in receipt
     assert "captured" not in receipt
+
+
+# --- a receipt reports what the server said, not what we hoped it said -------
+
+
+def test_receipt_treats_a_missing_accepted_key_as_unconfirmed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A 2xx body that never states a verdict is not a capture."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"reason": "stored"}).encode())
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "unconfirmed" in receipt
+    assert "session captured" not in receipt
+
+
+def test_receipt_summary_is_unconfirmed_for_a_non_boolean_accepted() -> None:
+    summary = sync_session.receipt_summary({"accepted": "yes"})
+    assert "unconfirmed" in summary
+    assert "session captured" not in summary
+
+
+# --- an early exit is still a run, and must leave a trace --------------------
+
+
+def _receipt_kinds() -> list[str]:
+    """The ``kind`` column of every receipt line."""
+    return [line.split()[1] for line in _receipt_text().splitlines() if line.split()]
+
+
+def test_receipt_records_a_run_with_no_token(monkeypatch: Any, tmp_path: Path) -> None:
+    """"Nothing to send" and "the token env var got unset" must not look alike."""
+    monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "CITADEL_MCP_ACCESS_TOKEN" in receipt
+    assert _receipt_kinds() == ["session-skip"]
+
+
+def test_receipt_records_a_crash_and_the_hook_still_exits_zero(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The outer ``except Exception: return 0`` used to erase the whole event."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+
+    def boom(entries: Any) -> None:
+        raise ValueError("transcript held sensitive detail")
+
+    monkeypatch.setattr(sync_session, "distill_transcript", boom)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "ValueError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "session captured" not in receipt
+    assert _receipt_kinds() == ["session-error"]
+
+
+def test_a_real_capture_keeps_the_plain_session_kind(monkeypatch: Any, tmp_path: Path) -> None:
+    """Skips are a distinct kind; an actual capture must not be relabelled."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"accepted": True}).encode())
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    assert _receipt_kinds() == ["session"]
+
+
+def test_skipped_empty_session_uses_the_skip_kind(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "post_ingest", _RecordingPost())
+    path = _write_transcript(tmp_path, [], monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    assert _receipt_kinds() == ["session-skip"]

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -395,3 +395,69 @@ def test_empty_session_is_not_sent(monkeypatch: Any, tmp_path: Path) -> None:
     receipt = _receipt_text()
     assert "skipped" in receipt
     assert "captured" not in receipt
+
+
+def test_receipt_when_server_states_no_decision(monkeypatch: Any, tmp_path: Path) -> None:
+    """A 2xx body that OMITS `accepted` states no decision — never "captured".
+
+    The receipt used to read `accepted is not False`, so a response missing the
+    key reported capture from nothing the server ever said.
+    """
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
+    _fake_urlopen_with_body(monkeypatch, json.dumps({"ok": True}).encode())
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "storage not confirmed" in receipt
+    assert "session captured" not in receipt
+
+
+# --- every exit path leaves a distinguishable receipt ------------------------
+
+
+def test_missing_token_leaves_receipt(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "session skipped" in receipt
+    assert "CITADEL_MCP_ACCESS_TOKEN" in receipt
+    assert "session captured" not in receipt
+
+
+def test_refused_transcript_path_leaves_distinct_receipt(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """An out-of-allowlist transcript is refused, not read — and says so.
+
+    Without its own receipt this silence read as "session had nothing to send".
+    """
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+    monkeypatch.delenv("CITADEL_TRANSCRIPT_ALLOW_ROOT", raising=False)
+    recorder = _RecordingPost()
+    monkeypatch.setattr(sync_session, "post_ingest", recorder)
+    path = _write_transcript(tmp_path, _sample_entries())  # no allow-root set
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    assert recorder.calls == []
+    receipt = _receipt_text()
+    assert "transcript path" in receipt
+    assert "no extractable session content" not in receipt  # a different silence
+    assert "session captured" not in receipt
+
+
+def test_crash_inside_run_leaves_receipt(monkeypatch: Any, tmp_path: Path) -> None:
+    """The outer except used to swallow the crash with no trace at all."""
+    monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
+
+    def boom(entries: Any) -> str:
+        raise RuntimeError("crash with sensitive detail")
+
+    monkeypatch.setattr(sync_session, "distill_transcript", boom)
+    path = _write_transcript(tmp_path, _sample_entries(), monkeypatch)
+    assert sync_session.run(io.StringIO(_hook_payload(path, tmp_path))) == 0
+    receipt = _receipt_text()
+    assert "session hook crashed" in receipt
+    assert "RuntimeError" in receipt
+    assert "sensitive detail" not in receipt
+    assert "session captured" not in receipt

--- a/tests/test_sync_start.py
+++ b/tests/test_sync_start.py
@@ -94,3 +94,41 @@ def test_fetch_failure_skips_digest_but_keeps_policy(monkeypatch, capsys) -> Non
 def test_fetch_recent_refuses_non_https() -> None:
     with pytest.raises(ValueError, match="non-HTTPS"):
         sync_start.fetch_recent("http://node.example", "ctdl_x")
+
+
+# --- a swallowed digest failure still leaves a trace -------------------------
+
+
+def _receipt_text() -> str:
+    from kb.hooks.receipt import activity_log_path
+
+    path = activity_log_path()
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def test_a_swallowed_digest_failure_is_recorded(monkeypatch) -> None:
+    """"The vault had nothing recent" and "the fetch blew up" looked identical.
+
+    Both printed the policy and nothing else, so a dev whose warm-start context
+    silently stopped arriving had no way to find out.
+    """
+
+    def boom(*a, **k):
+        raise ConnectionError("timeout against a host we must not log")
+
+    monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
+    monkeypatch.setattr(sync_start, "fetch_recent", boom)
+    assert sync_start.run(io.StringIO("{}")) == 0
+    receipt = _receipt_text()
+    assert "ConnectionError" in receipt
+    assert "must not log" not in receipt
+    assert "ctdl_x" not in receipt
+    assert [line.split()[1] for line in receipt.splitlines() if line.split()] == ["start-error"]
+
+
+def test_a_quiet_successful_start_writes_no_receipt(monkeypatch) -> None:
+    """SessionStart runs constantly; only a real failure is worth a line."""
+    monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
+    monkeypatch.setattr(sync_start, "fetch_recent", lambda *a, **k: [])
+    assert sync_start.run(io.StringIO("{}")) == 0
+    assert _receipt_text() == ""


### PR DESCRIPTION
Six surfaces reported an outcome they had never observed. Each read back the thing
it had *requested* and printed it as the thing that *happened*, so a node doing the
work and a node dropping it on the floor emitted the same bytes. This is one
repeated design failure found in six places, not six unrelated bugs.

The rule these fixes apply, literally:

> A surface that reports an outcome must report it from something it OBSERVED, not
> from something it REQUESTED. Where the observation is genuinely unavailable, the
> surface says so explicitly, as a state a caller can branch on, instead of
> defaulting to the optimistic value.

That last clause does most of the work. `remember()` returns before the graph write
in every branch, by design, so no ingest-time surface can honestly say "indexed".
None of them now claim to.

Two independent efforts solved this set in parallel without knowing about each
other. This branch is the reconciliation: one implementation, with each overlap
resolved on the merits rather than by whichever side merged cleanly. The
reconciliation commit records which side won each decision and why.

## A write reports how far it actually got

`cognee.add()` writes the relational and vector stores. Only `cognify` writes the
graph, and that is what makes a document retrievable. Cognify never ran
synchronously inside a write, so `accepted` was true the instant `add()` returned
and every connector downstream read it as "in the index".

**Indistinguishable before:** a write whose cognify was suppressed, one whose
cognify was scheduled onto a loop that then died, and one that was fully indexed
all produced `accepted=True` and nothing else.

**Distinguishable now:** `IngestResult` carries `index_state`, one of `unknown` /
`rejected` / `pending_cognify` / `cognify_not_scheduled` / `cognify_failed` /
`indexed`, set at the chokepoint in `Citadel.remember()` rather than re-derived by
each caller. `IngestResult.indexed` is tri-state. `None` means nothing was
observed, so a caller who forgets to branch and writes `bool(result.indexed)` gets
`False`. The failure mode of forgetting is pessimism, not a fabricated success.
`schedule_cognify()` now returns whether it actually scheduled anything, so
"a graph write is owed" and "nothing will ever perform this" stopped being the
same value.

Carried through to `/ingest`, `/api/contribute`, the Obsidian push, the GitHub
digest, the Linear sync, and the repo content sync. Where a document is written as
several chunks, the reported state is the worst across them: one indexed chunk may
not vouch for a document whose rest never reached the graph.

## The graph is drawn from observed writes, not requested ones

`MeshState.record_ingest` drew every accepted write as `status: "indexed"` with an
edge to `index:graph`. Both are claims about the Kuzu write, and `add()` does not
perform it.

**Indistinguishable before:** the mesh rendered a graph write that had not happened
yet, and for documents whose cognify silently never ran, never would.

**Distinguishable now:** the node is `indexed` / `unindexed` / `pending` from
`result.indexed`, the `index:graph` edge is drawn only once the write was observed,
and the event reads "Memory stored" rather than "Memory indexed" until then. The
`index:vector` edge stands on its own, because that write is what `add()` actually
does.

## The end-to-end canary says whether it ever ran

`_LAST_CANARY` is written only by the evolve scheduler, which is off unless
`CITADEL_EVOLVE_SCHEDULER_ENABLED` is set. `/readyz` folded a null canary into `ok`
with `canary is None or bool(canary.get("ok", True))`, which is two optimistic
defaults.

**Indistinguishable before:** on a default-config node the never-ran branch fired on
every request, so a node that had never checked its data plane answered exactly like
one that had proved it working.

**Distinguishable now:** the canary block reports `state` (`passed` / `failed` /
`never_ran`), `ok` as `True` / `False` / `None`, `scheduler_enabled` (was one ever
going to run), and `checked_at` (a pass from nine days ago no longer reads like one
from six minutes ago). `never_ran` is reported, not gated on: 503ing every
default-config node would evict healthy nodes from rotation, which is worse than the
gap. `citadel status` reads the new state with a fallback for older nodes.

Alongside it, `/readyz` now publishes a process-lifetime background-cognify ledger:
`runs_scheduled`, `runs_completed`, `runs_failed`, `runs_not_scheduled`. Only the
task body can stamp `completed`, so a node whose detached graph writes die shows
`runs_scheduled` climbing while `runs_completed` stays flat. Previously that node and
a healthy one were identical on every HTTP surface.

## The audit trail records the answer to "did you ask the user?"

Five MCP tools instruct the calling agent to obtain explicit approval before writing.
That instruction is prose handed to a model; nothing carried the answer back.

**Indistinguishable before:** an approved write and an unattended one produced
identical audit rows, and the trail could not answer "was this confirmed?" for any of
them.

**Distinguishable now:** the tools take an optional `user_confirmed: bool | None`,
which travels as the `X-Citadel-User-Confirmed` header and is written to the audit row
as `confirmed` / `not_confirmed` / `unknown`. An absent header is `unknown`, never the
optimistic value: an older client that cannot report and a user who said yes are
different facts. Which tools carry the field is declared on `TOOL_POLICIES`
(`requires_user_approval`) rather than inferred from the docstring, and a test parses
the source so a newly added tool that asks for approval without the flag fails CI. The
recorded value is mirrored back into the tool result, with a warning when the caller
reported nothing, so the agent can see what was written instead of trusting that its
argument arrived.

This is **recorded, not enforced**. The value is asserted by the caller. Role and seat
checks are unchanged and remain the only thing deciding who may call these tools.

Separately, the promotion run's secret-content refusal now records its reason in the
MCP audit view, which previously carried only `status_code=422`.

## A hook that skips leaves a different trace than one that worked

Both capture hooks are fail-silent by contract. Fail-silent had come to mean leaving
no trace at all, and `receipt_summary` tested `accepted is not False`, which reads a
MISSING key as success.

**Indistinguishable before:** exit 0 with no output was the same observable outcome
for "ran and legitimately had nothing to send", "the token env var is unset",
"capture.json is corrupt", and "it crashed". A 2xx body that stated no verdict was
reported as "captured".

**Distinguishable now:** only an explicit `accepted: true` is reported as a capture;
anything else says unconfirmed. Every exit path writes a receipt, under its own kind
(`push` / `push-skip` / `push-error`, and the session equivalents) so `citadel
activity --local` can filter rather than parse prose. The empty-allowlist receipt
names which of the three causes was observed (missing, unreadable, or onboarded but
empty), because only the middle one is a fault the dev has to go and repair. A refused
transcript path gets its own line instead of a silence identical to "nothing worth
sending". Crash receipts carry the exception class name only, never the message, since
the line lands in a file that outlives the session. The warm-start hook records a
swallowed digest failure, which previously looked exactly like a quiet vault.

## A search hit says which authority produced its trust tier

`infer_trust_tier` reads only `item["_citadel"]`. The in-process `--local` search path
handed cognee payloads straight to the shaper with no envelope attached, so every local
hit came back `unattested` whatever it actually was.

**Indistinguishable before:** a genuine session trace read over `--local` was
byte-identical to a hit that had been checked and had no provenance.

**Distinguishable now:** the local path stamps each hit with the dataset it was
actually read out of, so a session trace reports `reference-only` on both paths, and a
test asserts the two paths agree on the same hit. Where an envelope is still absent,
`trust_tier_basis` reports `unknown` next to the tier, marking it a fallback rather
than an observation, and the page carries one warning saying how many hits that covers.
`trust_tier` keeps its existing value domain, so no existing reader changes meaning.

## What a working and a broken node STILL emit identically

Being honest about the remaining gaps, since the whole point of this PR is not to
paper over them:

- **`pending_cognify` does not become `indexed` on its own.** Nothing revisits a write
  after the fact to confirm the graph write landed. A document stuck pending forever
  and one indexed three seconds later report the same state until something else looks.
  The `/readyz` ledger shows the aggregate divergence; it cannot attribute it to a
  document.
- **The background-cognify ledger is process-lifetime and resets on restart.** Railway
  redeploys on every merge to main, so these counters describe the current process, not
  the corpus. They are not a census.
- **`cognify_status` is per-process and per-dataset.** A cognify completing in another
  worker is invisible here, so `unknown` genuinely means unknown rather than "not
  indexed".
- **`user_confirmed` is caller-asserted and unverifiable.** A calling agent that sends
  `true` without asking anyone produces a row identical to one that asked. This records
  what was claimed; it is not and cannot be evidence of consent.
- **Empty `cognee_data_ids` is still ambiguous.** It means "no ids readable here", not
  "the write failed": some clients return a shape the ids cannot be read from.
  `files_add_unconfirmed` counts that condition rather than asserting a fault.
- **The corpus-level question is untouched.** This PR makes new writes report their own
  state. It says nothing about the documents already at `chunk_count 0`, and none of
  these fields are populated retroactively.

## Proof

Full suite, merged tree:

```
1496 passed, 1 skipped, 11 warnings in 22.28s
```

Reverting the source and keeping the tests, to show the tests exercise the source
rather than themselves. Reverting all of `kb/` removes names the new tests import, so
five modules fail to collect; that run is reported with
`--continue-on-collection-errors` and is not the load-bearing one:

```
57 failed, 1148 passed, 1 skipped, 11 warnings, 5 errors in 15.92s
```

The clean version reverts only the four files that remove no imported name
(`kb/mesh.py`, `kb/hooks/sync_push.py`, `kb/hooks/sync_session.py`,
`kb/hooks/sync_start.py`). Zero collection errors, non-zero collected count, real
assertion failures:

```
19 failed, 1477 passed, 1 skipped, 11 warnings in 23.55s
```

Restored:

```
1496 passed, 1 skipped, 11 warnings in 22.28s
```

`ruff check kb/ tests/` → `All checks passed!`

`git diff origin/main -- kb/webui` is empty: no committed build output rides along.

## Ordering

Issue #228 must not run before this lands. It reads the counters this PR changes the
meaning of, and would be measuring the old semantics.
