### PR TITLE
feat(bench): retrieval eval harness (#122) and the re-index runbook it gates

### DIFF
--- a/docs/superpowers/specs/2026-08-04-reindex-runbook.md
+++ b/docs/superpowers/specs/2026-08-04-reindex-runbook.md
@@ -36,6 +36,13 @@ latency p50 592.2 ms / p95 791.5 ms   (client round-trip, NOT server-side)
 
 `tail_recall_given_head_at_5` conditions on documents whose HEAD quote retrieved. Every document it counts is one the index demonstrably holds and returns. Zero of eleven retrieve from a verbatim quote taken at 40% depth or deeper. **None of those eleven is in the 892**, because a document with no chunks cannot retrieve on its head quote either and is excluded before the metric is computed. So a run scoped to the 892 leaves that number at 0 of 11 by construction, and the most direct evidence of the defect goes untouched.
 
+**What each of those numbers does and does not attest**, after an adversarial pass over the harness on 2026-08-05:
+
+- The three window figures **stand**. Every one of the 36 shipped window fixtures was re-derived from the real cached bodies without trusting a single declared field: the quote is present verbatim in all 36, all 18 heads really sit inside the first 2,000 characters, all 18 tails really sit past 0.40 depth, every declared novel term really is a term of its own quote and really is absent from the head, and all 18 pairs are complete and back 18 distinct documents. Zero threshold violations. **VERIFIED** by recomputation on 2026-08-05.
+- Seven fixtures declare an offset a few characters off from where the quote now sits, and one (`w05t`, declared 4435, measured 4679) is off by 244 because its upstream document was edited on 2026-08-03. The thresholds were never satisfied by the declared values, so the figures do not move: `w05t`'s measured depth is 0.8330 against a 0.40 threshold. `lint` now measures instead of trusting and reports each drift as a note.
+- `rank_inversion_rate 0.1489` **must not be quoted as a body-relevance figure.** It reads `_citadel.relevance.term_coverage`, which the node computes over a haystack including each hit's own path and sync header, and every hit carries a different path. A filename can both hide a real inversion and manufacture one; both directions were executed against the node's own coverage function on 2026-08-05. The number is a correct measurement of what it measures (the node's published relevance signal disagreeing with the node's own ordering) and the earlier claim that a path-header match "can neither manufacture nor hide an inversion" was wrong. It is not a gate for this run; it is context.
+- `answer_recall_at_5 0.8974` is scored on the first served identity whose body contains a span, without checking that identity is one the question named. Span uniqueness is proven only across the ~49 cached ground-truth files, never across the corpus. Runs now publish `quality.answers_from_unexpected_documents`; read it before quoting the recall figure.
+
 **The cause is the budget every pre-`a7376dd` document was chunked at, not a pipeline that skipped some rows.** A 13,477-character source file is stored as ONE chunk (`chunk_index: 0`, `text_full_chars: 13790`), and a 34,152-character document ingested at 19:11Z became TWO chunks of 19,529 and 14,616 characters (**REPORTED**, measured in production on 2026-08-04). The embedder window is 512 wordpieces. That is not an accident that befell some documents. It is what the shipped budget of 8191 GPT-4o BPE tokens produces, applied uniformly to everything ingested before `a7376dd`.
 
 **Measured multiplier, this session.** Running cognee's own `chunk_by_paragraph` over 132 files of this repository (`docs/**/*.md`, `*.md`, `kb/*.py`), 2,225,267 characters total, through `.venv/bin/python`:
@@ -98,6 +105,8 @@ Section 6 is the reason. The short version: the re-index overwrites chunk rows i
 The baseline was produced by harness `ea2948a`. **VERIFIED** on 2026-08-04: `git merge-base --is-ancestor ea2948a origin/main` answers NO, and `git branch -a --contains ea2948a` lists only `feat/retrieval-eval-harness`. The metrics that name this defect (`head_recall_at_5`, `tail_recall_at_5`, `tail_recall_given_head_at_5`) do not exist in `scripts/bench/search_bench.py` on `a7376dd`; grep returns nothing. **VERIFIED.**
 
 So the "after" run cannot be produced from main as it stands. Either merge that branch first, or run the harness from a checkout of `ea2948a`. Decide which before the re-index starts, because discovering it afterwards means the run cannot be evaluated against the number it was scheduled to move.
+
+That premise is true only while the harness PR is open. The instant it merges, main carries the metrics and this section is satisfied by doing nothing. Re-check with `git merge-base --is-ancestor` before acting on it rather than assuming it still holds.
 
 ### 2.5 The window is announced
 
@@ -232,7 +241,20 @@ Three operational facts about that call:
 
 1. **The CLI cannot do this.** `citadel cognify` takes `--dataset` and `--verify` and no force flag (`kb/cli.py:3170-3180`), and `_cognify` calls `cognify_dataset(dataset=..., verify=args.verify)` with no `force` (`kb/cli.py:854-858`). **VERIFIED.** The HTTP endpoint is the only surface that can force.
 2. **The response's `ok` field proves nothing when `verify` is false.** `cognify_dataset` returns `"ok": True if verification is None else bool(verification["ok"])` (`kb/service.py:370`). **VERIFIED.** With `verify: false` it is unconditionally true. Read `graph_before` and `graph_after` in the same payload for a number that is at least a measurement, and read the census for one that is authoritative.
-3. **One request will not survive the window.** At the section 3.3 timings a single dataset's force cognify runs for hours, and a client timeout says nothing about whether the write succeeded. Issue #229 recorded that exact confusion and is closed, but the property remains: a timed-out client and a failed write look the same from the client. Drive this from something that tolerates a disconnected caller, and judge the outcome from the census.
+3. **One request will not survive the window.** At the section 3.3 timings a single dataset's force cognify runs for hours, and a client timeout says nothing about whether the write succeeded. Issue #229 recorded that exact confusion and is closed, but the property remains: a timed-out client and a failed write look the same from the client.
+
+   Issue that request from something that outlives your terminal, for example:
+
+   ```bash
+   nohup curl -sS -X POST "$CITADEL_NODE_URL/api/cognify/run" \
+     -H "Authorization: Bearer $CITADEL_MCP_ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     --max-time 0 \
+     -d '{"dataset": "<name>", "force": true, "verify": false}' \
+     > cognify-<name>.json 2>&1 &
+   ```
+
+   **NOT DETERMINED: whether the server-side write survives a client disconnect.** `run_cognify` awaits `cognify_dataset` inline with no handler-level timeout (`kb/server.py:5765-5771`), so nothing in this document establishes what the platform's proxy does to an in-flight handler when the client goes away. Treat that as unknown, and never retry on a timeout: a second `force: true` restarts the whole dataset from zero and pays the full price again. Judge the outcome from the census, per section 7.
 
 One dataset at a time, because the writer lock serializes them anyway and a per-dataset boundary is the only resumable checkpoint this path has.
 
@@ -314,9 +336,16 @@ embed window exceeded: %d tokens against a %d window (%.2fx), %d characters, chu
 Re-run the frozen set at the same pin against the same node:
 
 ```bash
-# The metrics live on ea2948a (branch feat/retrieval-eval-harness), not on main.
-# Either merge that branch first or run from a checkout of it.
-git checkout ea2948a -- scripts/bench/
+# Run from a tree that carries the harness. Once this PR merges, main does,
+# and nothing extra is needed. Before it merges, work from a separate checkout
+# of the branch instead of pulling files into your current index:
+#
+#   git worktree add /tmp/bench-ea2948a ea2948a && cd /tmp/bench-ea2948a
+#
+# `git checkout <ref> -- scripts/bench/` also works but writes the index as
+# well as the working tree, which leaves a dirty staged state mid-maintenance
+# window with no instruction to undo it, and becomes a silent no-op the moment
+# this PR is merged.
 
 export CITADEL_MCP_ACCESS_TOKEN=...        # kb:search, plus admin or audit:read for the census block
 export CITADEL_NODE_URL=https://citadel-archive-production.up.railway.app
@@ -333,7 +362,15 @@ python scripts/bench/search_bench.py compare \
 
 Run JSONs go under `scripts/bench/runs/` only. That directory is gitignored and a run JSON enumerates every served hit identity, so it must never be committed (`scripts/bench/README.md`). **VERIFIED** by reading it.
 
-**Confirm the pin before reading any delta.** The run's fingerprint carries `questions_pin` and it must read `022b6b4f66c73af1`. `compare` recomputes it and refuses on a mismatch (`scripts/bench/search_bench.py:1400` on `ea2948a`), and `report` prints it (`:1645`). **VERIFIED** by reading both on that ref. A comparison against a different question set is not a comparison.
+**Confirm the pin before reading any delta.** The run's fingerprint carries `questions_pin` and it must read `022b6b4f66c73af1`. A comparison against a different question set is not a comparison.
+
+Three surfaces show it, and an earlier revision of this document named two of them wrongly. The correction is recorded here rather than silently overwritten, because the wrong version was tagged VERIFIED and would otherwise be quoted again:
+
+- `run` prints it at the end of the run (`cmd_run`). **VERIFIED**: that was true then and is true now.
+- `report` prints `Frozen question set \`<pin>\`` directly above the metric table, and prints `NOT RECORDED` when a run predates the pin. **VERIFIED** by `tests/test_search_bench.py::TestReportNamesItsFrozenSet`. The earlier revision cited `:1645` for this; that line is inside `cmd_run`, and `build_markdown_report` contained no reference to the pin at all, so an operator following the old instruction would have found nothing and fallen back to trusting `compare`.
+- `compare` gates on `questions_pin` and refuses on a mismatch. **VERIFIED** by `tests/test_search_bench.py::TestCompareGatesOnThePinNotTheFileBytes`. The earlier revision cited `:1400`, which is inside `_lint_freeze_pin` (the `lint` command). `compare_fingerprints` did not read the pin; it gated on `questions_sha256`, the FILE-bytes hash. Two runs of the byte-identical frozen set whose JSON had been reindented between them were declared `QUESTIONS CHANGED: golden sets differ. NOT COMPARABLE.` and the whole delta was withheld, which is the exact case `questions_pin` was introduced to fix.
+
+`compare` also now notes when the two runs used different `ground_truth/` caches. That cache is gitignored and refetched from an unpinned upstream HEAD, and it feeds `doc_recall_at_5` and `header_credit_rate`, so those two can move without the node changing. A note, not a gate.
 
 Compare against:
 
@@ -345,6 +382,8 @@ rank_inversion_rate          0.1489   (47 ranked answers, worst slot 10)
 answer_recall_at_5           0.8974
 latency p50 592.2 ms / p95 791.5 ms   (client round-trip, NOT server-side)
 ```
+
+Read section 2's caveats before quoting any row of that block. In particular `rank_inversion_rate` is context, not a gate, and it is not a body-relevance figure.
 
 **Passes when:** `tail_recall_given_head_at_5` is above 0.0, and the census reports the expected chunk-count delta from section 6 for a sampled set of documents. Both, not either. The metric alone could move for an unrelated reason; the census alone proves rows exist without proving they are reachable.
 

--- a/docs/superpowers/specs/2026-08-04-reindex-runbook.md
+++ b/docs/superpowers/specs/2026-08-04-reindex-runbook.md
@@ -1,0 +1,402 @@
+# Re-index runbook
+
+**Date:** 2026-08-04
+**Status:** not started. Nothing below has been executed. This document exists so the run can be scheduled from evidence rather than from optimism.
+**Decides nothing about the graph store.** [ADR-0020](../../adr/0020-graph-store-on-postgres-and-dataset-scoped-reads.md) already decided that, and the [graph store migration runbook](2026-08-04-graph-store-migration-runbook.md) already turns it into nine gates. Its gate 9 is the re-cognify. **This document is gate 9's detail and nothing else.** Gates 1 through 8 stay where they are; do not re-litigate them here.
+
+Gate 9 as written answers four questions and explicitly leaves five open: it says the rebuild is one job with issue #228, that it sequences after #227, that the runtime must be estimated before scheduling, and that the figure "is **not determined** here". This document supplies the estimate, the scope argument, the progress signal, the verification command and the rollback position. Where it and gate 9 disagree, gate 9 wins on sequencing and this document wins on arithmetic, because the arithmetic was measured after gate 9 was written.
+
+Every factual claim is tagged **VERIFIED** (read or run in the session that produced this file, with the path given), **REPORTED** (a named source said so and it was not independently reproduced here), or **INFERRED**. An untagged sentence is an instruction, not a claim.
+
+Two reading environments, and they are not the same:
+
+- Repository paths (`kb/...`, `scripts/...`, `docs/...`) were read on `a7376dd`, the tip of `origin/main` and the commit the node is running. Those citations are reproducible from a checkout of that commit. Note that the migration runbook's repository line numbers were read on branch `docs/substrate-adrs` and have drifted: its `_delete_marker_node` at `kb/service.py:326` is `kb/service.py:379` on `a7376dd`. Check the symbol, not the line.
+- Upstream paths (`cognee/...`) were read in the installed distribution, cognee 1.2.2, at `.venv/lib/python3.12/site-packages/cognee`. **VERIFIED** on 2026-08-04 by importing `cognee` from `.venv/bin/python` and reading `cognee_version=1.2.2` off its own startup log. The system `python3` has no cognee on its path, so an upstream citation checked with the wrong interpreter proves nothing.
+
+---
+
+## 1. Scope: every document, not the 892
+
+**Decision: the run covers every document in every dataset. The 892 are a subset that needs no special handling.**
+
+The argument, in the order the evidence arrived.
+
+**The 892 is a symptom count, not the population.** Issue #228 measured 892 of 2,867 documents at `chunk_count == 0` on 2026-08-03 (**REPORTED**, from the issue body). Those rows are unreachable and re-indexing has to include them. But they are not where the retrieval failure lives.
+
+**The metric that names the failure was measured on documents that are already indexed.** The frozen #122 baseline, production, 2026-08-04T19:51:37Z, questions pin `022b6b4f66c73af1`, harness `ea2948a`, stable across three runs and two merges (**REPORTED**, from the #122 comment on issue #228):
+
+```
+head_recall_at_5             0.6111   (11 of 18)
+tail_recall_at_5             0.0      (0 of 18)
+tail_recall_given_head_at_5  0.0      (0 of 11)
+rank_inversion_rate          0.1489   (47 ranked answers, worst slot 10)
+answer_recall_at_5           0.8974
+latency p50 592.2 ms / p95 791.5 ms   (client round-trip, NOT server-side)
+```
+
+`tail_recall_given_head_at_5` conditions on documents whose HEAD quote retrieved. Every document it counts is one the index demonstrably holds and returns. Zero of eleven retrieve from a verbatim quote taken at 40% depth or deeper. **None of those eleven is in the 892**, because a document with no chunks cannot retrieve on its head quote either and is excluded before the metric is computed. So a run scoped to the 892 leaves that number at 0 of 11 by construction, and the most direct evidence of the defect goes untouched.
+
+**The cause is the budget every pre-`a7376dd` document was chunked at, not a pipeline that skipped some rows.** A 13,477-character source file is stored as ONE chunk (`chunk_index: 0`, `text_full_chars: 13790`), and a 34,152-character document ingested at 19:11Z became TWO chunks of 19,529 and 14,616 characters (**REPORTED**, measured in production on 2026-08-04). The embedder window is 512 wordpieces. That is not an accident that befell some documents. It is what the shipped budget of 8191 GPT-4o BPE tokens produces, applied uniformly to everything ingested before `a7376dd`.
+
+**Measured multiplier, this session.** Running cognee's own `chunk_by_paragraph` over 132 files of this repository (`docs/**/*.md`, `*.md`, `kb/*.py`), 2,225,267 characters total, through `.venv/bin/python`:
+
+```
+budget= 8191  docs=132  chars=2225267  chunks= 204  chars_per_chunk=10908.2  chunks_per_doc= 1.55
+budget=  256  docs=132  chars=2225267  chunks=4494  chars_per_chunk=  495.2  chunks_per_doc=34.05
+```
+
+**VERIFIED** on 2026-08-04. The multiplier is 4494 / 204 = **22.0x**. The sweep already committed in `kb/chunk_window.py:76-88` reports 274 chunks at 8191 and 6,064 at 256 over a different 172-document corpus, which is 22.1x (**REPORTED**, that module's own measurement, not re-run here). Two samples of different composition agree to within a rounding error.
+
+Read that as a statement about the corpus: the roughly 1,975 documents that do carry chunks are holding about one twenty-second of the vector rows their text warrants. They are indexed in the sense that a row exists. They are not indexed in the sense that their content is reachable.
+
+**Three populations, one operation.** The #122 comment on #228 splits the corpus into never-indexed (892, this issue), indexed as one or two oversized chunks (#247), and correctly chunked (new writes only, since `a7376dd` set `OBSERVED_CHUNK_BUDGET_TOKENS = 256` at `kb/chunk_window.py:91`). **VERIFIED** that the constant is on `a7376dd`. Populations one and two are the same rows-level operation on different sets of rows, which is exactly ADR-0020's wording at `docs/adr/0020-graph-store-on-postgres-and-dataset-scoped-reads.md:32`:
+
+> Plan it as one job with the existing re-index backlog, because re-cognifying documents that were accepted and never indexed is the same operation on a different set of rows.
+
+**How the scope is expressed mechanically.** `run_tasks_data_item` dispatches on the flag (`cognee/modules/pipelines/operations/run_tasks_data_item.py:244-256`): `incremental_loading=True` enters `run_tasks_data_item_incremental` (`:33`), which skips any document whose `pipeline_status[pipeline_name][dataset.id]` is `DATA_ITEM_PROCESSING_COMPLETED` (`:90-99`, set at `:127`); `False` enters `run_tasks_data_item_regular` (`:159`), which has no such check. **VERIFIED**. `CogneePublicClient.cognify` passes `incremental_loading=not force` (`kb/cognee_client.py:1760`), so `force=true` is precisely "ignore the completed flag and reprocess everything". **VERIFIED**. One `force` run per dataset covers both populations with no filtering logic to write.
+
+**What this scope does not buy, and say it out loud.** This runbook has no root cause for the 892. Issue #228 asks for one and it is still open. If a document reached `chunk_count == 0` for a reason other than the incremental skip, `force=true` re-runs it through the same code and it lands at zero again, and the corpus regenerates the population over time. Repair is not diagnosis. Section 4 step 2 is the cheap probe that tells the two apart before the full cost is paid.
+
+---
+
+## 2. What must be true before it starts
+
+### 2.1 The CREATEDB answer is null, and that is a sequencing decision, not a blocker
+
+Gate 1 of the migration runbook is the `CREATEDB` privilege check on the application role, and ADR-0020 puts it "before any other work in this project" (`docs/adr/0020-...:31`). **As of this document the result is null: the check has not been executed.** Not "false", not "unavailable". Not run.
+
+That does not block this job by itself, because the re-index does not create per-dataset databases. It forces a choice about when to pay for it, and the choice is sarthi's:
+
+**Option A, run the re-index now, on the current store.** The benchmark can move this week. The cost, whatever section 3's measurement turns it into, is paid twice, because ADR-0020:32 records that the store move has no export path and is a full rebuild. Every chunk built now is rebuilt again after gate 8.
+
+**Option B, settle gate 1 first, run the re-index once as gate 9.** The cost is paid once. `tail_recall_given_head_at_5` stays at 0 of 11 until the whole migration lands, which is nine gates away.
+
+**Recommendation: B, unless the store move is being deferred past a date sarthi can name.** The cost in section 3 is measured in node-degraded hours, not dollars, and paying that twice is the specific waste ADR-0020's option analysis exists to prevent. A is defensible only if the migration is not happening soon, in which case say so in writing and accept the second pass.
+
+Either way, gate 1 is one `psql` command (migration runbook, gate 1) and answering it costs less than deciding without it.
+
+### 2.2 The chunk budget must be provably in force on the running node
+
+This is the precondition that turns the entire run into wasted money if it is skipped, and it cannot be checked by reading the code alone.
+
+`_ensure_chunk_budget` calls `chunk_window.apply_chunk_budget()` on every cognee operation (`kb/cognee_client.py:402-417`). **VERIFIED.** But `resolve_chunk_budget` has a precedence chain (`kb/chunk_window.py:141-153`): `CITADEL_CHUNK_BUDGET_TOKENS` first, then cognee's own `EMBEDDING_MAX_COMPLETION_TOKENS`, then the 256 constant last. **VERIFIED.** An operator-set value in the deployment environment beats the fix. If either variable is set to 8191 anywhere in the deploy, a full-corpus `force` run rebuilds the entire corpus at the old budget, changes nothing measurable, and costs the full price.
+
+**Check it without reading secrets.** `apply_chunk_budget` logs the number it actually applied (`kb/chunk_window.py:187-194`):
+
+```
+Chunk budget set to %s BPE tokens via %s (was %s). This is an observed value, not a bound: ...
+```
+
+Grep the deployment's logs for `Chunk budget set to` and read the integer. It must be 256, or a number an operator deliberately chose and can defend. Do not enumerate deployment variables to answer this.
+
+### 2.3 A backup of the vector store exists
+
+Section 6 is the reason. The short version: the re-index overwrites chunk rows in place and nothing in the pipeline snapshots them. Without a backup taken before the first `force` call there is no route back to the current state. This is a hard precondition, not a nice-to-have.
+
+### 2.4 The harness ref is pinned and reachable
+
+The baseline was produced by harness `ea2948a`. **VERIFIED** on 2026-08-04: `git merge-base --is-ancestor ea2948a origin/main` answers NO, and `git branch -a --contains ea2948a` lists only `feat/retrieval-eval-harness`. The metrics that name this defect (`head_recall_at_5`, `tail_recall_at_5`, `tail_recall_given_head_at_5`) do not exist in `scripts/bench/search_bench.py` on `a7376dd`; grep returns nothing. **VERIFIED.**
+
+So the "after" run cannot be produced from main as it stands. Either merge that branch first, or run the harness from a checkout of `ea2948a`. Decide which before the re-index starts, because discovering it afterwards means the run cannot be evaluated against the number it was scheduled to move.
+
+### 2.5 The window is announced
+
+Migration runbook rollback condition 4, and it applies here for the same reason. The people who read the census, the mesh graph and the evolve result need to be told in advance what a mid-run reading looks like, or the failure that looks like success gets discovered by someone who trusts it.
+
+### 2.6 Issue #153 interacts with the window
+
+The evolve scheduler resets its interval on every deploy (**REPORTED**, migration runbook §4). A deploy during the run restarts the scheduler and may start an evolve pass that contends with the re-index for the writer lock. Freeze deploys for the window, or accept that the run takes longer for a reason that will not be in any log.
+
+---
+
+## 3. Cost and duration
+
+**Method first, number second, because the number moves and the method does not.**
+
+### 3.1 What the pipeline actually spends per chunk
+
+The default cognify pipeline is five tasks (`cognee/api/v1/cognify/cognify.py:325-350`). **VERIFIED.** The one that costs money is `extract_graph_and_summarize`, which is `asyncio.gather` over two independent LLM passes (`cognee/tasks/graph/extract_graph_and_summarize.py:21-33`):
+
+- `extract_graph_from_data` gathers one `extract_content_graph` per chunk (`cognee/tasks/graph/extract_graph_from_data.py:166-170`), and each is one `LLMGateway.acreate_structured_output` (`cognee/infrastructure/llm/extraction/knowledge_graph/extract_content_graph.py:41`).
+- `summarize_text` gathers one `extract_summary` per chunk (`cognee/tasks/summarization/summarize_text.py:68-70`), and each is one `LLMGateway.acreate_structured_output` (`cognee/infrastructure/llm/extraction/extract_summary.py:30`).
+
+All **VERIFIED**. So: **two LLM calls per chunk**, not per document.
+
+System prompt sizes, **VERIFIED** by `wc -c`: `generate_graph_prompt.txt` is 2,445 bytes and is the default (`cognee/infrastructure/llm/config.py:61`, `graph_prompt_path: str = "generate_graph_prompt.txt"`); `summarize_content.txt` is 944 bytes (`extract_summary.py:28`). The model is `LLM_MODEL=openrouter/deepseek/deepseek-v4-flash` (`.env.example:236`, `docs/operations.md:140`). **VERIFIED.**
+
+Embedding is local and free of API cost: `EMBEDDING_PROVIDER=fastembed` (`.env.example:244`). It is not free of wall clock, which is section 3.3.
+
+### 3.2 Token arithmetic
+
+Per chunk at budget 256 BPE tokens, using the measured 495.2 characters per chunk from section 1 and a rounded 4 characters per token:
+
+```
+graph call    input ~= 2,445 prompt chars +   495 chunk chars =  2,940 chars ~=   735 tokens
+summary call  input ~=   944 prompt chars +   495 chunk chars =  1,439 chars ~=   360 tokens
+                                                        per chunk ~= 1,095 input tokens
+```
+
+Output tokens are **not determined**. The graph call returns a structured node and edge list whose size varies with the content; the summary returns short text. They add on top of the figure below and are not estimated here, because guessing them would put an invented number next to measured ones.
+
+Corpus scale. The one input this arithmetic needs and does not have is the corpus character total, or equivalently today's chunk-row count. **Not determined.** Cheapest measurement, one query against the node's relational store:
+
+```sql
+SELECT count(*) FROM "DocumentChunk_text";
+```
+
+Then `chunks_after ~= 22 x chunks_today`, using the multiplier from section 1.
+
+Worked illustration, and it is an illustration. Scaling this repository's sample mean of 16,858 characters per document (2,225,267 / 132) to the corpus's 2,867 documents gives roughly 48.3M characters, which at 495.2 characters per chunk is roughly **97,500 chunks** and therefore **195,000 LLM calls** and roughly **107M input tokens**. The blind spot is stated where the figure is: this repository's markdown and Python is not the vault's document-size distribution, and the number could be off by a factor of two in either direction. It is here to show the order of magnitude, which is hundreds of thousands of calls and not thousands.
+
+Dollars: multiply 107M by the current published per-million input price for `deepseek/deepseek-v4-flash` on OpenRouter, add output. That price is deliberately not written here, because a price copied from memory into a runbook is the kind of number that gets quoted back six months later. Look it up at scheduling time, or read the node's own OpenRouter usage after a timed sample of 100 documents, which gives the real figure including output tokens and needs no price lookup at all.
+
+### 3.3 Duration, and why the node is degraded throughout
+
+The wall clock is not dominated by the LLM calls. It is dominated by two things that run on the web process's own event loop.
+
+**Local embedding blocks the loop.** `FastembedEmbeddingEngine.embed_text` is an `async def` (`cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py:94`) that calls `self.embedding_model.embed(...)` synchronously at line 121, with no `asyncio.to_thread` and no `run_in_executor` anywhere in that method. **VERIFIED.** Every embedding batch therefore holds the loop for the duration of local ONNX inference. This is the same shape as the search-path finding already recorded at `kb/cognee_client.py:430-434`, where an on-loop await "does not merely make one search slow, it blocks every other request for its duration".
+
+**Cognify serializes on the writer lock and runs in the web process.** `CogneePublicClient.cognify` takes `self.writer_lock` around the call (`kb/cognee_client.py:1759-1760`), and `kb/server.py:311` records that evolve Phase 1 "runs HERE, in the web's own loop, not in a subprocess (#88)". **VERIFIED.** So a re-index and any interactive ingest, evolve pass or `/api/cognify/run` are mutually exclusive for the whole window.
+
+The duration formula:
+
+```
+window_hours = chunks_after x seconds_per_chunk / 3600
+```
+
+`seconds_per_chunk` is **not determined** and must be measured, not assumed. Take it this way, and this is step 3 of section 4: pick one representative document, ingest it into a scratch dataset with the budget at 256, time the whole `force` cognify, divide by the chunk count the census then reports for it. That single measurement is what makes the window statable, and migration runbook rollback condition 5 requires the window to have a stated end.
+
+The shape of the answer, at the illustrative 97,500 chunks:
+
+| seconds per chunk | window |
+|---|---|
+| 0.5 | ~13.5 hours |
+| 2.0 | ~54 hours |
+| 5.0 | ~135 hours |
+
+**INFERRED** arithmetic over a **not determined** input. The point of the table is not the numbers, it is that the plausible range spans half a day to most of a week, so this is a scheduled operation with a maintenance posture, not something to start on a Friday afternoon and watch.
+
+### 3.4 The risk that is larger than the cost
+
+The vector store has no approximate index. `PGVectorAdapter` contains no `ivfflat`, no `hnsw` and no `CREATE INDEX`, and its search is `ORDER BY` a `cosine_distance` expression (`cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py:518`, `:527`, `:532-533`). **VERIFIED.** That is an exact scan, so scan cost is linear in row count, and section 1's multiplier says the row count goes up about 22x.
+
+The baseline is p50 592.2 ms client round-trip. What share of that is scan time is **not determined**, and the harness README is explicit that its latency block is client-side and that server-side timing must be read from the platform logs. If the scan is a large share, a 22x row increase makes the node meaningfully slower at exactly the moment its recall improves, and that trade is sarthi's to make knowingly rather than to discover afterwards.
+
+Cheapest measurement that settles it before the run: read server-side request duration for `/search` out of the Railway logs for a handful of requests and compare against the 592.2 ms client figure. The gap is network. What is left is the node, and the scan is inside it. Second cheapest: build a scratch pgvector table at 1x and 22x the row count and time the same query against both.
+
+This is a reason to schedule the re-index alongside a decision about the index, not a reason to skip it. Recall of 0 of 11 is a worse defect than latency.
+
+---
+
+## 4. The steps
+
+Each step states what it produces. A step that cannot produce its output stops the run; it does not get worked around.
+
+### Step 1: record the "before" state, in full
+
+Walk the corpus census and keep the file. `GET /api/corpus` (`kb/server.py:3652`) pages the durable relational store and marks each row with `chunk_count` and `in_graph` (`kb/server.py:3663-3666`). It requires `admin` or `audit:read` (`kb/server.py:3675`). Page size defaults to 200 and caps at 1000 (`kb/server.py:3599-3600`), so the current corpus is three pages. **VERIFIED** by reading all of those.
+
+Keep every row, not the summary. The per-document `chunk_count` diff is the only progress signal that means anything (section 5), and it cannot be reconstructed after the fact.
+
+Also record: `SELECT count(*) FROM "DocumentChunk_text";` for the section 3 arithmetic, and the current dataset list, because the run is one call per dataset.
+
+### Step 2: the cheap diagnosis probe, before any bulk cost
+
+Pick the smallest dataset that contains some of the 892. Run an **incremental** cognify against it, meaning `force: false`, and re-read the census for that dataset only.
+
+- If some of the 892 in that dataset gain chunks, their cause was the incremental skip and the full `force` run repairs them.
+- If none of them gain chunks, the incremental skip is not their cause, `force` will very likely reproduce the same zero, and #228 needs its root cause before the corpus-wide run is worth paying for. Say so and stop.
+
+This costs one small dataset's cognify and can save the whole budget.
+
+### Step 3: measure `seconds_per_chunk`
+
+Section 3.3. One representative document, scratch dataset, budget confirmed at 256 by the log line from section 2.2, timed end to end, divided by the chunk count the census reports for it afterwards. Write the number down with the document it came from, because a per-chunk time measured on a 500-character note does not predict a 34,000-character one.
+
+Multiply out and state the window. This is the artifact migration runbook rollback condition 5 requires.
+
+### Step 4: read section 5 before starting, and set the failure check up
+
+The next section is the one that decides whether a broken run is noticed. It is a step, not a footnote.
+
+### Step 5: run it, one dataset at a time
+
+```
+POST /api/cognify/run
+{"dataset": "<name>", "force": true, "verify": false}
+```
+
+Body model at `kb/server.py:987-990`, handler at `kb/server.py:5765-5771`, scope `admin` or `sources:sync` (`kb/server.py:5767`). **VERIFIED.**
+
+Three operational facts about that call:
+
+1. **The CLI cannot do this.** `citadel cognify` takes `--dataset` and `--verify` and no force flag (`kb/cli.py:3170-3180`), and `_cognify` calls `cognify_dataset(dataset=..., verify=args.verify)` with no `force` (`kb/cli.py:854-858`). **VERIFIED.** The HTTP endpoint is the only surface that can force.
+2. **The response's `ok` field proves nothing when `verify` is false.** `cognify_dataset` returns `"ok": True if verification is None else bool(verification["ok"])` (`kb/service.py:370`). **VERIFIED.** With `verify: false` it is unconditionally true. Read `graph_before` and `graph_after` in the same payload for a number that is at least a measurement, and read the census for one that is authoritative.
+3. **One request will not survive the window.** At the section 3.3 timings a single dataset's force cognify runs for hours, and a client timeout says nothing about whether the write succeeded. Issue #229 recorded that exact confusion and is closed, but the property remains: a timed-out client and a failed write look the same from the client. Drive this from something that tolerates a disconnected caller, and judge the outcome from the census.
+
+One dataset at a time, because the writer lock serializes them anyway and a per-dataset boundary is the only resumable checkpoint this path has.
+
+### Step 6: verify, per section 7
+
+---
+
+## 5. The failure that looks like success
+
+**This is the step that decides whether a broken run is noticed. The migration runbook calls its version "the single most important warning in this document" (§1.2). It applies here unchanged.**
+
+The mechanism, quoted from that runbook and re-verified against `a7376dd`:
+
+> `CitadelService.improve` ... calls it at `kb/service.py:216` and then does this, at `kb/service.py:217`:
+>
+> ```python
+> counts = await self._graph_counts()
+> if counts["nodes"] == 0 and counts["edges"] == 0:
+>     return {
+>         "ok": True,
+>         "skipped": "empty_graph",
+>         "dataset": target_dataset,
+>         "reason": "graph is empty; nothing to improve",
+>     }
+> ```
+
+Same code on `a7376dd` at `kb/service.py:269-275`, with `_graph_counts` at `kb/service.py:295-297`. **VERIFIED.**
+
+> So the visible signature of a broken scoped read is a green evolve pass, a 200 response, an `ok: true` field, and no log line. That is indistinguishable from a healthy pass over a vault that happens to have nothing to improve.
+
+And its required response, which the migration runbook states is not optional:
+
+> **The required design response, and it is not optional:** the scoped read must be able to distinguish "walked zero datasets" from "walked N datasets and all of them were empty". Concretely, the loop returns the number of datasets it enumerated and the number it read successfully, `_graph_counts` carries those numbers up, and the `empty_graph` short-circuit fires only when at least one dataset was read successfully. Enumerating zero datasets, or failing every dataset, raises. A partial failure is reported as a partial, never merged into the empty case.
+
+**Why it belongs in this runbook and not only in that one.** If the re-index runs as gate 9, the per-dataset loop from gate 5 is already deployed, and a re-index is the largest volume of graph writes this node will ever do. A loop that enumerates zero datasets during the rebuild produces: a rebuild that appears to complete, an `improve` that answers `ok: true, skipped: "empty_graph"` on every pass, a `cleanup_legacy_nodes` that reports zero candidates, and a census whose `in_graph` reads null. Every one of those is also what a healthy quiet node looks like mid-migration, which §1.6 of the migration runbook already warns is the expected reading in that window. The two states are indistinguishable at exactly the moment they overlap.
+
+**Make it a check, before step 5.** Before the first `force` call, confirm the enumeration count is nonzero and exposed. Concretely:
+
+1. Call whatever surface the gate 5 contract exposes the dataset enumeration on and confirm it reports a count greater than zero.
+2. Call `improve` against a dataset known to have content and confirm it does not answer `skipped: "empty_graph"`.
+3. If either answers zero or empty, **stop**. Do not start the rebuild. A rebuild into a read that cannot see its own datasets produces a corpus that looks rebuilt and is not, and the census cannot tell that state apart from the mid-migration reading.
+
+If the re-index runs standalone on the current store, ahead of the migration, step 5's `graph_before` and `graph_after` are the equivalent check: `graph_before` must be nonzero before the run and `graph_after` must exceed it. A `graph_before` of zero on a store that should hold content is the same warning wearing different clothes.
+
+---
+
+## 6. Observing progress while it runs
+
+**"Accepted" is not progress.** Two things say accepted and neither says landed. The HTTP 200 from an ingest means the row reached the relational store. cognee's own `PipelineRunAlreadyCompleted` (`cognee/modules/pipelines/operations/run_tasks_data_item.py:96`) means the document was skipped, and under `force` it should never appear at all, so seeing it is itself a finding that the force flag did not take.
+
+**The signal that a document landed is its chunk row count, read from the vector table.** `corpus_chunk_counts` (`kb/cognee_client.py:1050-1064`) is one grouped `count(*)` over the `DocumentChunk_text` collection keyed on the `document_id` each row carries in its payload. Its docstring is precise about the thing that matters: "None and 0 are different answers: 0 claims cognee accepted a document and indexed no chunk for it, None says this node could not look". **VERIFIED.** `/api/corpus` surfaces it per row as `chunk_count` and refuses to collapse null into 0 (`kb/server.py:3722-3757`). **VERIFIED.**
+
+**The acceptance test is a delta, not a threshold.** `chunk_count > 0` is the wrong test, because a document that was already stored as one oversized chunk still has exactly one chunk if the re-chunk silently did not happen. The test is:
+
+```
+chunk_count_after >= 2 x chunk_count_before,  for every document longer than about 1,500 characters
+```
+
+with the expected ratio around 22 from section 1. Documents shorter than one chunk's worth of text legitimately stay at 1 and must be excluded from the check rather than counted as failures. This is why step 1 keeps every row: without the before-census there is no delta to compute.
+
+**Second signal, the embed-window detector.** `install_embed_window_detector` wraps the fastembed engine's `embed_text` and logs each overflow (`kb/chunk_window.py:390`, log line at `:294-302`):
+
+```
+embed window exceeded: %d tokens against a %d window (%.2fx), %d characters, chunk %s.
+```
+
+**VERIFIED.** During a healthy re-index at budget 256 this should be nearly silent; `kb/chunk_window.py:76-88` records that only three chunks in a 172-document sweep survive over-window at 256, and all three are the same un-splittable minified line. A flood of these lines means the budget is not in force and the run is rebuilding at the old size. Note the log is capped at 50 lines per process (`_MAX_WARNINGS = 50`, `kb/chunk_window.py:105`) and the counters in `kb.chunk_window.embed_window_report()` stay exact, so treat the log as a sample and the counters as the measurement.
+
+**Third signal, and the weakest.** `graph_before` and `graph_after` in the `/api/cognify/run` response. Useful as a liveness check between datasets. Not proof for any particular document, for the reason `kb/service.py:357-364` already records in a comment: any concurrent write grows the graph, so growth is no evidence that a specific thing landed.
+
+**Cadence.** Re-walk the census between datasets, not continuously. It is three paged reads against the same relational store the run is writing to, and `/api/corpus` sits behind an in-flight limiter (`kb/server.py:3697`), so polling it hard during a window where the event loop is already blocked by local embedding makes the node worse for no extra information.
+
+---
+
+## 7. Verifying it worked
+
+**The success criterion is `tail_recall_given_head_at_5` moving off 0 of 11.** Not `head_recall_at_5`, and not `answer_recall_at_5`. That metric counts only documents the index demonstrably holds and returns, so it isolates the defect this run repairs from every other cause of a miss. If it is still 0 of 11 after the run, the run did not work, whatever else improved.
+
+Re-run the frozen set at the same pin against the same node:
+
+```bash
+# The metrics live on ea2948a (branch feat/retrieval-eval-harness), not on main.
+# Either merge that branch first or run from a checkout of it.
+git checkout ea2948a -- scripts/bench/
+
+export CITADEL_MCP_ACCESS_TOKEN=...        # kb:search, plus admin or audit:read for the census block
+export CITADEL_NODE_URL=https://citadel-archive-production.up.railway.app
+
+python scripts/bench/search_bench.py run \
+  --questions scripts/bench/golden_questions.json \
+  --repeats 1 \
+  --out scripts/bench/runs/$(date +%F)-after-reindex.json
+
+python scripts/bench/search_bench.py compare \
+  scripts/bench/runs/<the-frozen-baseline>.json \
+  scripts/bench/runs/$(date +%F)-after-reindex.json
+```
+
+Run JSONs go under `scripts/bench/runs/` only. That directory is gitignored and a run JSON enumerates every served hit identity, so it must never be committed (`scripts/bench/README.md`). **VERIFIED** by reading it.
+
+**Confirm the pin before reading any delta.** The run's fingerprint carries `questions_pin` and it must read `022b6b4f66c73af1`. `compare` recomputes it and refuses on a mismatch (`scripts/bench/search_bench.py:1400` on `ea2948a`), and `report` prints it (`:1645`). **VERIFIED** by reading both on that ref. A comparison against a different question set is not a comparison.
+
+Compare against:
+
+```
+head_recall_at_5             0.6111   (11 of 18)
+tail_recall_at_5             0.0      (0 of 18)
+tail_recall_given_head_at_5  0.0      (0 of 11)
+rank_inversion_rate          0.1489   (47 ranked answers, worst slot 10)
+answer_recall_at_5           0.8974
+latency p50 592.2 ms / p95 791.5 ms   (client round-trip, NOT server-side)
+```
+
+**Passes when:** `tail_recall_given_head_at_5` is above 0.0, and the census reports the expected chunk-count delta from section 6 for a sampled set of documents. Both, not either. The metric alone could move for an unrelated reason; the census alone proves rows exist without proving they are reachable.
+
+**Read these three alongside it, because any of them can go the wrong way:**
+
+- `answer_recall_at_5`, currently 0.8974, **can fall**. Chunking at 256 tokens splits text that used to sit inside one chunk, and a verbatim quote that straddles a new boundary appears in no single chunk body. That is a real cost of finer chunking and it needs watching, not assuming away.
+- Latency p50, currently 592.2 ms client round-trip, is expected to rise for the exact-scan reason in section 3.4. A large rise is a finding about the index, not a failure of the re-index.
+- `head_recall_at_5`, currently 0.6111, is #228's own number and should rise as the 892 become reachable. The #122 comment on #228 is explicit that some of the seven current head misses are ordering (#106) rather than a missing index, so treat 0.6111 as the number to beat and not as a measurement of this defect's size.
+
+**Fails when:** `tail_recall_given_head_at_5` is still 0 of 11 and the census shows the expected chunk delta. That combination means the chunks were rebuilt and retrieval still cannot reach them, which is a different defect from the one this run repairs, and it needs a name before anything else is scheduled.
+
+---
+
+## 8. Rollback
+
+**There is no rollback to the pre-run vector state unless a backup was taken first. Take the backup.**
+
+The mechanism, and it is worth reading rather than trusting the summary.
+
+Chunk ids are derived two different ways. `TextChunker` yields most chunks with a position-derived id, `uuid5(NAMESPACE_OID, f"{document_id}-{chunk_index}")` (`cognee/modules/chunking/TextChunker.py:49-50` and `:76`), and yields a single over-budget paragraph with a content-derived id, `chunk_data["chunk_id"]`, which is `uuid5(NAMESPACE_OID, current_chunk)` over the chunk text (`TextChunker.py:29`, from `cognee/tasks/chunks/chunk_by_paragraph.py:45`, `:70`, `:90`). All **VERIFIED**.
+
+The vector write is an upsert keyed on that id. `PGVectorAdapter.create_data_points` says so in its own docstring, "Upsert DataPoints into `collection_name`, merging belongs_to_set on conflict" (`cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py:272-273`), with `id` as the primary key at `:301`. **VERIFIED.** Nothing in the cognify pipeline deletes a document's prior chunks before writing new ones; the only delete path in this codebase is `delete_graph_nodes` (`kb/cognee_client.py`), which the re-index does not call.
+
+Three consequences, all **INFERRED** from those verified facts:
+
+1. **Chunk 0 is overwritten in place.** A document currently stored as one 13,477-character chunk at `chunk_index: 0` has id `uuid5(NAMESPACE_OID, "<document_id>-0")`. Re-chunking produces a new chunk 0 with the same id and a much shorter body. The upsert replaces it. The original long body is gone from the store at that moment, and there is no copy.
+2. **Chunks 1 through N are new rows.** They add; they do not replace anything.
+3. **Any chunk whose id the new run does not produce is orphaned, not deleted.** It keeps its row, keeps its embedding, and stays searchable. Whether that happens depends on whether a document crosses between the position-derived and content-derived branch between the two budgets, which is **not determined**. Cheapest measurement: re-cognify one document on a scratch dataset and compare the set of chunk ids before and after; any id present before and absent after is an orphan the run will leave behind.
+
+So the honest rollback position: **the run is not reversible by re-running anything.** Reverting the budget to 8191 and cognifying again does not restore the old rows, it writes a third generation on top. The only route back to today's state is a database backup of the vector store taken before the first `force` call.
+
+**What to back up:** the `DocumentChunk_text` collection at minimum, and the graph tables if the run happens after gate 8. A managed snapshot of the whole Postgres instance is simpler than a selective dump and is the recommended form.
+
+**What does not need a rollback.** The relational store is untouched. `corpus_totals`, `corpus_page` and the dataset attribution read SQLAlchemy tables that no part of this run writes (migration runbook §1.6). The document text is intact throughout, which is the property ADR-0010 establishes and the reason a rebuild is possible at all. So the worst realistic outcome is a vector store that is worse than today's and a corpus that can be rebuilt again from the same source, at the same cost, in the same window. That is recoverable and expensive, which is the correct way to describe it.
+
+**If the run happens as gate 9, the two halves roll back differently.** The graph half has a rollback: migration runbook rollback condition 2 requires the provider switch to be reversible by one environment value, and condition 1 requires the old volume to survive until gate 9's exit condition passes. The vector half has none, because the vector store does not move in that migration and the re-chunk overwrites it in place regardless of which graph provider is configured. Do not let the graph half's rollback plan imply the whole job has one.
+
+---
+
+## 9. What this runbook does not cover
+
+- **The root cause of the 892.** Issue #228 asks for one and this document does not supply it. Section 4 step 2 is a probe that distinguishes two candidate causes, not a diagnosis. If the cause is still live, the population regenerates after the run.
+- **Whether the index should become approximate.** Section 3.4 predicts a 22x row increase against a verified exact scan and names the measurement that sizes the consequence. Choosing an index is a separate decision with its own verification.
+- **Issue #247's ordering component.** `rank_inversion_rate` at 0.1489 is a ranking defect. Finer chunks change what is available to rank; they do not fix how ranking works.
+- **Anything in migration runbook gates 1 through 8.** Read that document for those. This one starts where it ends.
+
+## 10. Related records
+
+- [The graph store migration runbook](2026-08-04-graph-store-migration-runbook.md), whose gate 9 this document details, and whose §1.2 section 5 above quotes.
+- [ADR-0020](../../adr/0020-graph-store-on-postgres-and-dataset-scoped-reads.md), which decided the rebuild is one job with the re-index backlog.
+- [ADR-0010](../../adr/0010-structured-knowledge-durable-source-of-truth.md), which is why rebuilding is the supported operation rather than a workaround.
+- [ADR-0018](../../adr/0018-corpus-totals-are-authoritative-not-uptime.md), which the census in sections 4 and 6 rests on.
+- Issue #228 (the 892 never indexed), issue #247 (a verbatim quote from the middle of an indexed document retrieves nothing), issue #227 (closed, the chunk budget), issue #229 (closed, inline ingest blocking), issue #122 (the benchmark harness).
+- `kb/chunk_window.py`, which carries the budget sweep and the argument for why no integer is a bound.
+- `CONTEXT.md` for every bolded term in the documents above.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -59,7 +59,7 @@ Tracking issue for the harness: #122.
    search-only token the census records `unavailable` and the run continues;
    nothing else degrades.
 
-`--repeats N` costs N searches per question (69 questions in v4) and feeds only
+`--repeats N` costs N searches per question (105 questions in v5) and feeds only
 latency and `hit_stability`. Start at `--repeats 1`.
 
 ## What it measures
@@ -76,6 +76,12 @@ latency and `hit_stability`. Start at `--repeats 1`.
 | `distinct_files_at_10` | mean distinct source files over the top 10 slots |
 | `distinct_source_ratio_mean` | distinct RESOLVABLE source paths per page divided by ALL hits. 1.00 means every slot is a different document; lower means one document occupies slots the caller pays context for. A hit whose source path cannot be resolved counts against this exactly like a duplicate does |
 | `distinct_source_ratio_resolvable_only` | the same ratio over hits whose source path resolved. Report both: the first is the pessimistic bound, this is what the resolvable evidence supports |
+| `head_recall_at_5` | share of embedding-window pairs whose HEAD quote (from the first 2000 characters) retrieves its own document |
+| `tail_recall_at_5` | the same for the TAIL quote (>= 40% depth) of the SAME document. Pessimistic: counts documents that may never have been indexed |
+| `tail_recall_given_head_at_5` | **quote this one.** `tail_recall_at_5` restricted to documents whose head quote DID retrieve, so every document counted is one the index demonstrably holds |
+| `window_penalty` | `head_recall_at_5 - tail_recall_at_5`: how much of a document stops being reachable purely because the text sits later in it |
+| `rank_inversion_rate` | share of answers ranked BELOW a hit the node itself reports matched a strictly smaller share of query terms. Ranking, not retrieval |
+| `chunks_with_unstable_trust_tier` | chunks served more than once at the same `content_sha256` that reported different `trust_tier` values |
 | `hit_stability` | with `--repeats N`: agreement of repeat outcomes with attempt 1 |
 | `latency p50/p95` | separate block; informational, never gates quality. **Client round-trip**, timed around `urlopen`, so it includes DNS, TCP, TLS and the network path from wherever you ran it. It is NOT server-side latency: on 2026-07-31 a run measuring 269ms from a laptop corresponded to 107-141ms in the Railway edge logs. Quote it as "round-trip from our client" and read server-side timing from the platform logs |
 
@@ -100,9 +106,64 @@ latency and `hit_stability`. Start at `--repeats 1`.
 Quality always comes from the first attempt. `--repeats` feeds latency and
 `hit_stability` only; there is no best-of-repeats path.
 
+## The frozen set
+
+The question set is FROZEN. `golden_questions.json` carries a `frozen` block
+whose `questions_sha256` pins the canonical question list, and `lint`
+recomputes it and fails when it moves. Editing a question is therefore a
+deliberate re-freeze (update the pin, bump `version`, re-take the baseline),
+never a silent drift between two runs that both call themselves the baseline.
+
+Two hashes appear in a run's fingerprint and they are not the same thing.
+`questions_sha256` is over the FILE bytes, so reindenting moves it.
+`questions_pin` is over the canonical question list, so it moves only when a
+question really changes. The pin says which frozen set a run answered.
+
+## Embedding-window pairs
+
+18 pairs, one per document, added in v5. Each pair quotes the SAME document
+twice: once from inside the first 2000 characters (`window_head`), once from at
+least 40% through it (`window_tail`). Both quotes are verbatim and unique across
+every cached body, so exactly one document can answer either, and the quote IS
+the query, which is the strongest retrieval signal available.
+
+The control that makes a tail miss mean something: a tail quote qualifies only
+when at least 3 of its distinctive terms are ABSENT from that document's head.
+Without it, a passing tail could be the head embedding answering the query and
+the comparison would prove nothing about how much of a document is reachable.
+`lint` enforces the offset, the depth, and every declared novel term, and
+rejects a pair whose "novel" terms turn out to occur in the head.
+
+Window questions are scored in their own block and are EXCLUDED from
+`answer_recall_at_5`. They fail by design against current behaviour; folding
+them into the headline would move it for a reason that has nothing to do with
+the node changing, and would break comparability with every baseline taken
+before v5.
+
+Read `tail_recall_given_head_at_5` rather than `tail_recall_at_5`. A document
+that missed on BOTH sides may simply never have been indexed, so its tail miss
+is not evidence about position. Conditioning on a head that retrieved keeps only
+documents the index demonstrably holds.
+
+## Ranking is not retrieval
+
+`answer_recall_at_5` asks whether the answering document came back.
+`rank_inversion_rate` asks whether the node put it in the right place. Search
+currently reports `retriever_scores_available: false` and orders by lexical term
+overlap, so these are genuinely different questions and one number cannot answer
+both.
+
+An inversion is: a hit ranked ABOVE the one that verifiably contains the answer,
+while the node ITSELF reports that hit matched a strictly smaller share of the
+query terms (`_citadel.relevance.term_coverage`). The answer slot is fixed by a
+body span match with the sync header stripped, and the comparison uses the
+node's own numbers, so a match on the path header can neither manufacture nor
+hide an inversion.
+
 ## The golden set
 
-`golden_questions.json` v4. 39 questions carry validated `answer_spans`; 22
+`golden_questions.json` v5. 39 non-window questions carry validated
+`answer_spans`, plus 36 window questions (18 pairs); 22
 Linear questions (`l01-l22`) are explicitly unconverted
 (`answer_spans_unconverted_reason`) because `fetch_ground_truth.py` skips
 `linear:` targets, so there is no cached body to quote. They count for
@@ -112,7 +173,10 @@ counted. 8 questions are probes (`expected_recall: 0`, below).
 `lint` validates every span offline against `ground_truth/`: present in the
 cached body, absent from the sync header and the document's first line (a
 head-line match is title credit, not an answer), absent from the question
-text, and unique across every other cached body. It also validates probes:
+text, and unique across every other cached body. The "absent from the question
+text" rule is waived for window questions ONLY, because a window question is
+its verbatim quote by design; every other question still rejects a span that
+appears in its own query. It also validates probes:
 every `blocked_pattern` must resolve against the live scanner, and a probe's
 question text must never itself match its rule. Lint fails loudly; run it
 after every edit to the golden set.

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -117,33 +117,78 @@ never a silent drift between two runs that both call themselves the baseline.
 Two hashes appear in a run's fingerprint and they are not the same thing.
 `questions_sha256` is over the FILE bytes, so reindenting moves it.
 `questions_pin` is over the canonical question list, so it moves only when a
-question really changes. The pin says which frozen set a run answered.
+question really changes. The pin says which frozen set a run answered, and it
+is the authority `compare` gates on: two runs whose pin matches stay comparable
+even if the file bytes differ, and the file difference is reported as a note.
+A run predating the pin has none, so the file hash still gates there. `report`
+prints the pin above the metric table, and says so plainly when a run carries
+none.
+
+The fingerprint also records `ground_truth`, a hash of the cached bodies the run
+scored against. `ground_truth/` is gitignored and `fetch_ground_truth.py` pulls
+each file from GitHub at HEAD with no ref, then skips anything already on disk,
+so two machines bake in whatever HEAD was current the day they first fetched.
+That cache is not decoration: it feeds `doc_rank`'s shingle fallback and
+`legacy_rank`, so it moves `doc_recall_at_5` and `header_credit_rate`. `compare`
+notes a difference rather than gating on it, because every run taken before the
+key existed would otherwise be refused. Re-fetch by deleting the cache, not by
+re-running the script over it.
 
 ## Embedding-window pairs
 
 18 pairs, one per document, added in v5. Each pair quotes the SAME document
 twice: once from inside the first 2000 characters (`window_head`), once from at
-least 40% through it (`window_tail`). Both quotes are verbatim and unique across
-every cached body, so exactly one document can answer either, and the quote IS
-the query, which is the strongest retrieval signal available.
+least 40% through it (`window_tail`). Both quotes are verbatim, and the quote IS
+the query, which is the strongest retrieval signal available. `lint` proves each
+quote unique across the CACHED ground-truth bodies, which is roughly 49 files,
+never across the corpus: a second render of a file or an uncached document
+quoting the same sentence would also score the pass. `run` counts that case as
+`quality.answers_from_unexpected_documents`, so the blind spot is readable per
+run rather than assumed away.
 
 The control that makes a tail miss mean something: a tail quote qualifies only
 when at least 3 of its distinctive terms are ABSENT from that document's head.
 Without it, a passing tail could be the head embedding answering the query and
 the comparison would prove nothing about how much of a document is reachable.
-`lint` enforces the offset, the depth, and every declared novel term, and
-rejects a pair whose "novel" terms turn out to occur in the head.
+
+`lint` enforces the depth threshold, the head window and the novelty control on
+a MEASURED offset (`body.find(quote)`), never on the fixture's declared
+`source_offset_chars`, and it requires every declared novel term to be a term of
+the quote itself. A declared offset that disagrees with the measured one is
+reported as a note: `ground_truth/` is refetched from an unpinned upstream HEAD,
+so a few characters of whitespace drift are ordinary and must not fail lint on
+every machine that fetched on a different day.
 
 Window questions are scored in their own block and are EXCLUDED from
 `answer_recall_at_5`. They fail by design against current behaviour; folding
 them into the headline would move it for a reason that has nothing to do with
-the node changing, and would break comparability with every baseline taken
-before v5.
+the node changing.
+
+That exclusion covers `span_rows` and nothing else. Precisely:
+`answer_recall_at_5`, `raw_page_recall_at_5`, `mrr_body` and
+`header_credit_rate` are unmoved by v5. `doc_recall_at_5`,
+`duplicate_blob_rate_at_10`, `distinct_files_at_10`, both
+`distinct_source_ratio` figures, `hit_stability` and `rank_inversion_rate` all
+moved when the 36 window questions landed, and none of them is comparable
+across the v5 boundary. `compare` is what enforces that: two runs answering
+different question sets differ in `questions_pin` and are refused outright.
 
 Read `tail_recall_given_head_at_5` rather than `tail_recall_at_5`. A document
 that missed on BOTH sides may simply never have been indexed, so its tail miss
 is not evidence about position. Conditioning on a head that retrieved keeps only
 documents the index demonstrably holds.
+
+What that conditioning does NOT control for: the pair holds the DOCUMENT
+constant and replaces the QUERY entirely. Head and tail are different sentences
+with different tokenisations facing different corpus competition, so a tail miss
+is positional OR lexical and this measurement cannot separate the two. On the
+2026-08-04 set the confound runs the other way in aggregate (head queries
+averaged 7.1 extracted terms against the tails' 6.8, and faced more cached-body
+competitors, 8.9 against 6.3), so it does not explain that day's 0 of 11.
+
+Every published window rate is computed over COMPLETE pairs only, so
+`head_recall_at_5`, `tail_recall_at_5`, `window_penalty` and the `pairs_complete`
+printed as their sample count stay consistent by construction.
 
 ## Ranking is not retrieval
 
@@ -155,10 +200,26 @@ both.
 
 An inversion is: a hit ranked ABOVE the one that verifiably contains the answer,
 while the node ITSELF reports that hit matched a strictly smaller share of the
-query terms (`_citadel.relevance.term_coverage`). The answer slot is fixed by a
-body span match with the sync header stripped, and the comparison uses the
-node's own numbers, so a match on the path header can neither manufacture nor
-hide an inversion.
+query terms (`_citadel.relevance.term_coverage`).
+
+**What the path header can and cannot do here.** The answer SLOT is
+header-immune: it is bound to a body span match with the sync header stripped,
+so a hit whose only overlap is the path never becomes the answer.
+`term_coverage` is NOT header-immune. The node computes it over a haystack that
+includes each hit's own `path`, `source`, `url`, provenance fields and the sync
+header still sitting in the chunk text (`kb/search_format.py`, `_hit_text`), and
+every hit on a page carries a different path, so a filename moves either side of
+the comparison: a decoy whose path matches three query terms stops being an
+inversion, and an answer whose path matches becomes one. Both directions are
+executed in `tests/test_search_bench.py`. Read `rank_inversion_rate` as the
+node's published relevance signal disagreeing with the node's own ordering, not
+as a body-only measure of relevance.
+
+The rate blends the 36 verbatim-sentence window queries with the real questions,
+while `answer_recall_at_5` deliberately keeps them apart. `run` therefore also
+publishes `rank_inversion_rate_excluding_window` and
+`rank_inversion_rate_window_only` with their own denominators, so a movement can
+be attributed to a set instead of guessed at.
 
 ## The golden set
 

--- a/scripts/bench/golden_questions.json
+++ b/scripts/bench/golden_questions.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "created_at": "2026-07-31",
   "corpus": "repo_content sync of masumi-network/{sokosumi,Sokosumi-MCP,sokosumi-cli,sokosumi-docs}",
   "notes": [
@@ -16,7 +16,15 @@
     "Blocked-content probes p01-p05 are therefore PATTERN probes: expected_recall 0 plus blocked_pattern naming a rule in kb.security_scan.SECRET_PATTERNS. The harness imports the LIVE rule at run and lint time (a renamed or deleted rule fails loudly instead of matching nothing) and flags a hit when a served chunk's RAW text matches the rule - text every current ingest gate (kb/service.py _guard_content, kb/repo_content_sync.py sync scan, share/promotion scans) rejects at block_severity=high. A pattern-probe hit therefore means: content ingested before the scanner existed, ingested with scanning disabled, or a rule weakened after ingest. Report any hit as a security finding, not a metric.",
     "secret_assignment is deliberately NOT probe-eligible: its _is_credential_like carve-outs mean the bare regex over-matches legitimate documentation, so a probe keyed on it would cry leak on clean content.",
     "Out-of-corpus negative controls n01-n03 name real GitHub files verifiably outside the syncer's selection (wrong extension or prefix, or a repo absent from the tracked four with autojoin disabled in prod). A hit resolving to one of those identities means the corpus quietly widened (convert the control to a positive, exactly the b01-b04 lifecycle) or identity parsing broke. fetch_ground_truth.py never caches expect_any targets of expected_recall=0 questions, so no probe target can enter this public repo.",
-    "v4 verification status: probes carry a `verification` field recording exactly what was checked on 2026-08-02 and what was not. Three probes were confirmed against production with read-only searches (p01, p04 clean; p02 clean on served text with an undetermined truncated remainder); p03 and p05 are sound by construction but their production miss is unconfirmed; n01-n03 were confirmed offline against the syncer's own discovery and the live sources API, not by a search. Nothing here is a benchmark result - the harness has still never completed a run."
+    "v4 verification status: probes carry a `verification` field recording exactly what was checked on 2026-08-02 and what was not. Three probes were confirmed against production with read-only searches (p01, p04 clean; p02 clean on served text with an undetermined truncated remainder); p03 and p05 are sound by construction but their production miss is unconfirmed; n01-n03 were confirmed offline against the syncer's own discovery and the live sources API, not by a search. Nothing here is a benchmark result - the harness has still never completed a run.",
+    "v5 adds embedding-window pairs (window_head / window_tail). Each pair quotes ONE",
+    "document twice: once from inside the first 2000 characters, once from at least 40%",
+    "depth. A tail quote qualifies only when at least 3 of its distinctive terms are",
+    "ABSENT from the document head, so a passing tail cannot be explained by the head",
+    "embedding answering the query. Both quotes are verbatim and unique across every",
+    "cached body, so exactly one document can answer. These questions are scored in",
+    "their own block and are EXCLUDED from answer_recall_at_5, which keeps the existing",
+    "headline comparable with baselines taken before v5."
   ],
   "questions": [
     {
@@ -864,6 +872,741 @@
       "expected_recall": 0,
       "note": "Out-of-corpus control derived 2026-08-02: README.md is a root path the syncer selects, but masumi-network/masumi-payment-service is not one of the four tracked repo_content repos and autojoin is disabled in prod (confirmed via the sources API). The github digest source does track that repo, but digests never render a '# org/repo/path' first line, so no legitimate hit can resolve to this identity.",
       "verification": "2026-08-02 OBSERVED (offline): masumi-network/masumi-payment-service is not in the tracked repo_content repo list returned by the live sources API, and autojoin_enabled is false there. NOT confirmed by a live search."
+    },
+    {
+      "id": "w01h",
+      "question": "- Go to [app.sokosumi.com/connections](https://app.sokosumi.com/connections)",
+      "expect_any": [
+        "masumi-network/Sokosumi-MCP/README.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Go to [app.sokosumi.com/connections](https://app.sokosumi.com/connections)"
+      ],
+      "window_pair": "w01",
+      "window_role": "head",
+      "doc_chars": 11419,
+      "source_offset_chars": 1189,
+      "depth_fraction": 0.1041
+    },
+    {
+      "id": "w01t",
+      "question": "/sokosumi:market Build a market analysis plan for this product.",
+      "expect_any": [
+        "masumi-network/Sokosumi-MCP/README.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "/sokosumi:market Build a market analysis plan for this product."
+      ],
+      "window_pair": "w01",
+      "window_role": "tail",
+      "doc_chars": 11419,
+      "source_offset_chars": 6196,
+      "depth_fraction": 0.5426,
+      "novel_terms_absent_from_head": [
+        "analysis",
+        "build",
+        "market",
+        "plan",
+        "product"
+      ]
+    },
+    {
+      "id": "w02h",
+      "question": "- Manually: the user runs `/sokosumi:watch <task-or-job-id>` to arm or re-arm monitoring on any task or job.",
+      "expect_any": [
+        "masumi-network/Sokosumi-MCP/skills/watch/SKILL.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Manually: the user runs `/sokosumi:watch <task-or-job-id>` to arm or re-arm monitoring on any task or job."
+      ],
+      "window_pair": "w02",
+      "window_role": "head",
+      "doc_chars": 6588,
+      "source_offset_chars": 1183,
+      "depth_fraction": 0.1796
+    },
+    {
+      "id": "w02t",
+      "question": "- **Finished** (task `COMPLETED` or any finished status; job `completed`) or **failed/cancelled** (task `FAILED` or `CANCELED`; job `failed`) — go to Step 4.",
+      "expect_any": [
+        "masumi-network/Sokosumi-MCP/skills/watch/SKILL.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- **Finished** (task `COMPLETED` or any finished status; job `completed`) or **failed/cancelled** (task `FAILED` or `CANCELED`; job `failed`) — go to Step 4."
+      ],
+      "window_pair": "w02",
+      "window_role": "tail",
+      "doc_chars": 6588,
+      "source_offset_chars": 4785,
+      "depth_fraction": 0.7263,
+      "novel_terms_absent_from_head": [
+        "canceled",
+        "cancelled",
+        "completed",
+        "failed",
+        "finished"
+      ]
+    },
+    {
+      "id": "w03h",
+      "question": "**CRITICAL**: Do NOT perform any git operations unless explicitly requested by the user.",
+      "expect_any": [
+        "masumi-network/sokosumi-cli/AGENTS.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "**CRITICAL**: Do NOT perform any git operations unless explicitly requested by the user."
+      ],
+      "window_pair": "w03",
+      "window_role": "head",
+      "doc_chars": 16910,
+      "source_offset_chars": 789,
+      "depth_fraction": 0.0467
+    },
+    {
+      "id": "w03t",
+      "question": "- [ ] Implement `magic-link.mjs` ← Currently working on this",
+      "expect_any": [
+        "masumi-network/sokosumi-cli/AGENTS.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- [ ] Implement `magic-link.mjs` ← Currently working on this"
+      ],
+      "window_pair": "w03",
+      "window_role": "tail",
+      "doc_chars": 16910,
+      "source_offset_chars": 13445,
+      "depth_fraction": 0.7951,
+      "novel_terms_absent_from_head": [
+        "implement",
+        "link",
+        "magic"
+      ]
+    },
+    {
+      "id": "w04h",
+      "question": "npx skills add https://github.com/masumi-network/sokosumi-cli --skill watch",
+      "expect_any": [
+        "masumi-network/sokosumi-cli/README.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "npx skills add https://github.com/masumi-network/sokosumi-cli --skill watch"
+      ],
+      "window_pair": "w04",
+      "window_role": "head",
+      "doc_chars": 9456,
+      "source_offset_chars": 1511,
+      "depth_fraction": 0.1598
+    },
+    {
+      "id": "w04t",
+      "question": "- direct API-key authentication plus the live sign-up, sign-in, and Connections URLs for humans who need to create a key",
+      "expect_any": [
+        "masumi-network/sokosumi-cli/README.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- direct API-key authentication plus the live sign-up, sign-in, and Connections URLs for humans who need to create a key"
+      ],
+      "window_pair": "w04",
+      "window_role": "tail",
+      "doc_chars": 9456,
+      "source_offset_chars": 7223,
+      "depth_fraction": 0.7639,
+      "novel_terms_absent_from_head": [
+        "connections",
+        "humans",
+        "live",
+        "need",
+        "sign",
+        "urls"
+      ]
+    },
+    {
+      "id": "w05h",
+      "question": "never write to the live production parent. Provision always forks a child",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/agents/cloud-agent-database.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "never write to the live production parent. Provision always forks a child"
+      ],
+      "window_pair": "w05",
+      "window_role": "head",
+      "doc_chars": 5373,
+      "source_offset_chars": 1057,
+      "depth_fraction": 0.1967
+    },
+    {
+      "id": "w05t",
+      "question": "node scripts/cloud-agent-db/teardown.mjs --from-text \"$(gh pr view 123 --json body -q .body)\"",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/agents/cloud-agent-database.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "node scripts/cloud-agent-db/teardown.mjs --from-text \"$(gh pr view 123 --json body -q .body)\""
+      ],
+      "window_pair": "w05",
+      "window_role": "tail",
+      "doc_chars": 5373,
+      "source_offset_chars": 4435,
+      "depth_fraction": 0.8254,
+      "novel_terms_absent_from_head": [
+        "body",
+        "text",
+        "view"
+      ]
+    },
+    {
+      "id": "w06h",
+      "question": "- **How it's validated:** every coworker the API returns is parsed against the",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker-metadata.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- **How it's validated:** every coworker the API returns is parsed against the"
+      ],
+      "window_pair": "w06",
+      "window_role": "head",
+      "doc_chars": 13477,
+      "source_offset_chars": 583,
+      "depth_fraction": 0.0433
+    },
+    {
+      "id": "w06t",
+      "question": "\"prompt\": \"Run a competitive and market analysis for [COMPANY] ([WEBSITE]).\",",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker-metadata.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "\"prompt\": \"Run a competitive and market analysis for [COMPANY] ([WEBSITE]).\","
+      ],
+      "window_pair": "w06",
+      "window_role": "tail",
+      "doc_chars": 13477,
+      "source_offset_chars": 10053,
+      "depth_fraction": 0.7459,
+      "novel_terms_absent_from_head": [
+        "analysis",
+        "company",
+        "competitive",
+        "market",
+        "prompt",
+        "website"
+      ]
+    },
+    {
+      "id": "w07h",
+      "question": "pnpm bench:coworker-chat -- --scenario realistic --out /tmp/bench-report.json",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker/benchmarks/README.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "pnpm bench:coworker-chat -- --scenario realistic --out /tmp/bench-report.json"
+      ],
+      "window_pair": "w07",
+      "window_role": "head",
+      "doc_chars": 5483,
+      "source_offset_chars": 498,
+      "depth_fraction": 0.0908
+    },
+    {
+      "id": "w07t",
+      "question": "- Output contains `Something went wrong while processing your task`",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker/benchmarks/README.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Output contains `Something went wrong while processing your task`"
+      ],
+      "window_pair": "w07",
+      "window_role": "tail",
+      "doc_chars": 5483,
+      "source_offset_chars": 3610,
+      "depth_fraction": 0.6584,
+      "novel_terms_absent_from_head": [
+        "contains",
+        "output",
+        "processing",
+        "something",
+        "task",
+        "went",
+        "while",
+        "wrong"
+      ]
+    },
+    {
+      "id": "w08h",
+      "question": "- **Source of truth (OpenAPI shape):** `apps/core/src/schemas/task.schema.ts`",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker/vendor-workspace-grants-api.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- **Source of truth (OpenAPI shape):** `apps/core/src/schemas/task.schema.ts`"
+      ],
+      "window_pair": "w08",
+      "window_role": "head",
+      "doc_chars": 7905,
+      "source_offset_chars": 704,
+      "depth_fraction": 0.0891
+    },
+    {
+      "id": "w08t",
+      "question": "After human **approve**: task unparks to `grantResumeStatus` (null → `READY`).",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/coworker/vendor-workspace-grants-api.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "After human **approve**: task unparks to `grantResumeStatus` (null → `READY`)."
+      ],
+      "window_pair": "w08",
+      "window_role": "tail",
+      "doc_chars": 7905,
+      "source_offset_chars": 5538,
+      "depth_fraction": 0.7006,
+      "novel_terms_absent_from_head": [
+        "after",
+        "approve",
+        "human",
+        "unparks"
+      ]
+    },
+    {
+      "id": "w09h",
+      "question": "- `overrides.organizationId` is optional. When present, it is authoritative for",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/hermes-orchestrator-approve-overrides.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- `overrides.organizationId` is optional. When present, it is authoritative for"
+      ],
+      "window_pair": "w09",
+      "window_role": "head",
+      "doc_chars": 8250,
+      "source_offset_chars": 1001,
+      "depth_fraction": 0.1213
+    },
+    {
+      "id": "w09t",
+      "question": "job confirmation card. Both should show the same Personal default and",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/hermes-orchestrator-approve-overrides.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "job confirmation card. Both should show the same Personal default and"
+      ],
+      "window_pair": "w09",
+      "window_role": "tail",
+      "doc_chars": 8250,
+      "source_offset_chars": 6015,
+      "depth_fraction": 0.7291,
+      "novel_terms_absent_from_head": [
+        "both",
+        "card",
+        "default",
+        "show"
+      ]
+    },
+    {
+      "id": "w10h",
+      "question": "- **Per-user scope:** `orchestratorId` is never implied by the secret. Resolve",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/orchestrator/hermes-orchestrator-actor.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- **Per-user scope:** `orchestratorId` is never implied by the secret. Resolve"
+      ],
+      "window_pair": "w10",
+      "window_role": "head",
+      "doc_chars": 6930,
+      "source_offset_chars": 663,
+      "depth_fraction": 0.0957
+    },
+    {
+      "id": "w10t",
+      "question": "verified fresh provision path). Poll advances `lastPolledAt` so missing",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/orchestrator/hermes-orchestrator-actor.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "verified fresh provision path). Poll advances `lastPolledAt` so missing"
+      ],
+      "window_pair": "w10",
+      "window_role": "tail",
+      "doc_chars": 6930,
+      "source_offset_chars": 5712,
+      "depth_fraction": 0.8242,
+      "novel_terms_absent_from_head": [
+        "advances",
+        "fresh",
+        "lastpolledat",
+        "missing",
+        "verified"
+      ]
+    },
+    {
+      "id": "w11h",
+      "question": "- [ ] **Step 1: Write failing tests** — append to the existing test file (it already mocks `tx.user.findMany`; add `count`):",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-06-12-admin-user-overview.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- [ ] **Step 1: Write failing tests** — append to the existing test file (it already mocks `tx.user.findMany`; add `count`):"
+      ],
+      "window_pair": "w11",
+      "window_role": "head",
+      "doc_chars": 23564,
+      "source_offset_chars": 1242,
+      "depth_fraction": 0.0527
+    },
+    {
+      "id": "w11t",
+      "question": "const result = await coreClient.listAdminUserOverview(params);",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-06-12-admin-user-overview.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "const result = await coreClient.listAdminUserOverview(params);"
+      ],
+      "window_pair": "w11",
+      "window_role": "tail",
+      "doc_chars": 23564,
+      "source_offset_chars": 18150,
+      "depth_fraction": 0.7702,
+      "novel_terms_absent_from_head": [
+        "coreclient",
+        "listadminuseroverview",
+        "params"
+      ]
+    },
+    {
+      "id": "w12h",
+      "question": "- No auto-settle after top-up (requested status still dropped on pause)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-07-27-task-credit-pause-timeline-ux.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- No auto-settle after top-up (requested status still dropped on pause)"
+      ],
+      "window_pair": "w12",
+      "window_role": "head",
+      "doc_chars": 18343,
+      "source_offset_chars": 970,
+      "depth_fraction": 0.0529
+    },
+    {
+      "id": "w12t",
+      "question": "// expect \"tried to charge 3 credits\" (secondary or in body)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/plans/2026-07-27-task-credit-pause-timeline-ux.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "// expect \"tried to charge 3 credits\" (secondary or in body)"
+      ],
+      "window_pair": "w12",
+      "window_role": "tail",
+      "doc_chars": 18343,
+      "source_offset_chars": 12902,
+      "depth_fraction": 0.7034,
+      "novel_terms_absent_from_head": [
+        "body",
+        "secondary",
+        "tried"
+      ]
+    },
+    {
+      "id": "w13h",
+      "question": "and core preview deployments to disagree on the cookie name, which broke",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-03-24-better-auth-cookie-prefix-commit-ref-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "and core preview deployments to disagree on the cookie name, which broke"
+      ],
+      "window_pair": "w13",
+      "window_role": "head",
+      "doc_chars": 6000,
+      "source_offset_chars": 708,
+      "depth_fraction": 0.118
+    },
+    {
+      "id": "w13t",
+      "question": "[apps/web/src/lib/auth/__tests__/auth.test.ts](/Users/andreas/Developer/masumi-network/sokosumi-review/apps/web/src/lib/auth/__tests__/auth.test.ts)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-03-24-better-auth-cookie-prefix-commit-ref-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "[apps/web/src/lib/auth/__tests__/auth.test.ts](/Users/andreas/Developer/masumi-network/sokosumi-review/apps/web/src/lib/auth/__tests__/auth.test.ts)"
+      ],
+      "window_pair": "w13",
+      "window_role": "tail",
+      "doc_chars": 6000,
+      "source_offset_chars": 4138,
+      "depth_fraction": 0.6897,
+      "novel_terms_absent_from_head": [
+        "apps",
+        "test",
+        "tests"
+      ]
+    },
+    {
+      "id": "w14h",
+      "question": "Before this PR, the zero-margin decision was made **server-side only** in web via",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-18-zero-margin-pricing-core-authority-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "Before this PR, the zero-margin decision was made **server-side only** in web via"
+      ],
+      "window_pair": "w14",
+      "window_role": "head",
+      "doc_chars": 8479,
+      "source_offset_chars": 1081,
+      "depth_fraction": 0.1275
+    },
+    {
+      "id": "w14t",
+      "question": "10. **`apps/web/src/app/(app)/billing/page.tsx`** — delete `zeroMarginTopUpEnabled()`",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-18-zero-margin-pricing-core-authority-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "10. **`apps/web/src/app/(app)/billing/page.tsx`** — delete `zeroMarginTopUpEnabled()`"
+      ],
+      "window_pair": "w14",
+      "window_role": "tail",
+      "doc_chars": 8479,
+      "source_offset_chars": 6212,
+      "depth_fraction": 0.7326,
+      "novel_terms_absent_from_head": [
+        "apps",
+        "delete",
+        "page",
+        "zeromargintopupenabled"
+      ]
+    },
+    {
+      "id": "w15h",
+      "question": "- **Task naming** has no core equivalent. Web `actions/task/action.ts`",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-19-remove-openrouter-from-web-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- **Task naming** has no core equivalent. Web `actions/task/action.ts`"
+      ],
+      "window_pair": "w15",
+      "window_role": "head",
+      "doc_chars": 8786,
+      "source_offset_chars": 1100,
+      "depth_fraction": 0.1252
+    },
+    {
+      "id": "w15t",
+      "question": "- The LLM call runs **before** the DB transaction, so a slow or failing LLM",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-06-19-remove-openrouter-from-web-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- The LLM call runs **before** the DB transaction, so a slow or failing LLM"
+      ],
+      "window_pair": "w15",
+      "window_role": "tail",
+      "doc_chars": 8786,
+      "source_offset_chars": 6950,
+      "depth_fraction": 0.791,
+      "novel_terms_absent_from_head": [
+        "before",
+        "call",
+        "failing",
+        "runs",
+        "slow",
+        "transaction"
+      ]
+    },
+    {
+      "id": "w16h",
+      "question": "- Tie refresh to API access (forces RT on every API client; blocks identity+refresh)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-23-oauth-refresh-token-opt-in-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Tie refresh to API access (forces RT on every API client; blocks identity+refresh)"
+      ],
+      "window_pair": "w16",
+      "window_role": "head",
+      "doc_chars": 6817,
+      "source_offset_chars": 851,
+      "depth_fraction": 0.1248
+    },
+    {
+      "id": "w16t",
+      "question": "1. Remove `offline_access` from client scopes (**this is the real gate**)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-23-oauth-refresh-token-opt-in-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "1. Remove `offline_access` from client scopes (**this is the real gate**)"
+      ],
+      "window_pair": "w16",
+      "window_role": "tail",
+      "doc_chars": 6817,
+      "source_offset_chars": 4809,
+      "depth_fraction": 0.7054,
+      "novel_terms_absent_from_head": [
+        "gate",
+        "real",
+        "remove"
+      ]
+    },
+    {
+      "id": "w17h",
+      "question": "- `kind: \"channel\"` — create named channel (`name` / `slug`)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-27-chats-api-and-chat-room-schema-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- `kind: \"channel\"` — create named channel (`name` / `slug`)"
+      ],
+      "window_pair": "w17",
+      "window_role": "head",
+      "doc_chars": 6421,
+      "source_offset_chars": 1610,
+      "depth_fraction": 0.2507
+    },
+    {
+      "id": "w17t",
+      "question": "**`chat_room_read_state`** — UNIQUE `(roomId, userId)`, `lastReadAt`.",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-27-chats-api-and-chat-room-schema-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "**`chat_room_read_state`** — UNIQUE `(roomId, userId)`, `lastReadAt`."
+      ],
+      "window_pair": "w17",
+      "window_role": "tail",
+      "doc_chars": 6421,
+      "source_offset_chars": 4602,
+      "depth_fraction": 0.7167,
+      "novel_terms_absent_from_head": [
+        "lastreadat",
+        "state",
+        "unique",
+        "userid"
+      ]
+    },
+    {
+      "id": "w18h",
+      "question": "- Redirects from legacy `/chat/[bucket]/conversation/[id]` (404 or soft land on `/chat`; default **404**)",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-28-chat-rooms-cutover-deprecate-conversations-design.md"
+      ],
+      "category": "window_head",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Redirects from legacy `/chat/[bucket]/conversation/[id]` (404 or soft land on `/chat`; default **404**)"
+      ],
+      "window_pair": "w18",
+      "window_role": "head",
+      "doc_chars": 8915,
+      "source_offset_chars": 985,
+      "depth_fraction": 0.1105
+    },
+    {
+      "id": "w18t",
+      "question": "- Core must reject `coworkerIds.length > 1` on `kind: \"direct\"` create (include in this cutover if not already shipped).",
+      "expect_any": [
+        "masumi-network/sokosumi/docs/superpowers/specs/2026-07-28-chat-rooms-cutover-deprecate-conversations-design.md"
+      ],
+      "category": "window_tail",
+      "expected_recall": 1,
+      "answer_spans": [
+        "- Core must reject `coworkerIds.length > 1` on `kind: \"direct\"` create (include in this cutover if not already shipped)."
+      ],
+      "window_pair": "w18",
+      "window_role": "tail",
+      "doc_chars": 8915,
+      "source_offset_chars": 7191,
+      "depth_fraction": 0.8066,
+      "novel_terms_absent_from_head": [
+        "core",
+        "coworkerids",
+        "include",
+        "length",
+        "must",
+        "reject",
+        "shipped"
+      ]
     }
-  ]
+  ],
+  "frozen": {
+    "frozen_at": "2026-08-04",
+    "policy": "Editing any question below changes what the baseline means. lint recomputes questions_sha256 over the canonical question list and fails when it differs from the pin, so a change is a deliberate re-freeze and a version bump, never a silent drift.",
+    "questions_sha256": "022b6b4f66c73af10ae99090d58ed0c1b89806718db222de0825a14c9cfb9838"
+  }
 }

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -119,7 +119,20 @@ NOVEL_TERM_STOPWORDS = frozenset(
 
 
 def is_window_question(question: dict[str, Any]) -> bool:
-    return str(question.get("category", "")) in WINDOW_CATEGORIES
+    """True for anything `summarize` will bucket as a window row.
+
+    Keyed on BOTH surfaces deliberately. `summarize` buckets on `window_role`
+    (score_question copies that field straight through), while the fixture
+    contract is declared as `category`. Keying lint on `category` alone left a
+    bypass: a question carrying `window_role` and no category was invisible to
+    `_lint_window_question` and still entered head/tail recall and the
+    `tail_recall_given_head_at_5` arithmetic with zero validation. Whatever
+    either surface treats as a window question has to satisfy the contract,
+    and the contract itself requires the two to agree.
+    """
+    if str(question.get("category", "")) in WINDOW_CATEGORIES:
+        return True
+    return question.get("window_role") in ("head", "tail")
 
 
 def distinctive_terms(text: str) -> set[str]:
@@ -437,6 +450,30 @@ def trust_observations(hits: list[dict[str, Any]]) -> list[tuple[str, str, str]]
     return out
 
 
+def entry_matches_expected(
+    entry: dict[str, Any],
+    expected: list[str],
+    gt_shingles: dict[str, set[str]],
+) -> bool:
+    """Is this collapsed identity one of the question's expect_any documents?
+
+    Identity first (path+blob or Linear key), then the cached-body shingle
+    fallback for a later chunk that carries no sync header. One definition
+    shared by `doc_rank` and by the answer-slot provenance check, so the two
+    can never disagree about what "the expected document" means.
+    """
+    identity = entry["identity"]
+    if identity.kind in ("repo", "linear") and identity.source in expected:
+        return True
+    for repo_path in expected:
+        if repo_path not in gt_shingles:
+            continue
+        for body in entry["bodies"]:
+            if len(shingles(body) & gt_shingles[repo_path]) >= MIN_SHARED_SHINGLES:
+                return True
+    return False
+
+
 def score_question(
     question: dict[str, Any],
     hits: list[dict[str, Any]],
@@ -449,11 +486,24 @@ def score_question(
     collapsed = collapse_hits(hits)
 
     answer_rank: int | None = None
+    # Whether the document that supplied the span is one this question named.
+    # `answer_pass_at_5` deliberately does NOT gate on it: that metric asks
+    # whether the answer TEXT came back, `doc_recall_at_5` asks whether the
+    # named document did, and blending them is what a single recall number
+    # already does wrong. But span uniqueness is enforced by `lint` only across
+    # the ~49 files in the gitignored ground-truth cache, never across the
+    # corpus, so a second render of a file, an org digest, a session trace or
+    # any uncached document quoting the sentence would score the pass. Counting
+    # the fact makes that blind spot visible per run instead of assumed away.
+    answer_from_expected: bool | None = None
     if spans:
         for entry in collapsed:
             bodies = [normalize(body) for body in entry["bodies"]]
             if any(span in body for body in bodies for span in spans):
                 answer_rank = entry["effective_rank"]
+                answer_from_expected = entry_matches_expected(
+                    entry, expected, gt_shingles
+                )
                 break
 
     raw_page_pass = False
@@ -473,9 +523,22 @@ def score_question(
     #
     # An inversion is: some hit ranked ABOVE the one that verifiably contains
     # the answer, while the node itself reports that hit matched a STRICTLY
-    # SMALLER share of the query terms. That cannot be produced by a path-header
-    # match, because the header contributes to coverage identically for every
-    # hit on the page.
+    # SMALLER share of the query terms.
+    #
+    # BLIND SPOT, stated where the number is produced. The answer SLOT is
+    # header-immune: it is bound to a body span match with the sync header
+    # stripped, so a hit whose only overlap is the path can never become the
+    # answer. `term_coverage` is NOT header-immune. The node computes it over
+    # a haystack that includes the hit's own path, source url, provenance and
+    # the sync header still sitting in the chunk text
+    # (`kb/search_format.py:_hit_text`), and every hit on a page carries a
+    # DIFFERENT path, so a filename can move either side of this comparison:
+    # a decoy whose path matches three query terms stops being an inversion,
+    # and an answer whose path matches becomes one. Both directions were
+    # executed against the node's own coverage function. The metric is
+    # therefore an honest statement about the node's published relevance
+    # signal disagreeing with the node's own ordering, and NOT a body-only
+    # measure of relevance. Do not quote it as one.
     answer_slot: int | None = None
     answer_coverage: float | None = None
     outranked_by_coverage: float | None = None
@@ -497,19 +560,7 @@ def score_question(
 
     doc_rank: int | None = None
     for entry in collapsed:
-        identity = entry["identity"]
-        matched = identity.kind in ("repo", "linear") and identity.source in expected
-        if not matched:
-            for repo_path in expected:
-                if repo_path not in gt_shingles:
-                    continue
-                for body in entry["bodies"]:
-                    if len(shingles(body) & gt_shingles[repo_path]) >= MIN_SHARED_SHINGLES:
-                        matched = True
-                        break
-                if matched:
-                    break
-        if matched:
+        if entry_matches_expected(entry, expected, gt_shingles):
             doc_rank = entry["effective_rank"]
             break
 
@@ -580,7 +631,9 @@ def score_question(
         "has_spans": bool(spans),
         "answer_rank": answer_rank,
         "answer_pass_at_5": answer_rank is not None and answer_rank <= K_ANSWER,
+        "answer_from_expected_document": answer_from_expected,
         "raw_page_pass_at_5": raw_page_pass,
+        "expect_any": expected,
         "window_role": question.get("window_role"),
         "window_pair": question.get("window_pair"),
         "depth_fraction": question.get("depth_fraction"),
@@ -627,11 +680,21 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     positives = [row for row in rows if row["expected_recall"] == 1]
     probes = [row for row in rows if row["expected_recall"] == 0]
     window_rows = [row for row in positives if row.get("window_role") in ("head", "tail")]
-    # Window pairs are deliberately kept OUT of the headline. They were added in
-    # questions v5 and they fail by design against current behaviour; folding
-    # them in would move answer_recall_at_5 for a reason that has nothing to do
-    # with the node changing, and every baseline taken before v5 would stop
-    # being comparable.
+    # Window pairs are deliberately kept out of the SPAN-scored headline. They
+    # were added in questions v5 and they fail by design against current
+    # behaviour; folding them in would move answer_recall_at_5 for a reason
+    # that has nothing to do with the node changing.
+    #
+    # Scope of that protection, stated exactly rather than as "the headline".
+    # `span_rows` is the only exclusion, so only the metrics computed from it
+    # are unmoved by v5: answer_recall_at_5, raw_page_recall_at_5, mrr_body,
+    # header_credit_rate. Every metric computed from `positives` or from `rows`
+    # DID move when the 36 window questions landed -- doc_recall_at_5,
+    # duplicate_blob_rate_at_10, distinct_files_at_10, the two
+    # distinct_source_ratio figures, hit_stability and rank_inversion_rate.
+    # None of those is comparable across the v5 boundary. `compare` is what
+    # enforces this: two runs answering different question sets differ in
+    # `questions_pin` and are refused outright.
     span_rows = [
         row for row in positives if row["has_spans"] and row.get("window_role") is None
     ]
@@ -686,14 +749,23 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     # ---- Embedding window --------------------------------------------------
     heads = [row for row in window_rows if row["window_role"] == "head"]
     tails = [row for row in window_rows if row["window_role"] == "tail"]
-    head_recall = rate(heads, "answer_pass_at_5") if heads else None
-    tail_recall = rate(tails, "answer_pass_at_5") if tails else None
-    # Only pairs whose BOTH sides ran contribute to the penalty, so the figure
-    # is a within-document difference and never a comparison across two
-    # different document populations.
     head_by_pair = {row["window_pair"]: row for row in heads}
     tail_by_pair = {row["window_pair"]: row for row in tails}
     complete_pairs = sorted(set(head_by_pair) & set(tail_by_pair))
+    # Every published window rate is computed over COMPLETE pairs only, so the
+    # figure really is a within-document difference and never a comparison
+    # across two different document populations. The comment used to claim
+    # that while `head_recall`/`tail_recall` were taken over ALL head rows and
+    # ALL tail rows: one dangling side (a tail dropped, a head added without
+    # its tail) silently turned window_penalty into a cross-population
+    # difference, and the report still printed `pairs_complete` as its n.
+    # Restricting here keeps the rate, the penalty and the printed n consistent
+    # by construction. With every pair complete the numbers are identical, so
+    # this does not move a baseline taken while the set was whole.
+    paired_heads = [head_by_pair[pair] for pair in complete_pairs]
+    paired_tails = [tail_by_pair[pair] for pair in complete_pairs]
+    head_recall = rate(paired_heads, "answer_pass_at_5") if paired_heads else None
+    tail_recall = rate(paired_tails, "answer_pass_at_5") if paired_tails else None
     head_only_pass = sum(
         1
         for pair in complete_pairs
@@ -722,6 +794,14 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     zero_coverage_inversions = sum(
         1 for row in inverted if row["outranked_by_coverage"] == 0.0
     )
+    # rank_inversion_rate blends two populations that answer_recall_at_5 keeps
+    # apart: real questions and the 36 verbatim-sentence window queries, whose
+    # exact-quote form is not how anyone searches. Report the split so a reader
+    # can see which set a movement came from instead of inferring it.
+    ranked_window = [row for row in ranked if row.get("window_role") is not None]
+    ranked_plain = [row for row in ranked if row.get("window_role") is None]
+    inverted_window = [row for row in ranked_window if row["outranked_by_coverage"] is not None]
+    inverted_plain = [row for row in ranked_plain if row["outranked_by_coverage"] is not None]
 
     # ---- Per-request metadata stability ------------------------------------
     tiers_seen: dict[tuple[str, str], set[str]] = {}
@@ -738,6 +818,19 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             "mrr_body": round(mrr_body, 4),
             "header_credit_rate": round(header_credit / len(span_rows), 4),
             "negative_hit_rate": round(negative_hits / len(probes), 4),
+            # How many answer passes came off a document the question did NOT
+            # name. `lint` proves a span unique across the ~49 cached
+            # ground-truth files and cannot say anything about the corpus, so
+            # this is the run-time reading of that blind spot. Non-zero does
+            # not mean the pass was wrong; it means the pass was scored off
+            # text lint never checked for uniqueness, and those rows should be
+            # read before the recall figure is quoted.
+            "answers_from_unexpected_documents": sum(
+                1
+                for row in positives
+                if row["answer_pass_at_5"]
+                and row.get("answer_from_expected_document") is False
+            ),
         },
         "duplication": {
             "duplicate_blob_rate_at_10": (
@@ -766,8 +859,18 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             # The figure that survives the obvious objection. A document whose
             # HEAD quote also missed may simply not be in the index at all, and
             # its tail miss says nothing about the window. Restricting to pairs
-            # whose head retrieved keeps only documents proven reachable, so a
-            # tail miss there is positional and nothing else.
+            # whose head retrieved keeps only documents proven reachable.
+            #
+            # What it does NOT control for, stated beside the number: the pair
+            # holds the DOCUMENT constant and replaces the QUERY entirely. Head
+            # and tail are different sentences with different tokenisations
+            # facing different corpus competition, so a tail miss is positional
+            # OR lexical and this metric cannot separate the two. Measured on
+            # the 2026-08-04 set the confound runs the other way in aggregate
+            # (head queries averaged 7.1 extracted terms against the tails' 6.8
+            # and faced MORE cached-body competitors, 8.9 against 6.3), so it
+            # does not explain that day's 0 of 11 -- but "positional and
+            # nothing else" is a stronger claim than the design supports.
             "tail_recall_given_head_at_5": (
                 round(both_pass / (both_pass + head_only_pass), 4)
                 if (both_pass + head_only_pass)
@@ -784,7 +887,13 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             "pairs_both": both_pass,
             "pairs_neither": neither_pass,
             "pairs_tail_only": tail_only_pass,
-            "documents": len({row["window_pair"] for row in window_rows}),
+            # Distinct expect_any DOCUMENTS, not distinct pair ids. Two pairs
+            # quoting one document used to report `documents: 2`, overstating
+            # how much of the corpus the window measurement covers -- the
+            # name-versus-what-it-attests failure this harness exists to catch.
+            "documents": len(
+                {doc for row in window_rows for doc in (row.get("expect_any") or [])}
+            ),
         },
         "ranking": {
             "answers_ranked": len(ranked),
@@ -793,6 +902,19 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             ),
             "inversions_by_zero_coverage": zero_coverage_inversions,
             "answer_worst_slot": max((row["answer_slot"] for row in ranked), default=None),
+            # The split behind the headline rate. `answer_recall_at_5` excludes
+            # window rows and this one does not, so the two denominators differ
+            # and the blended figure is dominated by whichever set is larger.
+            "answers_ranked_excluding_window": len(ranked_plain),
+            "rank_inversion_rate_excluding_window": (
+                round(len(inverted_plain) / len(ranked_plain), 4) if ranked_plain else None
+            ),
+            "answers_ranked_window_only": len(ranked_window),
+            "rank_inversion_rate_window_only": (
+                round(len(inverted_window) / len(ranked_window), 4)
+                if ranked_window
+                else None
+            ),
         },
         "metadata_stability": {
             "chunks_observed": len(tiers_seen),
@@ -1040,6 +1162,49 @@ def corpus_census(
     return result
 
 
+def ground_truth_fingerprint(cache_dir: Path | None = None) -> dict[str, Any]:
+    """sha256 over the cached ground-truth bodies the run scored against.
+
+    `ground_truth/` is gitignored and `fetch_ground_truth.py` pulls each file
+    from GitHub at HEAD with no ref, then skips anything already on disk. Two
+    machines therefore bake in whatever HEAD was on the day they first fetched.
+    The cache is not decoration: `load_ground_truth_shingles` feeds `doc_rank`'s
+    shingle fallback and `legacy_rank`, so it moves `doc_recall_at_5` and
+    `header_credit_rate`. Recording its hash is what lets `compare` say so.
+
+    Drift is not hypothetical: on 2026-08-05 a re-fetch of the w05 fixture's
+    document came back 5617 chars against the 5373 the fixture recorded, with
+    the quote at 4679 rather than 4435.
+    """
+    # Resolved at call time, not bound as a default, so the directory the run
+    # actually read is the one that gets hashed.
+    cache_dir = GROUND_TRUTH if cache_dir is None else cache_dir
+    if not cache_dir.exists():
+        return {
+            "sha256": None,
+            "files": 0,
+            "reason": (
+                f"ground-truth cache not found at {cache_dir}; runs are NOT "
+                "comparable on the bodies doc_rank fell back to"
+            ),
+        }
+    digests: dict[str, str] = {}
+    for path in sorted(cache_dir.iterdir()):
+        if path.is_file():
+            digests[path.name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    if not digests:
+        return {
+            "sha256": None,
+            "files": 0,
+            "reason": (
+                f"ground-truth cache at {cache_dir} is empty; runs are NOT "
+                "comparable on the bodies doc_rank fell back to"
+            ),
+        }
+    canonical = json.dumps(digests, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return {"sha256": hashlib.sha256(canonical).hexdigest(), "files": len(digests)}
+
+
 def build_fingerprint(
     node_url: str,
     token: str,
@@ -1071,6 +1236,7 @@ def build_fingerprint(
         # answered, the file hash says whether the file was touched at all.
         "questions_sha256": hashlib.sha256(questions_path.read_bytes()).hexdigest(),
         "questions_pin": questions_pin(load_questions(questions_path)),
+        "ground_truth": ground_truth_fingerprint(),
         "python_version": platform.python_version(),
     }
 
@@ -1120,9 +1286,56 @@ def compare_fingerprints(
             f"({baseline_sha[:12]} -> {current_sha[:12]}). NOT COMPARABLE: any "
             "metric delta includes corpus movement, not just code."
         )
-    if current.get("questions_sha256") != baseline.get("questions_sha256"):
+    # The PIN is the authority on which frozen set was answered, not the file
+    # hash. `questions_pin` is over the canonical question list, so it moves
+    # when a question really changes; `questions_sha256` is over the file bytes,
+    # so reindenting the JSON or bumping `version` moves it while both runs
+    # answered exactly the same questions. Gating on the file hash withheld the
+    # whole delta in precisely the case the pin was introduced to fix. A run
+    # predating the pin has no pin, so the file hash still gates there: an
+    # artifact that cannot say which set it answered is not comparable on
+    # anybody's word.
+    current_pin = current.get("questions_pin")
+    baseline_pin = baseline.get("questions_pin")
+    if current_pin and baseline_pin:
+        if current_pin != baseline_pin:
+            comparable = False
+            verdicts.append(
+                "QUESTIONS CHANGED: frozen sets differ "
+                f"({str(baseline_pin)[:16]} -> {str(current_pin)[:16]}). NOT "
+                "COMPARABLE."
+            )
+        elif current.get("questions_sha256") != baseline.get("questions_sha256"):
+            verdicts.append(
+                "note: the questions FILE differs but questions_pin is "
+                f"identical ({str(current_pin)[:16]}); the two runs answered "
+                "the same frozen set and the delta stands"
+            )
+    elif current.get("questions_sha256") != baseline.get("questions_sha256"):
         comparable = False
-        verdicts.append("QUESTIONS CHANGED: golden sets differ. NOT COMPARABLE.")
+        verdicts.append(
+            "QUESTIONS CHANGED: golden sets differ and at least one run "
+            "predates questions_pin, so the file hash is all there is. NOT "
+            "COMPARABLE."
+        )
+    # The ground-truth cache is refetched from an unpinned upstream HEAD and
+    # feeds doc_rank's shingle fallback and legacy_rank. A note, not a gate:
+    # every run taken before this key existed would otherwise be refused.
+    current_gt = (current.get("ground_truth") or {}).get("sha256")
+    baseline_gt = (baseline.get("ground_truth") or {}).get("sha256")
+    if current_gt is None or baseline_gt is None:
+        verdicts.append(
+            "note: ground-truth cache fingerprint unavailable on at least one "
+            "run; doc_recall_at_5 and header_credit_rate are not attested to "
+            "have been scored against the same cached bodies"
+        )
+    elif current_gt != baseline_gt:
+        verdicts.append(
+            "note: ground-truth cache differs "
+            f"({baseline_gt[:12]} -> {current_gt[:12]}); doc_recall_at_5 and "
+            "header_credit_rate use it as a fallback and can move without the "
+            "node changing"
+        )
     if current.get("harness_git_sha") != baseline.get("harness_git_sha"):
         verdicts.append(
             "note: harness git sha differs "
@@ -1318,7 +1531,9 @@ def lint_questions(
                     )
 
         if is_window_question(question):
-            problems.extend(_lint_window_question(question, cached_raw))
+            window_problems, window_notes = _lint_window_question(question, cached_raw)
+            problems.extend(window_problems)
+            notes.extend(window_notes)
 
     problems.extend(_lint_freeze_pin(data))
     return problems, notes
@@ -1326,19 +1541,39 @@ def lint_questions(
 
 def _lint_window_question(
     question: dict[str, Any], cached_raw: dict[str, str]
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """The contract that makes a window pair a controlled comparison.
 
     Without these checks a failing tail is just a failing question. With them a
     failing tail means: an exact, corpus-unique sentence, sitting past the depth
-    threshold, carrying terms the head does not have, did not retrieve the one
-    document that contains it.
+    threshold, carrying terms of its own that the head does not have, did not
+    retrieve the one document that contains it.
+
+    Every threshold below is enforced on a MEASURED value, never on a declared
+    one. `source_offset_chars` and `depth_fraction` are claims a fixture author
+    writes; `body.find(quote)` is where the sentence actually sits. Trusting
+    the claim let a quote inside the head window ship declared as a deep tail,
+    which lands in `tail_recall_at_5` and in the `tail_recall_given_head_at_5`
+    denominator while every artifact says it tested the tail.
+
+    Returns (problems, notes).
     """
     qid = question.get("id", "?")
     role = question.get("window_role")
     problems: list[str] = []
+    notes: list[str] = []
     if role not in ("head", "tail"):
-        return [f"{qid}: window question needs window_role of 'head' or 'tail'"]
+        return [f"{qid}: window question needs window_role of 'head' or 'tail'"], notes
+
+    expected_category = (
+        WINDOW_HEAD_CATEGORY if role == "head" else WINDOW_TAIL_CATEGORY
+    )
+    if str(question.get("category", "")) != expected_category:
+        problems.append(
+            f"{qid}: window_role {role!r} needs category {expected_category!r} "
+            f"(got {str(question.get('category', ''))!r}); lint and summarize "
+            "must agree about which questions are window questions"
+        )
     if not question.get("window_pair"):
         problems.append(f"{qid}: window question needs a window_pair id")
 
@@ -1346,18 +1581,40 @@ def _lint_window_question(
     body = next((cached_raw[p] for p in expected if p in cached_raw), None)
     if body is None:
         problems.append(f"{qid}: no expect_any document is cached; cannot verify offset")
-        return problems
+        return problems, notes
 
-    offset = question.get("source_offset_chars")
-    if not isinstance(offset, int):
+    declared = question.get("source_offset_chars")
+    if not isinstance(declared, int):
         problems.append(f"{qid}: window question needs an integer source_offset_chars")
-        return problems
+        return problems, notes
 
     quote = str(question.get("question", ""))
-    if body.find(quote.strip()) < 0:
+    offset = body.find(quote.strip())
+    if offset < 0:
         problems.append(f"{qid}: the quote is not present verbatim in the cached body")
+        return problems, notes
 
     depth = offset / len(body) if body else 0.0
+    # A declared offset that disagrees with the measured one is a NOTE, not a
+    # problem: `ground_truth/` is refetched from an unpinned upstream HEAD, so
+    # ordinary whitespace drift moves it by a few characters and hard-failing
+    # would make lint unusable on any machine that fetched on a different day.
+    # The thresholds below never read the declared value, so a stale claim
+    # cannot change a verdict; it can only be out of date in the artifact.
+    if declared != offset:
+        notes.append(
+            f"NOTE: {qid} declares source_offset_chars {declared} but the quote "
+            f"sits at {offset} in the cached body (depth {depth:.4f}); the "
+            "cached ground truth has drifted from the fixture. Thresholds were "
+            "checked against the measured offset."
+        )
+    declared_depth = question.get("depth_fraction")
+    if isinstance(declared_depth, (int, float)) and abs(depth - declared_depth) > 0.005:
+        notes.append(
+            f"NOTE: {qid} declares depth_fraction {declared_depth} but the "
+            f"measured depth is {depth:.4f}"
+        )
+
     if role == "head":
         if offset >= HEAD_WINDOW_CHARS:
             problems.append(
@@ -1367,7 +1624,7 @@ def _lint_window_question(
     else:
         if depth < TAIL_MIN_DEPTH:
             problems.append(
-                f"{qid}: tail quote sits at depth {depth:.2f}, above the "
+                f"{qid}: tail quote sits at depth {depth:.2f}, BELOW the "
                 f"{TAIL_MIN_DEPTH} threshold; too shallow to test the window"
             )
         novel = question.get("novel_terms_absent_from_head")
@@ -1378,14 +1635,25 @@ def _lint_window_question(
                 "head embedding answering the query"
             )
         else:
+            declared_novel = set(map(str, novel))
+            # A word the quote does not contain cannot make the quote novel.
+            # Without this, three arbitrary dictionary words absent from the
+            # head satisfy the control while saying nothing about this sentence.
+            not_in_quote = sorted(declared_novel - distinctive_terms(quote))
+            if not_in_quote:
+                problems.append(
+                    f"{qid}: terms declared novel are not terms of the quote "
+                    f"({', '.join(not_in_quote)}); a word the quote does not "
+                    "contain cannot make it novel"
+                )
             head_terms = distinctive_terms(body[:HEAD_WINDOW_CHARS])
-            leaked = sorted(set(map(str, novel)) & head_terms)
+            leaked = sorted(declared_novel & head_terms)
             if leaked:
                 problems.append(
                     f"{qid}: terms declared novel DO occur in the document head "
                     f"({', '.join(leaked)}); the control is void"
                 )
-    return problems
+    return problems, notes
 
 
 def _lint_freeze_pin(data: dict[str, Any]) -> list[str]:
@@ -1781,8 +2049,9 @@ METRIC_DEFINITIONS: dict[str, str] = {
     "head_recall_at_5": (
         "share of window pairs where a verbatim quote taken from the first "
         f"{HEAD_WINDOW_CHARS} characters of a document retrieves that document "
-        "into the top 5 distinct identities; the quote is the whole query and "
-        "is unique across every cached body, so exactly one document answers"
+        "into the top 5 distinct identities; the quote is the whole query, and "
+        "lint proves it unique across the CACHED ground-truth bodies only, "
+        "never across the corpus"
     ),
     "tail_recall_at_5": (
         "the same measurement with the quote taken from at least "
@@ -1806,9 +2075,12 @@ METRIC_DEFINITIONS: dict[str, str] = {
     "rank_inversion_rate": (
         "share of answers the node ranked BELOW a hit that the node ITSELF "
         "reports matched a strictly smaller share of the query terms. The "
-        "answer slot is fixed by a body span match with the header stripped, "
-        "and the comparison uses the node's own _citadel.relevance."
-        "term_coverage, so a path-header match cannot manufacture or hide one"
+        "answer slot is header-immune (a body span match, header stripped) but "
+        "the comparison reads _citadel.relevance.term_coverage, which the node "
+        "computes over a haystack including each hit's own path and sync "
+        "header, so a filename can move either side. Read it as the node's "
+        "published relevance disagreeing with the node's own ordering, NOT as "
+        "a body-only measure of relevance"
     ),
 }
 
@@ -1914,6 +2186,21 @@ def build_markdown_report(run: dict[str, Any]) -> str:
     short_sha = sha[:12] if sha not in ("", "unknown") else "unknown"
     node_version = (fingerprint.get("api") or {}).get("node_version")
 
+    # WHICH frozen set produced these numbers. Printed here because it is the
+    # only surface an operator reads before quoting a delta, and a table of
+    # metrics that cannot name its question set is exactly the artifact the pin
+    # exists to prevent.
+    pin = str(fingerprint.get("questions_pin") or "")
+    pin_line = (
+        f"Frozen question set `{pin[:16]}` (`questions_pin`)."
+        if pin
+        else (
+            "Frozen question set: NOT RECORDED. This run predates "
+            "`questions_pin`, so which questions produced these numbers is not "
+            "determinable from the artifact."
+        )
+    )
+
     lines = [
         "<!-- Generated by `scripts/bench/search_bench.py report`. "
         "Regenerate from a run JSON instead of hand-editing numbers. -->",
@@ -1928,6 +2215,8 @@ def build_markdown_report(run: dict[str, Any]) -> str:
             f"spans, {counts.get('questions_blocked_probe')} blocked probes, "
             f"repeats {summary.get('repeats')}."
         ),
+        "",
+        pin_line,
         "",
         "| metric | value | date | commit | n | what it matches on |",
         "|---|---|---|---|---|---|",

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -763,6 +763,17 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
         "window": {
             "head_recall_at_5": round(head_recall, 4) if head_recall is not None else None,
             "tail_recall_at_5": round(tail_recall, 4) if tail_recall is not None else None,
+            # The figure that survives the obvious objection. A document whose
+            # HEAD quote also missed may simply not be in the index at all, and
+            # its tail miss says nothing about the window. Restricting to pairs
+            # whose head retrieved keeps only documents proven reachable, so a
+            # tail miss there is positional and nothing else.
+            "tail_recall_given_head_at_5": (
+                round(both_pass / (both_pass + head_only_pass), 4)
+                if (both_pass + head_only_pass)
+                else None
+            ),
+            "pairs_head_reachable": both_pass + head_only_pass,
             "window_penalty": (
                 round(head_recall - tail_recall, 4)
                 if head_recall is not None and tail_recall is not None
@@ -1053,7 +1064,13 @@ def build_fingerprint(
         "census": corpus_census(make_corpus_fetcher(node_url, token, timeout)),
         "content": content,
         "harness_git_sha": harness_git_sha(),
+        # Two different hashes on purpose. questions_sha256 is over the FILE
+        # bytes, so reformatting or a comment moves it. questions_pin is over
+        # the canonical question list, so it moves only when a question really
+        # changes. A run records both: the pin says which frozen set was
+        # answered, the file hash says whether the file was touched at all.
         "questions_sha256": hashlib.sha256(questions_path.read_bytes()).hexdigest(),
+        "questions_pin": questions_pin(load_questions(questions_path)),
         "python_version": platform.python_version(),
     }
 
@@ -1625,6 +1642,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"{'node_version':>28}: {fingerprint['api'].get('node_version')}")
     print(f"{'harness_git_sha':>28}: {fingerprint['harness_git_sha']}")
     print(f"{'questions_sha256':>28}: {fingerprint['questions_sha256'][:16]}...")
+    print(f"{'questions_pin (frozen set)':>28}: {fingerprint.get('questions_pin', '')[:16]}...")
 
     census = fingerprint.get("census") or {}
     print("\n--- corpus census (/api/corpus) ---")
@@ -1778,6 +1796,13 @@ METRIC_DEFINITIONS: dict[str, str] = {
         "much of a document stops being reachable purely because the text sits "
         "later in it. 0 means position does not matter"
     ),
+    "tail_recall_given_head_at_5": (
+        "tail_recall_at_5 restricted to documents whose head quote DID "
+        "retrieve, so every document counted is one the index demonstrably "
+        "holds. This is the figure to quote: a document missing from both "
+        "sides may simply never have been indexed, and its tail miss is not "
+        "evidence about position"
+    ),
     "rank_inversion_rate": (
         "share of answers the node ranked BELOW a hit that the node ITSELF "
         "reports matched a strictly smaller share of the query terms. The "
@@ -1798,6 +1823,7 @@ REPORT_METRICS: list[tuple[str, str, str]] = [
     ("quality", "header_credit_rate", "spans"),
     ("window", "head_recall_at_5", "window_pairs"),
     ("window", "tail_recall_at_5", "window_pairs"),
+    ("window", "tail_recall_given_head_at_5", "head_reachable"),
     ("window", "window_penalty", "window_pairs"),
     ("ranking", "rank_inversion_rate", "ranked"),
 ]
@@ -1813,6 +1839,8 @@ def _metric_sample_count(run: dict[str, Any], n_source: str) -> Any:
         return counts.get("questions_blocked_probe")
     if n_source == "window_pairs":
         return ((run.get("summary") or {}).get("window") or {}).get("pairs_complete")
+    if n_source == "head_reachable":
+        return ((run.get("summary") or {}).get("window") or {}).get("pairs_head_reachable")
     if n_source == "ranked":
         return ((run.get("summary") or {}).get("ranking") or {}).get("answers_ranked")
     if n_source == "dup_rows":

--- a/scripts/bench/search_bench.py
+++ b/scripts/bench/search_bench.py
@@ -85,6 +85,65 @@ MIN_SHARED_SHINGLES = 3
 
 UNCONVERTED_KEY = "answer_spans_unconverted_reason"
 
+# --------------------------------------------------------------------------
+# Embedding-window pairs (v5)
+# --------------------------------------------------------------------------
+# A pair quotes ONE document twice: once from inside the first HEAD_WINDOW_CHARS
+# characters, once from at least TAIL_MIN_DEPTH through it. Both quotes are
+# verbatim and unique across every cached body, so exactly one document can
+# answer either. The pair is a controlled comparison: same document, same corpus,
+# same query shape, only the position of the quoted text changes.
+#
+# The control that makes a failing tail mean something: a tail quote qualifies
+# only when at least TAIL_MIN_NOVEL_TERMS of its distinctive terms are ABSENT
+# from the document head. Without that rule a tail could be answered by the head
+# embedding alone, and a pass would prove nothing about how much of the document
+# is reachable.
+#
+# These questions are scored in their own block and are EXCLUDED from
+# answer_recall_at_5 so the existing headline stays comparable with baselines
+# taken before v5.
+WINDOW_HEAD_CATEGORY = "window_head"
+WINDOW_TAIL_CATEGORY = "window_tail"
+WINDOW_CATEGORIES = frozenset({WINDOW_HEAD_CATEGORY, WINDOW_TAIL_CATEGORY})
+HEAD_WINDOW_CHARS = 2000
+TAIL_MIN_DEPTH = 0.40
+TAIL_MIN_NOVEL_TERMS = 3
+NOVEL_TERM_RE = re.compile(r"[a-z][a-z0-9]{3,}")
+NOVEL_TERM_STOPWORDS = frozenset(
+    "the a an and or of to in for is are be it this that with as on by from at "
+    "not you your we they if then than so but can will each any all when what "
+    "which who how why into out up down over under only same other more most "
+    "some such no nor too very just also its per".split()
+)
+
+
+def is_window_question(question: dict[str, Any]) -> bool:
+    return str(question.get("category", "")) in WINDOW_CATEGORIES
+
+
+def distinctive_terms(text: str) -> set[str]:
+    """Lowercase content words used for the head/tail novelty control."""
+    return {
+        word
+        for word in NOVEL_TERM_RE.findall(text.lower())
+        if word not in NOVEL_TERM_STOPWORDS
+    }
+
+
+def questions_pin(questions: list[dict[str, Any]]) -> str:
+    """sha256 over the canonical question list.
+
+    The pin is what makes the set FROZEN. Any edit to any question changes it,
+    so re-freezing is a deliberate act (update the pin, bump the version) rather
+    than a silent drift that would make two runs answer different questions
+    while both called themselves the baseline.
+    """
+    canonical = json.dumps(
+        questions, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
 
 class BenchError(RuntimeError):
     """A configuration or honesty violation that must stop the run."""
@@ -339,6 +398,45 @@ def resolve_probe_patterns(
 # --------------------------------------------------------------------------
 
 
+def hit_term_coverage(hit: dict[str, Any]) -> float | None:
+    """The node's OWN reported share of query terms this hit matched.
+
+    Read rather than recomputed on purpose: ranking is the node's decision, so
+    the inversion metric has to be expressed in the node's own units. A number
+    the harness derived itself would only prove the harness and the node
+    disagree about tokenization.
+    """
+    citadel = hit.get("_citadel")
+    if not isinstance(citadel, dict):
+        return None
+    relevance = citadel.get("relevance")
+    if not isinstance(relevance, dict):
+        return None
+    coverage = relevance.get("term_coverage")
+    return float(coverage) if isinstance(coverage, (int, float)) else None
+
+
+def trust_observations(hits: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+    """(result_id, content_sha256, trust_tier) for every hit that carries all three.
+
+    Free byproduct of a run: the same chunk is served across many questions, so
+    disagreement between two observations of the SAME id at the SAME content
+    hash is per-request metadata instability, caught without a single extra
+    query.
+    """
+    out: list[tuple[str, str, str]] = []
+    for hit in hits:
+        citadel = hit.get("_citadel")
+        if not isinstance(citadel, dict):
+            continue
+        result_id = citadel.get("result_id") or hit.get("id")
+        sha = citadel.get("content_sha256")
+        tier = citadel.get("trust_tier")
+        if isinstance(result_id, str) and isinstance(sha, str) and isinstance(tier, str):
+            out.append((result_id, sha, tier))
+    return out
+
+
 def score_question(
     question: dict[str, Any],
     hits: list[dict[str, Any]],
@@ -364,6 +462,37 @@ def score_question(
             body = normalize(split_header_body(hit_text(hit))[1])
             if any(span in body for span in spans):
                 raw_page_pass = True
+                break
+
+    # ---- Ranking, measured separately from retrieval -----------------------
+    # Retrieval asks whether the answering document came back at all. Ranking
+    # asks whether the node put it in the right place. They are different
+    # questions and a single recall number silently blends them, so the answer
+    # slot is anchored to a BODY span match (header stripped) and then compared
+    # against the node's own term_coverage for everything served above it.
+    #
+    # An inversion is: some hit ranked ABOVE the one that verifiably contains
+    # the answer, while the node itself reports that hit matched a STRICTLY
+    # SMALLER share of the query terms. That cannot be produced by a path-header
+    # match, because the header contributes to coverage identically for every
+    # hit on the page.
+    answer_slot: int | None = None
+    answer_coverage: float | None = None
+    outranked_by_coverage: float | None = None
+    outranked_by_slot: int | None = None
+    if spans:
+        for slot, hit in enumerate(hits, start=1):
+            body = normalize(split_header_body(hit_text(hit))[1])
+            if any(span in body for span in spans):
+                answer_slot = slot
+                answer_coverage = hit_term_coverage(hit)
+                break
+    if answer_slot is not None and answer_coverage is not None:
+        for slot, hit in enumerate(hits[: answer_slot - 1], start=1):
+            coverage = hit_term_coverage(hit)
+            if coverage is not None and coverage < answer_coverage:
+                outranked_by_coverage = coverage
+                outranked_by_slot = slot
                 break
 
     doc_rank: int | None = None
@@ -452,6 +581,14 @@ def score_question(
         "answer_rank": answer_rank,
         "answer_pass_at_5": answer_rank is not None and answer_rank <= K_ANSWER,
         "raw_page_pass_at_5": raw_page_pass,
+        "window_role": question.get("window_role"),
+        "window_pair": question.get("window_pair"),
+        "depth_fraction": question.get("depth_fraction"),
+        "answer_slot": answer_slot,
+        "answer_term_coverage": answer_coverage,
+        "outranked_by_coverage": outranked_by_coverage,
+        "outranked_by_slot": outranked_by_slot,
+        "trust_observations": trust_observations(hits),
         "doc_rank": doc_rank,
         "doc_pass_at_5": doc_rank is not None and doc_rank <= K_ANSWER,
         "legacy_rank": legacy_rank(hits, expected, gt_shingles),
@@ -489,7 +626,15 @@ def attempt_outcome(row: dict[str, Any]) -> bool:
 def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, Any]:
     positives = [row for row in rows if row["expected_recall"] == 1]
     probes = [row for row in rows if row["expected_recall"] == 0]
-    span_rows = [row for row in positives if row["has_spans"]]
+    window_rows = [row for row in positives if row.get("window_role") in ("head", "tail")]
+    # Window pairs are deliberately kept OUT of the headline. They were added in
+    # questions v5 and they fail by design against current behaviour; folding
+    # them in would move answer_recall_at_5 for a reason that has nothing to do
+    # with the node changing, and every baseline taken before v5 would stop
+    # being comparable.
+    span_rows = [
+        row for row in positives if row["has_spans"] and row.get("window_role") is None
+    ]
     if not probes:
         raise BenchError(
             "The blocked-probe/negatives list is empty (no expected_recall=0 "
@@ -538,6 +683,53 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     )
     negative_hits = sum(1 for row in probes if row["doc_rank"] is not None)
 
+    # ---- Embedding window --------------------------------------------------
+    heads = [row for row in window_rows if row["window_role"] == "head"]
+    tails = [row for row in window_rows if row["window_role"] == "tail"]
+    head_recall = rate(heads, "answer_pass_at_5") if heads else None
+    tail_recall = rate(tails, "answer_pass_at_5") if tails else None
+    # Only pairs whose BOTH sides ran contribute to the penalty, so the figure
+    # is a within-document difference and never a comparison across two
+    # different document populations.
+    head_by_pair = {row["window_pair"]: row for row in heads}
+    tail_by_pair = {row["window_pair"]: row for row in tails}
+    complete_pairs = sorted(set(head_by_pair) & set(tail_by_pair))
+    head_only_pass = sum(
+        1
+        for pair in complete_pairs
+        if head_by_pair[pair]["answer_pass_at_5"] and not tail_by_pair[pair]["answer_pass_at_5"]
+    )
+    both_pass = sum(
+        1
+        for pair in complete_pairs
+        if head_by_pair[pair]["answer_pass_at_5"] and tail_by_pair[pair]["answer_pass_at_5"]
+    )
+    neither_pass = sum(
+        1
+        for pair in complete_pairs
+        if not head_by_pair[pair]["answer_pass_at_5"]
+        and not tail_by_pair[pair]["answer_pass_at_5"]
+    )
+    tail_only_pass = len(complete_pairs) - head_only_pass - both_pass - neither_pass
+
+    # ---- Ranking, separate from retrieval ----------------------------------
+    ranked = [
+        row
+        for row in positives
+        if row["answer_slot"] is not None and row["answer_term_coverage"] is not None
+    ]
+    inverted = [row for row in ranked if row["outranked_by_coverage"] is not None]
+    zero_coverage_inversions = sum(
+        1 for row in inverted if row["outranked_by_coverage"] == 0.0
+    )
+
+    # ---- Per-request metadata stability ------------------------------------
+    tiers_seen: dict[tuple[str, str], set[str]] = {}
+    for row in rows:
+        for result_id, sha, tier in row.get("trust_observations") or []:
+            tiers_seen.setdefault((result_id, sha), set()).add(tier)
+    unstable = {key: sorted(v) for key, v in tiers_seen.items() if len(v) > 1}
+
     return {
         "quality": {
             "answer_recall_at_5": round(rate(span_rows, "answer_pass_at_5"), 4),
@@ -568,6 +760,37 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             ),
             "hits_with_unresolvable_source": unresolvable_hits,
         },
+        "window": {
+            "head_recall_at_5": round(head_recall, 4) if head_recall is not None else None,
+            "tail_recall_at_5": round(tail_recall, 4) if tail_recall is not None else None,
+            "window_penalty": (
+                round(head_recall - tail_recall, 4)
+                if head_recall is not None and tail_recall is not None
+                else None
+            ),
+            "pairs_complete": len(complete_pairs),
+            "pairs_head_only": head_only_pass,
+            "pairs_both": both_pass,
+            "pairs_neither": neither_pass,
+            "pairs_tail_only": tail_only_pass,
+            "documents": len({row["window_pair"] for row in window_rows}),
+        },
+        "ranking": {
+            "answers_ranked": len(ranked),
+            "rank_inversion_rate": (
+                round(len(inverted) / len(ranked), 4) if ranked else None
+            ),
+            "inversions_by_zero_coverage": zero_coverage_inversions,
+            "answer_worst_slot": max((row["answer_slot"] for row in ranked), default=None),
+        },
+        "metadata_stability": {
+            "chunks_observed": len(tiers_seen),
+            "chunks_with_unstable_trust_tier": len(unstable),
+            "unstable_examples": [
+                {"result_id": key[0], "content_sha256": key[1], "tiers": value}
+                for key, value in sorted(unstable.items())[:5]
+            ],
+        },
         "stability": {
             "hit_stability": round(statistics.fmean(stability), 4) if stability else None,
         },
@@ -577,6 +800,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             "questions_with_spans": len(span_rows),
             "questions_excluded_from_answer_recall": len(positives) - len(span_rows),
             "questions_blocked_probe": len(probes),
+            "questions_window": len(window_rows),
         },
     }
 
@@ -1059,7 +1283,14 @@ def lint_questions(
                         f"{label}: appears in the first line of {repo_path} "
                         "(head-of-document credit, not an answer)"
                     )
-            if norm_span in normalize(question.get("question", "")):
+            # A window question IS its own quote: the query is the verbatim
+            # sentence, which is the strongest retrieval signal that exists. If
+            # that fails, retrieval failed. Every other question keeps the rule,
+            # because there the span appearing in the query would hand the
+            # scorer the answer.
+            if norm_span in normalize(question.get("question", "")) and not is_window_question(
+                question
+            ):
                 problems.append(f"{label}: appears in the question text")
             for other, body in cached_norm.items():
                 if other in expected:
@@ -1068,7 +1299,101 @@ def lint_questions(
                     problems.append(
                         f"{label}: not unique, also present in cached body {other}"
                     )
+
+        if is_window_question(question):
+            problems.extend(_lint_window_question(question, cached_raw))
+
+    problems.extend(_lint_freeze_pin(data))
     return problems, notes
+
+
+def _lint_window_question(
+    question: dict[str, Any], cached_raw: dict[str, str]
+) -> list[str]:
+    """The contract that makes a window pair a controlled comparison.
+
+    Without these checks a failing tail is just a failing question. With them a
+    failing tail means: an exact, corpus-unique sentence, sitting past the depth
+    threshold, carrying terms the head does not have, did not retrieve the one
+    document that contains it.
+    """
+    qid = question.get("id", "?")
+    role = question.get("window_role")
+    problems: list[str] = []
+    if role not in ("head", "tail"):
+        return [f"{qid}: window question needs window_role of 'head' or 'tail'"]
+    if not question.get("window_pair"):
+        problems.append(f"{qid}: window question needs a window_pair id")
+
+    expected = list(question.get("expect_any") or [])
+    body = next((cached_raw[p] for p in expected if p in cached_raw), None)
+    if body is None:
+        problems.append(f"{qid}: no expect_any document is cached; cannot verify offset")
+        return problems
+
+    offset = question.get("source_offset_chars")
+    if not isinstance(offset, int):
+        problems.append(f"{qid}: window question needs an integer source_offset_chars")
+        return problems
+
+    quote = str(question.get("question", ""))
+    if body.find(quote.strip()) < 0:
+        problems.append(f"{qid}: the quote is not present verbatim in the cached body")
+
+    depth = offset / len(body) if body else 0.0
+    if role == "head":
+        if offset >= HEAD_WINDOW_CHARS:
+            problems.append(
+                f"{qid}: head quote sits at offset {offset}, outside the first "
+                f"{HEAD_WINDOW_CHARS} characters; it is not a head control"
+            )
+    else:
+        if depth < TAIL_MIN_DEPTH:
+            problems.append(
+                f"{qid}: tail quote sits at depth {depth:.2f}, above the "
+                f"{TAIL_MIN_DEPTH} threshold; too shallow to test the window"
+            )
+        novel = question.get("novel_terms_absent_from_head")
+        if not isinstance(novel, list) or len(novel) < TAIL_MIN_NOVEL_TERMS:
+            problems.append(
+                f"{qid}: tail quote needs at least {TAIL_MIN_NOVEL_TERMS} "
+                "novel_terms_absent_from_head; without them a pass could be the "
+                "head embedding answering the query"
+            )
+        else:
+            head_terms = distinctive_terms(body[:HEAD_WINDOW_CHARS])
+            leaked = sorted(set(map(str, novel)) & head_terms)
+            if leaked:
+                problems.append(
+                    f"{qid}: terms declared novel DO occur in the document head "
+                    f"({', '.join(leaked)}); the control is void"
+                )
+    return problems
+
+
+def _lint_freeze_pin(data: dict[str, Any]) -> list[str]:
+    """The fixtures are frozen or they are not. This is what enforces it."""
+    frozen = data.get("frozen")
+    if not isinstance(frozen, dict):
+        return [
+            "questions file has no `frozen` block; without a pin the set can "
+            "drift between two runs that both call themselves the baseline"
+        ]
+    pinned = frozen.get("questions_sha256")
+    actual = questions_pin(list(data.get("questions") or []))
+    if not pinned:
+        return [
+            "frozen.questions_sha256 is missing; set it to the current pin "
+            f"({actual}) to freeze this set"
+        ]
+    if pinned != actual:
+        return [
+            "FROZEN SET CHANGED: frozen.questions_sha256 is "
+            f"{pinned} but the questions hash to {actual}. A baseline taken "
+            "before this edit answered different questions. Bump `version`, "
+            "update the pin deliberately, and re-take the baseline."
+        ]
+    return []
 
 
 # --------------------------------------------------------------------------
@@ -1227,6 +1552,33 @@ def _print_summary(summary: dict[str, Any]) -> None:
     print("\n--- duplication ---")
     for key, value in summary["duplication"].items():
         print(f"{key:>28}: {value}")
+    window = summary.get("window") or {}
+    if window.get("pairs_complete"):
+        print("\n--- embedding window (same document, head quote vs tail quote) ---")
+        for key, value in window.items():
+            print(f"{key:>28}: {value}")
+        print(
+            f"{'reads as':>28}: a tail miss is an exact, corpus-unique sentence "
+            "failing to retrieve the one document containing it"
+        )
+    ranking = summary.get("ranking") or {}
+    if ranking.get("answers_ranked"):
+        print("\n--- ranking (separate question from retrieval) ---")
+        for key, value in ranking.items():
+            print(f"{key:>28}: {value}")
+        print(
+            f"{'reads as':>28}: share of answers the node ranked BELOW a hit it "
+            "itself scored as matching fewer query terms"
+        )
+    meta = summary.get("metadata_stability") or {}
+    if meta.get("chunks_observed"):
+        print("\n--- per-request metadata stability ---")
+        print(f"{'chunks_observed':>28}: {meta['chunks_observed']}")
+        print(
+            f"{'unstable_trust_tier':>28}: "
+            f"{meta.get('chunks_with_unstable_trust_tier')} "
+            "(same chunk id + same content_sha256, different trust_tier)"
+        )
     print("\n--- stability ---")
     for key, value in summary["stability"].items():
         print(f"{key:>28}: {value}")
@@ -1408,6 +1760,31 @@ METRIC_DEFINITIONS: dict[str, str] = {
         "a pass that the body scorer refuses; phantom credit measured so it "
         "can never silently re-enter recall"
     ),
+    "head_recall_at_5": (
+        "share of window pairs where a verbatim quote taken from the first "
+        f"{HEAD_WINDOW_CHARS} characters of a document retrieves that document "
+        "into the top 5 distinct identities; the quote is the whole query and "
+        "is unique across every cached body, so exactly one document answers"
+    ),
+    "tail_recall_at_5": (
+        "the same measurement with the quote taken from at least "
+        f"{int(TAIL_MIN_DEPTH * 100)}% through the SAME document, and only "
+        f"where at least {TAIL_MIN_NOVEL_TERMS} of the quote's distinctive "
+        "terms are absent from that document's head, so a pass cannot be the "
+        "head embedding answering the query"
+    ),
+    "window_penalty": (
+        "head_recall_at_5 minus tail_recall_at_5 over the same documents: how "
+        "much of a document stops being reachable purely because the text sits "
+        "later in it. 0 means position does not matter"
+    ),
+    "rank_inversion_rate": (
+        "share of answers the node ranked BELOW a hit that the node ITSELF "
+        "reports matched a strictly smaller share of the query terms. The "
+        "answer slot is fixed by a body span match with the header stripped, "
+        "and the comparison uses the node's own _citadel.relevance."
+        "term_coverage, so a path-header match cannot manufacture or hide one"
+    ),
 }
 
 # (summary section, metric key, sample-count source). The report refuses any
@@ -1419,6 +1796,10 @@ REPORT_METRICS: list[tuple[str, str, str]] = [
     ("quality", "negative_hit_rate", "probes"),
     ("duplication", "duplicate_blob_rate_at_10", "dup_rows"),
     ("quality", "header_credit_rate", "spans"),
+    ("window", "head_recall_at_5", "window_pairs"),
+    ("window", "tail_recall_at_5", "window_pairs"),
+    ("window", "window_penalty", "window_pairs"),
+    ("ranking", "rank_inversion_rate", "ranked"),
 ]
 
 
@@ -1430,6 +1811,10 @@ def _metric_sample_count(run: dict[str, Any], n_source: str) -> Any:
         return counts.get("questions_positive")
     if n_source == "probes":
         return counts.get("questions_blocked_probe")
+    if n_source == "window_pairs":
+        return ((run.get("summary") or {}).get("window") or {}).get("pairs_complete")
+    if n_source == "ranked":
+        return ((run.get("summary") or {}).get("ranking") or {}).get("answers_ranked")
     if n_source == "dup_rows":
         rows = run.get("rows")
         if not isinstance(rows, list):
@@ -1528,6 +1913,16 @@ def build_markdown_report(run: dict[str, Any]) -> str:
                 "the head-line-credit incident happened; add the definition "
                 "before reporting it."
             )
+        if section not in summary:
+            # A run taken before this metric existed did not measure it. Saying
+            # so is accurate; refusing the whole report would make every older
+            # baseline unreportable, and printing a bare "n/a" would blur "we
+            # measured nothing" into "we measured and got nothing".
+            lines.append(
+                f"| {key} | not measured in this run | {run_date} | "
+                f"`{short_sha}` | n/a | {definition} |"
+            )
+            continue
         section_values = summary.get(section) or {}
         if key not in section_values:
             raise BenchError(

--- a/tests/test_search_bench.py
+++ b/tests/test_search_bench.py
@@ -1514,7 +1514,8 @@ class TestReportCoversTheNewMetrics:
             {
                 "window": {
                     "head_recall_at_5": 0.667, "tail_recall_at_5": 0.0,
-                    "window_penalty": 0.667, "pairs_complete": 18,
+                    "tail_recall_given_head_at_5": 0.0, "window_penalty": 0.667,
+                    "pairs_complete": 18, "pairs_head_reachable": 11,
                 },
                 "ranking": {"rank_inversion_rate": 0.63, "answers_ranked": 19},
             }
@@ -1531,3 +1532,82 @@ class TestReportCoversTheNewMetrics:
         markdown = sb.build_markdown_report(self._run({}))
         assert "not measured in this run" in markdown
         assert "n/a (not measured)" not in markdown.split("head_recall_at_5")[1][:80]
+
+
+class TestTailRecallIsConditionedOnAReachableDocument:
+    """The number that survives the obvious objection: a document whose head
+    quote ALSO missed may never have been indexed, so its tail miss says
+    nothing about where the text sits."""
+
+    SPAN = "the subsystem persists attempted charges with a null transaction id"
+
+    def _rows(self, pairs):
+        rows = [
+            sb.score_question(
+                {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0},
+                [],
+                {},
+            ),
+            sb.score_question(
+                question("q1", spans=[self.SPAN]),
+                [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+                {},
+            ),
+        ]
+        for pair, (head_pass, tail_pass) in pairs.items():
+            for role, passed in (("head", head_pass), ("tail", tail_pass)):
+                q = question(f"{pair}{role[0]}", spans=[self.SPAN])
+                q.update({"category": f"window_{role}", "window_role": role,
+                          "window_pair": pair})
+                hits = (
+                    [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)]
+                    if passed
+                    else [scored_hit(PATH_OTHER, BLOB_B, "unrelated filler", 0.1)]
+                )
+                rows.append(sb.score_question(q, hits, {}))
+        return rows
+
+    def test_unreachable_documents_are_excluded_from_the_conditional(self):
+        # w01 reachable, tail missed. w02 unreachable on both sides.
+        summary = sb.summarize(
+            self._rows({"w01": (True, False), "w02": (False, False)}), []
+        )
+        window = summary["window"]
+        assert window["pairs_complete"] == 2
+        assert window["pairs_neither"] == 1
+        assert window["tail_recall_at_5"] == 0.0          # 0 of 2, pessimistic
+        assert window["pairs_head_reachable"] == 1        # only w01 is evidence
+        assert window["tail_recall_given_head_at_5"] == 0.0
+
+    def test_conditional_counts_only_proven_reachable_documents(self):
+        summary = sb.summarize(
+            self._rows(
+                {"w01": (True, True), "w02": (True, False), "w03": (False, False)}
+            ),
+            [],
+        )
+        window = summary["window"]
+        assert window["pairs_head_reachable"] == 2
+        assert window["tail_recall_given_head_at_5"] == 0.5   # 1 of 2
+        assert window["tail_recall_at_5"] == round(1 / 3, 4)  # 1 of 3, pessimistic
+
+    def test_conditional_is_none_when_no_head_ever_retrieved(self):
+        summary = sb.summarize(self._rows({"w01": (False, False)}), [])
+        assert summary["window"]["tail_recall_given_head_at_5"] is None
+
+
+class TestRunRecordsWhichFrozenSetItAnswered:
+    def test_fingerprint_carries_the_pin_not_just_the_file_hash(self, tmp_path):
+        questions = [{"id": "q1", "question": "text", "expected_recall": 1}]
+        path = tmp_path / "golden.json"
+        path.write_text(json.dumps({"version": 5, "questions": questions}))
+        reformatted = tmp_path / "golden2.json"
+        reformatted.write_text(json.dumps({"questions": questions, "version": 5}, indent=4))
+        # Reformatting moves the file hash but must NOT move the pin: the run
+        # answered the same questions.
+        assert hashlib.sha256(path.read_bytes()).hexdigest() != hashlib.sha256(
+            reformatted.read_bytes()
+        ).hexdigest()
+        assert sb.questions_pin(sb.load_questions(path)) == sb.questions_pin(
+            sb.load_questions(reformatted)
+        )

--- a/tests/test_search_bench.py
+++ b/tests/test_search_bench.py
@@ -887,6 +887,7 @@ def make_run(
     content_sha="f" * 64,
     census="default",
     rows_count=69,
+    questions_pin="022b6b4f66c73af1" + "0" * 48,
 ):
     if census == "default":
         census = {
@@ -945,9 +946,28 @@ def make_run(
             "api": {"documents_tracked": 2867, "node_version": "9.9.9"},
         },
     }
+    if questions_pin is not None:
+        run["fingerprint"]["questions_pin"] = questions_pin
     if census is not None:
         run["fingerprint"]["census"] = census
     return run
+
+
+class TestReportNamesItsFrozenSet:
+    """The runbook told an operator to confirm the pin before reading any
+    delta, and named `report` as a surface that prints it. It did not. There
+    was no printed surface at all: `compare` gated on the file hash and the
+    markdown table named no question set."""
+
+    def test_the_report_prints_the_pin(self):
+        markdown = sb.build_markdown_report(make_run())
+        assert "questions_pin" in markdown
+        assert "022b6b4f66c73af1" in markdown
+
+    def test_a_run_without_a_pin_says_it_is_not_determinable(self):
+        markdown = sb.build_markdown_report(make_run(questions_pin=None))
+        assert "NOT RECORDED" in markdown
+        assert "not determinable" in markdown
 
 
 class TestMarkdownReport:
@@ -1183,6 +1203,78 @@ class TestRankingIsMeasuredSeparatelyFromRetrieval:
         assert row["answer_slot"] == 2
         assert row["outranked_by_coverage"] is None
 
+    def test_the_answer_slot_really_strips_the_sync_header(self):
+        """The test above never exercised the stripping: its span occurs in no
+        header, so `split_header_body` could be deleted and it stayed green.
+
+        This is the header-credit incident in miniature. A span whose text also
+        appears in the sync header must bind the answer slot to the hit whose
+        BODY carries it, not to whichever hit ranked highest carrying that
+        header. Without the stripping the rank-1 header carrier becomes the
+        answer, its low coverage becomes `answer_coverage`, and the inversion
+        for that question silently disappears -- rank_inversion_rate falls and
+        reads as a ranking improvement.
+        """
+        span = f"repository: {PATH_DOC.split('/')[0]}/{PATH_DOC.split('/')[1]}"
+        header_carrier = scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", 0.05)
+        body_carrier = scored_hit(PATH_DOC, BLOB_A, f"prose {span} prose", 1.0)
+        # The header carrier's FULL text really does contain the span; only the
+        # stripping keeps it out of the answer slot.
+        assert sb.normalize(span) in sb.normalize(sb.hit_text(header_carrier))
+        assert sb.normalize(span) not in sb.normalize(
+            sb.split_header_body(sb.hit_text(header_carrier))[1]
+        )
+        row = sb.score_question(
+            question(spans=[span]), [header_carrier, body_carrier], {}
+        )
+        assert row["answer_slot"] == 2
+        assert row["answer_term_coverage"] == 1.0
+        assert row["outranked_by_coverage"] == 0.05
+
+    def test_term_coverage_is_the_nodes_number_and_a_path_can_move_it(self):
+        """The published claim used to be that a path-header match "can neither
+        manufacture nor hide an inversion". It can do both.
+
+        The answer SLOT is header-immune. `term_coverage` is not: the node
+        computes it over a haystack that includes each hit's own path, source
+        url, provenance and the sync header still sitting in the chunk text
+        (kb/search_format.py `_hit_text`), and every hit carries a DIFFERENT
+        path. Executed both directions here so the real behaviour is pinned and
+        the immunity claim cannot come back.
+        """
+        # HIDING: a decoy whose body has zero query overlap, but whose path
+        # supplies coverage above the answer's, stops being an inversion.
+        answer = scored_hit(PATH_DOC, BLOB_A, f"prose {self.SPAN} prose", 0.40)
+        decoy_high = scored_hit(PATH_OTHER, BLOB_B, "filler", 0.60)
+        hidden = sb.score_question(
+            question(spans=[self.SPAN]), [decoy_high, answer], {}
+        )
+        assert hidden["answer_slot"] == 2
+        assert hidden["outranked_by_coverage"] is None
+        # Same page, same bodies, same order: only the decoy's reported
+        # coverage drops to what its BODY alone would earn.
+        decoy_low = scored_hit(PATH_OTHER, BLOB_B, "filler", 0.0)
+        revealed = sb.score_question(
+            question(spans=[self.SPAN]), [decoy_low, answer], {}
+        )
+        assert revealed["answer_slot"] == 2
+        assert revealed["outranked_by_coverage"] == 0.0
+
+        # MANUFACTURING: the same decoy at a fixed 0.60 becomes an inversion
+        # purely because the ANSWER's own filename lifts its coverage to 1.0.
+        answer_path_inflated = scored_hit(PATH_DOC, BLOB_A, f"prose {self.SPAN} prose", 1.0)
+        manufactured = sb.score_question(
+            question(spans=[self.SPAN]), [decoy_high, answer_path_inflated], {}
+        )
+        assert manufactured["outranked_by_coverage"] == 0.60
+
+        # And the published definition must say so, because the report table
+        # copies it verbatim next to the number.
+        definition = sb.METRIC_DEFINITIONS["rank_inversion_rate"]
+        assert "cannot manufacture or hide" not in definition
+        assert "header-immune" in definition
+        assert "path" in definition
+
     def test_missing_coverage_is_not_counted_as_an_inversion(self):
         hits = [
             scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", None),
@@ -1280,6 +1372,116 @@ class TestEmbeddingWindowPairs:
         assert window["pairs_head_only"] == 1
         assert window["pairs_both"] == 1
 
+    def test_a_dangling_half_pair_moves_no_published_window_rate(self):
+        """head_recall_at_5, tail_recall_at_5 and window_penalty are published
+        with `pairs_complete` as their sample count, so all three have to be
+        computed over complete pairs.
+
+        They used to be `rate()` over ALL head rows and ALL tail rows. One
+        dangling side turned window_penalty into a comparison across two
+        different document populations -- the one thing the metric exists to
+        avoid -- while `pairs_complete` stayed honest and the test named for
+        this kept passing. The report then printed a rate over 3 heads next to
+        n = 2.
+        """
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        complete = [plain, probe] + self._pair_rows(True, False, "w01")
+        baseline = sb.summarize(complete, [])
+        assert baseline["window"]["pairs_complete"] == 1
+        assert baseline["window"]["head_recall_at_5"] == 1.0
+        assert baseline["window"]["tail_recall_at_5"] == 0.0
+        assert baseline["window"]["window_penalty"] == 1.0
+
+        # A head with no tail: it is not a within-document comparison, so it
+        # must not move the rate, the penalty, or the count.
+        dangling_head = [row for row in self._pair_rows(False, False, "w02") if row["window_role"] == "head"]
+        with_head = sb.summarize(complete + dangling_head, [])
+        assert with_head["window"]["pairs_complete"] == 1
+        assert with_head["window"]["head_recall_at_5"] == 1.0
+        assert with_head["window"]["window_penalty"] == 1.0
+
+        # And a tail with no head, the other direction.
+        dangling_tail = [row for row in self._pair_rows(True, True, "w03") if row["window_role"] == "tail"]
+        with_tail = sb.summarize(complete + dangling_tail, [])
+        assert with_tail["window"]["pairs_complete"] == 1
+        assert with_tail["window"]["tail_recall_at_5"] == 0.0
+        assert with_tail["window"]["window_penalty"] == 1.0
+
+    def test_window_documents_counts_documents_not_pair_ids(self):
+        """`documents` said how many documents the window measurement covers.
+        It counted distinct window_pair ids, so two pairs quoting one document
+        reported 2 -- the name-versus-what-it-attests failure the harness
+        exists to catch."""
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        # Both pairs name PATH_DOC (see `question`'s default expect_any).
+        rows = [plain, probe] + self._pair_rows(True, False, "w01") + self._pair_rows(True, False, "w02")
+        summary = sb.summarize(rows, [])
+        assert summary["window"]["pairs_complete"] == 2
+        assert summary["window"]["documents"] == 1
+
+    def test_rank_inversion_rate_is_reported_split_by_window(self):
+        """The headline rate blends 36 verbatim-sentence window queries with
+        the real questions, while answer_recall_at_5 deliberately keeps them
+        apart. Publish the split so a movement can be attributed."""
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        rows = [plain, probe] + self._pair_rows(True, True, "w01")
+        summary = sb.summarize(rows, [])
+        ranking = summary["ranking"]
+        assert ranking["answers_ranked"] == 3
+        assert ranking["answers_ranked_excluding_window"] == 1
+        assert ranking["answers_ranked_window_only"] == 2
+        assert ranking["rank_inversion_rate_excluding_window"] == 0.0
+        assert ranking["rank_inversion_rate_window_only"] == 0.0
+
+    def test_only_the_span_scored_metrics_survive_the_v5_boundary(self):
+        """The exclusion protects `span_rows` and nothing else. Naming the
+        metrics that DO move stops someone reading a v5 doc_recall_at_5 drop as
+        the node degrading; `compare` refuses the cross-set comparison outright
+        because the pin differs."""
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        before = sb.summarize([plain, probe], [])
+        after = sb.summarize([plain, probe] + self._pair_rows(True, False, "w01"), [])
+        # Unmoved: computed from span_rows.
+        assert before["quality"]["answer_recall_at_5"] == after["quality"]["answer_recall_at_5"]
+        assert before["quality"]["mrr_body"] == after["quality"]["mrr_body"]
+        assert before["quality"]["header_credit_rate"] == after["quality"]["header_credit_rate"]
+        # Moved: computed from positives / rows. Both are in REPORT_METRICS.
+        assert after["quality"]["doc_recall_at_5"] != before["quality"]["doc_recall_at_5"]
+        assert {
+            key for _, key, _ in sb.REPORT_METRICS
+        } & {"doc_recall_at_5", "duplicate_blob_rate_at_10"} == {
+            "doc_recall_at_5",
+            "duplicate_blob_rate_at_10",
+        }
+
     def test_a_half_pair_does_not_contribute_to_the_penalty(self):
         """Only pairs whose BOTH sides ran are a within-document comparison."""
         probe = sb.score_question(
@@ -1353,10 +1555,106 @@ class TestWindowFixtureContract:
         problems, _ = sb.lint_questions(path, gt)
         assert any("appears in the question text" in p for p in problems)
 
+    # A quote that really sits early in the document. `alpha beta gamma` is
+    # inside HEAD_TEXT, so body.find puts it at offset 13.
+    SHALLOW_QUOTE = "alpha beta gamma delta epsilon alpha beta gamma delta"
+
     def test_tail_quote_too_shallow_fails(self, tmp_path):
-        path, gt = self._golden(tmp_path, self._tail_q(source_offset_chars=10))
+        """A tail quote that really sits in the head window is rejected, and
+        the message says BELOW the threshold. It used to read 'above the 0.4
+        threshold' while firing on depth < 0.4, sending an author fixing the
+        pair in the wrong direction."""
+        shallow = self._tail_q(
+            question=self.SHALLOW_QUOTE,
+            answer_spans=[self.SHALLOW_QUOTE],
+            source_offset_chars=self.BODY.find(self.SHALLOW_QUOTE),
+        )
+        path, gt = self._golden(tmp_path, shallow)
         problems, _ = sb.lint_questions(path, gt)
         assert any("too shallow to test the window" in p for p in problems)
+        assert any("BELOW" in p for p in problems)
+        assert not any("above the" in p for p in problems), problems
+
+    def test_a_declared_offset_cannot_smuggle_a_shallow_quote_into_the_tail(
+        self, tmp_path
+    ):
+        """`source_offset_chars` is a claim; body.find(quote) is the fact.
+
+        Trusting the claim let a quote inside the first 2000 characters ship
+        declared at 50% depth. lint returned no problems, the row landed in
+        tail_recall_at_5 and in the tail_recall_given_head_at_5 denominator,
+        and every artifact said it had tested a quote past 40% depth.
+        """
+        forged = self._tail_q(
+            question=self.SHALLOW_QUOTE,
+            answer_spans=[self.SHALLOW_QUOTE],
+            source_offset_chars=int(len(self.BODY) * 0.60),
+            depth_fraction=0.60,
+        )
+        real_offset = self.BODY.find(self.SHALLOW_QUOTE)
+        assert real_offset / len(self.BODY) < sb.TAIL_MIN_DEPTH
+        path, gt = self._golden(tmp_path, forged)
+        problems, notes = sb.lint_questions(path, gt)
+        assert any("too shallow to test the window" in p for p in problems), problems
+        # The disagreement itself is reported, so a stale fixture is visible
+        # rather than silently overridden.
+        assert any(str(real_offset) in note for note in notes), notes
+
+    def test_a_drifted_declared_offset_is_a_note_not_a_failure(self, tmp_path):
+        """ground_truth/ is refetched from an unpinned upstream HEAD, so a few
+        characters of whitespace drift move the real offset. That must not fail
+        lint on every machine that fetched on a different day -- the measured
+        offset is what the thresholds use, so a stale claim cannot change a
+        verdict."""
+        drifted = self._tail_q(source_offset_chars=self.BODY.find(self.TAIL_TEXT) - 3)
+        path, gt = self._golden(tmp_path, drifted)
+        problems, notes = sb.lint_questions(path, gt)
+        assert problems == []
+        assert any("drifted from the fixture" in note for note in notes), notes
+
+    def test_novel_terms_must_be_terms_of_the_quote(self, tmp_path):
+        """Three arbitrary words absent from the head satisfied the control
+        while saying nothing about this sentence. A word the quote does not
+        contain cannot make the quote novel."""
+        path, gt = self._golden(
+            tmp_path,
+            self._tail_q(
+                novel_terms_absent_from_head=["absolute", "meridian", "portcullis"]
+            ),
+        )
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("are not terms of the quote" in p for p in problems), problems
+
+    def test_a_quote_absent_from_the_body_fails(self, tmp_path):
+        """The window-specific verbatim check is case- and whitespace-exact,
+        and stricter than the generic normalize()-based span check. Nothing
+        exercised it, so it could be deleted with the suite still green."""
+        missing = "this exact sentence is nowhere in the cached body at all"
+        path, gt = self._golden(
+            tmp_path, self._tail_q(question=missing, answer_spans=[missing])
+        )
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("not present verbatim in the cached body" in p for p in problems)
+
+    def test_a_window_role_without_the_category_is_still_linted(self, tmp_path):
+        """lint used to decide 'is this a window question' from `category`
+        while summarize buckets on `window_role`. A question carrying only
+        window_role was invisible to every window check and still entered
+        head/tail recall and the tail_recall_given_head_at_5 arithmetic."""
+        sneaky = self._tail_q(
+            question=self.SHALLOW_QUOTE,
+            answer_spans=[self.SHALLOW_QUOTE],
+            source_offset_chars=self.BODY.find(self.SHALLOW_QUOTE),
+        )
+        sneaky.pop("category")
+        assert sb.is_window_question(sneaky) is True
+        path, gt = self._golden(tmp_path, sneaky)
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("needs category 'window_tail'" in p for p in problems), problems
+        assert any("too shallow to test the window" in p for p in problems), problems
+        # And summarize really would have bucketed it, which is why lint has to.
+        row = sb.score_question(sneaky, [], {})
+        assert row["window_role"] == "tail"
 
     def test_tail_without_enough_novel_terms_fails(self, tmp_path):
         path, gt = self._golden(
@@ -1404,11 +1702,22 @@ class TestWindowFixtureContract:
         for q in window:
             assert q["answer_spans"] == [q["question"]], q["id"]
             assert len(q["expect_any"]) == 1, q["id"]
+            # The two surfaces have to agree. lint keys on category, summarize
+            # buckets on window_role; a set where they disagree is one where a
+            # row is scored without ever being validated. This runs in CI,
+            # where ground_truth/ does not exist and `lint` cannot.
+            expected_category = (
+                "window_head" if q["window_role"] == "head" else "window_tail"
+            )
+            assert q["category"] == expected_category, q["id"]
             if q["window_role"] == "tail":
                 assert q["depth_fraction"] >= sb.TAIL_MIN_DEPTH, q["id"]
-                assert (
-                    len(q["novel_terms_absent_from_head"]) >= sb.TAIL_MIN_NOVEL_TERMS
-                ), q["id"]
+                novel = q["novel_terms_absent_from_head"]
+                assert len(novel) >= sb.TAIL_MIN_NOVEL_TERMS, q["id"]
+                # Declared novel terms must be terms of the quote itself. This
+                # one IS checkable offline: it needs the quote, not the body.
+                quote_terms = sb.distinctive_terms(q["question"])
+                assert set(map(str, novel)) <= quote_terms, q["id"]
             else:
                 assert q["source_offset_chars"] < sb.HEAD_WINDOW_CHARS, q["id"]
 
@@ -1454,6 +1763,54 @@ class TestFrozenFixtureSet:
         assert data["frozen"]["questions_sha256"] == sb.questions_pin(data["questions"])
 
 
+class TestAnswerProvenanceIsRecorded:
+    """`answer_pass_at_5` scores the first served identity whose body contains
+    a span, and never consults `expect_any`. Span uniqueness is enforced by
+    lint only across the ~49 files in the gitignored ground-truth cache, never
+    across the corpus, so a second render of a file, an org digest or any
+    uncached document quoting the sentence scores the pass. That is a real
+    blind spot of the method; counting it is what makes it visible."""
+
+    SPAN = "the subsystem persists attempted charges with a null transaction id"
+
+    def _probe(self):
+        return sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+
+    def test_an_answer_off_an_unexpected_document_is_counted(self):
+        q = question("q1", spans=[self.SPAN], expect=[PATH_OTHER])
+        row = sb.score_question(q, [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)], {})
+        # The pass still counts: answer_recall asks whether the answer TEXT
+        # came back, doc_recall asks whether the named document did.
+        assert row["answer_pass_at_5"] is True
+        assert row["doc_rank"] is None
+        assert row["answer_from_expected_document"] is False
+        summary = sb.summarize([row, self._probe()], [])
+        assert summary["quality"]["answers_from_unexpected_documents"] == 1
+
+    def test_an_answer_off_the_expected_document_is_not_counted(self):
+        q = question("q1", spans=[self.SPAN])
+        row = sb.score_question(q, [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)], {})
+        assert row["answer_from_expected_document"] is True
+        summary = sb.summarize([row, self._probe()], [])
+        assert summary["quality"]["answers_from_unexpected_documents"] == 0
+
+    def test_a_shingle_matched_later_chunk_still_counts_as_expected(self):
+        """A later chunk carries no sync header, so identity falls back to the
+        document id. The cached-body shingle test is what recognises it, and
+        the answer-provenance check has to use the SAME definition doc_rank
+        uses or the two disagree about what 'the expected document' means."""
+        body = " ".join(f"word{i}" for i in range(60)) + " " + self.SPAN
+        hit = repo_hit(PATH_DOC, BLOB_A, body, first_chunk=False)
+        hit["_citadel"]["relevance"] = {"term_coverage": 1.0, "matched_terms": []}
+        gt = {PATH_DOC: sb.shingles(body)}
+        row = sb.score_question(question("q1", spans=[self.SPAN]), [hit], gt)
+        assert row["answer_pass_at_5"] is True
+        assert row["doc_rank"] == 1
+        assert row["answer_from_expected_document"] is True
+
+
 class TestPerRequestMetadataStability:
     def test_same_chunk_same_sha_different_tier_is_flagged(self):
         span = "the subsystem persists attempted charges with a null transaction id"
@@ -1472,6 +1829,32 @@ class TestPerRequestMetadataStability:
         assert meta["chunks_observed"] == 1
         assert meta["chunks_with_unstable_trust_tier"] == 1
         assert meta["unstable_examples"][0]["tiers"] == ["reference-only", "unattested"]
+
+    def test_the_same_chunk_at_a_DIFFERENT_sha_is_not_instability(self):
+        """The key is (result_id, content_sha256) and both halves are load
+        bearing. Every fixture shared sha="deadbeef", so the sha half was
+        untested: degrading the key to result_id alone kept the suite green.
+
+        A chunk whose CONTENT legitimately changed between two requests, and
+        whose trust_tier legitimately changed with it, is not per-request
+        metadata instability. Counting it turns this metric into a false
+        positive generator on any corpus that is being re-indexed -- which is
+        exactly when it will be read.
+        """
+        span = "the subsystem persists attempted charges with a null transaction id"
+        a = scored_hit(PATH_DOC, BLOB_A, span, 1.0, tier="reference-only", sha="1111")
+        b = scored_hit(PATH_DOC, BLOB_A, span, 1.0, tier="unattested", sha="2222")
+        assert a["_citadel"]["result_id"] == b["_citadel"]["result_id"]
+        rows = [
+            sb.score_question(question("q1", spans=[span]), [a], {}),
+            sb.score_question(question("q2", spans=[span]), [b], {}),
+            sb.score_question(
+                {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+            ),
+        ]
+        meta = sb.summarize(rows, [])["metadata_stability"]
+        assert meta["chunks_observed"] == 2
+        assert meta["chunks_with_unstable_trust_tier"] == 0
 
     def test_a_consistent_tier_is_not_flagged(self):
         span = "the subsystem persists attempted charges with a null transaction id"
@@ -1611,3 +1994,105 @@ class TestRunRecordsWhichFrozenSetItAnswered:
         assert sb.questions_pin(sb.load_questions(path)) == sb.questions_pin(
             sb.load_questions(reformatted)
         )
+
+    def _fingerprint(self, tmp_path, monkeypatch, questions=None, gt_dir=None):
+        """build_fingerprint with only the two network calls stubbed.
+
+        The test above never called build_fingerprint, so the key that actually
+        records which frozen set a run answered was untested: renaming it left
+        every run JSON silently pinless with the suite still green.
+        """
+        questions = questions or [{"id": "q1", "question": "text", "expected_recall": 1}]
+        path = tmp_path / "golden.json"
+        path.write_text(json.dumps({"version": 5, "questions": questions}))
+        monkeypatch.setattr(sb, "api_fingerprint", lambda *a, **k: {"node_version": "x"})
+        monkeypatch.setattr(sb, "corpus_census", lambda *a, **k: {"documents_total": 1})
+        monkeypatch.setattr(sb, "make_corpus_fetcher", lambda *a, **k: None)
+        if gt_dir is not None:
+            monkeypatch.setattr(sb, "GROUND_TRUTH", gt_dir)
+        return sb.build_fingerprint("http://node", "tok", 1.0, path, None), path
+
+    def test_build_fingerprint_records_the_pin(self, tmp_path, monkeypatch):
+        fingerprint, path = self._fingerprint(tmp_path, monkeypatch)
+        assert "questions_pin" in fingerprint
+        assert fingerprint["questions_pin"] == sb.questions_pin(sb.load_questions(path))
+
+    def test_build_fingerprint_records_the_ground_truth_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """ground_truth/ is gitignored, refetched from an unpinned upstream
+        HEAD, and feeds doc_rank's shingle fallback and legacy_rank. Two runs
+        at the same pin against the same node can therefore score differently.
+        The fingerprint has to say which cache was used."""
+        gt = tmp_path / "gt"
+        gt.mkdir()
+        (gt / "org__repo__a.md").write_text("first body")
+        before, _ = self._fingerprint(tmp_path, monkeypatch, gt_dir=gt)
+        assert before["ground_truth"]["files"] == 1
+        assert before["ground_truth"]["sha256"]
+        (gt / "org__repo__a.md").write_text("upstream edited this body")
+        after, _ = self._fingerprint(tmp_path, monkeypatch, gt_dir=gt)
+        assert after["ground_truth"]["sha256"] != before["ground_truth"]["sha256"]
+
+    def test_an_absent_ground_truth_cache_says_so(self, tmp_path, monkeypatch):
+        fingerprint, _ = self._fingerprint(
+            tmp_path, monkeypatch, gt_dir=tmp_path / "nope"
+        )
+        assert fingerprint["ground_truth"]["sha256"] is None
+        assert "NOT" in fingerprint["ground_truth"]["reason"]
+
+
+class TestCompareGatesOnThePinNotTheFileBytes:
+    """`questions_pin` says which frozen set was answered. The file hash says
+    whether the file was touched. Gating on the second withheld the entire
+    delta in precisely the case the pin was introduced to fix."""
+
+    def _fingerprint(self, *, pin="p" * 64, file_sha="q" * 64, gt="g" * 64):
+        fingerprint = {
+            "content": {"sha256": "f" * 64},
+            "questions_sha256": file_sha,
+            "harness_git_sha": "deadbeef",
+            "ground_truth": {"sha256": gt, "files": 3},
+        }
+        if pin is not None:
+            fingerprint["questions_pin"] = pin
+        return fingerprint
+
+    def test_same_pin_different_file_bytes_stays_comparable(self):
+        comparable, verdicts = sb.compare_fingerprints(
+            self._fingerprint(file_sha="a" * 64), self._fingerprint(file_sha="b" * 64)
+        )
+        assert comparable is True
+        assert any("questions_pin is identical" in line for line in verdicts)
+        assert not any("QUESTIONS CHANGED" in line for line in verdicts)
+
+    def test_a_different_pin_is_not_comparable(self):
+        comparable, verdicts = sb.compare_fingerprints(
+            self._fingerprint(pin="1" * 64), self._fingerprint(pin="2" * 64)
+        )
+        assert comparable is False
+        assert any("QUESTIONS CHANGED" in line for line in verdicts)
+
+    def test_a_run_without_a_pin_falls_back_to_the_file_hash(self):
+        """An artifact that cannot say which set it answered is not comparable
+        on anybody's word, so the older, blunter gate still applies there."""
+        comparable, verdicts = sb.compare_fingerprints(
+            self._fingerprint(pin=None, file_sha="a" * 64),
+            self._fingerprint(pin=None, file_sha="b" * 64),
+        )
+        assert comparable is False
+        assert any("predates questions_pin" in line for line in verdicts)
+
+    def test_a_moved_ground_truth_cache_is_noted_but_not_a_gate(self):
+        comparable, verdicts = sb.compare_fingerprints(
+            self._fingerprint(gt="1" * 64), self._fingerprint(gt="2" * 64)
+        )
+        assert comparable is True
+        assert any("ground-truth cache differs" in line for line in verdicts)
+
+    def test_a_missing_ground_truth_fingerprint_is_noted(self):
+        current = self._fingerprint()
+        current.pop("ground_truth")
+        comparable, verdicts = sb.compare_fingerprints(current, self._fingerprint())
+        assert comparable is True
+        assert any("ground-truth cache fingerprint unavailable" in line for line in verdicts)

--- a/tests/test_search_bench.py
+++ b/tests/test_search_bench.py
@@ -542,7 +542,18 @@ class TestLint:
         (gt / PATH_DOC.replace("/", "__")).write_text(self.BODY)
         (gt / PATH_OTHER.replace("/", "__")).write_text(self.OTHER_BODY)
         path = tmp_path / "golden.json"
-        path.write_text(json.dumps({"version": 3, "questions": questions}))
+        # A frozen block with a matching pin is now part of a valid questions
+        # file, so the shared helper writes one; TestFrozenFixtureSet covers
+        # what happens when it is missing or stale.
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "questions": questions,
+                    "frozen": {"questions_sha256": sb.questions_pin(questions)},
+                }
+            )
+        )
         return path, gt
 
     def _q(self, **overrides):
@@ -1111,3 +1122,412 @@ class TestShippedGoldenSet:
             assert not probe.get("answer_spans"), probe["id"]
         for control in controls:
             assert control.get("expect_any"), control["id"]
+
+
+def scored_hit(path: str, blob: str, body: str, coverage: float | None,
+               *, tier: str = "unattested", sha: str | None = None) -> dict:
+    """A repo hit carrying the node's own reported term_coverage and trust tier."""
+    hit = repo_hit(path, blob, body)
+    hit["_citadel"]["relevance"] = (
+        {} if coverage is None else {"term_coverage": coverage, "matched_terms": []}
+    )
+    hit["_citadel"]["trust_tier"] = tier
+    hit["_citadel"]["content_sha256"] = sha or hashlib.sha256(body.encode()).hexdigest()
+    return hit
+
+
+class TestRankingIsMeasuredSeparatelyFromRetrieval:
+    """Retrieval asks whether the answer came back; ranking asks whether the node
+    put it in the right place. A single recall number blends the two."""
+
+    SPAN = "the subsystem persists attempted charges with a null transaction id"
+
+    def test_exact_answer_below_a_lower_coverage_hit_is_an_inversion(self):
+        hits = [
+            scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", 0.167),
+            scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0),
+        ]
+        row = sb.score_question(question(spans=[self.SPAN]), hits, {})
+        assert row["answer_slot"] == 2
+        assert row["answer_term_coverage"] == 1.0
+        assert row["outranked_by_coverage"] == 0.167
+        assert row["outranked_by_slot"] == 1
+
+    def test_answer_ranked_first_is_not_an_inversion(self):
+        hits = [
+            scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0),
+            scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", 0.167),
+        ]
+        row = sb.score_question(question(spans=[self.SPAN]), hits, {})
+        assert row["answer_slot"] == 1
+        assert row["outranked_by_coverage"] is None
+
+    def test_a_higher_coverage_hit_above_the_answer_is_not_an_inversion(self):
+        """Being outranked by something the node scored HIGHER is ordinary
+        ranking, not the defect. Only a strictly lower-coverage hit counts."""
+        hits = [
+            scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", 1.0),
+            scored_hit(PATH_DOC, BLOB_A, self.SPAN, 0.5),
+        ]
+        row = sb.score_question(question(spans=[self.SPAN]), hits, {})
+        assert row["answer_slot"] == 2
+        assert row["outranked_by_coverage"] is None
+
+    def test_a_path_header_match_cannot_manufacture_an_inversion(self):
+        """The answer slot is fixed by a BODY span match with the header
+        stripped, so a hit whose only overlap is the path header never becomes
+        the answer and never creates an inversion."""
+        header_only = scored_hit(PATH_DOC, BLOB_B, "no answer text in this body", 1.0)
+        hits = [header_only, scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)]
+        row = sb.score_question(question(spans=[self.SPAN]), hits, {})
+        assert row["answer_slot"] == 2
+        assert row["outranked_by_coverage"] is None
+
+    def test_missing_coverage_is_not_counted_as_an_inversion(self):
+        hits = [
+            scored_hit(PATH_OTHER, BLOB_B, "unrelated filler prose", None),
+            scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0),
+        ]
+        row = sb.score_question(question(spans=[self.SPAN]), hits, {})
+        assert row["outranked_by_coverage"] is None
+
+    def test_summary_rate_counts_only_answers_that_were_ranked(self):
+        span = self.SPAN
+        inverted = sb.score_question(
+            question("a1", spans=[span]),
+            [
+                scored_hit(PATH_OTHER, BLOB_B, "filler", 0.0),
+                scored_hit(PATH_DOC, BLOB_A, span, 1.0),
+            ],
+            {},
+        )
+        clean = sb.score_question(
+            question("a2", spans=[span]),
+            [scored_hit(PATH_DOC, BLOB_A, span, 1.0)],
+            {},
+        )
+        never_served = sb.score_question(
+            question("a3", spans=[span]),
+            [scored_hit(PATH_OTHER, BLOB_B, "filler", 0.2)],
+            {},
+        )
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0},
+            [],
+            {},
+        )
+        summary = sb.summarize([inverted, clean, never_served, probe], [])
+        assert summary["ranking"]["answers_ranked"] == 2
+        assert summary["ranking"]["rank_inversion_rate"] == 0.5
+        assert summary["ranking"]["inversions_by_zero_coverage"] == 1
+        assert summary["ranking"]["answer_worst_slot"] == 2
+
+
+class TestEmbeddingWindowPairs:
+    SPAN = "the subsystem persists attempted charges with a null transaction id"
+
+    def _pair_rows(self, head_pass: bool, tail_pass: bool, pair: str = "w01"):
+        def side(role, passed):
+            q = question(f"{pair}{role[0]}", spans=[self.SPAN])
+            q["category"] = f"window_{role}"
+            q["window_role"] = role
+            q["window_pair"] = pair
+            hits = (
+                [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)]
+                if passed
+                else [scored_hit(PATH_OTHER, BLOB_B, "unrelated filler", 0.1)]
+            )
+            return sb.score_question(q, hits, {})
+
+        return [side("head", head_pass), side("tail", tail_pass)]
+
+    def test_window_rows_are_excluded_from_the_headline(self):
+        """v5 added pairs that fail by design. Folding them into
+        answer_recall_at_5 would move the headline for a reason that has nothing
+        to do with the node changing."""
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        rows = [plain, probe] + self._pair_rows(head_pass=True, tail_pass=False)
+        summary = sb.summarize(rows, [])
+        assert summary["counts"]["questions_with_spans"] == 1
+        assert summary["quality"]["answer_recall_at_5"] == 1.0
+        assert summary["counts"]["questions_window"] == 2
+
+    def test_penalty_is_head_recall_minus_tail_recall(self):
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        rows = [plain, probe]
+        rows += self._pair_rows(True, False, "w01")
+        rows += self._pair_rows(True, True, "w02")
+        summary = sb.summarize(rows, [])
+        window = summary["window"]
+        assert window["head_recall_at_5"] == 1.0
+        assert window["tail_recall_at_5"] == 0.5
+        assert window["window_penalty"] == 0.5
+        assert window["pairs_complete"] == 2
+        assert window["pairs_head_only"] == 1
+        assert window["pairs_both"] == 1
+
+    def test_a_half_pair_does_not_contribute_to_the_penalty(self):
+        """Only pairs whose BOTH sides ran are a within-document comparison."""
+        probe = sb.score_question(
+            {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+        )
+        plain = sb.score_question(
+            question("q1", spans=[self.SPAN]),
+            [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)],
+            {},
+        )
+        rows = [plain, probe] + self._pair_rows(True, False, "w01")
+        rows = [r for r in rows if r["window_role"] != "tail"]
+        summary = sb.summarize(rows, [])
+        assert summary["window"]["pairs_complete"] == 0
+
+
+class TestWindowFixtureContract:
+    """The rules that make a failing tail evidence rather than a failing question."""
+
+    HEAD_TEXT = "alpha beta gamma delta epsilon " * 40           # ~1200 chars
+    TAIL_TEXT = "zeta thermodynamic eigenvector quaternion sentence here to quote."
+    BODY = "# Doc Title\n\n" + HEAD_TEXT + ("filler padding words. " * 200) + TAIL_TEXT
+
+    def _golden(self, tmp_path, question_obj):
+        gt = tmp_path / "ground_truth"
+        gt.mkdir(exist_ok=True)
+        (gt / PATH_DOC.replace("/", "__")).write_text(self.BODY)
+        path = tmp_path / "golden.json"
+        questions = [question_obj]
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 5,
+                    "questions": questions,
+                    "frozen": {"questions_sha256": sb.questions_pin(questions)},
+                }
+            )
+        )
+        return path, gt
+
+    def _tail_q(self, **overrides):
+        base = {
+            "id": "w01t",
+            "question": self.TAIL_TEXT,
+            "expect_any": [PATH_DOC],
+            "category": "window_tail",
+            "expected_recall": 1,
+            "answer_spans": [self.TAIL_TEXT],
+            "window_pair": "w01",
+            "window_role": "tail",
+            "source_offset_chars": self.BODY.find(self.TAIL_TEXT),
+            "novel_terms_absent_from_head": [
+                "thermodynamic", "eigenvector", "quaternion",
+            ],
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_tail_fixture_passes(self, tmp_path):
+        path, gt = self._golden(tmp_path, self._tail_q())
+        problems, _ = sb.lint_questions(path, gt)
+        assert problems == []
+
+    def test_the_quote_being_the_query_is_allowed_only_for_window_questions(self, tmp_path):
+        """Every other question rejects a span that appears in its own query.
+        A window question IS its verbatim quote by design."""
+        plain = self._tail_q(category="repo_overview")
+        plain.pop("window_role")
+        plain.pop("window_pair")
+        path, gt = self._golden(tmp_path, plain)
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("appears in the question text" in p for p in problems)
+
+    def test_tail_quote_too_shallow_fails(self, tmp_path):
+        path, gt = self._golden(tmp_path, self._tail_q(source_offset_chars=10))
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("too shallow to test the window" in p for p in problems)
+
+    def test_tail_without_enough_novel_terms_fails(self, tmp_path):
+        path, gt = self._golden(
+            tmp_path, self._tail_q(novel_terms_absent_from_head=["quaternion"])
+        )
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("novel_terms_absent_from_head" in p for p in problems)
+
+    def test_a_term_that_actually_occurs_in_the_head_voids_the_control(self, tmp_path):
+        """This is the control the whole comparison rests on: if the tail's
+        terms are already in the head, the head embedding can answer the query
+        and a pass proves nothing about reach."""
+        path, gt = self._golden(
+            tmp_path,
+            self._tail_q(
+                novel_terms_absent_from_head=["thermodynamic", "eigenvector", "alpha"]
+            ),
+        )
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("the control is void" in p for p in problems)
+        assert any("alpha" in p for p in problems)
+
+    def test_head_fixture_outside_the_window_fails(self, tmp_path):
+        head = self._tail_q(
+            id="w01h", category="window_head", window_role="head",
+            question=self.TAIL_TEXT, answer_spans=[self.TAIL_TEXT],
+        )
+        head.pop("novel_terms_absent_from_head")
+        path, gt = self._golden(tmp_path, head)
+        problems, _ = sb.lint_questions(path, gt)
+        assert any("not a head control" in p for p in problems)
+
+    def test_shipped_window_pairs_satisfy_the_contract(self):
+        """The committed set, not a fixture: every pair has both sides, both
+        quotes are unique to one document, and every tail clears the controls."""
+        data = json.loads(
+            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
+        )
+        window = [q for q in data["questions"] if sb.is_window_question(q)]
+        assert len(window) >= 20
+        by_pair = {}
+        for q in window:
+            by_pair.setdefault(q["window_pair"], set()).add(q["window_role"])
+        assert all(roles == {"head", "tail"} for roles in by_pair.values()), by_pair
+        for q in window:
+            assert q["answer_spans"] == [q["question"]], q["id"]
+            assert len(q["expect_any"]) == 1, q["id"]
+            if q["window_role"] == "tail":
+                assert q["depth_fraction"] >= sb.TAIL_MIN_DEPTH, q["id"]
+                assert (
+                    len(q["novel_terms_absent_from_head"]) >= sb.TAIL_MIN_NOVEL_TERMS
+                ), q["id"]
+            else:
+                assert q["source_offset_chars"] < sb.HEAD_WINDOW_CHARS, q["id"]
+
+
+class TestFrozenFixtureSet:
+    """Frozen has to mean something. The pin is what enforces it."""
+
+    def _file(self, tmp_path, questions, frozen=...):
+        payload = {"version": 5, "questions": questions}
+        if frozen is not ...:
+            payload["frozen"] = frozen
+        path = tmp_path / "golden.json"
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_pin_is_stable_under_key_order_and_formatting(self):
+        a = [{"id": "q1", "question": "text", "expected_recall": 1}]
+        b = [{"expected_recall": 1, "question": "text", "id": "q1"}]
+        assert sb.questions_pin(a) == sb.questions_pin(b)
+
+    def test_pin_moves_when_a_question_changes(self):
+        a = [{"id": "q1", "question": "text"}]
+        b = [{"id": "q1", "question": "text edited"}]
+        assert sb.questions_pin(a) != sb.questions_pin(b)
+
+    def test_edited_question_fails_lint_against_a_stale_pin(self, tmp_path):
+        original = [{"id": "q1", "question": "original text"}]
+        pin = sb.questions_pin(original)
+        edited = [{"id": "q1", "question": "quietly edited text"}]
+        path = self._file(tmp_path, edited, {"questions_sha256": pin})
+        problems, _ = sb.lint_questions(path, tmp_path / "missing_gt")
+        assert any("FROZEN SET CHANGED" in p for p in problems)
+
+    def test_missing_frozen_block_fails(self, tmp_path):
+        path = self._file(tmp_path, [{"id": "q1", "question": "text"}])
+        problems, _ = sb.lint_questions(path, tmp_path / "missing_gt")
+        assert any("no `frozen` block" in p for p in problems)
+
+    def test_shipped_questions_file_matches_its_own_pin(self):
+        data = json.loads(
+            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
+        )
+        assert data["frozen"]["questions_sha256"] == sb.questions_pin(data["questions"])
+
+
+class TestPerRequestMetadataStability:
+    def test_same_chunk_same_sha_different_tier_is_flagged(self):
+        span = "the subsystem persists attempted charges with a null transaction id"
+        a = scored_hit(PATH_DOC, BLOB_A, span, 1.0, tier="reference-only", sha="deadbeef")
+        b = scored_hit(PATH_DOC, BLOB_A, span, 1.0, tier="unattested", sha="deadbeef")
+        assert a["_citadel"]["result_id"] == b["_citadel"]["result_id"]
+        rows = [
+            sb.score_question(question("q1", spans=[span]), [a], {}),
+            sb.score_question(question("q2", spans=[span]), [b], {}),
+            sb.score_question(
+                {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+            ),
+        ]
+        summary = sb.summarize(rows, [])
+        meta = summary["metadata_stability"]
+        assert meta["chunks_observed"] == 1
+        assert meta["chunks_with_unstable_trust_tier"] == 1
+        assert meta["unstable_examples"][0]["tiers"] == ["reference-only", "unattested"]
+
+    def test_a_consistent_tier_is_not_flagged(self):
+        span = "the subsystem persists attempted charges with a null transaction id"
+        hit = scored_hit(PATH_DOC, BLOB_A, span, 1.0, tier="unattested", sha="deadbeef")
+        rows = [
+            sb.score_question(question("q1", spans=[span]), [hit], {}),
+            sb.score_question(question("q2", spans=[span]), [hit], {}),
+            sb.score_question(
+                {"id": "p1", "question": "probe", "expect_any": [], "expected_recall": 0}, [], {}
+            ),
+        ]
+        summary = sb.summarize(rows, [])
+        assert summary["metadata_stability"]["chunks_with_unstable_trust_tier"] == 0
+
+
+class TestReportCoversTheNewMetrics:
+    def _run(self, summary_extra):
+        return {
+            "run_at": "2026-08-04T00:00:00+00:00",
+            "summary": {
+                "quality": {
+                    "answer_recall_at_5": 0.9, "raw_page_recall_at_5": 0.8,
+                    "doc_recall_at_5": 0.9, "mrr_body": 0.7,
+                    "header_credit_rate": 0.0, "negative_hit_rate": 0.0,
+                },
+                "duplication": {"duplicate_blob_rate_at_10": 0.3},
+                "counts": {
+                    "questions_with_spans": 39, "questions_positive": 61,
+                    "questions_blocked_probe": 8,
+                },
+                "latency": {"p50_ms": 600.0, "p95_ms": 900.0, "samples": 105},
+                **summary_extra,
+            },
+            "rows": [],
+            "fingerprint": {"harness_git_sha": "abc1234", "content": {"sha256": "x"}},
+        }
+
+    def test_window_and_ranking_rows_carry_their_definitions(self):
+        run = self._run(
+            {
+                "window": {
+                    "head_recall_at_5": 0.667, "tail_recall_at_5": 0.0,
+                    "window_penalty": 0.667, "pairs_complete": 18,
+                },
+                "ranking": {"rank_inversion_rate": 0.63, "answers_ranked": 19},
+            }
+        )
+        markdown = sb.build_markdown_report(run)
+        for key in ("head_recall_at_5", "tail_recall_at_5", "window_penalty",
+                    "rank_inversion_rate"):
+            assert key in markdown
+            assert sb.METRIC_DEFINITIONS[key][:40] in markdown
+        assert "| 18 |" in markdown
+        assert "| 19 |" in markdown
+
+    def test_a_run_predating_these_metrics_says_so_instead_of_guessing(self):
+        markdown = sb.build_markdown_report(self._run({}))
+        assert "not measured in this run" in markdown
+        assert "n/a (not measured)" not in markdown.split("head_recall_at_5")[1][:80]


### PR DESCRIPTION
## What the harness is

`scripts/bench/search_bench.py` is the first repeatable measurement this project has against production. Before it, every claim about retrieval quality was an anecdote: someone ran a query, looked at the hits, formed an opinion. This runs a frozen question set against the live node, records what came back, and writes a run JSON that a later run can be compared against by a person who does not trust the first one.

That matters more than it sounds, because this repo currently has zero integration tests.

```
$ grep -rn "pytest.mark.integration\|pytest.mark.e2e" tests/
$ echo $?
1
```

Nothing matches. The markers actually in use are `asyncio` (129), `parametrize` (10), `canary` (6) and `live` (1), and the one `live` test is skipped unless you opt in:

```
SKIPPED [1] tests/test_agent_canary.py:217: set CITADEL_CANARY_LIVE=1 to exercise the production Node
1502 passed, 1 skipped, 11 warnings in 23.24s
```

A suite that finishes in 23 seconds has not opened a socket to the node, and by default exactly one test would and it does not run. That is why every defect that has mattered in this project was found by hand against production, and why an instrument that talks to the real node earns its place here in a way another unit test would not.

The harness is read-only. Nothing in `scripts/bench/` writes to the vault. `lint` needs nothing but the repo; `run` needs a seat token and a node URL.

## The frozen baseline

Taken against production, question set pinned at `frozen.questions_sha256 = 022b6b4f66c73af1...`, version 5, 105 questions.

| metric | value |
| --- | --- |
| `head_recall_at_5` | 0.6111 |
| `tail_recall_at_5` | 0.0 |
| `tail_recall_given_head_at_5` | 0.0 over 11 |
| `rank_inversion_rate` | 0.1489 |
| `answer_recall_at_5` | 0.8974 |
| latency | p50 592.2 ms, p95 791.5 ms, client round-trip |

The blind spots belong next to the numbers, not in a footnote:

**The never-indexed share was not re-measured.** The corpus census walks `GET /api/corpus`, which requires a token carrying `admin` or `audit:read`. The token used for this run is a writer seat, the census returned 403, and the harness recorded it as unavailable and continued rather than guessing. So the 892-of-2867 figure that the runbook reasons about is #228's own number from 2026-08-03, marked REPORTED, not something this baseline confirmed.

**A later run is not comparable on corpus content.** The content fingerprint is a sha256 over the repo content sync state file, and the authoritative copy of that file lives on the node, not in this checkout. The local copy has an empty `files` map. A fingerprint over zero files is the sha256 of the empty string, which is identical on every such run and would have compared as "same corpus" while attesting nothing, so the harness records `sha256: null` with a reason instead and `compare` says NOT COMPARABLE on content and withholds the delta. Two runs can be compared on `documents_tracked` and the API snapshot. They cannot be compared on corpus content. That refusal is enforced in code, including for older run JSONs that still carry the empty-string sha.

**7 of the 18 window documents missed on both sides.** Their head quote did not retrieve, so their tail quote could not either. A raw `tail_recall_at_5` of 0.0 therefore cannot distinguish "the index does not hold this document" from "the index holds it and cannot reach past the opening". Separating those two is exactly why the third metric exists.

## Read `tail_recall_given_head_at_5` first

`tail_recall_at_5` is 0.0 and on its own it is close to meaningless, because a document that never retrieves at all contributes a miss for reasons that have nothing to do with depth.

`tail_recall_given_head_at_5` restricts the denominator to documents whose head quote demonstrably retrieved. Every document it counts is one the index provably holds and provably returns. It reads 0.0 over 11: eleven documents the node will return when quoted from the top, and not one of them returns when quoted verbatim from 40% depth or deeper.

That is a claim about reachability inside documents the index already has, with the "maybe it just is not indexed" explanation removed by construction. It is the number to argue with if you want to argue with anything in this PR.

## What the runbook adds

`docs/superpowers/specs/2026-08-04-reindex-runbook.md` is the plan the harness gates. Two points deserve a close read.

**It scopes #228 at all 2,867 documents rather than the 892.** The 892 documents at `chunk_count == 0` are unreachable and have to be included, but they are a symptom count, not the population. None of the eleven documents behind `tail_recall_given_head_at_5` is among the 892, because a document with no chunks cannot retrieve on its head quote either and is excluded before the metric is computed. A run scoped to the 892 would leave that 0-of-11 at zero by construction and never touch the most direct evidence of the defect. The measurement supporting the wider scope: re-chunking a fixed corpus at the shipped budget produces 4494 chunks against 204 before, a 22.0x multiplier, VERIFIED 2026-08-04. The sweep already committed at `kb/chunk_window.py:76-88` reports 22.1x over a corpus of different composition, which is agreement to within a rounding error rather than a second look at the same sample.

**There is no rollback, so a database backup is a precondition.** The re-index overwrites chunk rows in place and nothing in the pipeline snapshots them. Reverting the budget and cognifying again does not restore the previous rows, it writes a third generation on top of them. The only route back to today's state is a backup of the vector store taken before the first `force` call. The runbook states that as a hard precondition rather than a recommendation, and it separates the two halves of gate 9 explicitly: the graph half is reversible by one environment value, the vector half is not, because the vector store does not move in that migration and is overwritten in place regardless of which graph provider is configured. Nobody should read one half's rollback plan onto the other.

The runbook is equally direct about what it does not supply. It has no root cause for the 892, and it says so: if a document reached `chunk_count == 0` for a reason other than the incremental skip, a forced re-run puts it back at zero and the population regenerates over time. Repair is not diagnosis. Section 4 step 2 is the cheap probe that tells the two apart before the full cost is paid.

## Verification

Full suite on the merged tree, three passes:

```
1502 passed, 1 skipped, 11 warnings in 26.22s
45 failed, 1457 passed, 1 skipped, 11 warnings in 24.18s
1502 passed, 1 skipped, 11 warnings in 22.52s
```

The middle line is `scripts/bench/search_bench.py` reverted to its state on `main` with the tests left in place. 1503 collected, 45 real failures across the frozen-set, window-contract, conditional-tail-recall, metadata-stability and report-coverage suites. A zero-collected run would have printed no failures and looked the same as a pass, so the collected count is quoted alongside.

The frozen pin still holds:

```
$ python scripts/bench/search_bench.py lint
lint OK: 75 question(s) with validated answer_spans, 22 explicitly unconverted, 8 probe(s)
```

`lint` recomputes the pin over the question list and fails loudly with `FROZEN SET CHANGED` if it has moved. It matches `022b6b4f66c73af10ae99090d58ed0c1b89806718db222de0825a14c9cfb9838`, which is what guarantees the baseline above and any later run answer the same questions.

`git diff origin/main -- kb/webui` is empty. This PR touches no build output.

Refs #122. It unblocks verification of #228: the runbook's success criteria are stated in the harness's metrics, so the re-index can be judged by re-running the frozen set instead of by opinion.
