### PR TITLE
fix: harden indexing and readiness for v0.5.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,11 @@ CITADEL_LLM_ENRICHMENT_ENABLED=true
 CITADEL_LLM_MODEL=deepseek/deepseek-v4-flash
 # Source material below this size is ingested as-is (chars).
 CITADEL_LLM_ENRICHMENT_THRESHOLD_CHARS=4000
+# Deterministic pre-ingest boundary when enrichment is disabled or unavailable.
+# Character backstop for lossless splitting. Actual pieces are sized against
+# Cognee's configured BPE counter with a safety margin; the embed-boundary
+# detector remains the production authority for overflow reporting.
+CITADEL_DETERMINISTIC_CHUNK_CHARS=1200
 
 # Self-improvement loop (POST /api/learning-agent/optimize + pipeline stage).
 # Strictly bounded and additive: re-tags/summarizes recent ingests, never deletes.

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -18,7 +18,6 @@ import urllib.parse
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -851,11 +850,15 @@ async def _improve(args: argparse.Namespace) -> None:
 
 
 @_needs_server
-async def _cognify(args: argparse.Namespace) -> None:
+async def _cognify(args: argparse.Namespace) -> int:
     from kb.service import Citadel
 
     kb = Citadel.from_env()
-    result = await kb.cognify_dataset(dataset=args.dataset, verify=args.verify)
+    result = await kb.cognify_dataset(
+        dataset=args.dataset,
+        verify=args.verify,
+        force=args.force,
+    )
     _print_json(result)
     return _result_exit(result)
 
@@ -2484,12 +2487,17 @@ async def _onboard(args: argparse.Namespace) -> int:
 
 
 def _cli_version() -> str:
+    # The source module is the canonical value in a checkout and is also
+    # bundled into wheels. Installed metadata can lag after an editable source
+    # change, which made the CLI report an older release than the server.
     try:
-        return _pkg_version("citadel-archive")
-    except PackageNotFoundError:
         from kb import __version__
 
         return __version__
+    except (ImportError, AttributeError):
+        from importlib.metadata import version
+
+        return version("citadel-archive")
 
 
 def _install_channel() -> tuple[str, str]:
@@ -3172,6 +3180,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Cognify already-added data in a dataset (recover uncognified data)",
     )
     cognify.add_argument("--dataset")
+    cognify.add_argument(
+        "--force",
+        action="store_true",
+        help="Reprocess data Cognee marks as already processed; this is not a source reindex",
+    )
     cognify.add_argument(
         "--verify",
         action="store_true",

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -14,12 +14,41 @@ from urllib.parse import unquote, urlparse
 from uuid import NAMESPACE_OID, UUID, uuid5
 
 from kb import chunk_window
+from kb.document_provenance import parse_document_provenance
 
 logger = logging.getLogger(__name__)
 
 # Strong refs to detached background cognify tasks so the loop does not GC them
 # mid-flight (and so they can be awaited/observed in tests).
 _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
+
+
+async def drain_background_cognify_tasks(timeout_seconds: float = 30.0) -> None:
+    """Give queued cognify work a bounded shutdown window.
+
+    A task that outlives the web process leaves its durable add behind without
+    its graph/vector projection. The next boot recovery still repairs it, but a
+    graceful shutdown should first let the current batch finish.
+    """
+    tasks = [task for task in _BACKGROUND_COGNIFY_TASKS if not task.done()]
+    if not tasks:
+        return
+    done, pending = await asyncio.wait(tasks, timeout=max(0.0, timeout_seconds))
+    if pending:
+        logger.warning(
+            "Cancelling %d background cognify task(s) after %.1fs shutdown window; "
+            "startup recovery will retry their datasets",
+            len(pending),
+            max(0.0, timeout_seconds),
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+    # Retrieve exceptions from tasks that finished during the wait so the
+    # shutdown path does not emit an unobserved-task warning.
+    for task in done:
+        if not task.cancelled():
+            task.exception()
 
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -29,6 +58,27 @@ def _float_env(name: str, default: float) -> float:
         return float(raw)
     except ValueError:
         return default
+
+
+DEFAULT_CORPUS_HEALTH_MAX_DOCUMENTS = 10_000
+
+
+def _corpus_health_max_documents() -> int:
+    raw = os.getenv(
+        "CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS",
+        str(DEFAULT_CORPUS_HEALTH_MAX_DOCUMENTS),
+    ).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            "CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS must be a positive integer"
+        ) from exc
+    if value < 1:
+        raise RuntimeError(
+            "CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS must be a positive integer"
+        )
+    return value
 
 
 def _utc_datetime(value: datetime) -> datetime:
@@ -88,6 +138,9 @@ NODE_DATASET_MAP_TIMEOUT_SECONDS = _float_env(
 # attribution, never to an empty vault.
 NODE_DATASET_MAP_FAILURE_TTL_SECONDS = _float_env(
     "CITADEL_NODE_DATASET_MAP_FAILURE_TTL_SECONDS", 5.0
+)
+NODE_PROVENANCE_MAP_TIMEOUT_SECONDS = _float_env(
+    "CITADEL_NODE_PROVENANCE_MAP_TIMEOUT_SECONDS", 5.0
 )
 # The whole-graph Kuzu read is expensive (5,382 nodes / 33,859 edges, ~0.3s+)
 # and is now front-loaded on every dashboard open. TTL-cache the RAW read so N
@@ -266,6 +319,7 @@ class CogneeGateway(Protocol):
         dataset_name: str,
         session_id: str | None = None,
         tags: tuple[str, ...] = (),
+        provenance: dict[str, Any] | None = None,
         defer_cognify: bool = False,
     ) -> Any:
         ...
@@ -305,6 +359,15 @@ class CogneeGateway(Protocol):
     async def cognify(self, *, datasets: list[str], force: bool = False) -> Any:
         ...
 
+    async def list_dataset_names(self) -> list[str]:
+        ...
+
+    async def node_provenance_map(self) -> dict[str, dict[str, str]]:
+        ...
+
+    async def document_provenance(self, document_id: str) -> dict[str, str] | None:
+        ...
+
     async def get_document(self, document_id: str) -> dict[str, Any] | None:
         ...
 
@@ -312,6 +375,9 @@ class CogneeGateway(Protocol):
         ...
 
     async def graph_data(self) -> tuple[list[Any], list[Any]]:
+        ...
+
+    async def corpus_health(self, *, limit: int = 64) -> dict[str, Any]:
         ...
 
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:
@@ -507,13 +573,16 @@ class CogneePublicClient:
         dataset_name: str,
         session_id: str | None = None,
         tags: tuple[str, ...] = (),
+        provenance: dict[str, Any] | None = None,
         defer_cognify: bool = False,
     ) -> Any:
         self._prepare_cognee_environment()
         import cognee
 
         await self._ensure_cognee_ready(cognee)
-        metadata = {"citadel_tags": list(tags)} if tags else None
+        metadata: dict[str, Any] = {"citadel_tags": list(tags)} if tags else {}
+        if provenance:
+            metadata["citadel_provenance"] = dict(provenance)
         # Durable knowledge writes always go to cognee's permanent graph
         # (add+cognify), never its per-session cache. When a session_id was
         # supplied, cognee routed the write into the session cache, which (a)
@@ -523,7 +592,7 @@ class CogneePublicClient:
         # scaffolded "Session ID:/Question:/Answer:" blob every sync cycle.
         # session_id is still accepted (callers pass it as provenance) but no
         # longer diverts the write away from the durable path.
-        data = self._data_with_metadata(data, metadata)
+        data = self._data_with_metadata(data, metadata or None)
 
         # Add is a fast write to the relational + vector stores; it does NOT touch
         # the Kuzu graph (cognify is the graph write). Metadata rides in the
@@ -854,6 +923,87 @@ class CogneePublicClient:
                 mapping.setdefault(str(data_id), []).append(dataset_name)
         return mapping
 
+    async def node_provenance_map(self) -> dict[str, dict[str, str]]:
+        """Return server-written provenance keyed by graph document id.
+
+        Cognee graph nodes do not expose ``Data.external_metadata``. Read the
+        durable relational column separately and fail soft to an empty map so a
+        metadata outage cannot turn a working graph into a 500 response.
+        """
+        try:
+            return await asyncio.wait_for(
+                self._read_node_provenance_map(),
+                timeout=NODE_PROVENANCE_MAP_TIMEOUT_SECONDS,
+            )
+        except Exception:  # noqa: BLE001 - provenance is display metadata
+            logger.warning(
+                "node provenance map read failed; graph will show unattested nodes",
+                exc_info=True,
+            )
+            return {}
+
+    async def _read_node_provenance_map(self) -> dict[str, dict[str, str]]:
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.data.models import Data
+        from cognee.modules.users.methods import get_default_user
+
+        from sqlalchemy import select
+
+        user = await get_default_user()
+        engine = get_relational_engine()
+        mapping: dict[str, dict[str, str]] = {}
+        async with engine.get_async_session() as session:
+            rows = await session.execute(
+                select(Data.id, Data.external_metadata).where(Data.owner_id == user.id)
+            )
+            for data_id, external_metadata in rows.all():
+                provenance = parse_document_provenance(external_metadata)
+                if provenance:
+                    mapping[str(data_id)] = provenance
+        return mapping
+
+    async def document_provenance(self, document_id: str) -> dict[str, str] | None:
+        """Read one document's validated provenance for drill-down responses."""
+        try:
+            data_id = UUID(str(document_id))
+        except (TypeError, ValueError):
+            return None
+        try:
+            self._prepare_cognee_environment()
+            import cognee
+
+            await self._ensure_cognee_ready(cognee)
+            from cognee.infrastructure.databases.relational import get_relational_engine
+            from cognee.modules.data.models import Data
+            from cognee.modules.users.methods import get_default_user
+
+            from sqlalchemy import select
+
+            user = await get_default_user()
+            engine = get_relational_engine()
+            async with engine.get_async_session() as session:
+                row = (
+                    await session.execute(
+                        select(Data.external_metadata).where(
+                            Data.id == data_id,
+                            Data.owner_id == user.id,
+                        )
+                    )
+                ).scalar_one_or_none()
+            provenance = parse_document_provenance(row)
+            return provenance or None
+        except Exception:  # noqa: BLE001 - drill-down metadata is best effort
+            logger.warning(
+                "document provenance read failed for %s",
+                document_id,
+                exc_info=True,
+            )
+            return None
+
     async def document_counts_by_dataset(self) -> dict[str, int]:
         """Durable per-dataset document counts, straight from the relational store.
 
@@ -1047,6 +1197,131 @@ class CogneePublicClient:
             "by_dataset_default_owner": by_dataset_default_owner,
         }
 
+    async def corpus_health(self, *, limit: int = 64) -> dict[str, Any]:
+        """Run a bounded keyset walk over relational projection state.
+
+        ``graph_data()`` can contain stale or unrelated nodes, so its node count
+        cannot prove that accepted relational documents have vector chunks. Walk
+        every relational row in bounded pages and join the existing vector and
+        graph presence checks for those exact ids. Missing measurements raise so
+        callers cannot turn an unavailable store into a healthy result.
+
+        The walk stops before exceeding ``CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS``.
+        A cap hit is an explicit non-ready result, not a partial success.
+        """
+        probe_limit = max(1, min(int(limit), 256))
+        max_documents = _corpus_health_max_documents()
+        totals = await self.corpus_totals()
+        total_documents = totals.get("documents")
+        if (
+            isinstance(total_documents, bool)
+            or not isinstance(total_documents, int)
+            or total_documents < 0
+        ):
+            raise RuntimeError("corpus totals returned an invalid document count")
+
+        empty_result = {
+            "relational_documents": total_documents,
+            "probe_limit": probe_limit,
+            "probe_max_documents": max_documents,
+            "probe_documents": 0,
+            "probe_pages": 0,
+            "probe_complete": False,
+            "probe_cap_exceeded": False,
+            "probe_chunked_documents": 0,
+            "probe_graph_documents": 0,
+            "probe_fully_indexed_documents": 0,
+            "probe_ok": False,
+        }
+        if total_documents > max_documents:
+            return {**empty_result, "probe_cap_exceeded": True}
+
+        after_created_at: str | None = None
+        after_id: str | None = None
+        document_ids_seen: set[str] = set()
+        chunked_ids: set[str] = set()
+        graph_ids_seen: set[str] = set()
+        fully_indexed_ids: set[str] = set()
+        pages = 0
+
+        while len(document_ids_seen) < total_documents:
+            page_limit = min(
+                probe_limit,
+                max_documents - len(document_ids_seen),
+                total_documents - len(document_ids_seen),
+            )
+            rows = list(
+                await self.corpus_page(
+                    after_created_at=after_created_at,
+                    after_id=after_id,
+                    limit=page_limit,
+                )
+                or []
+            )
+            if not rows:
+                break
+            if len(rows) > page_limit:
+                raise RuntimeError("corpus page exceeded its requested limit")
+
+            page_ids: list[str] = []
+            for row in rows:
+                if not isinstance(row, dict) or not row.get("id"):
+                    raise RuntimeError("corpus page returned a row without an id")
+                document_id = str(row["id"])
+                if document_id in document_ids_seen:
+                    raise RuntimeError(
+                        f"corpus page returned duplicate document {document_id}"
+                    )
+                document_ids_seen.add(document_id)
+                page_ids.append(document_id)
+            if len(document_ids_seen) > total_documents:
+                raise RuntimeError("corpus pages exceeded the reported document total")
+
+            chunk_counts = await self.corpus_chunk_counts(page_ids)
+            if chunk_counts is None:
+                raise RuntimeError("vector chunk measurement is unavailable")
+            graph_ids = await self.corpus_graph_presence(page_ids)
+            if graph_ids is None:
+                raise RuntimeError("graph presence measurement is unavailable")
+
+            graph_id_set = {str(document_id) for document_id in graph_ids}
+            page_chunked_ids = {
+                document_id
+                for document_id in page_ids
+                if int(chunk_counts.get(document_id, 0)) > 0
+            }
+            page_graph_ids = set(page_ids) & graph_id_set
+            chunked_ids.update(page_chunked_ids)
+            graph_ids_seen.update(page_graph_ids)
+            fully_indexed_ids.update(page_chunked_ids & page_graph_ids)
+            pages += 1
+
+            if len(document_ids_seen) >= total_documents:
+                break
+            last_row = rows[-1]
+            if not last_row.get("created_at") or not last_row.get("id"):
+                raise RuntimeError("corpus page cannot form a keyset cursor")
+            after_created_at = str(last_row["created_at"])
+            after_id = str(last_row["id"])
+
+        probe_complete = len(document_ids_seen) == total_documents
+
+        return {
+            "relational_documents": total_documents,
+            "probe_limit": probe_limit,
+            "probe_max_documents": max_documents,
+            "probe_documents": len(document_ids_seen),
+            "probe_pages": pages,
+            "probe_complete": probe_complete,
+            "probe_cap_exceeded": False,
+            "probe_chunked_documents": len(chunked_ids),
+            "probe_graph_documents": len(graph_ids_seen),
+            "probe_fully_indexed_documents": len(fully_indexed_ids),
+            "probe_ok": probe_complete
+            and bool(document_ids_seen)
+            and len(fully_indexed_ids) == len(document_ids_seen),
+        }
+
     async def corpus_chunk_counts(
         self, document_ids: list[str]
     ) -> dict[str, int] | None:
@@ -1188,6 +1463,23 @@ class CogneePublicClient:
             return False
         return was_missing
 
+    async def list_dataset_names(self) -> list[str]:
+        """Return the durable dataset names owned by the current Cognee user."""
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        from cognee import datasets as cognee_datasets
+
+        rows = await cognee_datasets.list_datasets()
+        return sorted(
+            {
+                str(getattr(row, "name", "") or "").strip()
+                for row in rows
+                if str(getattr(row, "name", "") or "").strip()
+            }
+        )
+
     async def delete_graph_nodes(self, node_ids: list[str]) -> int:
         """Delete nodes by id from BOTH the graph and the chunk vector store (#15).
 
@@ -1317,8 +1609,22 @@ class CogneePublicClient:
         doc_id = str(document_id)
         document = await self._document_from_graph(doc_id, follow_parent=True)
         if document is not None:
+            return await self._attach_document_provenance(document)
+        document = await self._document_from_chunk_store(doc_id)
+        if document is None:
+            return None
+        return await self._attach_document_provenance(document)
+
+    async def _attach_document_provenance(self, document: dict[str, Any]) -> dict[str, Any]:
+        """Add validated promotion fields to a drill-down document response."""
+        provenance = await self.document_provenance(str(document.get("id") or ""))
+        if not provenance:
             return document
-        return await self._document_from_chunk_store(doc_id)
+        result = dict(document)
+        metadata = dict(result.get("metadata") or {})
+        metadata.update(provenance)
+        result["metadata"] = metadata
+        return result
 
     async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
         """Owner node ids for the ADR-0009 drill-down visibility rule — WITHOUT

--- a/kb/conflicts.py
+++ b/kb/conflicts.py
@@ -63,6 +63,7 @@ class ConflictRecord:
     summary: str
     side_a: ConflictSide
     side_b: ConflictSide
+    dataset: str | None = None
     status: str = OPEN
     resolution_note: str | None = None
     resolved_at: str | None = None
@@ -76,6 +77,7 @@ class ConflictCandidate:
     side_a: ConflictSide
     side_b: ConflictSide
     dedupe_key: str
+    dataset: str | None = None
 
 
 class KnowledgeConflictStore:
@@ -87,7 +89,10 @@ class KnowledgeConflictStore:
 
     def record(self, candidate: ConflictCandidate) -> dict[str, Any]:
         data = self._load()
-        conflict_id = stable_conflict_id(f"{candidate.kind}:{candidate.dedupe_key}")
+        dedupe_key = f"{candidate.kind}:{candidate.dedupe_key}"
+        if candidate.dataset:
+            dedupe_key = f"{candidate.dataset}:{dedupe_key}"
+        conflict_id = stable_conflict_id(dedupe_key)
         existing = data["conflicts"].get(conflict_id)
         if existing and existing.get("status") == OPEN:
             return existing
@@ -99,6 +104,7 @@ class KnowledgeConflictStore:
             summary=candidate.summary,
             side_a=candidate.side_a,
             side_b=candidate.side_b,
+            dataset=candidate.dataset,
         )
         data["conflicts"][conflict_id] = asdict(record)
         self._prune(data)
@@ -190,6 +196,7 @@ def obsidian_push_conflict_candidate(
     sync_conflict: dict[str, Any],
     *,
     vault_name: str | None = None,
+    dataset: str | None = None,
 ) -> ConflictCandidate:
     """Build a Knowledge Conflict candidate from an Obsidian push conflict."""
     path = str(sync_conflict.get("path") or "unknown note")
@@ -211,6 +218,7 @@ def obsidian_push_conflict_candidate(
             timestamp=sync_conflict.get("updated_at"),
         ),
         dedupe_key=str(sync_conflict.get("id") or f"{vault}:{path}"),
+        dataset=dataset,
     )
 
 
@@ -218,6 +226,7 @@ def detect_contribution_conflict(
     data: str,
     *,
     config: CitadelConfig,
+    dataset: str | None = None,
 ) -> ConflictCandidate | None:
     """Cheap ingest-time check: does a contribution's title match existing
     indexed content with a different content hash?
@@ -237,6 +246,7 @@ def detect_contribution_conflict(
         contribution_hash,
         data=data,
         config=config,
+        dataset=dataset,
     )
     if candidate:
         return candidate
@@ -245,6 +255,7 @@ def detect_contribution_conflict(
         contribution_hash,
         data=data,
         config=config,
+        dataset=dataset,
     )
 
 
@@ -262,6 +273,7 @@ def _github_digest_conflict(
     *,
     data: str,
     config: CitadelConfig,
+    dataset: str | None,
 ) -> ConflictCandidate | None:
     state = _load_state(Path(config.github_sync_state_path))
     digest = str(state.get("last_digest") or "").strip()
@@ -292,6 +304,7 @@ def _github_digest_conflict(
                 timestamp=state.get("last_digest_at") or state.get("last_checked_at"),
             ),
             dedupe_key=f"{org}:{section_title.casefold()}:{contribution_hash[:16]}",
+            dataset=dataset,
         )
     return None
 
@@ -302,6 +315,7 @@ def _obsidian_document_conflict(
     *,
     data: str,
     config: CitadelConfig,
+    dataset: str | None,
 ) -> ConflictCandidate | None:
     state = _load_state(Path(config.obsidian_sync_state_path))
     documents = state.get("documents")
@@ -337,5 +351,6 @@ def _obsidian_document_conflict(
                 timestamp=document.get("updated_at"),
             ),
             dedupe_key=f"{document.get('id')}:{contribution_hash[:16]}",
+            dataset=dataset,
         )
     return None

--- a/kb/document_provenance.py
+++ b/kb/document_provenance.py
@@ -1,0 +1,64 @@
+"""Server-written provenance attached to durable Cognee documents."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+PROVENANCE_KEY = "citadel_provenance"
+PROVENANCE_KIND_PROMOTION = "promotion"
+TRUST_REFERENCE = "reference-only"
+TRUST_UNATTESTED = "unattested"
+_TRUST_TIERS = frozenset({TRUST_REFERENCE, TRUST_UNATTESTED})
+
+
+def promotion_provenance(
+    *,
+    promoted_by: str,
+    promoted_at: str,
+    source_dataset: str,
+) -> dict[str, Any]:
+    """Build the metadata written after a promotion path accepts a document."""
+    return {
+        "kind": PROVENANCE_KIND_PROMOTION,
+        "trust_tier": TRUST_UNATTESTED,
+        "promoted_by": promoted_by,
+        "promoted_at": promoted_at,
+        "source_dataset": source_dataset,
+    }
+
+
+def parse_document_provenance(external_metadata: Any) -> dict[str, str]:
+    """Return only validated server provenance from Cognee external metadata."""
+    if isinstance(external_metadata, str):
+        try:
+            external_metadata = json.loads(external_metadata)
+        except (TypeError, ValueError):
+            return {}
+    if not isinstance(external_metadata, dict):
+        return {}
+    raw = external_metadata.get(PROVENANCE_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    if raw.get("kind") != PROVENANCE_KIND_PROMOTION:
+        return {}
+
+    promoted_by = raw.get("promoted_by")
+    promoted_at = raw.get("promoted_at")
+    if not isinstance(promoted_by, str) or not promoted_by.strip():
+        return {}
+    if not isinstance(promoted_at, str) or not promoted_at.strip():
+        return {}
+
+    result = {
+        "kind": PROVENANCE_KIND_PROMOTION,
+        "promoted_by": promoted_by.strip()[:200],
+        "promoted_at": promoted_at.strip()[:80],
+    }
+    trust_tier = raw.get("trust_tier")
+    if trust_tier in _TRUST_TIERS:
+        result["trust_tier"] = trust_tier
+    source_dataset = raw.get("source_dataset")
+    if isinstance(source_dataset, str) and source_dataset.strip():
+        result["source_dataset"] = source_dataset.strip()[:200]
+    return result

--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -18,6 +18,8 @@ import logging
 import re
 from typing import Any, Callable
 
+from kb.document_provenance import TRUST_REFERENCE, TRUST_UNATTESTED
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_NODES = 200
@@ -150,6 +152,27 @@ def _raw_props_by_id(raw_nodes: list[Any]) -> dict[str, dict[str, Any]]:
         if isinstance(properties, dict):
             index[node_id] = properties
     return index
+
+
+def _graph_provenance(value: Any) -> dict[str, str]:
+    """Keep only server-written provenance fields supplied by the gateway."""
+    if not isinstance(value, dict) or value.get("kind") != "promotion":
+        return {}
+    promoted_by = value.get("promoted_by")
+    promoted_at = value.get("promoted_at")
+    if not isinstance(promoted_by, str) or not promoted_by.strip():
+        return {}
+    if not isinstance(promoted_at, str) or not promoted_at.strip():
+        return {}
+    result = {
+        "kind": "promotion",
+        "promoted_by": promoted_by.strip()[:200],
+        "promoted_at": promoted_at.strip()[:80],
+    }
+    trust_tier = value.get("trust_tier")
+    if trust_tier in {TRUST_REFERENCE, TRUST_UNATTESTED}:
+        result["trust_tier"] = trust_tier
+    return result
 
 
 def _basename_label(location: str) -> str:
@@ -328,6 +351,7 @@ def build_graph_payload(
     *,
     limit: int = DEFAULT_MAX_NODES,
     dataset_map: dict[str, list[str]] | None = None,
+    provenance_map: dict[str, dict[str, Any]] | None = None,
     presence: list[dict[str, Any]] | None = None,
     collapse_orphan_documents: bool = False,
 ) -> dict[str, Any]:
@@ -344,7 +368,13 @@ def build_graph_payload(
     of their document via ``is_part_of`` edges, and one synthetic hub node per
     dataset (``dataset:<name>``) is appended with ``belongs_to`` edges. Hubs are
     synthetic: they do not count against ``limit`` or into ``total_nodes``.
-    ``None``/``{}`` keeps the exact pre-attribution behavior.
+    ``None``/``{}`` keeps the pre-attribution dataset and hub behavior; content
+    nodes still carry their explicit ``trust_tier``.
+
+    ``provenance_map`` contains server-written document metadata keyed by graph
+    node id. Promotion fields are copied to the document and its
+    ``is_part_of`` chunks. Every content node carries an attested trust tier:
+    ``reference-only`` for Shared Session Traces, ``unattested`` otherwise.
 
     ``presence`` (``[{"dataset": name, "label": label, "documents": count?},
     ...]``) appends a universal hub per entry regardless of surviving content
@@ -365,6 +395,7 @@ def build_graph_payload(
     """
     limit = max(1, limit)
     dataset_map = dataset_map or {}
+    provenance_map = provenance_map or {}
     nodes: list[dict[str, Any]] = []
     kept_ids: set[str] = set()
     node_by_id: dict[str, dict[str, Any]] = {}
@@ -428,6 +459,41 @@ def build_graph_payload(
                     other["datasets"] = list(names)
                 if doc_id in internal_nodes:
                     doc_chunk_ids.setdefault(doc_id, []).append(other_id)
+
+    provenance_by_id: dict[str, dict[str, str]] = {}
+    for node_id in node_by_id:
+        provenance = _graph_provenance(provenance_map.get(node_id))
+        if provenance:
+            provenance_by_id[node_id] = provenance
+    if provenance_map:
+        # Document metadata is keyed by the TextDocument id. Propagate it only
+        # across is_part_of, never across entity relationships, so a promoted
+        # document does not falsely promote every entity it mentions.
+        for raw in raw_edges:
+            try:
+                source, target, relationship = str(raw[0]), str(raw[1]), str(raw[2])
+            except (TypeError, IndexError, KeyError):
+                continue
+            if relationship != "is_part_of":
+                continue
+            for owner_id, child_id in ((source, target), (target, source)):
+                owner_provenance = _graph_provenance(provenance_map.get(owner_id))
+                if owner_provenance and child_id in node_by_id:
+                    provenance_by_id.setdefault(child_id, owner_provenance)
+
+    for node in nodes:
+        names = node.get("datasets") or ([node["dataset"]] if node.get("dataset") else [])
+        provenance = provenance_by_id.get(node["id"])
+        node["trust_tier"] = (
+            provenance.get("trust_tier")
+            if provenance and provenance.get("trust_tier") in {TRUST_REFERENCE, TRUST_UNATTESTED}
+            else TRUST_REFERENCE
+            if TRUST_REFERENCE in names
+            else TRUST_UNATTESTED
+        )
+        if provenance:
+            node["promoted_by"] = provenance["promoted_by"]
+            node["promoted_at"] = provenance["promoted_at"]
 
     if doc_chunk_ids:
         # Derive readable document labels: pick the chunk with the smallest
@@ -713,6 +779,7 @@ class KnowledgeMesh:
         raw_nodes = list(raw_nodes)
         raw_edges = list(raw_edges)
         dataset_map: dict[str, list[str]] = {}
+        provenance_map: dict[str, dict[str, Any]] = {}
         node_dataset_map = getattr(self.gateway, "node_dataset_map", None)
         if callable(node_dataset_map):
             try:
@@ -724,6 +791,17 @@ class KnowledgeMesh:
                     exc.__class__.__name__,
                 )
                 dataset_map = {}
+        node_provenance_map = getattr(self.gateway, "node_provenance_map", None)
+        if callable(node_provenance_map):
+            try:
+                provenance_map = await node_provenance_map() or {}
+            except Exception as exc:
+                logger.warning(
+                    "Knowledge mesh provenance map read failed with %s; "
+                    "showing unattested nodes",
+                    exc.__class__.__name__,
+                )
+                provenance_map = {}
         if presence:
             # Fill presence document counts from the RAW map, before caller
             # scoping strips hidden names: contribution counts are presence
@@ -776,6 +854,7 @@ class KnowledgeMesh:
                 raw_edges,
                 limit=limit,
                 dataset_map=dataset_map,
+                provenance_map=provenance_map,
                 presence=presence,
                 collapse_orphan_documents=collapse_orphans,
             )

--- a/kb/learning.py
+++ b/kb/learning.py
@@ -136,7 +136,10 @@ class LearningProcess:
             except Exception as exc:
                 if self.mesh:
                     await self.mesh.record_error(
-                        self.config, operation=operation, error=str(exc)
+                        self.config,
+                        operation=operation,
+                        error=str(exc),
+                        dataset=target_dataset,
                     )
                 raise
             results.append(result)
@@ -164,7 +167,7 @@ class LearningProcess:
 
         conflict = None
         if detect_conflicts and accepted_any:
-            conflict = self._detect_conflict(data)
+            conflict = self._detect_conflict(data, dataset=target_dataset)
             if conflict and self.mesh:
                 await self.mesh.record_conflict(self.config, conflict=conflict)
 
@@ -218,16 +221,31 @@ class LearningProcess:
             inputs.append((_chunk_text(chunk), [*tags, *chunk.tags]))
         return inputs
 
-    async def record_failure(self, *, operation: str, error: str) -> None:
+    async def record_failure(
+        self,
+        *,
+        operation: str,
+        error: str,
+        dataset: str | None = None,
+    ) -> None:
         """Record a learning-related failure on the mesh projection."""
         if self.mesh:
-            await self.mesh.record_error(self.config, operation=operation, error=error)
+            await self.mesh.record_error(
+                self.config,
+                operation=operation,
+                error=error,
+                dataset=dataset,
+            )
 
-    def _detect_conflict(self, data: str) -> dict[str, Any] | None:
+    def _detect_conflict(self, data: str, *, dataset: str) -> dict[str, Any] | None:
         if not self.conflicts:
             return None
         try:
-            candidate = detect_contribution_conflict(data, config=self.config)
+            candidate = detect_contribution_conflict(
+                data,
+                config=self.config,
+                dataset=dataset,
+            )
         except Exception as exc:  # pragma: no cover - defensive; detection is best-effort.
             logger.warning(
                 "Knowledge conflict detection failed with %s; continuing",

--- a/kb/learning.py
+++ b/kb/learning.py
@@ -16,7 +16,12 @@ import logging
 from typing import Any, Literal
 
 from kb.conflicts import KnowledgeConflictStore, detect_contribution_conflict
-from kb.llm_enrichment import EnrichedChunk, EnrichmentOutcome, enrich_source_material
+from kb.llm_enrichment import (
+    EnrichedChunk,
+    EnrichmentOutcome,
+    deterministic_source_chunks,
+    enrich_source_material,
+)
 from kb.mesh import MeshState
 from kb.security_scan import SecretContentError, SecurityScanEntry, scan_text_entries
 from kb.models import IngestResult
@@ -79,6 +84,7 @@ class LearningProcess:
         dataset: str | None = None,
         tags: list[str] | None = None,
         session_id: str | None = None,
+        provenance: dict[str, Any] | None = None,
         operation: str = "ingest",
         run_improve: bool = False,
         detect_conflicts: bool = True,
@@ -122,6 +128,7 @@ class LearningProcess:
             enrichment = self._enrich(data)
             effective_run_improve = run_improve
         chunk_inputs = self._chunk_inputs(data, list(tags or []), enrichment)
+        coalesce_cognify = len(chunk_inputs) > 1 and not defer_cognify
 
         results: list[IngestResult] = []
         for chunk_data, chunk_tags in chunk_inputs:
@@ -131,7 +138,8 @@ class LearningProcess:
                     dataset=dataset,
                     tags=chunk_tags,
                     session_id=session_id,
-                    defer_cognify=defer_cognify,
+                    provenance=provenance,
+                    defer_cognify=defer_cognify or coalesce_cognify,
                 )
             except Exception as exc:
                 if self.mesh:
@@ -151,6 +159,11 @@ class LearningProcess:
                     dataset=target_dataset,
                     tags=list(chunk_tags),
                 )
+
+        if coalesce_cognify and any(result.accepted for result in results):
+            scheduler = getattr(getattr(self.citadel, "cognee", None), "schedule_cognify", None)
+            if callable(scheduler):
+                scheduler([target_dataset])
 
         if enrichment is not None and self.mesh:
             await self.mesh.record_enrichment(
@@ -215,10 +228,13 @@ class LearningProcess:
         enrichment: EnrichmentOutcome | None,
     ) -> list[tuple[str, list[str]]]:
         if enrichment is None or not enrichment.chunks:
-            return [(data, tags)]
+            chunks = deterministic_source_chunks(data)
+            return [(chunk, tags) for chunk in chunks] or [(data, tags)]
         inputs: list[tuple[str, list[str]]] = []
         for chunk in enrichment.chunks:
-            inputs.append((_chunk_text(chunk), [*tags, *chunk.tags]))
+            chunk_tags = [*tags, *chunk.tags]
+            for chunk_data in deterministic_source_chunks(_chunk_text(chunk)):
+                inputs.append((chunk_data, chunk_tags))
         return inputs
 
     async def record_failure(

--- a/kb/llm_enrichment.py
+++ b/kb/llm_enrichment.py
@@ -24,6 +24,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
 
+from kb import chunk_window
 from kb.secure_http import open_secure
 
 from kb.retry import run_with_retries
@@ -34,6 +35,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_LLM_MODEL = "deepseek/deepseek-v4-flash"
 DEFAULT_THRESHOLD_CHARS = 4000
 DEFAULT_MAX_CHUNK_CHARS = 4000
+DEFAULT_DETERMINISTIC_CHUNK_CHARS = 1200
+DETERMINISTIC_CHUNK_CHARS_ENV = "CITADEL_DETERMINISTIC_CHUNK_CHARS"
+DETERMINISTIC_BPE_SAFETY_MARGIN_TOKENS = 32
 MAX_CHUNKS = 20
 MAX_TAGS_PER_CHUNK = 6
 MIN_TAGS_PER_CHUNK = 3
@@ -89,6 +93,42 @@ def enrichment_threshold_chars() -> int:
         "CITADEL_LLM_ENRICHMENT_THRESHOLD_CHARS",
         default=DEFAULT_THRESHOLD_CHARS,
     ))
+
+
+def deterministic_chunk_chars() -> int:
+    """Return the character backstop used by the lossless pre-ingest splitter.
+
+    The actual chunk boundary is chosen in Cognee's GPT-4o BPE units. This cap
+    prevents a tokenizer failure from producing an unbounded piece.
+    """
+    return max(
+        1,
+        _int_env(
+            DETERMINISTIC_CHUNK_CHARS_ENV,
+            default=DEFAULT_DETERMINISTIC_CHUNK_CHARS,
+        ),
+    )
+
+
+def deterministic_chunk_bpe_budget() -> int:
+    """Return the BPE budget the pre-ingest splitter must fit.
+
+    Leave room for small counter differences between Citadel's lossless replica
+    and the installed Cognee tokenizer path. Lower explicit values still take
+    effect through :func:`chunk_window.resolve_chunk_budget`.
+    """
+    safe_observed_budget = max(
+        1,
+        chunk_window.OBSERVED_CHUNK_BUDGET_TOKENS
+        - DETERMINISTIC_BPE_SAFETY_MARGIN_TOKENS,
+    )
+    return max(
+        1,
+        min(
+            chunk_window.resolve_chunk_budget(),
+            safe_observed_budget,
+        ),
+    )
 
 
 def redacted_preview(text: str, *, length: int = LOG_PREVIEW_CHARS) -> str:
@@ -217,6 +257,14 @@ def paragraph_chunks(data: str, *, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> 
     current: list[str] = []
     current_len = 0
     for paragraph in paragraphs:
+        pieces = _split_oversized_paragraph(paragraph, max_chars=max_chars)
+        if len(pieces) > 1:
+            if current:
+                chunks.append("\n\n".join(current))
+                current = []
+                current_len = 0
+            chunks.extend(pieces)
+            continue
         added = len(paragraph) + (2 if current else 0)
         if current and current_len + added > max_chars:
             chunks.append("\n\n".join(current))
@@ -227,6 +275,201 @@ def paragraph_chunks(data: str, *, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> 
     if current:
         chunks.append("\n\n".join(current))
     return chunks
+
+
+_SAFE_SPLIT_CHARS = ("\n", "\r", " ", "\t", ".", ",", ";", "!", "?", ")", "]", "}")
+
+
+def _split_oversized_paragraph(paragraph: str, *, max_chars: int) -> list[str]:
+    """Split one paragraph without silently dropping its bytes.
+
+    Cognee's paragraph fallback leaves a long table row, code block, or minified
+    line intact. Prefer a nearby structural boundary, then use a hard boundary
+    when the input has none. The whole source was security-scanned before this
+    function runs, so splitting never acts as a secret-scan bypass.
+    """
+    if len(paragraph) <= max_chars:
+        return [paragraph]
+
+    pieces: list[str] = []
+    start = 0
+    while start < len(paragraph):
+        limit = min(start + max_chars, len(paragraph))
+        if limit == len(paragraph):
+            cut = limit
+        else:
+            boundary = max(
+                (paragraph.rfind(char, start, limit) for char in _SAFE_SPLIT_CHARS),
+                default=-1,
+            )
+            cut = boundary + 1 if boundary > start else limit
+        pieces.append(paragraph[start:cut])
+        start = cut
+    return pieces
+
+
+def _count_bpe(text: str) -> int | None:
+    encoding = chunk_window._bpe_encoding()
+    if encoding is None:
+        return None
+    try:
+        # Cognee's chunk_by_sentence sums token counts for each segment from
+        # chunk_by_word. Counting the whole string would undercount merges at
+        # segment boundaries and let Cognee split the piece again downstream.
+        return sum(
+            len(encoding.encode(word))
+            for word in chunk_window.split_cognee_words(text)
+        )
+    except Exception:  # pragma: no cover - tokenizer failure is fail-soft.
+        return None
+
+
+def _largest_fitting_prefix(
+    text: str,
+    *,
+    prefix: str,
+    max_chars: int,
+    budget: int,
+) -> int:
+    """Find the largest exact character prefix that fits ``budget`` BPE tokens.
+
+    Walk Cognee's segments once. Only the segment that crosses the budget needs
+    a character search, which avoids retokenizing the whole candidate for every
+    binary-search probe.
+    """
+    upper = min(len(text), max_chars)
+    if upper <= 0:
+        return 0
+    encoding = chunk_window._bpe_encoding()
+    if encoding is None:
+        return upper
+
+    candidate = prefix + text[:upper]
+    prefix_length = len(prefix)
+    candidate_length = len(candidate)
+    consumed = 0
+    cursor = 0
+    for word in chunk_window._iter_cognee_words(candidate):
+        word_start = cursor
+        word_end = word_start + len(word)
+        cursor = word_end
+        word_tokens = len(encoding.encode(word))
+        if consumed + word_tokens <= budget:
+            consumed += word_tokens
+            if word_end > prefix_length:
+                fitting_end = min(word_end, candidate_length) - prefix_length
+            else:
+                fitting_end = 0
+            if fitting_end >= upper:
+                return upper
+            continue
+
+        if word_end <= prefix_length:
+            return 0
+
+        body_start = max(0, prefix_length - word_start)
+        body_end = min(len(word), candidate_length - word_start)
+        available = max(0, body_end - body_start)
+        low = 0
+        high = available
+        best = 0
+        while low <= high:
+            middle = (low + high) // 2
+            word_tokens = len(encoding.encode(word[: body_start + middle]))
+            if consumed + word_tokens <= budget:
+                best = middle
+                low = middle + 1
+            else:
+                high = middle - 1
+        return max(0, word_start + body_start + best - prefix_length)
+
+    return upper
+
+
+def _prefer_safe_boundary(text: str, *, start: int, end: int) -> int:
+    """Move a fitting cut left to a nearby boundary without dropping text."""
+    boundary = max(
+        (text.rfind(char, start, end) for char in _SAFE_SPLIT_CHARS),
+        default=-1,
+    )
+    return boundary + 1 if boundary > start else end
+
+
+def _lossless_chunks(
+    data: str,
+    *,
+    prefix: str = "",
+    max_chars: int,
+    bpe_budget: int,
+) -> list[str]:
+    """Split exact text while accounting for an optional repeated prefix."""
+    if not data:
+        return [prefix] if prefix else []
+    body_budget = max(1, max_chars - len(prefix))
+    chunks: list[str] = []
+    start = 0
+    while start < len(data):
+        fitting = _largest_fitting_prefix(
+            data[start:],
+            prefix=prefix,
+            max_chars=body_budget,
+            budget=bpe_budget,
+        )
+        cut = (
+            fitting
+            if start + fitting >= len(data)
+            else _prefer_safe_boundary(data, start=start, end=start + fitting)
+        )
+        if cut <= start:
+            cut = min(start + 1, len(data))
+        chunks.append(prefix + data[start:cut])
+        start = cut
+    return chunks
+
+
+def deterministic_source_chunks(
+    data: str,
+    *,
+    max_chars: int | None = None,
+) -> list[str]:
+    """Create lossless, BPE-bounded chunks for every ingest path.
+
+    Repo-content documents carry a sync header before ``---``. That header is
+    repeated on every piece so a later search can still resolve each piece to
+    its repository path and blob. Other inputs use the paragraph splitter
+    directly. The body text is sliced, never stripped or regrouped.
+    """
+    limit = deterministic_chunk_chars() if max_chars is None else max_chars
+    limit = max(1, limit)
+    bpe_budget = deterministic_chunk_bpe_budget()
+    marker = "\n---\n\n"
+    marker_index = data.find(marker)
+    header = data[:marker_index] if marker_index >= 0 else ""
+    is_repo_header = data.startswith("# ") and all(
+        f"\n{field}:" in header
+        for field in ("Repository", "Source", "Commit", "Blob")
+    )
+    if is_repo_header:
+        prefix_end = marker_index + len(marker)
+        prefix = data[:prefix_end]
+        body = data[prefix_end:]
+        if body.strip():
+            if len(prefix) >= limit:
+                raise ValueError(
+                    "repo content provenance header exceeds the deterministic "
+                    f"chunk limit ({len(prefix)} >= {limit} characters)"
+                )
+            return _lossless_chunks(
+                body,
+                prefix=prefix,
+                max_chars=limit,
+                bpe_budget=bpe_budget,
+            )
+    return _lossless_chunks(
+        data,
+        max_chars=limit,
+        bpe_budget=bpe_budget,
+    )
 
 
 def _clean_tags(value: Any) -> tuple[str, ...]:

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -876,14 +876,22 @@ class MeshState:
                 "id": "graph",
                 "name": "Graph mesh",
                 "status": "active",
-                "records": len([node for node in self.nodes.values() if node["type"] != "index"]),
+                "records": None,
+                "scope": "not_measured",
+                "description": (
+                    "Graph total is reported in stats.nodes; the reader path does not measure it here."
+                ),
                 "updated_at": self.events[0]["created_at"] if self.events else None,
             },
             {
                 "id": "vector",
                 "name": "Vector index",
                 "status": "active",
-                "records": self.documents,
+                "records": None,
+                "scope": "not_measured",
+                "description": (
+                    "Vector chunk total requires the admin corpus census; the reader path does not measure it."
+                ),
                 "updated_at": self.events[0]["created_at"] if self.events else None,
             },
             {
@@ -891,6 +899,8 @@ class MeshState:
                 "name": "Feedback memory",
                 "status": "active",
                 "records": self.feedback_items,
+                "scope": "since_restart",
+                "description": "Feedback events recorded since this process started.",
                 "updated_at": self.events[0]["created_at"] if self.events else None,
             },
             {
@@ -898,6 +908,8 @@ class MeshState:
                 "name": "Global context",
                 "status": "enabled" if config.build_global_context_index else "standby",
                 "records": self.upgrades,
+                "scope": "since_restart",
+                "description": "Upgrade events recorded since this process started.",
                 "updated_at": self.events[0]["created_at"] if self.events else None,
             },
         ]

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -315,7 +315,7 @@ class MeshState:
     ) -> dict[str, Any]:
         """Return a bounded, newest-first event timeline for resume/backfill reads.
 
-        ``visible`` scopes events to the caller by ``details.dataset`` (ADR-0009).
+        ``visible`` scopes events to the caller by event details (ADR-0009).
         It runs BEFORE the limit slice so a caller still receives a full page of
         their own events rather than whatever survives filtering one page of
         everyone's. ``latest_event_id`` stays global on purpose: --watch resumes
@@ -337,7 +337,7 @@ class MeshState:
                 events = [
                     event
                     for event in events
-                    if visible((event.get("details") or {}).get("dataset"))
+                    if visible(event)
                 ]
             return {
                 "generated_at": utc_now(),
@@ -683,6 +683,7 @@ class MeshState:
                 "metadata": {
                     "source_type": "obsidian_vault",
                     "vault_id": vault.get("id"),
+                    "dataset": dataset or config.default_dataset,
                     "team_id": vault.get("team_id"),
                     "last_push_at": vault.get("last_push_at"),
                     "accepted": len(result.get("accepted", [])),
@@ -706,6 +707,7 @@ class MeshState:
                     "metadata": {
                         "source_type": "obsidian_vault",
                         "vault_id": vault.get("id"),
+                        "dataset": dataset or config.default_dataset,
                         "rev": document.get("rev"),
                         "content_hash": document.get("content_hash"),
                     },
@@ -788,10 +790,18 @@ class MeshState:
                     "kind": conflict.get("kind"),
                     "status": conflict.get("status"),
                     "summary": str(conflict.get("summary") or "")[:280],
+                    "dataset": conflict.get("dataset"),
                 },
             )
 
-    async def record_error(self, config: CitadelConfig, *, operation: str, error: str) -> None:
+    async def record_error(
+        self,
+        config: CitadelConfig,
+        *,
+        operation: str,
+        error: str,
+        dataset: str | None = None,
+    ) -> None:
         async with self._lock:
             self._ensure_base_graph(config)
             self.errors += 1
@@ -799,7 +809,11 @@ class MeshState:
             await self._record_event(
                 "error",
                 "Operation failed",
-                {"operation": operation, "error": redact_secrets(error[:280])},
+                {
+                    "operation": operation,
+                    "error": redact_secrets(error[:280]),
+                    "dataset": dataset,
+                },
             )
 
     def _ensure_base_graph(self, config: CitadelConfig) -> None:

--- a/kb/obsidian_sync.py
+++ b/kb/obsidian_sync.py
@@ -6,7 +6,7 @@ from hashlib import sha1, sha256
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from kb.access import AccessIdentity
 
@@ -138,16 +138,29 @@ class ObsidianSyncStore:
         self._save(data)
         return vault
 
-    def source_status(self, *, source_type: str | None = None) -> dict[str, Any]:
+    def source_status(
+        self,
+        *,
+        source_type: str | None = None,
+        visible_owner: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> dict[str, Any]:
         data = self._load()
         vaults = list(data.get("vaults", {}).values())
         if source_type and source_type != "obsidian_vault":
             vaults = []
-        documents = list(data.get("documents", {}).values())
+        if visible_owner is not None:
+            vaults = [vault for vault in vaults if visible_owner(vault)]
+        visible_vault_ids = {vault.get("id") for vault in vaults}
+        documents = [
+            document
+            for document in data.get("documents", {}).values()
+            if document.get("source_id") in visible_vault_ids
+        ]
         conflicts = [
             conflict
             for conflict in data.get("conflicts", {}).values()
             if conflict.get("status") == "open"
+            and conflict.get("source_id") in visible_vault_ids
         ]
         by_source: dict[str, dict[str, Any]] = {
             vault["id"]: {

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from kb.access import AccessIdentity, AccessStore, is_seat_dataset, now_iso
 from kb.config import CitadelConfig
+from kb.document_provenance import promotion_provenance
 from kb.learning import LearningProcess
 from kb.llm_enrichment import (
     default_llm_model,
@@ -529,6 +530,8 @@ class PromotionEngine:
         seat_dataset: str,
         identity: AccessIdentity,
         proposal: ProposedPromotion,
+        *,
+        provenance_actor: AccessIdentity | None = None,
     ) -> str:
         """Promote one qualifying item via the org-ready dual-write path.
 
@@ -559,6 +562,14 @@ class PromotionEngine:
         if proposal.reference_status:
             promotion_tags.append(f"promotion-ref:{proposal.reference_status}")
 
+        provenance_identity = provenance_actor or identity
+        promoted_at = now_iso()
+        provenance = promotion_provenance(
+            promoted_by=provenance_identity.actor_id,
+            promoted_at=promoted_at,
+            source_dataset=seat_dataset,
+        )
+
         central = None
         try:
             targets = resolve_write_targets(
@@ -574,6 +585,7 @@ class PromotionEngine:
                 targets=targets,
                 tags=promotion_tags,
                 session_id=None,
+                provenance=provenance,
                 operation="promotion",
             )
         except SecretContentError as exc:
@@ -652,6 +664,8 @@ class PromotionEngine:
                 "tags": promotion_tags,
                 "reference_status": proposal.reference_status,
                 "capture_tags": list(proposal.capture_tags),
+                "promoted_by": provenance["promoted_by"],
+                "promoted_at": promoted_at,
             },
         )
         return "promoted"
@@ -832,7 +846,12 @@ class PromotionEngine:
             reference_status=item.reference_status,
         )
         identity = self._promotion_identity(item.seat_dataset)
-        outcome = await self._promote(item.seat_dataset, identity, proposal)
+        outcome = await self._promote(
+            item.seat_dataset,
+            identity,
+            proposal,
+            provenance_actor=actor,
+        )
         promoted = outcome == "promoted"
         decided = self.access_store.decide_promotion_pending(
             item_id,

--- a/kb/server.py
+++ b/kb/server.py
@@ -105,6 +105,15 @@ from kb.security_scan import (
     redact_secrets,
     scan_text_entries,
 )
+from kb.visibility import (
+    can_bypass_dataset_allowlist,
+    conflict_visible_to,
+    dataset_visible_to,
+    effective_scopes,
+    enforce_dataset_allowlist,
+    event_visible_to,
+    owner_visible_to,
+)
 from kb.self_improve import SelfImprovement
 from kb.service import Citadel
 from kb.skills import skill_catalog, skill_integrity, skill_path
@@ -1461,27 +1470,11 @@ def require_role(request: Request, minimum_role: str) -> AccessIdentity:
     return identity
 
 
-def effective_scopes(identity: AccessIdentity) -> tuple[str, ...]:
-    if identity.scopes:
-        return identity.scopes
-    if identity.source == "env":
-        return default_scopes(identity.role)
-    return ()
-
-
 def require_access(request: Request, minimum_role: str, scope: str) -> AccessIdentity:
     identity = require_role(request, minimum_role)
     if scope not in effective_scopes(identity):
         raise HTTPException(status_code=403, detail=f"Scope required: {scope}.")
     return identity
-
-
-def can_bypass_dataset_allowlist(identity: AccessIdentity) -> bool:
-    if identity.source == "env":
-        return True
-    if identity.role == "admin":
-        return True
-    return "access:manage" in effective_scopes(identity)
 
 
 def env_exclude_patterns() -> tuple[str, ...]:
@@ -1642,41 +1635,6 @@ def redact_pending_item(item: dict[str, Any]) -> dict[str, Any]:
             # "not scanned", which the UI must not show as a pass.
             logger.exception("Deferred secret scan failed for promotion item")
     return redacted
-
-
-def enforce_dataset_allowlist(identity: AccessIdentity, dataset: str) -> None:
-    if can_bypass_dataset_allowlist(identity):
-        return
-    if dataset == SESSION_TRACES_DATASET:
-        # Org-wide consultable prior work: readable by every authenticated caller;
-        # writes are gated by the share-session endpoint instead.
-        return
-    if dataset in identity.allowed_datasets:
-        return
-    # Seat nodes are private memory: the seat: namespace is default-deny even for
-    # callers that carry no allowlist at all. Without this, any legacy or non-seat
-    # token (whose allowed_datasets is empty) could read or write another seat's
-    # node by naming it explicitly. Non-seat datasets stay open for unscoped tokens
-    # to preserve backward compatibility.
-    if is_seat_dataset(dataset):
-        raise HTTPException(status_code=403, detail=f"Dataset not allowed: {dataset}.")
-    if not identity.allowed_datasets:
-        return
-    raise HTTPException(status_code=403, detail=f"Dataset not allowed: {dataset}.")
-
-
-def dataset_visible_to(identity: AccessIdentity, dataset: str) -> bool:
-    """Boolean twin of enforce_dataset_allowlist for read-side projections.
-
-    Used where a hidden dataset should silently disappear from a payload
-    (e.g. /api/mesh/graph attribution) instead of rejecting the request.
-    Delegates to enforce_dataset_allowlist so the two can never drift.
-    """
-    try:
-        enforce_dataset_allowlist(identity, dataset)
-    except HTTPException:
-        return False
-    return True
 
 
 def scope_override_active(
@@ -3378,8 +3336,9 @@ async def me_summary(request: Request) -> dict[str, Any]:
         # Scope the timeline page to this seat Node *before* the limit slice.
         # Filtering only after a mixed visible page (Central + shared traces)
         # can drop all Node activity when org traffic is busy.
-        def _node_visible(dataset: str | None) -> bool:
-            return dataset == node
+        def _node_visible(event: dict[str, Any]) -> bool:
+            details = event.get("details") if isinstance(event.get("details"), dict) else {}
+            return details.get("dataset") == node
 
         try:
             timeline = await get_mesh().timeline(limit=12, visible=_node_visible)
@@ -4490,11 +4449,7 @@ def scope_mesh_snapshot(
         if edge.get("source") not in dropped and edge.get("target") not in dropped
     ]
     kept_events = [
-        event
-        for event in snapshot.get("events", [])
-        if _mesh_dataset_visible(
-            identity, (event.get("details") or {}).get("dataset"), cache
-        )
+        event for event in snapshot.get("events", []) if event_visible_to(identity, event)
     ]
     return {
         **snapshot,
@@ -4536,14 +4491,11 @@ async def knowledge_events(
         raise HTTPException(status_code=422, detail="Timeline limit must be between 1 and 160.")
     # ADR-0009: the timeline carries Node content (event messages, dataset names,
     # and error operations/reasons), so scope it to the caller exactly as the two
-    # sibling projections do — /api/mesh via scope_mesh_snapshot and /events via
-    # _mesh_dataset_visible. This endpoint previously discarded the identity and
+    # sibling projections do, /api/mesh via scope_mesh_snapshot and /events via
+    # event_visible_to. This endpoint previously discarded the identity and
     # returned every seat's events to any reader token.
-    visible_cache: dict[str, bool] = {}
-    visible = (
-        None
-        if can_bypass_dataset_allowlist(identity)
-        else (lambda dataset: _mesh_dataset_visible(identity, dataset, visible_cache))
+    visible = None if can_bypass_dataset_allowlist(identity) else (
+        lambda event: event_visible_to(identity, event)
     )
     timeline = await get_mesh().timeline(
         after_id=after_id,
@@ -4632,7 +4584,9 @@ async def list_knowledge_conflicts(request: Request, status: str | None = None) 
     if status not in {None, "open", "resolved"}:
         raise HTTPException(status_code=422, detail="Unsupported conflict status filter.")
     store = get_conflict_store()
-    conflicts = store.list(status=status)
+    conflicts = [
+        conflict for conflict in store.list(status=status) if conflict_visible_to(actor, conflict)
+    ]
     get_access_store().record_event(
         action="conflicts.list",
         actor=actor,
@@ -4643,7 +4597,7 @@ async def list_knowledge_conflicts(request: Request, status: str | None = None) 
         "ok": True,
         "status": status or "all",
         "conflicts": jsonable_encoder(conflicts),
-        "open_count": store.open_count(),
+        "open_count": sum(1 for conflict in conflicts if conflict.get("status") == "open"),
     }
 
 
@@ -4654,8 +4608,27 @@ async def resolve_knowledge_conflict(
     request: Request,
 ) -> Any:
     actor = require_access(request, "writer", "kb:ingest")
+    store = get_conflict_store()
     try:
-        resolved = get_conflict_store().resolve(
+        conflict = store.get(conflict_id)
+    except KeyError as exc:
+        get_access_store().record_event(
+            action="conflicts.resolve",
+            actor=actor,
+            success=False,
+            detail={"conflict_id": conflict_id, "reason": "not_found"},
+        )
+        raise HTTPException(status_code=404, detail="Conflict not found.") from exc
+    if not conflict_visible_to(actor, conflict):
+        get_access_store().record_event(
+            action="conflicts.resolve",
+            actor=actor,
+            success=False,
+            detail={"conflict_id": conflict_id, "reason": "not_found"},
+        )
+        raise HTTPException(status_code=404, detail="Conflict not found.")
+    try:
+        resolved = store.resolve(
             conflict_id,
             resolution_note=body.resolution_note,
             resolved_by=actor.actor_id,
@@ -4750,7 +4723,7 @@ def _last_source_error(source_type: str) -> tuple[str | None, str | None]:
 
 @app.get("/api/sources")
 async def sources(request: Request, type: str | None = None) -> Any:
-    require_access(request, "reader", "sources:read")
+    identity = require_access(request, "reader", "sources:read")
     sources_payload: list[dict[str, Any]] = []
     # When the evolve cycle last completed. Without it, a node that has not
     # evolved in a week looks identical to one that evolved five minutes ago,
@@ -4842,7 +4815,14 @@ async def sources(request: Request, type: str | None = None) -> Any:
         summary["linear_issues"] = linear_status.get("issue_count", 0)
 
     if type in {None, "obsidian_vault"}:
-        obsidian_status = get_obsidian_sync().source_status(source_type="obsidian_vault")
+        obsidian_status = get_obsidian_sync().source_status(
+            source_type="obsidian_vault",
+            visible_owner=lambda vault: owner_visible_to(
+                identity,
+                vault.get("owner_actor_id"),
+                vault.get("owner_seat_slug"),
+            ),
+        )
         # One vault-wide error: pushes are audited per sync, not per vault, so
         # the same last-failure applies to every vault entry rather than being
         # attributed to one of them arbitrarily.
@@ -4868,7 +4848,12 @@ async def run_github_sync(body: GitHubSyncBody, request: Request) -> Any:
         result = await get_github_syncer().run(force=body.force)
     except Exception as exc:  # pragma: no cover - depends on GitHub and runtime Cognee config.
         logger.error("GitHub sync run failed: %s", exc.__class__.__name__)
-        await mesh_state.record_error(citadel.config, operation="github_sync", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="github_sync",
+            error=str(exc),
+            dataset=citadel.config.github_sync_dataset,
+        )
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     await mesh_state.record_github_sync(citadel.config, result)
     return jsonable_encoder(result)
@@ -4919,7 +4904,10 @@ async def _run_webhook_reingest(syncer: GitHubOrgSyncer) -> None:
             exc,
         )
         await get_mesh().record_error(
-            get_citadel().config, operation="github_sync", error=str(exc)
+            get_citadel().config,
+            operation="github_sync",
+            error=str(exc),
+            dataset=get_citadel().config.github_sync_dataset,
         )
 
 
@@ -5010,7 +4998,12 @@ async def run_linear_sync(body: LinearSyncBody, request: Request) -> Any:
         result = await get_linear_syncer().run(force=body.force)
     except Exception as exc:  # pragma: no cover - depends on Linear API and runtime Cognee config.
         logger.error("Linear sync run failed: %s", exc.__class__.__name__)
-        await mesh_state.record_error(citadel.config, operation="linear_sync", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="linear_sync",
+            error=str(exc),
+            dataset=citadel.config.linear_sync_dataset,
+        )
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     if not result.get("ok"):
         raise HTTPException(status_code=503, detail=result.get("reason", "Linear sync unavailable"))
@@ -5030,6 +5023,7 @@ async def run_repo_content_sync(body: RepoContentSyncBody, request: Request) -> 
             citadel.config,
             operation="repo_content_sync",
             error=str(exc),
+            dataset=citadel.config.repo_content_sync_dataset,
         )
         get_access_store().record_event(
             action="repo_content_sync.run",
@@ -5255,6 +5249,7 @@ async def push_obsidian_sync(body: ObsidianPushBody, request: Request) -> Any:
             obsidian_push_conflict_candidate(
                 sync_conflict,
                 vault_name=manifest["vault"].get("name"),
+                dataset=push_dataset,
             )
         )
         await mesh_state.record_conflict(citadel.config, conflict=conflict_record)
@@ -5679,7 +5674,12 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
         )
     except Exception as exc:  # pragma: no cover - depends on external sources and Cognee config.
         logger.error("Learning agent run failed: %s", exc.__class__.__name__)
-        await mesh_state.record_error(citadel.config, operation="learning_agent", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="learning_agent",
+            error=str(exc),
+            dataset=citadel.config.default_dataset,
+        )
         get_access_store().record_event(
             action="learning_agent.run",
             actor=actor,
@@ -5942,9 +5942,8 @@ async def events(request: Request) -> StreamingResponse:
     queue = mesh_state.subscribe()
     # ADR-0009: the SSE stream serves the same content-leaking projection as
     # /api/mesh, so scope the initial snapshot and every live event to the
-    # caller (bypass callers see all). Cache visibility across events.
+    # caller (bypass callers see all).
     bypass = can_bypass_dataset_allowlist(identity)
-    visible_cache: dict[str, bool] = {}
 
     async def stream() -> Any:
         try:
@@ -5956,9 +5955,7 @@ async def events(request: Request) -> StreamingResponse:
                 except TimeoutError:
                     yield ": ping\n\n"
                     continue
-                if not bypass and not _mesh_dataset_visible(
-                    identity, (event.get("details") or {}).get("dataset"), visible_cache
-                ):
+                if not bypass and not event_visible_to(identity, event):
                     continue
                 yield sse("mesh-event", event)
         finally:
@@ -6277,8 +6274,13 @@ async def recent_contributions(
         actions=CONTRIBUTION_ACTIONS,
         actor_id=actor_id,
         success=True,
-        limit=limit,
+        limit=100,
     )
+    events = [
+        event
+        for event in events
+        if event.get("success") and event_visible_to(actor, event)
+    ][:limit]
     return {
         "ok": True,
         "contributions": events,
@@ -6483,7 +6485,12 @@ async def knowledge(
                 top_k=limit,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
-            await mesh_state.record_error(citadel.config, operation="search", error=str(exc))
+            await mesh_state.record_error(
+                citadel.config,
+                operation="search",
+                error=str(exc),
+                dataset=search_datasets[0],
+            )
             raise HTTPException(status_code=500, detail=str(exc)) from exc
     latency_ms = (time.perf_counter() - started) * 1000.0
     for search_dataset, _ in merged:
@@ -6545,7 +6552,12 @@ async def optimize_learning_agent(body: OptimizeBody, request: Request) -> Any:
             actor=actor,
         )
     except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
-        await mesh_state.record_error(citadel.config, operation="self_improve", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="self_improve",
+            error=str(exc),
+            dataset=citadel.config.default_dataset,
+        )
         get_access_store().record_event(
             action="learning_agent.optimize",
             actor=actor,
@@ -6598,7 +6610,12 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
                 top_k=fetch_k,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
-            await mesh_state.record_error(citadel.config, operation="search", error=str(exc))
+            await mesh_state.record_error(
+                citadel.config,
+                operation="search",
+                error=str(exc),
+                dataset=search_datasets[0],
+            )
             record_mcp_audit(
                 request,
                 actor=actor,
@@ -6614,7 +6631,10 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
     if timed_out:
         await mesh_state.record_error(
-            citadel.config, operation="search", error="search budget exceeded"
+            citadel.config,
+            operation="search",
+            error="search budget exceeded",
+            dataset=search_datasets[0],
         )
 
     # Shaping order: envelope -> rank -> filter -> trim -> drilldown. The
@@ -6925,7 +6945,12 @@ async def feedback(body: FeedbackBody, request: Request) -> Any:
             )
         )
     except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
-        await mesh_state.record_error(citadel.config, operation="feedback", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="feedback",
+            error=str(exc),
+            dataset=dataset,
+        )
         record_mcp_audit(
             request,
             actor=actor,
@@ -6986,7 +7011,12 @@ async def run_improve(
             session_ids=body.session_ids,
         )
     except Exception as exc:  # pragma: no cover - depends on runtime Cognee configuration.
-        await mesh_state.record_error(citadel.config, operation="improve", error=str(exc))
+        await mesh_state.record_error(
+            citadel.config,
+            operation="improve",
+            error=str(exc),
+            dataset=dataset,
+        )
         if request:
             record_mcp_audit(
                 request,

--- a/kb/server.py
+++ b/kb/server.py
@@ -14,8 +14,6 @@ import threading
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
@@ -32,6 +30,7 @@ from fastapi.responses import (
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
+from kb import __version__ as _SERVICE_VERSION
 from kb.access import (
     CENTRAL_DATASET,
     SESSION_TRACES_DATASET,
@@ -51,6 +50,7 @@ from kb.backup_mirror import BackupMirror, BackupMirrorDisabled, BackupMirrorPub
 from kb.conflicts import KnowledgeConflictStore, obsidian_push_conflict_candidate
 from kb.tags import normalize_tags
 from kb.cognee_client import assert_cognee_dataset_api
+from kb.cognee_client import drain_background_cognify_tasks
 from kb.config import CitadelConfig
 from kb.contact_store import ContactStore
 from kb.github_sync import GitHubOrgSyncer
@@ -161,6 +161,14 @@ _LAST_CANARY: dict[str, Any] | None = None
 # over an empty graph were the #27 failure mode).
 _MIN_TRACKED_FOR_CORPUS = 10
 _INDEXED_FLOOR = 1
+_CORPUS_HEALTH_PROBE_LIMIT = 64
+try:
+    _CORPUS_HEALTH_CACHE_TTL_SECONDS = max(
+        0.0, float(os.getenv("CITADEL_CORPUS_HEALTH_CACHE_TTL_SECONDS", "5"))
+    )
+except ValueError:
+    _CORPUS_HEALTH_CACHE_TTL_SECONDS = 5.0
+_CORPUS_HEALTH_CACHE: tuple[float, int, dict[str, Any]] | None = None
 
 # In-flight counts for the soft concurrency cap / 429 backpressure contract
 # (#50). Single-loop server → increment/decrement need no lock. Search and the
@@ -353,14 +361,19 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             "yes",
             "on",
         }
+        global _LAST_CANARY
         try:
             # verify=True runs the end-to-end ingest+cognify+search canary and
             # records its verdict for /readyz (#27).
             result = await get_citadel().cognify_dataset(force=force, verify=True)
-            global _LAST_CANARY
             verification = result.get("verification") or {}
+            canary_ok = (
+                result.get("ok") is True
+                and isinstance(verification, dict)
+                and verification.get("ok") is True
+            )
             _LAST_CANARY = {
-                "ok": bool(result.get("ok")),
+                "ok": canary_ok,
                 "search_hit": verification.get("search_hit"),
                 "graph_grew": result.get("graph_grew"),
                 "marker": verification.get("marker"),
@@ -373,7 +386,13 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             )
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
+            _LAST_CANARY = {
+                "ok": False,
+                "search_hit": False,
+                "graph_grew": False,
+                "error": type(exc).__name__,
+            }
             logger.exception("Evolve scheduler: cognify failed")
         finally:
             # Stamp the pass even when a stage failed. This records that the
@@ -514,6 +533,10 @@ async def lifespan(app: FastAPI) -> Any:
                 "Seat dataset backfill failed; seats created before provisioning "
                 "may still fail every search (#147)"
             )
+        try:
+            await schedule_startup_cognify_recovery(get_citadel())
+        except Exception:
+            logger.exception("Startup cognify recovery failed to schedule")
         evolve_task = _start_evolve_scheduler()
         repo_stats_task = _start_repo_stats_scheduler()
         try:
@@ -522,16 +545,31 @@ async def lifespan(app: FastAPI) -> Any:
             await _stop_evolve_scheduler(evolve_task)
             # Same cancel-and-await shutdown; the helper is not evolve specific.
             await _stop_evolve_scheduler(repo_stats_task)
+            await drain_background_cognify_tasks()
 
 
 # Single-source the service version so /.well-known/citadel.json and the CLI
-# never drift. Prefer installed package metadata; fall back to the in-source
-# kb.__version__ because the Railway node runs from source (not dist-installed),
-# where importlib.metadata raises and a hardcoded version would mislead.
-try:
-    _SERVICE_VERSION = _pkg_version("citadel-archive")
-except PackageNotFoundError:
-    from kb import __version__ as _SERVICE_VERSION
+# never drift. Installed metadata can lag in an editable checkout, so prefer
+# the package source value that is bundled into both source deployments and
+# wheels.
+
+
+def _build_identity() -> dict[str, str | None]:
+    """Expose deployment identity without exposing runtime configuration."""
+
+    def first_env(*names: str) -> str | None:
+        for name in names:
+            value = os.environ.get(name, "").strip()
+            if value:
+                return value
+        return None
+
+    return {
+        "commit_sha": first_env("RAILWAY_GIT_COMMIT_SHA", "GIT_COMMIT_SHA", "BUILD_SHA"),
+        "deployment_id": first_env("RAILWAY_DEPLOYMENT_ID", "RAILWAY_SNAPSHOT_ID"),
+        "branch": first_env("RAILWAY_GIT_BRANCH", "GIT_BRANCH"),
+    }
+
 
 app = FastAPI(
     title="Citadel Archive",
@@ -2009,6 +2047,32 @@ async def search_across_datasets(
     if not per_dataset:
         return merged
 
+    # Cognee 1.2.2 drops vector distances at this boundary. When any candidate
+    # has an attested lexical match, use that signal across dataset boundaries;
+    # preserve dataset order for ties and for pages with no lexical match.
+    terms = query_terms(query)
+    if len(per_dataset) > 1 and terms:
+        ranked_candidates: list[tuple[float, int, int, str, Any]] = []
+        for dataset_index, (dataset, results) in enumerate(per_dataset):
+            for result_index, result in enumerate(results):
+                coverage = (
+                    hit_term_coverage(result, terms)[0]
+                    if isinstance(result, dict)
+                    else 0.0
+                )
+                ranked_candidates.append(
+                    (coverage, dataset_index, result_index, dataset, result)
+                )
+        if any(candidate[0] > 0.0 for candidate in ranked_candidates):
+            ranked_candidates.sort(
+                key=lambda candidate: (-candidate[0], candidate[1], candidate[2])
+            )
+            for _coverage, _dataset_index, _result_index, dataset, result in ranked_candidates:
+                take(dataset, [result], 1)
+                if len(merged) >= top_k:
+                    break
+            return merged
+
     reserve = max(1, top_k // 5) if len(per_dataset) > 1 else 0
     primary_dataset, primary_results = per_dataset[0]
     take(primary_dataset, primary_results, top_k - reserve)
@@ -2026,6 +2090,7 @@ async def execute_learning_writes(
     targets: list[WriteTarget],
     tags: list[str],
     session_id: str | None,
+    provenance: dict[str, Any] | None = None,
     operation: str,
     detect_conflicts: bool = True,
     run_improve: bool = False,
@@ -2034,11 +2099,16 @@ async def execute_learning_writes(
     outcomes: list[LearningOutcome] = []
     primary: LearningOutcome | None = None
     for target in targets:
+        # Promotion provenance attests the full Central write. The light seat
+        # mirror is source material and must not claim that promotion succeeded
+        # if the later Central write is rejected.
+        target_provenance = provenance if target.tier == "full" else None
         outcome = await learning.learn(
             data,
             dataset=target.dataset,
             tags=tags,
             session_id=session_id,
+            provenance=target_provenance,
             operation=operation,
             detect_conflicts=detect_conflicts and target.tier == "full",
             run_improve=run_improve and target.tier == "full",
@@ -2061,6 +2131,7 @@ async def retry_failed_learning_writes(
     outcomes: list[LearningOutcome],
     tags: list[str],
     session_id: str | None,
+    provenance: dict[str, Any] | None = None,
     operation: str,
     detect_conflicts: bool = True,
     run_improve: bool = False,
@@ -2081,6 +2152,7 @@ async def retry_failed_learning_writes(
             dataset=target.dataset,
             tags=tags,
             session_id=session_id,
+            provenance=provenance,
             operation=operation,
             detect_conflicts=detect_conflicts and target.tier == "full",
             run_improve=run_improve and target.tier == "full",
@@ -2488,6 +2560,46 @@ async def backfill_seat_datasets(citadel: Citadel, store: AccessStore) -> dict[s
             counts["failed"],
         )
     return counts
+
+
+async def schedule_startup_cognify_recovery(citadel: Citadel) -> list[str]:
+    """Queue incremental recovery for every durable dataset after boot.
+
+    ``cognee.add`` is durable before cognify, so a killed request or process can
+    leave rows that have never reached the searchable projection. Incremental
+    cognify is idempotent and only processes work Cognee still considers pending;
+    this sweep is therefore a recovery pass, not a forced rebuild.
+    """
+    if os.getenv("CITADEL_STARTUP_COGNIFY_RECOVERY", "true").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        logger.info("Startup cognify recovery disabled by CITADEL_STARTUP_COGNIFY_RECOVERY")
+        return []
+    client = getattr(citadel, "cognee", None)
+    list_names = getattr(client, "list_dataset_names", None)
+    schedule = getattr(client, "schedule_cognify", None)
+    if not callable(list_names) or not callable(schedule):
+        logger.warning("Startup cognify recovery unavailable: gateway lacks dataset enumeration")
+        return []
+    try:
+        datasets = await list_names()
+    except Exception:
+        logger.exception("Startup cognify recovery could not enumerate datasets")
+        return []
+    names = list(
+        dict.fromkeys(
+            name.strip()
+            for name in datasets
+            if isinstance(name, str) and name.strip()
+        )
+    )
+    if names:
+        schedule(names)
+        logger.info("Startup cognify recovery queued for %d dataset(s)", len(names))
+    return names
 
 
 def known_datasets(config: Any) -> list[str]:
@@ -4146,8 +4258,13 @@ async def revoke_access_token(token_id: str, request: Request) -> dict[str, Any]
 
 
 @app.get("/healthz")
-async def healthz() -> dict[str, str | bool]:
-    return {"ok": True, "service": "citadel"}
+async def healthz() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "service": "citadel",
+        "version": app.version,
+        "build": _build_identity(),
+    }
 
 
 @app.get("/api/state")
@@ -4228,6 +4345,7 @@ async def public_state(request: Request, response: Response) -> dict[str, Any]:
         "ok": True,
         "service": "Citadel Archive",
         "version": app.version,
+        "build": _build_identity(),
         "healthy": True,
         "sources": sources,
         "totals": {
@@ -4252,6 +4370,7 @@ async def citadel_discovery_manifest(request: Request, response: Response) -> di
             "name": "Citadel Archive",
             "kind": "organization_vault",
             "version": app.version,
+            "build": _build_identity(),
             "base_url": base,
         },
         "public_endpoints": {
@@ -4345,12 +4464,27 @@ async def get_skill(slug: str) -> FileResponse:
 
 
 async def _corpus_health() -> dict[str, Any]:
-    """Data-plane volume gate: are tracked sources actually indexed? (#27)
+    """Data-plane volume gate using a bounded relational projection probe. (#27)
 
-    Fail-soft — any error returns ok=True with a ``degraded`` note so readiness
-    never flaps on a transient graph read; the real signal is "many sources
-    tracked but the graph is empty".
+    A failed read is a readiness failure, not an empty or healthy corpus. The
+    liveness endpoint remains separate, so a transient graph read does not
+    make the process look dead while ``/readyz`` correctly withholds traffic.
+    The legacy graph node count remains in the response for mesh compatibility,
+    but it is not evidence that relational documents have vector chunks.
     """
+    global _CORPUS_HEALTH_CACHE
+
+    citadel = get_citadel()
+    cache_key = id(citadel)
+    cached = _CORPUS_HEALTH_CACHE
+    if (
+        cached is not None
+        and cached[1] == cache_key
+        and _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0
+        and time.monotonic() - cached[0] < _CORPUS_HEALTH_CACHE_TTL_SECONDS
+    ):
+        return dict(cached[2])
+
     try:
         tracked = 0
         github_status = await get_github_syncer().status()
@@ -4359,7 +4493,79 @@ async def _corpus_health() -> dict[str, Any]:
         tracked += int(repo_content_status.get("tracked_files") or 0)
         linear_status = await get_linear_syncer().status()
         tracked += int(linear_status.get("issue_count") or 0)
-        counts = await get_citadel()._graph_counts()
+
+        measured_read = getattr(getattr(citadel, "cognee", None), "corpus_health", None)
+        if callable(measured_read):
+            measured = await measured_read(limit=_CORPUS_HEALTH_PROBE_LIMIT)
+            if not isinstance(measured, dict):
+                raise RuntimeError("bounded corpus probe returned a non-object")
+            for field in (
+                "relational_documents",
+                "probe_limit",
+                "probe_documents",
+                "probe_chunked_documents",
+                "probe_graph_documents",
+                "probe_fully_indexed_documents",
+            ):
+                value = measured.get(field)
+                if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                    raise RuntimeError(f"bounded corpus probe returned invalid {field}")
+            for field in ("probe_complete", "probe_ok"):
+                if type(measured.get(field)) is not bool:
+                    raise RuntimeError(f"bounded corpus probe returned invalid {field}")
+            if measured["probe_documents"] > measured["probe_limit"]:
+                raise RuntimeError("bounded corpus probe exceeded its limit")
+            for field in ("probe_max_documents", "probe_pages"):
+                if field in measured:
+                    value = measured[field]
+                    if (
+                        isinstance(value, bool)
+                        or not isinstance(value, int)
+                        or value < 0
+                    ):
+                        raise RuntimeError(f"bounded corpus probe returned invalid {field}")
+            if "probe_max_documents" in measured and measured["probe_documents"] > measured[
+                "probe_max_documents"
+            ]:
+                raise RuntimeError("bounded corpus probe exceeded its hard cap")
+            if "probe_cap_exceeded" in measured:
+                if type(measured["probe_cap_exceeded"]) is not bool:
+                    raise RuntimeError(
+                        "bounded corpus probe returned invalid probe_cap_exceeded"
+                    )
+                if measured["probe_cap_exceeded"] and (
+                    measured["probe_complete"] or measured["probe_ok"]
+                ):
+                    raise RuntimeError("capped corpus probe cannot be complete")
+
+            counts = await citadel._graph_counts()
+            indexed = int(counts.get("nodes") or 0)
+            edges = int(counts.get("edges") or 0)
+            # A measured client must prove the bounded page is the complete
+            # corpus before readiness can be green. The tracked-source floor
+            # remains part of the legacy fallback below.
+            ok = (
+                measured["probe_complete"] is True
+                and measured["probe_ok"] is True
+            )
+            result = {
+                **measured,
+                "ok": ok,
+                "tracked_sources": tracked,
+                # Compatibility for MeshState: this is a graph-node count, not
+                # a relational-document index count and not the readiness gate.
+                "indexed_docs": indexed,
+                "indexed_graph_nodes": indexed,
+                "indexed_edges": edges,
+                "measurement": "bounded_relational_projection_probe",
+            }
+            if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
+                _CORPUS_HEALTH_CACHE = (time.monotonic(), cache_key, result)
+            return result
+
+        # Preserve the old method-boundary fallback for local fakes and older
+        # clients that do not expose the bounded probe yet.
+        counts = await citadel._graph_counts()
         indexed = int(counts.get("nodes") or 0)
         # `_graph_counts` already reads the whole graph for `nodes`; `edges` comes
         # back in the same call for free. /api/mesh used to publish the in-memory
@@ -4373,15 +4579,18 @@ async def _corpus_health() -> dict[str, Any]:
             "indexed_docs": indexed,
             "indexed_edges": edges,
         }
-    except Exception as exc:  # noqa: BLE001 - readiness must not flap on a transient read
-        logger.warning("corpus health check degraded (fail-soft to ok): %s", exc)
-        return {
-            "ok": True,
+    except Exception as exc:  # noqa: BLE001 - convert dependency failures to readiness state
+        logger.warning("corpus health check degraded: %s", exc)
+        result = {
+            "ok": False,
             "tracked_sources": None,
             "indexed_docs": None,
             "indexed_edges": None,
             "degraded": str(exc),
         }
+        if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
+            _CORPUS_HEALTH_CACHE = (time.monotonic(), cache_key, result)
+        return result
 
 
 @app.get("/readyz")
@@ -4390,8 +4599,15 @@ async def readyz(request: Request) -> Any:
     config = get_citadel().config
     corpus = await _corpus_health()
     canary = _LAST_CANARY
-    # RED when the corpus gate trips or the last end-to-end canary failed.
-    ok = corpus["ok"] and (canary is None or bool(canary.get("ok", True)))
+    # A configured scheduler must prove one end-to-end pass before readiness is
+    # green. Local installs with scheduling disabled keep the corpus-only
+    # readiness contract, but a failed or malformed canary is always RED.
+    canary_ok = (
+        not config.evolve_scheduler_enabled
+        if canary is None
+        else isinstance(canary, dict) and canary.get("ok") is True
+    )
+    ok = corpus["ok"] and canary_ok
     payload = {
         "ok": ok,
         "service": "citadel",
@@ -4469,9 +4685,9 @@ async def mesh(request: Request) -> Any:
     # dashboard actually reads, was never updated to supply it. In production it
     # still returned `documents: 1, indexed_chunks: 1` against a real 17991
     # indexed, which is what makes a healthy vault look empty on login.
-    # `_corpus_health` is the same source /readyz and `citadel status` use, and
-    # is fail-soft: on a transient read error it returns None totals and
-    # `snapshot` falls back to the in-memory values rather than raising here.
+    # `_corpus_health` is the same source /readyz and `citadel status` use. On a
+    # transient read error it returns None totals, and `snapshot` falls back to
+    # the in-memory values rather than raising here.
     snapshot = await get_mesh().snapshot(citadel.config, corpus=await _corpus_health())
     return jsonable_encoder(scope_mesh_snapshot(snapshot, identity))
 
@@ -5791,6 +6007,28 @@ async def run_cognify(body: CognifyRunBody, request: Request) -> Any:
             },
         )
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if not isinstance(result, dict) or result.get("ok") is not True:
+        detail = {
+            "verify": body.verify,
+            "force": body.force,
+            "error": result.get("error") if isinstance(result, dict) else "invalid result",
+        }
+        get_access_store().record_event(
+            action="cognify.run",
+            actor=actor,
+            success=False,
+            dataset=dataset,
+            detail=detail,
+        )
+        record_mcp_audit(
+            request,
+            actor=actor,
+            success=False,
+            dataset=dataset,
+            detail={"operation": "cognify.run", **detail},
+        )
+        raise HTTPException(status_code=503, detail=detail)
 
     verification = result.get("verification") or {}
     get_access_store().record_event(

--- a/kb/service.py
+++ b/kb/service.py
@@ -72,6 +72,7 @@ class Citadel:
         dataset: str | None = None,
         tags: Iterable[str] | None = None,
         session_id: str | None = None,
+        provenance: dict[str, Any] | None = None,
         defer_cognify: bool = False,
     ) -> IngestResult:
         target_dataset = dataset or self.config.default_dataset
@@ -115,6 +116,7 @@ class Citadel:
                 dataset_name=target_dataset,
                 session_id=session_id,
                 tags=merged_tags,
+                provenance=provenance,
                 defer_cognify=defer_cognify,
             )
         except BaseException:

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -873,7 +873,7 @@ function renderSnapshot(snapshot) {
       item.innerHTML = `
         <div>
           <div class="index-name">${escapeHtml(index.name)}</div>
-          <div class="index-meta">${escapeHtml(index.records)} records</div>
+          <div class="index-meta">${escapeHtml(formatIndexRecords(index))}</div>
         </div>
         <span class="status-chip status-${escapeHtml(index.status)}">${escapeHtml(index.status)}</span>
       `;
@@ -881,6 +881,12 @@ function renderSnapshot(snapshot) {
     });
   }
 
+}
+
+function formatIndexRecords(index) {
+  if (typeof index.records !== "number") return "Not measured";
+  if (index.scope === "since_restart") return `${index.records} records since restart`;
+  return `${index.records} records`;
 }
 
 function renderTimelineStats(snapshot) {
@@ -1358,7 +1364,7 @@ function renderDashboardIndexes(indexes = []) {
     item.innerHTML = `
       <div>
         <strong>${escapeHtml(index.name)}</strong>
-        <p>${escapeHtml(index.records)} records</p>
+        <p>${escapeHtml(formatIndexRecords(index))}</p>
       </div>
       <span class="status-chip status-${escapeHtml(index.status)}">${escapeHtml(index.status)}</span>
     `;
@@ -1391,7 +1397,8 @@ function renderKnowledgeIndexes(indexes = []) {
   if (!knowledgeIndexList) return;
   knowledgeIndexList.innerHTML = "";
   const recordCount = indexes.reduce((total, index) => total + Number(index.records || 0), 0);
-  if (knowledgeRecordCount) knowledgeRecordCount.textContent = String(recordCount);
+  const allRecordsMeasured = indexes.length > 0 && indexes.every((index) => typeof index.records === "number");
+  if (knowledgeRecordCount) knowledgeRecordCount.textContent = allRecordsMeasured ? String(recordCount) : "Not measured";
   if (!indexes.length) {
     knowledgeIndexList.append(emptyState("No index status", "The retrieval indexes have not reported yet."));
     return;
@@ -1404,7 +1411,7 @@ function renderKnowledgeIndexes(indexes = []) {
         <strong>${escapeHtml(index.name)}</strong>
         <p>${escapeHtml(index.description || "Knowledge retrieval index")}</p>
       </div>
-      <span class="status-chip status-${escapeHtml(index.status)}">${escapeHtml(index.records)} records</span>
+      <span class="status-chip status-${escapeHtml(index.status)}">${escapeHtml(formatIndexRecords(index))}</span>
     `;
     knowledgeIndexList.append(item);
   });
@@ -2485,6 +2492,7 @@ async function loadKnowledgeGraph(force = false) {
     return;
   }
   state.realGraphLoading = true;
+  meshAlert.hidden = true;
   updateGraphMeta("Loading Knowledge Mesh");
   try {
     const payload = await fetchMeshGraphWithBackoff();
@@ -2495,18 +2503,23 @@ async function loadKnowledgeGraph(force = false) {
       updateGraphMeta();
       updateRealGraphEmpty();
       renderGraphLegend();
+      meshAlert.hidden = true;
     }
   } catch (error) {
     if (error && error.status === 429) {
-      // Retries exhausted: soft, non-error status (no toast) so a login-burst
-      // 429 doesn't read as a failure. Next view switch / refresh retries.
+      // Retries exhausted: keep the failure local to the graph panel and leave
+      // the Retry control available instead of silently requiring a page refresh.
       if (state.graphMode === "knowledge") {
         updateGraphMeta("Knowledge Mesh is busy — refresh in a moment");
+        meshAlert.hidden = false;
+        meshAlertText.textContent = "Knowledge Mesh is busy. Retry in a moment.";
       }
     } else {
       showToast(`Could not load the Knowledge Mesh: ${error.message}`, "error");
       if (state.graphMode === "knowledge") {
         updateGraphMeta("Knowledge Mesh unavailable");
+        meshAlert.hidden = false;
+        meshAlertText.textContent = error.message || "Try refreshing the vault.";
       }
     }
   } finally {
@@ -4014,7 +4027,13 @@ document.getElementById("logoutButton").addEventListener("click", async () => {
   }
   window.location.assign("/login");
 });
-document.getElementById("meshRetryButton").addEventListener("click", () => loadMesh());
+document.getElementById("meshRetryButton").addEventListener("click", () => {
+  if (state.graphMode === "knowledge") {
+    loadKnowledgeGraph(true);
+  } else {
+    loadMesh();
+  }
+});
 document.getElementById("fitButton").addEventListener("click", () => {
   resetGraphView();
 });

--- a/kb/status.py
+++ b/kb/status.py
@@ -67,6 +67,8 @@ MCP_AGENT_FALLBACK = (
 CODE_AUTH_REQUIRED = "AUTH_REQUIRED"
 CODE_SEARCH_UNAVAILABLE = "SEARCH_UNAVAILABLE"
 CODE_TIMEOUT = "TIMEOUT"
+CODE_READINESS_UNAVAILABLE = "READINESS_UNAVAILABLE"
+CODE_READINESS_PROTOCOL = "READINESS_PROTOCOL_ERROR"
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -197,7 +199,20 @@ def check_node_health(base_url: str, *, timeout: float = _TIMEOUT) -> Check:
         return Check("node", ok=False, detail=_humanize_net_error(exc))
     latency = int((time.monotonic() - started) * 1000)
     ok = bool(data.get("ok"))
-    return Check("node", ok=ok, detail="healthy" if ok else "unhealthy", latency_ms=latency)
+    node_data = {
+        key: data[key]
+        for key in ("version", "build")
+        if key in data
+    }
+    detail = "healthy" if ok else "unhealthy"
+    version = node_data.get("version")
+    build = node_data.get("build")
+    commit_sha = build.get("commit_sha") if isinstance(build, dict) else None
+    if version:
+        detail += f" v{version}"
+    if commit_sha:
+        detail += f" ({str(commit_sha)[:12]})"
+    return Check("node", ok=ok, detail=detail, latency_ms=latency, data=node_data)
 
 
 def check_auth(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -> Check:
@@ -295,7 +310,9 @@ def check_search(
 def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -> Check | None:
     """Data-plane corpus health from the Node's honest /readyz (#27).
 
-    Returns None (non-gating) when there is no token or /readyz is unreachable;
+    Tokenless status remains local-only and does not probe /readyz. Once a token
+    is present, a transport or protocol failure is a failed readiness check;
+    otherwise ``gather_status`` would treat a missing data-plane signal as green.
     /readyz answers 503 with a body when the corpus gate or canary is RED, so we
     parse the body off the HTTPError too.
     """
@@ -307,19 +324,78 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
         data = _request("GET", url, token=token, timeout=timeout)
     except urllib.error.HTTPError as exc:
         if exc.code != 503:
-            return None
+            return Check(
+                "corpus",
+                ok=False,
+                detail=_humanize_net_error(exc),
+                data={"code": CODE_READINESS_UNAVAILABLE},
+            )
         try:
             data = json.loads(exc.read().decode() or "{}")
-        except (ValueError, OSError):
-            return None
-    except Exception:
-        return None
+        except (UnicodeError, ValueError, OSError) as parse_exc:
+            return Check(
+                "corpus",
+                ok=False,
+                detail=f"invalid /readyz response: {parse_exc}",
+                data={"code": CODE_READINESS_PROTOCOL},
+            )
+    except Exception as exc:
+        return Check(
+            "corpus",
+            ok=False,
+            detail=_humanize_net_error(exc),
+            data={"code": CODE_READINESS_UNAVAILABLE},
+        )
     latency = int((time.monotonic() - started) * 1000)
-    corpus = data.get("corpus") or {}
+
+    if not isinstance(data, dict):
+        return Check(
+            "corpus",
+            ok=False,
+            detail="invalid /readyz response: expected an object",
+            latency_ms=latency,
+            data={"code": CODE_READINESS_PROTOCOL},
+        )
+    if not isinstance(data.get("ok"), bool):
+        return Check(
+            "corpus",
+            ok=False,
+            detail="invalid /readyz response: ok must be a boolean",
+            latency_ms=latency,
+            data={"code": CODE_READINESS_PROTOCOL},
+        )
+
+    corpus = data.get("corpus")
+    if not isinstance(corpus, dict) or not isinstance(corpus.get("ok"), bool):
+        return Check(
+            "corpus",
+            ok=False,
+            detail="invalid /readyz response: corpus.ok must be a boolean",
+            latency_ms=latency,
+            data={"code": CODE_READINESS_PROTOCOL},
+        )
+
     canary = data.get("canary")
+    if canary is not None and not isinstance(canary, dict):
+        return Check(
+            "corpus",
+            ok=False,
+            detail="invalid /readyz response: canary must be an object or null",
+            latency_ms=latency,
+            data={"code": CODE_READINESS_PROTOCOL, "canary": canary},
+        )
+    if canary is not None and not isinstance(canary.get("ok"), bool):
+        return Check(
+            "corpus",
+            ok=False,
+            detail="invalid /readyz response: canary.ok must be a boolean",
+            latency_ms=latency,
+            data={"code": CODE_READINESS_PROTOCOL, "canary": canary},
+        )
+
     indexed = corpus.get("indexed_docs")
     tracked = corpus.get("tracked_sources")
-    ok = bool(corpus.get("ok", True)) and (canary is None or bool(canary.get("ok", True)))
+    ok = data["ok"] and corpus["ok"] and (canary is None or canary["ok"])
     detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
     return Check("corpus", ok=ok, detail=detail, latency_ms=latency, data={"canary": canary})
 

--- a/kb/visibility.py
+++ b/kb/visibility.py
@@ -1,0 +1,88 @@
+"""Visibility decisions shared by Seat, Node, Central, and projections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from kb.access import (
+    SESSION_TRACES_DATASET,
+    AccessIdentity,
+    default_scopes,
+    is_seat_dataset,
+)
+
+
+def effective_scopes(identity: AccessIdentity) -> tuple[str, ...]:
+    if identity.scopes:
+        return identity.scopes
+    if identity.source == "env":
+        return default_scopes(identity.role)
+    return ()
+
+
+def can_bypass_dataset_allowlist(identity: AccessIdentity) -> bool:
+    if identity.source == "env":
+        return True
+    if identity.role == "admin":
+        return True
+    return "access:manage" in effective_scopes(identity)
+
+
+def enforce_dataset_allowlist(identity: AccessIdentity, dataset: str) -> None:
+    if can_bypass_dataset_allowlist(identity):
+        return
+    if dataset == SESSION_TRACES_DATASET:
+        return
+    if dataset in identity.allowed_datasets:
+        return
+    if is_seat_dataset(dataset):
+        raise HTTPException(status_code=403, detail=f"Dataset not allowed: {dataset}.")
+    if not identity.allowed_datasets:
+        return
+    raise HTTPException(status_code=403, detail=f"Dataset not allowed: {dataset}.")
+
+
+def dataset_visible_to(identity: AccessIdentity, dataset: str) -> bool:
+    """Return whether a dataset may appear in a scoped projection."""
+    try:
+        enforce_dataset_allowlist(identity, dataset)
+    except HTTPException:
+        return False
+    return True
+
+
+def owner_visible_to(
+    identity: AccessIdentity,
+    owner_actor_id: str | None,
+    owner_seat_slug: str | None = None,
+) -> bool:
+    """Return whether an actor-owned record may appear in a projection."""
+    if can_bypass_dataset_allowlist(identity):
+        return True
+    return bool(
+        (owner_actor_id and owner_actor_id == identity.actor_id)
+        or (owner_seat_slug and owner_seat_slug == identity.seat_slug)
+    )
+
+
+def conflict_visible_to(identity: AccessIdentity, conflict: dict[str, Any]) -> bool:
+    """Scope a Knowledge Conflict by its recorded dataset."""
+    if can_bypass_dataset_allowlist(identity):
+        return True
+    dataset = conflict.get("dataset")
+    return isinstance(dataset, str) and dataset_visible_to(identity, dataset)
+
+
+def event_visible_to(identity: AccessIdentity, event: dict[str, Any]) -> bool:
+    """Scope activity events while failing closed for unscoped sensitive events."""
+    if can_bypass_dataset_allowlist(identity):
+        return True
+    details = event.get("details") if isinstance(event.get("details"), dict) else {}
+    dataset = details.get("dataset")
+    if not isinstance(dataset, str):
+        dataset = event.get("dataset")
+    if event.get("type") in {"conflict", "error"} and not isinstance(dataset, str):
+        return False
+    return not isinstance(dataset, str) or dataset_visible_to(identity, dataset)

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -123,11 +123,17 @@ def _repo_content_sync_stage() -> int:
     return run_async(_repo_content_sync_stage_async())
 
 
-def _cognify_mode(*, verify: bool) -> int:
+def _cognify_mode(*, verify: bool, force: bool = False) -> int:
     from kb.service import Citadel
 
     dataset = os.getenv("CITADEL_COGNIFY_DATASET") or None
-    result = run_async(Citadel.from_env().cognify_dataset(dataset=dataset, verify=verify))
+    result = run_async(
+        Citadel.from_env().cognify_dataset(
+            dataset=dataset,
+            verify=verify,
+            force=force,
+        )
+    )
     logger.info(
         "Cognify finished: dataset=%s graph_before=%s graph_after=%s grew=%s verify=%s",
         result.get("dataset"),
@@ -136,6 +142,9 @@ def _cognify_mode(*, verify: bool) -> int:
         result.get("graph_grew"),
         (result.get("verification") or {}).get("ok") if verify else result.get("verify"),
     )
+    if result.get("ok") is False:
+        logger.error("Cognify failed: %s", result)
+        return 1
     if verify and not (result.get("verification") or {}).get("ok"):
         logger.error("Cognify verification failed: %s", result.get("verification"))
         return 1
@@ -207,6 +216,13 @@ def _cognify_via_api(url: str, *, force: bool) -> int:
         logger.error("Cognify API timed out after %ss: %s", _cognify_timeout(), exc)
         return 1
 
+    if not isinstance(result, dict):
+        logger.error("Cognify API returned an invalid result: %r", result)
+        return 1
+    if result.get("ok") is False:
+        logger.error("Cognify API reported failure: %s", result)
+        return 1
+
     logger.info(
         "Cognify (API) finished: graph_before=%s graph_after=%s grew=%s",
         result.get("graph_before"),
@@ -231,7 +247,10 @@ def _cognify_stage() -> int:
             "(e.g. http://citadel-archive.railway.internal:8080) to cognify via the web."
         )
         return 1
-    return _cognify_mode(verify=False)
+    return _cognify_mode(
+        verify=False,
+        force=_bool(os.getenv("CITADEL_COGNIFY_FORCE")),
+    )
 
 
 async def _promotion_stage_async() -> int:
@@ -624,7 +643,10 @@ def run(mode: str | None = None) -> int:
 
         return run_backup_mirror()
     if resolved_mode in {"cognify", "cognify-verify"}:
-        return _cognify_mode(verify=resolved_mode == "cognify-verify")
+        return _cognify_mode(
+            verify=resolved_mode == "cognify-verify",
+            force=_bool(os.getenv("CITADEL_COGNIFY_FORCE")),
+        )
     if resolved_mode in {"pipeline", "all", "cron"}:
         return run_pipeline()
     if resolved_mode == "evolve":

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -657,8 +657,73 @@ async def test_ensure_dataset_makes_a_seat_resolvable_to_cognee(
     assert await client.ensure_dataset("seat:alice") is True
     resolved = await get_authorized_dataset_by_name("seat:alice", user, "read")
     assert resolved is not None and resolved.name == "seat:alice"
-
     assert await client.ensure_dataset("seat:alice") is False
+
+
+@pytest.mark.asyncio
+async def test_node_provenance_map_reads_only_valid_server_metadata(
+    cognee_sqlite: Any, monkeypatch: Any
+) -> None:
+    from cognee.infrastructure.databases.relational import create_db_and_tables
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.data.models import Data
+    from cognee.modules.users.methods import get_default_user
+    from uuid import uuid4
+
+    await create_db_and_tables()
+    user = await get_default_user()
+    promoted_id = uuid4()
+    ignored_id = uuid4()
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        session.add(
+            Data(
+                id=promoted_id,
+                name="promoted",
+                content_hash="provenance-hash",
+                mime_type="text/plain",
+                owner_id=user.id,
+                tenant_id=user.tenant_id,
+                external_metadata={
+                    "citadel_provenance": {
+                        "kind": "promotion",
+                        "trust_tier": "unattested",
+                        "promoted_by": "operator-1",
+                        "promoted_at": "2026-08-05T10:00:00+00:00",
+                    }
+                },
+            )
+        )
+        session.add(
+            Data(
+                id=ignored_id,
+                name="untrusted",
+                content_hash="ignored-hash",
+                mime_type="text/plain",
+                owner_id=user.id,
+                tenant_id=user.tenant_id,
+                external_metadata={"citadel_provenance": {"kind": "forged"}},
+            )
+        )
+        await session.commit()
+
+    client = _real_cognee_client(monkeypatch)
+
+    assert await client.node_provenance_map() == {
+        str(promoted_id): {
+            "kind": "promotion",
+            "promoted_by": "operator-1",
+            "promoted_at": "2026-08-05T10:00:00+00:00",
+            "trust_tier": "unattested",
+        }
+    }
+    assert await client.document_provenance(str(promoted_id)) == {
+        "kind": "promotion",
+        "promoted_by": "operator-1",
+        "promoted_at": "2026-08-05T10:00:00+00:00",
+        "trust_tier": "unattested",
+    }
+    assert await client.document_provenance(str(ignored_id)) is None
 
 
 @pytest.mark.asyncio
@@ -992,12 +1057,24 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
         dataset_name="masumi-network",
         session_id="masumi-github-daily",
         tags=("github",),
+        provenance={
+            "kind": "promotion",
+            "promoted_by": "operator-1",
+            "promoted_at": "2026-08-05T10:00:00+00:00",
+        },
     )
     assert "session_id" not in captured["kwargs"]
     assert captured["kwargs"] == {"dataset_name": "masumi-network"}
     assert isinstance(captured["data"], DataItem)
     assert captured["data"].data == "real digest"
-    assert captured["data"].external_metadata == {"citadel_tags": ["github"]}
+    assert captured["data"].external_metadata == {
+        "citadel_tags": ["github"],
+        "citadel_provenance": {
+            "kind": "promotion",
+            "promoted_by": "operator-1",
+            "promoted_at": "2026-08-05T10:00:00+00:00",
+        },
+    }
     assert result == {"added": {"ok": True}, "cognify": "suppressed"}
 
 
@@ -1071,6 +1148,33 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(monkeypatch: 
     client.schedule_cognify([])
     await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == []
+
+
+@pytest.mark.asyncio
+async def test_list_dataset_names_returns_nonempty_owned_names(monkeypatch: Any) -> None:
+    async def run_startup_migrations() -> None:
+        return None
+
+    class Dataset:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    async def list_datasets() -> list[Dataset]:
+        return [Dataset("seat:sarthi"), Dataset(""), Dataset("seat:sarthi")]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(
+            run_startup_migrations=run_startup_migrations,
+            datasets=SimpleNamespace(
+                list_datasets=list_datasets,
+            ),
+        ),
+    )
+    client = CogneePublicClient()
+
+    assert await client.list_dataset_names() == ["seat:sarthi"]
 
 
 @pytest.mark.asyncio
@@ -1553,3 +1657,121 @@ async def test_corpus_chunk_counts_says_not_measured_off_pgvector(
 
     assert await client.corpus_chunk_counts(["3b9c0d05-0000-0000-0000-000000000001"]) is None
     assert await client.corpus_chunk_counts([]) == {}
+
+
+@pytest.mark.asyncio
+async def test_corpus_health_joins_bounded_row_projection_measurements(
+    monkeypatch: Any,
+) -> None:
+    client = CogneePublicClient()
+    monkeypatch.delenv("CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS", raising=False)
+    calls: dict[str, Any] = {"pages": [], "chunk_ids": [], "graph_ids": []}
+    pages = [
+        [
+            {"id": "doc-a", "created_at": "2026-01-01T00:00:00+00:00"},
+            {"id": "doc-b", "created_at": "2026-01-02T00:00:00+00:00"},
+        ],
+        [{"id": "doc-c", "created_at": "2026-01-03T00:00:00+00:00"}],
+    ]
+
+    async def corpus_totals() -> dict[str, Any]:
+        return {"documents": 3}
+
+    async def corpus_page(**kwargs: Any) -> list[dict[str, Any]]:
+        calls["pages"].append(
+            (kwargs["after_created_at"], kwargs["after_id"], kwargs["limit"])
+        )
+        return pages[len(calls["pages"]) - 1]
+
+    async def corpus_chunk_counts(document_ids: list[str]) -> dict[str, int]:
+        calls["chunk_ids"].append(document_ids)
+        return {document_id: 2 for document_id in document_ids}
+
+    async def corpus_graph_presence(document_ids: list[str]) -> set[str]:
+        calls["graph_ids"].append(document_ids)
+        return set(document_ids) | {"stale-graph-node"}
+
+    monkeypatch.setattr(client, "corpus_totals", corpus_totals)
+    monkeypatch.setattr(client, "corpus_page", corpus_page)
+    monkeypatch.setattr(client, "corpus_chunk_counts", corpus_chunk_counts)
+    monkeypatch.setattr(client, "corpus_graph_presence", corpus_graph_presence)
+
+    health = await client.corpus_health(limit=2)
+
+    assert calls == {
+        "pages": [
+            (None, None, 2),
+            ("2026-01-02T00:00:00+00:00", "doc-b", 1),
+        ],
+        "chunk_ids": [["doc-a", "doc-b"], ["doc-c"]],
+        "graph_ids": [["doc-a", "doc-b"], ["doc-c"]],
+    }
+    assert health == {
+        "relational_documents": 3,
+        "probe_limit": 2,
+        "probe_max_documents": 10_000,
+        "probe_documents": 3,
+        "probe_pages": 2,
+        "probe_complete": True,
+        "probe_cap_exceeded": False,
+        "probe_chunked_documents": 3,
+        "probe_graph_documents": 3,
+        "probe_fully_indexed_documents": 3,
+        "probe_ok": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_corpus_health_fails_closed_before_scanning_past_document_cap(
+    monkeypatch: Any,
+) -> None:
+    client = CogneePublicClient()
+    monkeypatch.setenv("CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS", "2")
+
+    async def corpus_totals() -> dict[str, Any]:
+        return {"documents": 3}
+
+    async def corpus_page(**_: Any) -> list[dict[str, Any]]:
+        raise AssertionError("cap check must happen before page enumeration")
+
+    monkeypatch.setattr(client, "corpus_totals", corpus_totals)
+    monkeypatch.setattr(client, "corpus_page", corpus_page)
+
+    health = await client.corpus_health()
+
+    assert health == {
+        "relational_documents": 3,
+        "probe_limit": 64,
+        "probe_max_documents": 2,
+        "probe_documents": 0,
+        "probe_pages": 0,
+        "probe_complete": False,
+        "probe_cap_exceeded": True,
+        "probe_chunked_documents": 0,
+        "probe_graph_documents": 0,
+        "probe_fully_indexed_documents": 0,
+        "probe_ok": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_corpus_health_fails_closed_when_vector_measurement_is_unavailable(
+    monkeypatch: Any,
+) -> None:
+    client = CogneePublicClient()
+
+    async def corpus_totals() -> dict[str, Any]:
+        return {"documents": 1}
+
+    async def corpus_page(**_: Any) -> list[dict[str, Any]]:
+        return [{"id": "doc-a"}]
+
+    async def corpus_chunk_counts(_: list[str]) -> None:
+        return None
+
+    monkeypatch.setattr(client, "corpus_totals", corpus_totals)
+    monkeypatch.setattr(client, "corpus_page", corpus_page)
+    monkeypatch.setattr(client, "corpus_chunk_counts", corpus_chunk_counts)
+
+    with pytest.raises(RuntimeError, match="vector chunk measurement is unavailable"):
+        await client.corpus_health()

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -57,6 +58,20 @@ def test_recording_same_open_conflict_twice_is_deduplicated(tmp_path: Path) -> N
 
     assert first["id"] == second["id"]
     assert len(store.list()) == 1
+
+
+def test_scoped_conflicts_with_same_key_do_not_collide(tmp_path: Path) -> None:
+    store = KnowledgeConflictStore(tmp_path / "conflicts.json")
+
+    alice = store.record(
+        replace(candidate("same"), dataset="seat:alice")
+    )
+    bob = store.record(
+        replace(candidate("same"), dataset="seat:bob")
+    )
+
+    assert alice["id"] != bob["id"]
+    assert {item["dataset"] for item in store.list()} == {"seat:alice", "seat:bob"}
 
 
 def test_store_is_bounded_and_drops_resolved_records_first(tmp_path: Path) -> None:

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -191,9 +191,10 @@ async def test_github_sync_ingests_daily_digest_and_persists_state(tmp_path: Any
     assert result["commit_count"] == 1
     assert result["ingested"] is True
     assert result["improved"] is True
-    assert "masumi-network/agent" in citadel.ingest_calls[0]["data"]
-    assert "teach the archive about commits" in citadel.ingest_calls[0]["data"]
-    assert citadel.ingest_calls[0]["dataset"] == "masumi-network"
+    ingested_text = "\n".join(call["data"] for call in citadel.ingest_calls)
+    assert "masumi-network/agent" in ingested_text
+    assert "teach the archive about commits" in ingested_text
+    assert all(call["dataset"] == "masumi-network" for call in citadel.ingest_calls)
     assert citadel.improve_calls[0]["session_ids"] == ["masumi-github-daily"]
     state = json.loads(Path(config.github_sync_state_path).read_text(encoding="utf-8"))
     assert "teach the archive about commits" in state["last_digest"]
@@ -239,12 +240,14 @@ async def test_github_sync_can_skip_unchanged_ingest(tmp_path: Any) -> None:
     )
 
     await syncer.run()
+    first_ingest_count = len(citadel.ingest_calls)
     second = await syncer.run()
 
     assert second["changed_count"] == 0
     assert second["event_count"] == 0
     assert second["commit_count"] == 0
-    assert len(citadel.ingest_calls) == 1
+    assert first_ingest_count >= 1
+    assert len(citadel.ingest_calls) == first_ingest_count
 
 
 @pytest.mark.asyncio
@@ -497,6 +500,7 @@ async def test_corrupt_state_raises_instead_of_everything_changed(tmp_path: Any)
     citadel = FakeCitadel(config)
     syncer = GitHubOrgSyncer(citadel, client=FakeGitHubClient(), org="masumi-network")
     await syncer.run()  # seed a real state file
+    first_ingest_count = len(citadel.ingest_calls)
     corrupt = '{"version": 1, "org": "masumi-network", "repos"'
     Path(config.github_sync_state_path).write_text(corrupt, encoding="utf-8")
 
@@ -505,7 +509,8 @@ async def test_corrupt_state_raises_instead_of_everything_changed(tmp_path: Any)
 
     # No digest was fabricated from the corrupt state, and the file was left
     # untouched as evidence.
-    assert len(citadel.ingest_calls) == 1
+    assert first_ingest_count >= 1
+    assert len(citadel.ingest_calls) == first_ingest_count
     assert Path(config.github_sync_state_path).read_text(encoding="utf-8") == corrupt
 
 

--- a/tests/test_graph_ui_contract.py
+++ b/tests/test_graph_ui_contract.py
@@ -1,0 +1,33 @@
+"""Static dashboard graph controls stay connected to both graph APIs."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+STATIC = REPO / "kb" / "static"
+
+
+def test_graph_retry_control_retries_the_active_data_source() -> None:
+    script = (STATIC / "app.js").read_text(encoding="utf-8")
+    retry_handler = script[script.index('document.getElementById("meshRetryButton")') :]
+
+    assert 'if (state.graphMode === "knowledge")' in retry_handler
+    assert "loadKnowledgeGraph(true)" in retry_handler
+    assert "loadMesh()" in retry_handler
+
+
+def test_knowledge_graph_failures_surface_the_inline_retry_state() -> None:
+    script = (STATIC / "app.js").read_text(encoding="utf-8")
+    loader = script[script.index("async function loadKnowledgeGraph") : script.index("function setGraphMode")]
+
+    assert "meshAlert.hidden = false" in loader
+    assert "meshAlertText.textContent" in loader
+    assert "Knowledge Mesh is busy. Retry in a moment." in loader
+
+
+def test_index_ui_does_not_render_unmeasured_counts_as_zero() -> None:
+    script = (STATIC / "app.js").read_text(encoding="utf-8")
+
+    assert "function formatIndexRecords(index)" in script
+    assert 'return "Not measured"' in script
+    assert 'knowledgeRecordCount.textContent = allRecordsMeasured ? String(recordCount) : "Not measured"' in script

--- a/tests/test_knowledge_mesh.py
+++ b/tests/test_knowledge_mesh.py
@@ -45,9 +45,24 @@ async def test_graph_maps_cognee_tuples_to_nodes_and_edges() -> None:
     assert graph["ok"] is True
     assert graph["fallback"] is False
     assert graph["nodes"] == [
-        {"id": "node-1", "label": "Citadel", "type": "Entity"},
-        {"id": "node-2", "label": "Cognee", "type": "Tool"},
-        {"id": "node-3", "label": "node-3", "type": "node"},
+        {
+            "id": "node-1",
+            "label": "Citadel",
+            "type": "Entity",
+            "trust_tier": "unattested",
+        },
+        {
+            "id": "node-2",
+            "label": "Cognee",
+            "type": "Tool",
+            "trust_tier": "unattested",
+        },
+        {
+            "id": "node-3",
+            "label": "node-3",
+            "type": "node",
+            "trust_tier": "unattested",
+        },
     ]
     assert {"source": "node-1", "target": "node-2", "relationship": "uses"} in graph["edges"]
     # Empty relationship names fall back to "related"; dangling edges are dropped.
@@ -139,15 +154,20 @@ class FakeDatasetGateway(FakeGraphGateway):
         *,
         dataset_map: dict[str, list[str]] | None = None,
         map_error: Exception | None = None,
+        provenance_map: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(nodes, edges)
         self.dataset_map = dataset_map or {}
         self.map_error = map_error
+        self.provenance_map = provenance_map or {}
 
     async def node_dataset_map(self) -> dict[str, list[str]]:
         if self.map_error:
             raise self.map_error
         return self.dataset_map
+
+    async def node_provenance_map(self) -> dict[str, dict[str, Any]]:
+        return self.provenance_map
 
 
 DOC_NODES = [
@@ -269,6 +289,51 @@ async def test_graph_attributes_datasets_through_gateway() -> None:
     doc = next(node for node in graph["nodes"] if node["id"] == "doc-1")
     assert doc["dataset"] == "seat:alice"
     assert any(node["id"] == "dataset:seat:alice" for node in graph["nodes"])
+
+
+def test_graph_projects_server_provenance_to_document_and_chunks() -> None:
+    payload = build_graph_payload(
+        DOC_NODES,
+        DOC_EDGES,
+        provenance_map={
+            "doc-1": {
+                "kind": "promotion",
+                "trust_tier": "unattested",
+                "promoted_by": "operator-1",
+                "promoted_at": "2026-08-05T10:00:00+00:00",
+            }
+        },
+    )
+
+    doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
+    chunk = next(node for node in payload["nodes"] if node["id"] == "chunk-1")
+    assert doc["trust_tier"] == "unattested"
+    assert doc["promoted_by"] == "operator-1"
+    assert doc["promoted_at"] == "2026-08-05T10:00:00+00:00"
+    assert chunk["promoted_by"] == "operator-1"
+    assert chunk["promoted_at"] == "2026-08-05T10:00:00+00:00"
+
+
+async def test_graph_reads_server_provenance_from_gateway() -> None:
+    mesh = KnowledgeMesh(
+        FakeDatasetGateway(
+            DOC_NODES,
+            DOC_EDGES,
+            provenance_map={
+                "doc-1": {
+                    "kind": "promotion",
+                    "promoted_by": "operator-1",
+                    "promoted_at": "2026-08-05T10:00:00+00:00",
+                }
+            },
+        )
+    )
+
+    graph = await mesh.graph()
+
+    doc = next(node for node in graph["nodes"] if node["id"] == "doc-1")
+    assert doc["promoted_by"] == "operator-1"
+    assert doc["trust_tier"] == "unattested"
 
 
 async def test_graph_dataset_map_failure_degrades_to_plain_graph() -> None:

--- a/tests/test_llm_enrichment.py
+++ b/tests/test_llm_enrichment.py
@@ -27,6 +27,7 @@ def clean_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in (
         "CITADEL_LLM_ENRICHMENT_ENABLED",
         "CITADEL_LLM_ENRICHMENT_THRESHOLD_CHARS",
+        "CITADEL_DETERMINISTIC_CHUNK_CHARS",
         "CITADEL_LLM_MODEL",
         "OPENROUTER_API_KEY",
         "LLM_API_KEY",
@@ -48,11 +49,122 @@ LONG_MATERIAL = (
 def test_paragraph_chunks_split_on_blank_lines_and_respect_max_chars() -> None:
     chunks = paragraph_chunks(LONG_MATERIAL, max_chars=60)
 
-    assert len(chunks) == 2
+    assert len(chunks) == 3
     assert chunks[0].startswith("First paragraph")
     assert chunks[1].startswith("Second paragraph")
+    assert chunks[1] + chunks[2] == LONG_MATERIAL.split("\n\n", 1)[1]
+    assert all(len(chunk) <= 60 for chunk in chunks)
     # Small paragraphs are grouped back together under a large cap.
     assert paragraph_chunks(LONG_MATERIAL, max_chars=10_000) == [LONG_MATERIAL]
+
+
+def test_paragraph_chunks_split_oversized_paragraphs_without_dropping_text() -> None:
+    material = "row one\nrow two\n" + ("x" * 31)
+
+    chunks = paragraph_chunks(material, max_chars=12)
+
+    assert all(len(chunk) <= 12 for chunk in chunks)
+    assert "".join(chunks) == material
+
+
+def test_deterministic_source_chunks_preserve_whitespace_and_unicode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CITADEL_CHUNK_BUDGET_TOKENS", "32")
+    data = "  α\n\n界界界\t" + ("emoji 🧭 " * 60) + "  "
+
+    chunks = llm_enrichment.deterministic_source_chunks(data, max_chars=1200)
+
+    assert "".join(chunks) == data
+    assert len(chunks) > 1
+    assert all(
+        llm_enrichment._count_bpe(chunk) <= 32
+        for chunk in chunks
+        if llm_enrichment._count_bpe(chunk) is not None
+    )
+
+
+def test_deterministic_source_chunks_repeat_repo_header() -> None:
+    prefix = (
+        "# org/repo/README.md\n\n"
+        "Repository: org/repo\n"
+        "Source: https://github.com/org/repo/blob/main/README.md\n"
+        "Commit: abc\n"
+        "Blob: def\n"
+        "\n---\n\n"
+    )
+    body = "first body line\nsecond body line\n" + ("z" * 40)
+
+    chunks = llm_enrichment.deterministic_source_chunks(
+        prefix + body,
+        max_chars=150,
+    )
+
+    assert len(chunks) > 1
+    assert all(chunk.startswith(prefix) for chunk in chunks)
+    assert "".join(chunk[len(prefix) :] for chunk in chunks) == body
+
+
+def test_repo_header_over_chunk_limit_fails_closed() -> None:
+    prefix = (
+        "# org/repo/README.md\n\n"
+        "Repository: org/repo\n"
+        "Source: https://github.com/org/repo/blob/main/README.md\n"
+        "Commit: abc\n"
+        "Blob: def\n"
+        "\n---\n\n"
+    )
+
+    with pytest.raises(ValueError, match="provenance header exceeds"):
+        llm_enrichment.deterministic_source_chunks(prefix + "body", max_chars=10)
+
+
+def test_deterministic_chunks_survive_cognee_paragraph_chunking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    from cognee.tasks.chunks import chunk_by_paragraph
+
+    chunk_by_sentence_module = importlib.import_module(
+        "cognee.tasks.chunks.chunk_by_sentence"
+    )
+
+    monkeypatch.setenv("CITADEL_CHUNK_BUDGET_TOKENS", "256")
+    encoding = llm_enrichment.chunk_window._bpe_encoding()
+    assert encoding is not None
+    monkeypatch.setattr(
+        chunk_by_sentence_module,
+        "get_word_size",
+        lambda text: len(encoding.encode(text)),
+    )
+
+    prefix = (
+        "# org/repo/notes.md\n\n"
+        "Repository: org/repo\n"
+        "Source: https://github.com/org/repo/blob/main/notes.md\n"
+        "Commit: abc\n"
+        "Blob: def\n"
+        "\n---\n\n"
+    )
+    data = prefix + ("semantic retrieval details " * 500)
+    chunks = llm_enrichment.deterministic_source_chunks(data)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        downstream = list(chunk_by_paragraph(chunk, max_chunk_size=256))
+        assert len(downstream) == 1
+        assert downstream[0]["text"] == chunk
+        assert downstream[0]["chunk_size"] <= 256
+
+
+def test_markdown_horizontal_rule_is_not_treated_as_repo_header() -> None:
+    data = "# Plain note\n\n---\n\n" + ("body " * 80)
+
+    chunks = llm_enrichment.deterministic_source_chunks(data, max_chars=40)
+
+    assert len(chunks) > 1
+    assert not any(chunk.startswith("# Plain note\n\n---\n\n# Plain note") for chunk in chunks)
 
 
 def test_disabled_enrichment_is_a_pure_passthrough() -> None:
@@ -206,6 +318,8 @@ class RecordingCitadel:
 
     def __init__(self) -> None:
         self.ingest_calls: list[dict[str, Any]] = []
+        self.cognify_calls: list[list[str]] = []
+        self.cognee = self
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
         self.ingest_calls.append({"data": data, **kwargs})
@@ -213,6 +327,9 @@ class RecordingCitadel:
 
     async def improve(self, **kwargs: Any) -> dict[str, Any]:
         return {"ok": True}
+
+    def schedule_cognify(self, datasets: list[str]) -> None:
+        self.cognify_calls.append(datasets)
 
 
 async def test_learning_process_ingests_enriched_chunks_with_merged_tags(
@@ -236,6 +353,7 @@ async def test_learning_process_ingests_enriched_chunks_with_merged_tags(
     snapshot = await mesh.snapshot(citadel.config)
 
     assert len(citadel.ingest_calls) == 2
+    assert citadel.cognify_calls == [["notes"]]
     assert citadel.ingest_calls[0]["data"] == "Summary: First part\n\nChunk one"
     assert citadel.ingest_calls[0]["tags"] == ["team", "alpha"]
     assert citadel.ingest_calls[1]["tags"] == ["team", "beta"]
@@ -263,6 +381,21 @@ async def test_learning_process_keeps_single_ingest_when_enrichment_disabled() -
     assert citadel.ingest_calls[0]["data"] == "Plain note"
     assert result.enrichment is None
     assert result.chunk_ingests == ()
+
+
+async def test_learning_process_bounds_long_plain_material(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CITADEL_DETERMINISTIC_CHUNK_CHARS", "32")
+    citadel = RecordingCitadel()
+    learning = LearningProcess(citadel)
+
+    result = await learning.learn("line one\nline two\n" + ("z" * 80))
+
+    assert result.accepted_chunks > 1
+    assert len(citadel.ingest_calls) == result.accepted_chunks
+    assert all(len(call["data"]) <= 32 for call in citadel.ingest_calls)
+    assert citadel.cognify_calls == [["notes"]]
 
 
 async def test_learning_process_survives_enrichment_explosions(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -101,10 +101,11 @@ async def test_events_deque_is_bounded_at_160() -> None:
 async def test_error_details_are_clipped_to_280_characters() -> None:
     mesh = MeshState()
 
-    await mesh.record_error(CONFIG, operation="ingest", error="x" * 500)
+    await mesh.record_error(CONFIG, operation="ingest", error="x" * 500, dataset="notes")
     snapshot = await mesh.snapshot(CONFIG)
 
     assert len(snapshot["events"][0]["details"]["error"]) == 280
+    assert snapshot["events"][0]["details"]["dataset"] == "notes"
 
 
 async def test_subscribers_receive_published_events() -> None:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -197,7 +197,9 @@ async def test_rehydrate_seeds_graph_and_timestamp_not_counters() -> None:
     assert len(source_nodes) == 2
     assert {node["label"] for node in repo_nodes} == {"one", "two"}
     graph_index = next(index for index in snapshot["indexes"] if index["id"] == "graph")
-    assert graph_index["records"] > 0
+    assert graph_index["records"] is None
+    assert graph_index["scope"] == "not_measured"
+    assert snapshot["stats"]["nodes"] > 0
 
 
 async def test_rehydrate_baseline_then_live_ingest_does_not_double_count() -> None:
@@ -341,7 +343,7 @@ async def test_snapshot_reports_authoritative_corpus_totals() -> None:
 
 @pytest.mark.asyncio
 async def test_snapshot_falls_back_when_corpus_is_unavailable() -> None:
-    """_corpus_health fails soft and returns None counts; do not report None."""
+    """MeshState keeps local counts when corpus totals are unavailable."""
     config = CitadelConfig()
     mesh = MeshState()
     mesh.documents = 4

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -55,7 +55,15 @@ class FakeLearning:
     async def learn(self, data: str, **kwargs: Any) -> LearningOutcome:
         dataset = kwargs.get("dataset") or CENTRAL
         tags = tuple(kwargs.get("tags") or ())
-        self.calls.append({"data": data, "dataset": kwargs.get("dataset"), "tier": kwargs.get("tier"), "tags": kwargs.get("tags")})
+        self.calls.append(
+            {
+                "data": data,
+                "dataset": kwargs.get("dataset"),
+                "tier": kwargs.get("tier"),
+                "tags": kwargs.get("tags"),
+                "provenance": kwargs.get("provenance"),
+            }
+        )
         if self.central_reject_reason and dataset == CENTRAL:
             result = IngestResult(False, self.central_reject_reason, dataset, tags)
         else:
@@ -157,9 +165,13 @@ async def test_relevant_clean_item_is_promoted_to_central_with_audit(tmp_path: P
     assert result["promoted"] == 1
     # Promotion routed through the org-ready dual-write -> a real Central write.
     assert len(learning.central_writes) == 1
+    assert learning.calls[0]["provenance"] is None
     assert "org-ready" in learning.central_writes[0]["tags"]
     assert "promotion-agent" in learning.central_writes[0]["tags"]
     assert "promotion-seat:alice" in learning.central_writes[0]["tags"]
+    assert learning.central_writes[0]["provenance"]["kind"] == "promotion"
+    assert learning.central_writes[0]["provenance"]["promoted_by"] == "promotion-engine"
+    assert learning.central_writes[0]["provenance"]["source_dataset"] == SEAT
     promote_events = store.recent_audit_events(action="promotion.promote")
     assert len(promote_events) == 1
     assert promote_events[0]["success"] is True
@@ -730,5 +742,6 @@ async def test_approve_pending_surfaces_the_write_reason(
     assert result["promoted"] is False
     assert result["ok"] is False
     assert result["write_reason"] == "duplicate_in_process"
+    assert learning.central_writes[0]["provenance"]["promoted_by"] == "alice"
     # The item is consumed regardless, matching the contract on main.
     assert store.get_promotion_pending(item.id).status != "pending"

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -80,9 +80,16 @@ def test_cognify_mode_runs_cognify_without_verify(monkeypatch: Any) -> None:
     calls: list[dict[str, Any]] = []
 
     class FakeCitadel:
-        async def cognify_dataset(self, *, dataset: Any, verify: bool) -> dict[str, Any]:
-            calls.append({"dataset": dataset, "verify": verify})
-            return {"ok": True, "dataset": dataset, "graph_grew": True, "verify": verify}
+        async def cognify_dataset(
+            self, *, dataset: Any, verify: bool, force: bool
+        ) -> dict[str, Any]:
+            calls.append({"dataset": dataset, "verify": verify, "force": force})
+            return {
+                "ok": True,
+                "dataset": dataset,
+                "graph_grew": True,
+                "verify": verify,
+            }
 
     import kb.service as service
 
@@ -90,7 +97,26 @@ def test_cognify_mode_runs_cognify_without_verify(monkeypatch: Any) -> None:
     monkeypatch.delenv("CITADEL_COGNIFY_DATASET", raising=False)
 
     assert run_railway.run("cognify") == 0
-    assert calls == [{"dataset": None, "verify": False}]
+    assert calls == [{"dataset": None, "verify": False, "force": False}]
+
+
+def test_cognify_mode_passes_force_and_fails_on_top_level_false(monkeypatch: Any) -> None:
+    calls: list[bool] = []
+
+    class FakeCitadel:
+        async def cognify_dataset(
+            self, *, dataset: Any, verify: bool, force: bool
+        ) -> dict[str, Any]:
+            calls.append(force)
+            return {"ok": False, "dataset": dataset, "verify": verify, "force": force}
+
+    import kb.service as service
+
+    monkeypatch.setattr(service.Citadel, "from_env", classmethod(lambda cls: FakeCitadel()))
+    monkeypatch.setenv("CITADEL_COGNIFY_FORCE", "true")
+
+    assert run_railway.run("cognify") == 1
+    assert calls == [True]
 
 
 def test_cognify_stage_refuses_in_process_when_scheduler_enabled(monkeypatch: Any) -> None:
@@ -110,12 +136,15 @@ def test_cognify_stage_refuses_in_process_when_scheduler_enabled(monkeypatch: An
 
 def test_cognify_verify_mode_fails_when_verification_fails(monkeypatch: Any) -> None:
     class FakeCitadel:
-        async def cognify_dataset(self, *, dataset: Any, verify: bool) -> dict[str, Any]:
+        async def cognify_dataset(
+            self, *, dataset: Any, verify: bool, force: bool
+        ) -> dict[str, Any]:
             return {
                 "ok": True,
                 "dataset": dataset,
                 "graph_grew": False,
                 "verify": verify,
+                "force": force,
                 "verification": {"ok": False, "search_hit": False, "graph_grew": False},
             }
 
@@ -375,7 +404,7 @@ def test_cognify_stage_routes_to_api_when_target_url_set(monkeypatch: Any) -> No
         api_calls.append((url, force))
         return 0
 
-    def fail_mode(*, verify: bool) -> int:
+    def fail_mode(*, verify: bool, force: bool) -> int:
         raise AssertionError("cognify must go through the API, not asyncio.run")
 
     monkeypatch.setattr(run_railway, "_cognify_via_api", fake_api)
@@ -390,7 +419,7 @@ def test_cognify_stage_runs_in_process_without_target_url(monkeypatch: Any) -> N
 
     mode_calls: list[bool] = []
 
-    def fake_mode(*, verify: bool) -> int:
+    def fake_mode(*, verify: bool, force: bool) -> int:
         mode_calls.append(verify)
         return 0
 
@@ -434,6 +463,25 @@ def test_cognify_via_api_posts_to_endpoint(monkeypatch: Any) -> None:
 
 def test_cognify_via_api_fails_without_admin_key(monkeypatch: Any) -> None:
     monkeypatch.delenv("CITADEL_ADMIN_KEY", raising=False)
+    assert run_railway._cognify_via_api("http://localhost:8080", force=False) == 1
+
+
+def test_cognify_via_api_fails_when_response_reports_failure(monkeypatch: Any) -> None:
+    import urllib.request
+
+    class _FakeResp:
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *exc: Any) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return b'{"ok": false, "error": "cognify failed"}'
+
+    monkeypatch.setenv("CITADEL_ADMIN_KEY", "admin-key")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: _FakeResp())
+
     assert run_railway._cognify_via_api("http://localhost:8080", force=False) == 1
 
 

--- a/tests/test_search_across_datasets.py
+++ b/tests/test_search_across_datasets.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from kb.server import search_across_datasets
+
+
+def test_exact_secondary_dataset_match_beats_unrelated_primary_result() -> None:
+    class FakeCitadel:
+        async def search(
+            self,
+            query: str,
+            *,
+            dataset: str,
+            session_id: Any,
+            top_k: int,
+        ) -> list[dict[str, str]]:
+            if dataset == "central":
+                return [{"id": "central-1", "text": "unrelated operational note"}]
+            return [{"id": "node-1", "text": "quokka-beacon-8823"}]
+
+    merged = asyncio.run(
+        search_across_datasets(
+            FakeCitadel(),
+            query="quokka-beacon-8823",
+            datasets=["central", "node"],
+            sessions={},
+            top_k=2,
+        )
+    )
+
+    assert [dataset for dataset, _result in merged] == ["node", "central"]
+    assert merged[0][1]["id"] == "node-1"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,7 +19,7 @@ import kb.server as server_module
 
 from kb.access import AccessIdentity, AccessStore, SESSION_TRACES_DATASET
 from kb.config import CitadelConfig
-from kb.conflicts import KnowledgeConflictStore
+from kb.conflicts import ConflictCandidate, ConflictSide, KnowledgeConflictStore
 from kb.knowledge_mesh import KnowledgeMesh
 from kb.mesh import MeshState
 from kb.models import FeedbackResult, IngestResult
@@ -1129,6 +1129,36 @@ def test_knowledge_events_scopes_timeline_to_the_caller(tmp_path: Any) -> None:
     assert {"masumi-network", "personal"} <= unscoped_datasets
 
 
+def test_knowledge_events_hide_other_seat_error_details(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    alice_token = admin.post(
+        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
+    ).json()["token"]
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+
+    async def fail(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("PRIVATE_ERROR_MARKER")
+
+    monkeypatch.setattr(server_module, "_search_within_budget", fail)
+    api = TestClient(app, base_url="https://testserver")
+    alice_headers = {"Authorization": f"Bearer {alice_token}"}
+    bob_headers = {"Authorization": f"Bearer {bob_token}"}
+
+    failed_search = api.post(
+        "/search", json={"query": "private"}, headers=alice_headers
+    )
+    bob_events = api.get("/api/knowledge/events?limit=50", headers=bob_headers)
+
+    assert failed_search.status_code == 500
+    assert bob_events.status_code == 200
+    assert "PRIVATE_ERROR_MARKER" not in json.dumps(bob_events.json())
+
+
 def test_reader_access_can_view_and_search_but_not_mutate() -> None:
     client = authed_client("test-reader")
 
@@ -2172,12 +2202,18 @@ def test_obsidian_vault_is_not_readable_or_writable_by_another_actor(tmp_path: A
         },
         headers=intruder_headers,
     )
+    owner_sources = api.get("/api/sources?type=obsidian_vault", headers=owner_headers)
+    intruder_sources = api.get("/api/sources?type=obsidian_vault", headers=intruder_headers)
 
     assert owner_manifest.status_code == 200
     assert intruder_manifest.status_code == 404
     assert intruder_pull.status_code == 404
     assert intruder_document.status_code == 404
     assert intruder_push.status_code == 404
+    assert owner_sources.status_code == 200
+    assert [source["id"] for source in owner_sources.json()["sources"]] == [vault_id]
+    assert intruder_sources.status_code == 200
+    assert intruder_sources.json()["sources"] == []
     # The owner still has full access, and an admin/bypass token is unaffected.
     assert api.get(f"/api/documents/{document_id}", headers=owner_headers).status_code == 200
     assert admin.get(f"/api/obsidian/manifest?vault_id={vault_id}").status_code == 200
@@ -2794,6 +2830,51 @@ def test_knowledge_conflict_listing_and_resolution_are_role_gated(tmp_path: Any)
     assert "conflicts.resolve" in actions
 
 
+def test_knowledge_conflicts_are_scoped_to_the_calling_seat(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    alice_token = admin.post(
+        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
+    ).json()["token"]
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.conflict_store = KnowledgeConflictStore(tmp_path / "conflicts.json")
+    conflict = app.state.conflict_store.record(
+        ConflictCandidate(
+            kind="seat_conflict",
+            summary="Alice private conflict",
+            side_a=ConflictSide(source="alice", excerpt="ALICE_PRIVATE_MARKER"),
+            side_b=ConflictSide(source="alice-old", excerpt="old private text"),
+            dedupe_key="alice-private",
+            dataset="seat:alice",
+        )
+    )
+    api = TestClient(app, base_url="https://testserver")
+    alice_headers = {"Authorization": f"Bearer {alice_token}"}
+    bob_headers = {"Authorization": f"Bearer {bob_token}"}
+
+    alice_list = api.get("/api/conflicts", headers=alice_headers)
+    bob_list = api.get("/api/conflicts", headers=bob_headers)
+    bob_resolve = api.post(
+        f"/api/conflicts/{conflict['id']}/resolve",
+        json={"resolution_note": "cross-seat attempt"},
+        headers=bob_headers,
+    )
+    alice_resolve = api.post(
+        f"/api/conflicts/{conflict['id']}/resolve",
+        json={"resolution_note": "kept Alice's newer note"},
+        headers=alice_headers,
+    )
+
+    assert alice_list.status_code == 200
+    assert alice_list.json()["conflicts"][0]["side_a"]["excerpt"] == "ALICE_PRIVATE_MARKER"
+    assert bob_list.status_code == 200
+    assert bob_list.json()["conflicts"] == []
+    assert bob_resolve.status_code == 404
+    assert alice_resolve.status_code == 200
+
+
 def test_knowledge_conflicts_require_authentication() -> None:
     client = TestClient(app, base_url="https://testserver")
 
@@ -3034,6 +3115,48 @@ def test_mesh_projection_hides_seat_content_from_plain_readers(tmp_path: Any) ->
     # Owner and admin both retain their own/all content.
     assert secret in json.dumps(alice_view)
     assert secret in json.dumps(admin_view)
+
+
+def test_mesh_projection_hides_private_obsidian_nodes_from_plain_readers(
+    tmp_path: Any,
+) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    alice_token = admin.post(
+        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
+    ).json()["token"]
+    reader_token = admin.post(
+        "/api/access/tokens",
+        json={"name": "plain-reader", "role": "reader", "kind": "service_account"},
+    ).json()["token"]
+    mesh = server_module.get_mesh()
+    asyncio.run(
+        mesh.record_obsidian_sync(
+            server_module.get_citadel().config,
+            vault={"id": "vault-private", "name": "Private Vault"},
+            result={
+                "accepted": [
+                    {"path": "Secrets.md", "rev": 1, "content_hash": "hash"}
+                ],
+                "skipped": [],
+                "conflicts": [],
+            },
+            dataset="seat:alice",
+        )
+    )
+
+    api = TestClient(app, base_url="https://testserver")
+    reader_view = api.get(
+        "/api/mesh", headers={"Authorization": f"Bearer {reader_token}"}
+    ).json()
+    alice_view = api.get(
+        "/api/mesh", headers={"Authorization": f"Bearer {alice_token}"}
+    ).json()
+
+    reader_blob = json.dumps(reader_view)
+    assert "Secrets.md" not in reader_blob
+    assert "Private Vault" not in reader_blob
+    assert "Secrets.md" in json.dumps(alice_view)
 
 
 class IsolationDatasetGateway:
@@ -3711,6 +3834,57 @@ def test_recent_contributions_omits_rejected_writes(tmp_path: Any) -> None:
     assert recent.status_code == 200
     assert recent.json()["contributions"] == []
 
+def test_recent_contributions_hide_other_seat_nodes(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    alice_token = admin.post(
+        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
+    ).json()["token"]
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    api = TestClient(app, base_url="https://testserver")
+    alice_headers = {"Authorization": f"Bearer {alice_token}"}
+    bob_headers = {"Authorization": f"Bearer {bob_token}"}
+    alice = app.state.access_store.authenticate_token(alice_token)
+    bob = app.state.access_store.authenticate_token(bob_token)
+    assert alice is not None
+    assert bob is not None
+    app.state.access_store.record_event(
+        action="contribute",
+        actor=alice.identity,
+        success=True,
+        dataset="seat:alice",
+        detail={"title": "Alice private"},
+    )
+    app.state.access_store.record_event(
+        action="contribute",
+        actor=bob.identity,
+        success=True,
+        dataset="seat:bob",
+        detail={"title": "Bob private"},
+    )
+    alice_recent = api.get("/api/contributions/recent", headers=alice_headers)
+    bob_recent = api.get("/api/contributions/recent", headers=bob_headers)
+
+    assert alice_recent.status_code == 200
+    assert bob_recent.status_code == 200
+    assert all(
+        event["dataset"] == "seat:alice"
+        for event in alice_recent.json()["contributions"]
+    )
+    assert all(
+        event["dataset"] == "seat:bob"
+        for event in bob_recent.json()["contributions"]
+    )
+    assert all(
+        "Bob private" not in str(event)
+        for event in alice_recent.json()["contributions"]
+    )
+    assert all(
+        "Alice private" not in str(event)
+        for event in bob_recent.json()["contributions"]
+    )
 
 def test_contribute_routes_through_learning_process_and_audits(tmp_path: Any) -> None:
     client = authed_client("test-writer")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 import hashlib
 import hmac
 import json
@@ -62,6 +63,9 @@ class FakeCitadel:
 
     async def improve(self, **kwargs: Any) -> dict[str, Any]:
         return {"dataset": kwargs["dataset"], "session_ids": kwargs["session_ids"]}
+
+    async def _graph_counts(self) -> dict[str, int]:
+        return {"nodes": 280, "edges": 514}
 
     async def cognify_dataset(self, *, dataset: Any = None, verify: bool = False, force: bool = False) -> dict[str, Any]:
         return {
@@ -273,7 +277,44 @@ def test_healthz() -> None:
     response = client.get("/healthz")
 
     assert response.status_code == 200
-    assert response.json() == {"ok": True, "service": "citadel"}
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["service"] == "citadel"
+    assert payload["version"] == app.version
+    assert set(payload["build"]) == {"commit_sha", "deployment_id", "branch"}
+
+
+def test_healthz_reports_railway_build_identity_without_secrets(monkeypatch: Any) -> None:
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123")
+    monkeypatch.setenv("RAILWAY_DEPLOYMENT_ID", "deployment-7")
+    monkeypatch.setenv("RAILWAY_GIT_BRANCH", "release/v0.5.0")
+    monkeypatch.setenv("CITADEL_ACCESS_TOKEN", "must-not-appear")
+
+    payload = TestClient(app).get("/healthz").json()
+
+    assert payload["build"] == {
+        "commit_sha": "abc123",
+        "deployment_id": "deployment-7",
+        "branch": "release/v0.5.0",
+    }
+    assert "must-not-appear" not in json.dumps(payload)
+
+
+def test_startup_cognify_recovery_enumerates_and_queues_datasets() -> None:
+    scheduled: list[list[str]] = []
+
+    class RecoveryGateway:
+        async def list_dataset_names(self) -> list[str]:
+            return ["seat:sarthi", "masumi-network", "seat:sarthi", None]  # type: ignore[list-item]
+
+        def schedule_cognify(self, datasets: list[str]) -> None:
+            scheduled.append(datasets)
+
+    client = SimpleNamespace(cognee=RecoveryGateway())
+    names = asyncio.run(server_module.schedule_startup_cognify_recovery(client))
+
+    assert names == ["seat:sarthi", "masumi-network"]
+    assert scheduled == [["seat:sarthi", "masumi-network"]]
 
 
 def test_security_headers_are_applied_to_http_responses() -> None:
@@ -411,7 +452,8 @@ def test_landing_flow_bundle_is_committed_and_served() -> None:
     assert styles.status_code == 200
     # esbuild is configured with globalName CitadelFlow; landing.js calls
     # window.CitadelFlow.mount() once the script has loaded.
-    assert script.text.startswith("var CitadelFlow=")
+    # esbuild may emit a strict-mode directive before the global export.
+    assert "var CitadelFlow=" in script.text[:128]
     assert ".react-flow" in styles.text
 
 
@@ -900,6 +942,12 @@ def test_no_vendor_name_on_user_facing_surfaces() -> None:
 def test_api_uses_configured_citadel_service() -> None:
     client = authed_client()
 
+    class EmptyRepoContentSyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_files": 0}
+
+    app.state.repo_content_syncer = EmptyRepoContentSyncer()
+
     ready = client.get("/readyz")
     ingest = client.post("/ingest", json={"data": "A useful note", "tags": ["research"]})
     search = client.post("/search", json={"query": "useful", "top_k": 3})
@@ -932,7 +980,9 @@ def test_api_uses_configured_citadel_service() -> None:
         "document_drilldown_available": False,
     }
     assert mesh.status_code == 200
-    assert mesh.json()["stats"]["tracked_sources"] == 1
+    # Corpus health sums the configured source status counts: 3 GitHub repos,
+    # 0 repo-content files, and 2 Linear issues.
+    assert mesh.json()["stats"]["tracked_sources"] == 5
     assert indexes.status_code == 200
     assert len(indexes.json()["indexes"]) == 4
     assert sync_status.status_code == 200
@@ -1029,6 +1079,22 @@ def test_admin_can_run_cognify_recovery_and_verification() -> None:
     assert verify.status_code == 200
     assert verify.json()["verify"] is True
     assert verify.json()["verification"]["ok"] is True
+
+
+def test_cognify_run_fails_when_service_reports_failure() -> None:
+    class FailedCognifyCitadel(FakeCitadel):
+        async def cognify_dataset(
+            self, *, dataset: Any = None, verify: bool = False, force: bool = False
+        ) -> dict[str, Any]:
+            return {"ok": False, "error": "graph unavailable", "dataset": dataset}
+
+    client = authed_client()
+    app.state.citadel = FailedCognifyCitadel()
+
+    response = client.post("/api/cognify/run", json={})
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "graph unavailable"
 
 
 def test_cognify_run_requires_admin() -> None:
@@ -2560,6 +2626,239 @@ def test_readyz_ok_when_graph_populated() -> None:
     ready = client.get("/readyz")
     assert ready.status_code == 200
     assert ready.json()["corpus"]["ok"] is True
+
+
+def test_readyz_requires_a_canary_when_scheduler_is_enabled(monkeypatch: Any) -> None:
+    class ScheduledCitadel(FakeCitadel):
+        config = replace(FakeCitadel.config, evolve_scheduler_enabled=True)
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    client = authed_client("test-reader")
+    app.state.citadel = ScheduledCitadel()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+    assert ready.json()["canary"] is None
+
+
+def test_readyz_rejects_a_failed_canary(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        server_module,
+        "_LAST_CANARY",
+        {"ok": False, "search_hit": False, "graph_grew": False, "error": "RuntimeError"},
+    )
+    client = authed_client("test-reader")
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+
+
+def test_readyz_reports_503_when_corpus_read_fails() -> None:
+    class BrokenGraphCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            raise RuntimeError("graph unavailable")
+
+    class HealthySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    client = authed_client("test-reader")
+    app.state.citadel = BrokenGraphCitadel()
+    app.state.github_syncer = HealthySyncer()
+    app.state.repo_content_syncer = HealthySyncer()
+    app.state.linear_syncer = HealthySyncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+    assert ready.json()["corpus"] == {
+        "ok": False,
+        "tracked_sources": None,
+        "indexed_docs": None,
+        "indexed_edges": None,
+        "degraded": "graph unavailable",
+    }
+
+
+def test_readyz_does_not_use_unrelated_graph_nodes_as_corpus_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MeasuredCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 2,
+                "probe_limit": 64,
+                "probe_documents": 2,
+                "probe_complete": True,
+                "probe_chunked_documents": 0,
+                "probe_graph_documents": 2,
+                "probe_fully_indexed_documents": 0,
+                "probe_ok": False,
+            }
+
+    class GraphOnlyCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = MeasuredCorpus()
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    client = authed_client("test-reader")
+    app.state.citadel = GraphOnlyCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    corpus = ready.json()["corpus"]
+    assert corpus["ok"] is False
+    assert corpus["indexed_docs"] == 280
+    assert corpus["indexed_graph_nodes"] == 280
+    assert corpus["relational_documents"] == 2
+    assert corpus["probe_chunked_documents"] == 0
+    assert corpus["probe_graph_documents"] == 2
+    assert corpus["probe_fully_indexed_documents"] == 0
+    assert corpus["probe_ok"] is False
+
+
+def test_readyz_rejects_a_healthy_but_partial_corpus_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class PartialCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 65,
+                "probe_limit": 64,
+                "probe_documents": 64,
+                "probe_complete": False,
+                "probe_chunked_documents": 64,
+                "probe_graph_documents": 64,
+                "probe_fully_indexed_documents": 64,
+                "probe_ok": True,
+            }
+
+    class PartialCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = PartialCorpus()
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    client = authed_client("test-reader")
+    app.state.citadel = PartialCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+    assert ready.json()["corpus"]["probe_complete"] is False
+    assert ready.json()["corpus"]["probe_ok"] is True
+
+
+def test_readyz_rejects_a_capped_corpus_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CappedCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 10001,
+                "probe_limit": 64,
+                "probe_max_documents": 10000,
+                "probe_documents": 0,
+                "probe_pages": 0,
+                "probe_complete": False,
+                "probe_cap_exceeded": True,
+                "probe_chunked_documents": 0,
+                "probe_graph_documents": 0,
+                "probe_fully_indexed_documents": 0,
+                "probe_ok": False,
+            }
+
+    class CappedCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = CappedCorpus()
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    client = authed_client("test-reader")
+    app.state.citadel = CappedCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    corpus = ready.json()["corpus"]
+    assert corpus["ok"] is False
+    assert corpus["probe_cap_exceeded"] is True
+    assert corpus["probe_complete"] is False
+    assert corpus["probe_ok"] is False
+
+
+def test_corpus_health_cache_is_shared_by_readyz_and_mesh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    class MeasuredCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            nonlocal calls
+            calls += 1
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 1,
+                "probe_limit": 64,
+                "probe_documents": 1,
+                "probe_complete": True,
+                "probe_chunked_documents": 1,
+                "probe_graph_documents": 1,
+                "probe_fully_indexed_documents": 1,
+                "probe_ok": True,
+            }
+
+    class MeasuredCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = MeasuredCorpus()
+
+    class BusySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_LAST_CANARY", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    client = authed_client("test-reader")
+    app.state.citadel = MeasuredCitadel()
+    app.state.github_syncer = BusySyncer()
+    app.state.repo_content_syncer = BusySyncer()
+    app.state.linear_syncer = BusySyncer()
+
+    assert client.get("/readyz").status_code == 200
+    assert client.get("/api/mesh").status_code == 200
+    assert calls == 1
 
 
 def test_search_across_datasets_runs_concurrently() -> None:
@@ -6629,9 +6928,8 @@ def test_api_mesh_falls_back_to_uptime_counters_when_corpus_read_fails(
 ) -> None:
     """A degraded corpus read must not blank the dashboard or 500.
 
-    `_corpus_health` is fail-soft and returns None totals on a transient graph
-    error. The endpoint has to survive that, because the alternative is that one
-    slow Kuzu read takes the whole dashboard down.
+    The endpoint still survives a degraded corpus payload, because a transient
+    Kuzu read must not take the dashboard down.
     """
     client = authed_client()
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -49,12 +49,13 @@ def test_discovery_manifest_is_public_and_verifiable() -> None:
     assert response.headers["cache-control"] == "public, max-age=300"
     payload = response.json()
     assert payload["ok"] is True
-    from kb.server import _SERVICE_VERSION
+    from kb.server import _SERVICE_VERSION, _build_identity
 
     assert payload["service"] == {
         "name": "Citadel Archive",
         "kind": "organization_vault",
         "version": _SERVICE_VERSION,
+        "build": _build_identity(),
         "base_url": "https://citadel.example",
     }
     assert payload["public_endpoints"]["discovery"] == (

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -206,7 +206,12 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
         "open",
         _route(
             {
-                "/healthz": {"ok": True, "service": "citadel"},
+                "/healthz": {
+                    "ok": True,
+                    "service": "citadel",
+                    "version": "0.5.0",
+                    "build": {"commit_sha": "abc123456789"},
+                },
                 "/api/session": {
                     "ok": True,
                     "role": "writer",
@@ -216,6 +221,11 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
                     "actor": {"name": "Sarthi"},
                 },
                 "/search": {"results": [{"id": 1}]},
+                "/readyz": {
+                    "ok": True,
+                    "corpus": {"ok": True, "tracked_sources": 200, "indexed_docs": 280},
+                    "canary": None,
+                },
                 "/api/contributions/recent": {"contributions": [{"title": "feat: x", "created_at": "2026-06-27T10:00:00"}]},
             }
         ),
@@ -231,6 +241,13 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
     assert report.identity["seat_slug"] == "sarthi"
     names = {c.name: c.ok for c in report.checks}
     assert names["node"] and names["auth"] and names["search"]
+    node = next(check for check in report.checks if check.name == "node")
+    assert node.data == {
+        "version": "0.5.0",
+        "build": {"commit_sha": "abc123456789"},
+    }
+    assert "v0.5.0" in node.detail
+    assert "abc123456789" in node.detail
     assert report.recent[0]["title"] == "feat: x"
     readiness = report.readiness()
     assert readiness["authenticated"] is True
@@ -332,6 +349,65 @@ def test_check_corpus_ok_when_readyz_healthy(monkeypatch) -> None:
     check = status_mod.check_corpus("https://node.example", "ctdl_tok")
     assert check is not None and check.ok is True
     assert "280 indexed / 200 tracked" in check.detail
+
+
+def test_check_corpus_fails_closed_when_readyz_transport_fails(monkeypatch) -> None:
+    def fail_request(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(status_mod, "_request", fail_request)
+
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+
+    assert check is not None
+    assert check.ok is False
+    assert check.data["code"] == status_mod.CODE_READINESS_UNAVAILABLE
+    assert check.detail == "connection refused"
+
+
+def test_check_corpus_fails_closed_on_malformed_canary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        status_mod,
+        "_request",
+        lambda *args, **kwargs: {
+            "ok": True,
+            "corpus": {"ok": True, "tracked_sources": 200, "indexed_docs": 280},
+            "canary": [],
+        },
+    )
+
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+
+    assert check is not None
+    assert check.ok is False
+    assert check.data["code"] == status_mod.CODE_READINESS_PROTOCOL
+    assert "canary" in check.detail
+
+
+def test_gather_status_fails_closed_when_readyz_is_unavailable(tmp_path: Path, monkeypatch) -> None:
+    def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
+        url = request.full_url
+        if "/healthz" in url:
+            return _FakeResp({"ok": True})
+        if "/api/session" in url:
+            return _FakeResp({"ok": True, "role": "writer", "seat_slug": "s"})
+        if "/readyz" in url:
+            raise OSError("readiness unavailable")
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(status_mod._OPENER, "open", fake_open)
+
+    report = gather_status(
+        "https://node.example",
+        "ctdl_tok",
+        repo=tmp_path,
+        config_path=tmp_path / "c.json",
+        with_recent=False,
+    )
+
+    assert report.healthy is False
+    corpus = next(check for check in report.checks if check.name == "corpus")
+    assert corpus.ok is False
 
 
 def test_gather_status_node_down(tmp_path: Path) -> None:
@@ -477,7 +553,7 @@ def test_status_command_json_and_exit(tmp_path: Path, monkeypatch, capsys) -> No
     monkeypatch.setattr(
         status_mod._OPENER,
         "open",
-        _route({"/healthz": {"ok": True}, "/api/session": {"ok": True, "role": "writer", "seat_slug": "s"}, "/search": {"results": []}, "/api/contributions/recent": {"contributions": []}}),
+        _route({"/healthz": {"ok": True}, "/api/session": {"ok": True, "role": "writer", "seat_slug": "s"}, "/readyz": {"ok": True, "corpus": {"ok": True}, "canary": None}, "/search": {"results": []}, "/api/contributions/recent": {"contributions": []}}),
     )
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_tok")
     args = argparse.Namespace(

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from kb.access import AccessIdentity
+from kb.visibility import (
+    conflict_visible_to,
+    dataset_visible_to,
+    enforce_dataset_allowlist,
+    event_visible_to,
+    owner_visible_to,
+)
+
+
+def seat_identity(slug: str, *, actor_id: str | None = None) -> AccessIdentity:
+    return AccessIdentity(
+        role="writer",
+        actor_id=actor_id or f"principal_{slug}",
+        actor_kind="user",
+        actor_name=slug.title(),
+        source="api_token",
+        scopes=("kb:read", "kb:ingest"),
+        allowed_datasets=(f"seat:{slug}",),
+        seat_slug=slug,
+    )
+
+
+def test_seat_dataset_allowlist_is_shared_by_read_and_write_checks() -> None:
+    alice = seat_identity("alice")
+
+    enforce_dataset_allowlist(alice, "seat:alice")
+
+    assert dataset_visible_to(alice, "seat:alice") is True
+    assert dataset_visible_to(alice, "seat:bob") is False
+    with pytest.raises(HTTPException) as error:
+        enforce_dataset_allowlist(alice, "seat:bob")
+    assert error.value.status_code == 403
+
+
+def test_projection_visibility_fails_closed_for_unscoped_conflicts() -> None:
+    alice = seat_identity("alice")
+    alice_conflict = {"dataset": "seat:alice"}
+    legacy_conflict = {"summary": "missing dataset"}
+
+    assert conflict_visible_to(alice, alice_conflict) is True
+    assert conflict_visible_to(alice, {"dataset": "seat:bob"}) is False
+    assert conflict_visible_to(alice, legacy_conflict) is False
+    assert event_visible_to(
+        alice,
+        {"type": "conflict", "details": {"dataset": "seat:alice"}},
+    ) is True
+    assert event_visible_to(alice, {"type": "conflict", "details": {}}) is False
+    assert event_visible_to(alice, {"type": "error", "details": {}}) is False
+    assert event_visible_to(
+        alice,
+        {"type": "error", "details": {"dataset": "seat:alice"}},
+    ) is True
+    assert event_visible_to(alice, {"action": "contribute", "dataset": "seat:alice"}) is True
+
+
+def test_owner_visibility_accepts_actor_or_seat_identity() -> None:
+    alice = seat_identity("alice", actor_id="actor-a")
+
+    assert owner_visible_to(alice, "actor-a") is True
+    assert owner_visible_to(alice, "other-actor", "alice") is True
+    assert owner_visible_to(alice, "other-actor", "bob") is False

--- a/uv.lock
+++ b/uv.lock
@@ -726,7 +726,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'server'", specifier = ">=3.14.3,<4.0.0" },
-    { name = "cognee", extras = ["fastembed", "postgres-binary"], marker = "extra == 'server'", specifier = ">=1.2.2,<2.0.0" },
+    { name = "cognee", extras = ["fastembed", "postgres-binary"], marker = "extra == 'server'", specifier = ">=1.2.2,<1.3.0" },
     { name = "cryptography", marker = "extra == 'server'", specifier = ">=50.0.0,<51.0.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.116.2,<1.0.0" },
     { name = "google-auth", marker = "extra == 'server'", specifier = ">=2.40.0,<3.0.0" },


### PR DESCRIPTION
## What changed

- Add deterministic lossless chunking with Cognee token-budget backstop.
- Add explicit cognify force handling and failure propagation through CLI, API, and Railway entrypoints.
- Track background cognify work and recover unfinished datasets on startup and shutdown.
- Measure exact relational documents against vector chunks and graph presence for readiness.
- Add capped keyset corpus scans. Readiness fails closed on incomplete or over-cap measurements.
- Fix dataset visibility, provenance, promotion metadata, graph trust labels, and unmeasured index counters.
- Add regression coverage for indexing, readiness, graph, search, promotion, and sync paths.

## Why

The previous readiness path could treat unrelated graph nodes as indexed corpus data. Ingestion also lacked a deterministic source splitter and could report successful cognify when the underlying task failed.

## Validation

- 1569 passed, 1 skipped, 11 warnings
- ruff check .
- npm run typecheck --workspace web
- git diff --check

## Release note

This is a draft PR only. No tag, release, production deploy, or production reindex was performed.