### PR TITLE
fix(indexing): make deferred cognify retries durable and live

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,8 @@ CITADEL_EVOLVE_INTERVAL_SECONDS=21600
 # on the web container, so point it at localhost. Unset = legacy in-process path.
 CITADEL_COGNIFY_TARGET_URL=http://localhost:8080
 CITADEL_COGNIFY_TIMEOUT_SECONDS=1800
+# Durable dataset-level retry state. Put this on the persistent Railway volume.
+CITADEL_COGNIFY_QUEUE_PATH=/data/.citadel/cognify_queue.json
 # Where the pipeline stores last-seen skill content hashes for change detection.
 CITADEL_SKILLS_STATE_PATH=/data/.citadel/skills_catalog.json
 

--- a/docs/adr/0025-durable-cognify-retry-queue.md
+++ b/docs/adr/0025-durable-cognify-retry-queue.md
@@ -24,8 +24,11 @@ Each record contains only dataset names and retry metadata. Queue mutations use
 a sidecar file lock, atomic replacement, and an fsynced file and directory.
 Workers claim leases before cognifying. Successful work is acknowledged;
 failures are returned with bounded exponential backoff; expired leases become
-available again. The web lifespan starts a drain on boot, so work queued by a
-previous process can resume.
+available again. A failed job schedules a wakeup in the live process, so it can
+retry without a new ingest or a process restart. Long-running cognify work
+renews its lease; shutdown cancellation returns active work to the queue. The
+web lifespan starts a drain on boot, so work queued by a previous process can
+resume.
 
 The queue does not replace the in-process graph writer lock. It controls durable
 ownership of deferred work; the existing writer lock still serializes graph
@@ -46,6 +49,9 @@ writes within a process.
 - Queue corruption or an unavailable queue fails closed and logs an explicit
   error. It is not interpreted as an empty queue.
 - The queue stores no document bodies, IDs, or user content.
+- A live worker keeps retry timing and lease ownership durable across failures;
+  the lease heartbeat prevents a long cognify from being reclaimed by another
+  worker while it is still running.
 - A production repair and post-repair census are still required for historical
   zero-chunk documents. This decision does not close that operational part of
   #228.
@@ -53,6 +59,8 @@ writes within a process.
 ## Verification
 
 - [VERIFIED] Queue tests cover atomic writes, cross-process enqueue, leases,
-  backoff, stale-lease recovery, acknowledgement, and malformed state.
-- [VERIFIED] Client tests cover no-loop persistence, failure rescheduling,
-  startup drain, and truthful failure reporting.
+  lease renewal, backoff, stale-lease recovery, acknowledgement, and malformed
+  state.
+- [VERIFIED] Client tests cover no-loop persistence, live failure retry,
+  lease renewal during long cognify, cancellation rescheduling, startup drain,
+  and truthful failure reporting.

--- a/docs/adr/0025-durable-cognify-retry-queue.md
+++ b/docs/adr/0025-durable-cognify-retry-queue.md
@@ -7,11 +7,12 @@
 
 ## Context
 
-`cognee.add()` writes relational and vector state. The graph projection is
-written later by `cognify()`. Before this decision, `schedule_cognify()` created
-an in-process task and logged failures. A process exit, a missing event loop, or
-a failed cognify could therefore leave accepted data without a durable retry
-record.
+`cognee.add()` writes relational source records. It also opens the graph engine
+during generic pipeline completion, but it does not persist chunks, vector
+embeddings, or a graph projection. `cognify()` writes those projections. Before
+this decision, `schedule_cognify()` created an in-process task and logged
+failures. A process exit, a missing event loop, or a failed cognify could
+therefore leave accepted data without a durable retry record.
 
 ## Decision
 
@@ -29,6 +30,21 @@ retry without a new ingest or a process restart. Long-running cognify work
 renews its lease; shutdown cancellation returns active work to the queue. The
 web lifespan starts a drain on boot, so work queued by a previous process can
 resume.
+
+Before claiming queue work, a worker must acquire the non-blocking execution
+lock beside the canonical queue path. Contention leaves the job unclaimed and
+schedules a bounded poll. The worker retains this lock through cognify, child
+task cleanup, and durable acknowledgement or rescheduling. If cancellation
+cleanup stalls, the worker retains the lock and another process cannot start the
+same work. A process exit closes the lock descriptor, so a replacement worker
+can acquire the lock and recover the durable lease after it expires.
+
+Lock order is execution lock, queue state lock, maintenance lock, writer lock,
+queue state lock, then execution unlock. Code holding the queue state lock must
+never wait for the execution lock. A queue lease proves durable retry ownership;
+the execution lock grants permission to run deferred graph work.
+Heartbeat renewal may take the queue state lock while maintenance or writer
+locks are held, but it never requests the execution lock.
 
 The queue does not replace the in-process graph writer lock. It controls durable
 ownership of deferred work; the existing writer lock still serializes graph
@@ -52,6 +68,17 @@ writes within a process.
 - A live worker keeps retry timing and lease ownership durable across failures;
   the lease heartbeat prevents a long cognify from being reclaimed by another
   worker while it is still running.
+- Execution-lock contention does not claim work or increment its attempt. The
+  lock covers deferred queue workers. Direct cognify paths remain subject to
+  ADR-0015's single-process owner and the graph backend's own process lock.
+- Retaining the execution lock during uncooperative cancellation may stop queue
+  progress until the child task ends or the process exits. This is the accepted
+  fail-closed behavior: stalled work is safer than overlapping graph work.
+- The configured state root is a trusted operational boundary. Lock sidecars
+  must not be unlinked or replaced while a worker is running; backup restore or
+  lock cleanup requires all workers to stop first. Deferred graph work must stay
+  attached to the process holding the execution lock. Forked Python children
+  close inherited guard descriptors before running child code.
 - A production repair and post-repair census are still required for historical
   zero-chunk documents. This decision does not close that operational part of
   #228.
@@ -59,8 +86,10 @@ writes within a process.
 ## Verification
 
 - [VERIFIED] Queue tests cover atomic writes, cross-process enqueue, leases,
-  lease renewal, backoff, stale-lease recovery, acknowledgement, and malformed
-  state.
+  lease renewal, backoff, stale-lease recovery, acknowledgement, malformed
+  state, cross-process execution contention, process-exit release, fork
+  descriptor closing, and symlink refusal.
 - [VERIFIED] Client tests cover no-loop persistence, live failure retry,
   lease renewal during long cognify, cancellation rescheduling, startup drain,
-  and truthful failure reporting.
+  truthful failure reporting, bounded lock-contention polling, and prevention of
+  lease-expiry reclaim while cancellation cleanup is stalled.

--- a/docs/adr/0025-durable-cognify-retry-queue.md
+++ b/docs/adr/0025-durable-cognify-retry-queue.md
@@ -1,0 +1,58 @@
+# Dataset-Level Cognify Retry Queue
+
+- Status: Accepted
+- Date: 2026-08-07
+- Relates to: [#228](https://github.com/masumi-network/Citadel/issues/228),
+  [ADR-0015](0015-one-process-owns-the-graph.md)
+
+## Context
+
+`cognee.add()` writes relational and vector state. The graph projection is
+written later by `cognify()`. Before this decision, `schedule_cognify()` created
+an in-process task and logged failures. A process exit, a missing event loop, or
+a failed cognify could therefore leave accepted data without a durable retry
+record.
+
+## Decision
+
+Citadel uses a content-free, dataset-level retry queue stored at
+`CITADEL_COGNIFY_QUEUE_PATH`. The default path is `cognify_queue.json` under the
+configured Citadel state root. The production path belongs on the persistent
+Railway volume.
+
+Each record contains only dataset names and retry metadata. Queue mutations use
+a sidecar file lock, atomic replacement, and an fsynced file and directory.
+Workers claim leases before cognifying. Successful work is acknowledged;
+failures are returned with bounded exponential backoff; expired leases become
+available again. The web lifespan starts a drain on boot, so work queued by a
+previous process can resume.
+
+The queue does not replace the in-process graph writer lock. It controls durable
+ownership of deferred work; the existing writer lock still serializes graph
+writes within a process.
+
+## Options
+
+- In-memory task tracking: rejected because it loses work on process exit.
+- Direct retry in the request: rejected because graph writes would extend write
+  latency and still would not survive a process failure.
+- A database queue: deferred. The current queue needs only small dataset-level
+  records, and the state-volume file matches the existing deployment state
+  pattern without adding schema migration work to #228.
+
+## Consequences
+
+- `schedule_cognify()` reports whether the durable queue accepted the work.
+- Queue corruption or an unavailable queue fails closed and logs an explicit
+  error. It is not interpreted as an empty queue.
+- The queue stores no document bodies, IDs, or user content.
+- A production repair and post-repair census are still required for historical
+  zero-chunk documents. This decision does not close that operational part of
+  #228.
+
+## Verification
+
+- [VERIFIED] Queue tests cover atomic writes, cross-process enqueue, leases,
+  backoff, stale-lease recovery, acknowledgement, and malformed state.
+- [VERIFIED] Client tests cover no-loop persistence, failure rescheduling,
+  startup drain, and truthful failure reporting.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Number 0008 was never used.
 | [0021](0021-retrieval-interface-owns-ranking-and-provenance.md) | Citadel defines the retrieval interface; the engine is one implementation behind it. Not yet implemented. |
 | [0022](0022-evidence-is-retained-and-attested-at-capture.md) | Evidence is retained and fingerprinted at capture, not recomputed at read. Not yet implemented. |
 | [0023](0023-control-plane-outside-the-application.md) | One organization, one instance. The control plane is a separate system. Not yet implemented. |
+| [0025](0025-durable-cognify-retry-queue.md) | Deferred cognify work is persisted as a dataset-level retry queue and resumed on web startup. |
 
 The four newest records come from the design session written up in
 [`../superpowers/specs/2026-08-03-citadel-substrate-design.md`](../superpowers/specs/2026-08-03-citadel-substrate-design.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -179,6 +179,7 @@ CITADEL_WRITER_KEYS=<32+ char random>
 CITADEL_ADMIN_KEY=<32+ char random>
 CITADEL_ACCESS_STORE_PATH=/data/.citadel/access.json
 CITADEL_AUDIT_MAX_EVENTS=1000
+CITADEL_COGNIFY_QUEUE_PATH=/data/.citadel/cognify_queue.json
 ```
 
 Prefer minted tokens (Access page, or `POST /api/access/tokens`) over env keys

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -11,12 +11,14 @@ import os
 import secrets
 from collections.abc import AsyncIterator, Iterator, Mapping
 from datetime import datetime, timezone
+from pathlib import Path
 from time import monotonic, perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 from uuid import NAMESPACE_OID, UUID, uuid5
 
 from kb import chunk_window
+from kb.cognify_queue import CognifyRetryQueue
 from kb.logging_utils import configure_cognee_logging
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Strong refs to detached background cognify tasks so the loop does not GC them
 # mid-flight (and so they can be awaited/observed in tests).
 _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
+DEFAULT_COGNIFY_QUEUE_PATH = Path(".citadel/cognify_queue.json")
 
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -332,7 +335,7 @@ class CogneeGateway(Protocol):
     ) -> Any:
         raise NotImplementedError
 
-    def schedule_cognify(self, datasets: list[str]) -> None:
+    def schedule_cognify(self, datasets: list[str]) -> bool:
         raise NotImplementedError
 
     async def recall(
@@ -441,8 +444,18 @@ class CogneeGateway(Protocol):
 
 
 class CogneePublicClient:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        queue_path: str | Path | None = None,
+        retry_queue: CognifyRetryQueue | None = None,
+    ) -> None:
         self._startup_migrations_done = False
+        configured_queue_path = queue_path or os.getenv("CITADEL_COGNIFY_QUEUE_PATH")
+        self.cognify_queue = retry_queue or CognifyRetryQueue(
+            configured_queue_path or DEFAULT_COGNIFY_QUEUE_PATH
+        )
+        self._cognify_queue_task: asyncio.Task[Any] | None = None
         # Serializes graph writes within this process — Kuzu is a single-writer
         # embedded DB, so two overlapping cognify calls (an inline ingest cognify,
         # the evolve scheduler, /api/cognify/run) must not collide (#47). One client
@@ -704,30 +717,46 @@ class CogneePublicClient:
             # writer lock and starve the request (#46/#52). Add-only here; the caller
             # calls schedule_cognify() once when the batch is done.
             return {"added": added, "cognify": "deferred"}
-        self._schedule_background_cognify(dataset_name)
-        return {"added": added, "background_cognify": True}
+        queued = self._schedule_background_cognify(dataset_name)
+        return {"added": added, "background_cognify": queued}
 
-    def _schedule_background_cognify(self, dataset_name: str) -> None:
+    def _schedule_background_cognify(self, dataset_name: str) -> bool:
         """Schedule a tracked, writer-lock-guarded cognify so ingest stays fast.
 
         Replaces cognee's fire-and-forget run_in_background cognify with one that
         acquires our writer lock (via cognify()) — serializing the Kuzu write and
         surfacing failures instead of swallowing them (#47/#56).
         """
-        self.schedule_cognify([dataset_name])
+        return self.schedule_cognify([dataset_name])
 
-    def schedule_cognify(self, datasets: list[str]) -> None:
+    def schedule_cognify(self, datasets: list[str]) -> bool:
         """Schedule ONE tracked, writer-lock-guarded background cognify.
 
         Lets a bulk writer (the Linear resync) coalesce a single cognify over every
         dataset it touched instead of one-per-write, so the request is not starved by
         a storm of per-issue cognifies (#46/#52). The single cognify still serializes
         on the writer lock (single Kuzu writer, #47) and logs — never crashes — on
-        failure. No-op with no running loop (sync caller) or no datasets.
+        failure. Returns whether the durable queue accepted the work.
         """
         wanted = list(dict.fromkeys(datasets))  # de-dup, preserve order
         if not wanted:
-            return
+            return False
+        try:
+            self.cognify_queue.enqueue(wanted)
+        except Exception:  # noqa: BLE001 - a corrupt queue must be visible and fail closed
+            logger.exception(
+                "cognify NOT queued for datasets %s: durable retry state is unavailable",
+                wanted,
+            )
+            return False
+        self._start_cognify_queue_drain()
+        return True
+
+    def resume_cognify_queue(self) -> None:
+        """Resume due cognify work after a process restart."""
+        self._start_cognify_queue_drain()
+
+    def _start_cognify_queue_drain(self) -> None:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -737,28 +766,73 @@ class CogneePublicClient:
             # vectors, and Kuzu graph state. Skipping it makes a document that
             # exists as a row and cannot be retrieved. Say so.
             logger.error(
-                "cognify NOT scheduled for %s: no running event loop. The data "
-                "is stored but will not be searchable until a cognify runs.",
-                wanted,
+                "cognify retry drain not started: no running event loop; "
+                "durable work will resume on the next server startup"
             )
             return
 
-        async def _run() -> None:
-            try:
-                await self.cognify(datasets=wanted)
-            except Exception:  # noqa: BLE001 - background task: log, never crash the loop
-                logger.exception("background cognify for datasets %s failed", wanted)
-            else:
-                # Log SUCCESS too. Previously only failures were logged, so a
-                # cognify that never ran — because the process exited before this
-                # detached task was scheduled — was indistinguishable in the logs
-                # from one that completed. That is how a whole repository stayed
-                # missing from the index while every surface reported it synced.
-                logger.info("background cognify finished for datasets %s", wanted)
+        existing = self._cognify_queue_task
+        if existing is not None and not existing.done():
+            return
 
-        task = loop.create_task(_run())
+        task = loop.create_task(self._drain_cognify_queue())
+        self._cognify_queue_task = task
         _BACKGROUND_COGNIFY_TASKS.add(task)
-        task.add_done_callback(_BACKGROUND_COGNIFY_TASKS.discard)
+
+        def _finished(done: asyncio.Task[Any]) -> None:
+            _BACKGROUND_COGNIFY_TASKS.discard(done)
+            if self._cognify_queue_task is done:
+                self._cognify_queue_task = None
+
+        task.add_done_callback(_finished)
+
+    async def _drain_cognify_queue(self) -> None:
+        while True:
+            try:
+                lease = self.cognify_queue.claim()
+            except Exception:  # noqa: BLE001 - queue corruption must be visible
+                logger.exception("cognify retry queue claim failed")
+                return
+            if lease is None:
+                return
+            try:
+                await self.cognify(datasets=list(lease.datasets))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - retry after the lease expires
+                try:
+                    self.cognify_queue.reschedule(
+                        lease,
+                        error=f"{exc.__class__.__name__}: {exc}",
+                    )
+                except Exception:  # noqa: BLE001 - preserve the original failure
+                    logger.exception("cognify retry reschedule failed")
+                logger.exception(
+                    "background cognify failed for datasets %s; retry persisted",
+                    lease.datasets,
+                )
+                return
+            try:
+                self.cognify_queue.acknowledge(lease)
+            except Exception:  # noqa: BLE001 - expired lease will be recovered
+                logger.exception(
+                    "cognify retry acknowledgement failed for datasets %s",
+                    lease.datasets,
+                )
+                return
+            logger.info("background cognify finished for datasets %s", lease.datasets)
+
+    async def stop_cognify_queue(self) -> None:
+        """Cancel the local drain; an active lease remains recoverable."""
+        task = self._cognify_queue_task
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        if self._cognify_queue_task is task:
+            self._cognify_queue_task = None
 
     async def recall(
         self,

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -834,7 +834,7 @@ class CogneePublicClient:
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if heartbeat in done:
-                await heartbeat
+                heartbeat.result()
                 raise RuntimeError(
                     f"cognify retry lease heartbeat stopped for {lease.job_id}"
                 )
@@ -940,7 +940,7 @@ class CogneePublicClient:
         if not task.done():
             task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
-            await task
+            _ = await task
         if self._cognify_queue_task is task:
             self._cognify_queue_task = None
 

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -18,7 +18,7 @@ from urllib.parse import unquote, urlparse
 from uuid import NAMESPACE_OID, UUID, uuid5
 
 from kb import chunk_window
-from kb.cognify_queue import CognifyRetryQueue
+from kb.cognify_queue import CognifyLease, CognifyRetryQueue
 from kb.logging_utils import configure_cognee_logging
 
 logger = logging.getLogger(__name__)
@@ -456,6 +456,7 @@ class CogneePublicClient:
             configured_queue_path or DEFAULT_COGNIFY_QUEUE_PATH
         )
         self._cognify_queue_task: asyncio.Task[Any] | None = None
+        self._cognify_queue_retry_handle: asyncio.TimerHandle | None = None
         # Serializes graph writes within this process — Kuzu is a single-writer
         # embedded DB, so two overlapping cognify calls (an inline ingest cognify,
         # the evolve scheduler, /api/cognify/run) must not collide (#47). One client
@@ -749,6 +750,7 @@ class CogneePublicClient:
                 wanted,
             )
             return False
+        self._cancel_cognify_retry()
         self._start_cognify_queue_drain()
         return True
 
@@ -786,6 +788,48 @@ class CogneePublicClient:
 
         task.add_done_callback(_finished)
 
+    def _cancel_cognify_retry(self) -> None:
+        handle = self._cognify_queue_retry_handle
+        if handle is not None:
+            handle.cancel()
+            self._cognify_queue_retry_handle = None
+
+    def _schedule_cognify_retry(self) -> None:
+        try:
+            delay = self.cognify_queue.next_wakeup_delay()
+        except Exception:  # noqa: BLE001 - queue corruption must be visible
+            logger.exception("cognify retry wakeup scheduling failed")
+            return
+        if delay is None:
+            return
+        self._cancel_cognify_retry()
+        loop = asyncio.get_running_loop()
+
+        def _wake() -> None:
+            self._cognify_queue_retry_handle = None
+            self._start_cognify_queue_drain()
+
+        self._cognify_queue_retry_handle = loop.call_later(delay, _wake)
+
+    async def _cognify_with_lease(self, lease: CognifyLease) -> Any:
+        heartbeat = asyncio.create_task(self._renew_cognify_lease(lease))
+        try:
+            return await self.cognify(datasets=list(lease.datasets))
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+
+    async def _renew_cognify_lease(self, lease: CognifyLease) -> None:
+        interval = min(max(self.cognify_queue.lease_seconds / 3, 0.1), 30.0)
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                self.cognify_queue.renew(lease)
+            except Exception:  # noqa: BLE001 - expiry is handled by acknowledgement
+                logger.exception("cognify retry lease renewal failed for %s", lease.job_id)
+                return
+
     async def _drain_cognify_queue(self) -> None:
         while True:
             try:
@@ -794,10 +838,15 @@ class CogneePublicClient:
                 logger.exception("cognify retry queue claim failed")
                 return
             if lease is None:
+                self._schedule_cognify_retry()
                 return
             try:
-                await self.cognify(datasets=list(lease.datasets))
+                await self._cognify_with_lease(lease)
             except asyncio.CancelledError:
+                try:
+                    self.cognify_queue.reschedule(lease, error="cognify worker cancelled")
+                except Exception:  # noqa: BLE001 - preserve cancellation semantics
+                    logger.exception("cognify retry cancellation reschedule failed")
                 raise
             except Exception as exc:  # noqa: BLE001 - retry after the lease expires
                 try:
@@ -811,6 +860,7 @@ class CogneePublicClient:
                     "background cognify failed for datasets %s; retry persisted",
                     lease.datasets,
                 )
+                self._schedule_cognify_retry()
                 return
             try:
                 self.cognify_queue.acknowledge(lease)
@@ -823,7 +873,8 @@ class CogneePublicClient:
             logger.info("background cognify finished for datasets %s", lease.datasets)
 
     async def stop_cognify_queue(self) -> None:
-        """Cancel the local drain; an active lease remains recoverable."""
+        """Cancel the local drain and return active work to the retry queue."""
+        self._cancel_cognify_retry()
         task = self._cognify_queue_task
         if task is None:
             return

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # mid-flight (and so they can be awaited/observed in tests).
 _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
 DEFAULT_COGNIFY_QUEUE_PATH = Path(".citadel/cognify_queue.json")
+COGNIFY_EXECUTION_LOCK_POLL_SECONDS = 1.0
 
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
@@ -691,8 +692,10 @@ class CogneePublicClient:
         data = self._data_with_metadata(data, metadata or None)
 
         # Add is a fast write to Cognee's relational/source stores; it does NOT
-        # create chunks, embeddings, or touch the Kuzu graph. Cognify is the
-        # chunk, vector, and graph write. Metadata rides in the
+        # create chunks, embeddings, or a graph projection. It still opens the
+        # graph engine during generic pipeline completion, so ADR-0015's
+        # single-process rule applies. Cognify is the chunk, vector, and graph
+        # write. Metadata rides in the
         # DataItem (external_metadata) via _data_with_metadata, never as an add()
         # keyword — cognee rejects external_metadata as a kwarg.
         added = await cognee.add(data, dataset_name=dataset_name)
@@ -794,14 +797,25 @@ class CogneePublicClient:
             handle.cancel()
             self._cognify_queue_retry_handle = None
 
-    def _schedule_cognify_retry(self) -> None:
+    def _schedule_cognify_retry(
+        self,
+        *,
+        minimum_delay: float = 0.0,
+        maximum_delay: float | None = None,
+    ) -> None:
         try:
             delay = self.cognify_queue.next_wakeup_delay()
         except Exception:  # noqa: BLE001 - queue corruption must be visible
             logger.exception("cognify retry wakeup scheduling failed")
-            return
+            delay = min(self.cognify_queue.backoff_seconds, 30.0)
         if delay is None:
-            return
+            if minimum_delay <= 0:
+                return
+            delay = minimum_delay
+        else:
+            delay = max(delay, minimum_delay)
+        if maximum_delay is not None:
+            delay = min(delay, maximum_delay)
         self._cancel_cognify_retry()
         loop = asyncio.get_running_loop()
 
@@ -812,13 +826,24 @@ class CogneePublicClient:
         self._cognify_queue_retry_handle = loop.call_later(delay, _wake)
 
     async def _cognify_with_lease(self, lease: CognifyLease) -> Any:
+        cognify = asyncio.create_task(self.cognify(datasets=list(lease.datasets)))
         heartbeat = asyncio.create_task(self._renew_cognify_lease(lease))
         try:
-            return await self.cognify(datasets=list(lease.datasets))
-        finally:
-            heartbeat.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            done, _ = await asyncio.wait(
+                {cognify, heartbeat},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if heartbeat in done:
                 await heartbeat
+                raise RuntimeError(
+                    f"cognify retry lease heartbeat stopped for {lease.job_id}"
+                )
+            return await cognify
+        finally:
+            for task in (cognify, heartbeat):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(cognify, heartbeat, return_exceptions=True)
 
     async def _renew_cognify_lease(self, lease: CognifyLease) -> None:
         interval = min(max(self.cognify_queue.lease_seconds / 3, 0.1), 30.0)
@@ -826,11 +851,36 @@ class CogneePublicClient:
             await asyncio.sleep(interval)
             try:
                 self.cognify_queue.renew(lease)
-            except Exception:  # noqa: BLE001 - expiry is handled by acknowledgement
+            except Exception:  # noqa: BLE001 - lease loss must stop active graph work
                 logger.exception("cognify retry lease renewal failed for %s", lease.job_id)
-                return
+                raise
 
     async def _drain_cognify_queue(self) -> None:
+        try:
+            execution_guard = self.cognify_queue.try_acquire_execution()
+        except Exception:  # noqa: BLE001 - execution ownership must fail closed
+            logger.exception("cognify retry execution lock unavailable")
+            self._schedule_cognify_retry(
+                minimum_delay=COGNIFY_EXECUTION_LOCK_POLL_SECONDS,
+                maximum_delay=30.0,
+            )
+            return
+        if execution_guard is None:
+            logger.info("cognify retry execution lock busy; work remains unclaimed")
+            self._schedule_cognify_retry(
+                minimum_delay=COGNIFY_EXECUTION_LOCK_POLL_SECONDS,
+                maximum_delay=COGNIFY_EXECUTION_LOCK_POLL_SECONDS,
+            )
+            return
+        try:
+            await self._drain_cognify_queue_locked()
+        finally:
+            try:
+                execution_guard.release()
+            except Exception:  # noqa: BLE001 - descriptor close still releases on exit
+                logger.exception("cognify retry execution lock release failed")
+
+    async def _drain_cognify_queue_locked(self) -> None:
         while True:
             try:
                 lease = self.cognify_queue.claim()
@@ -847,7 +897,15 @@ class CogneePublicClient:
                     self.cognify_queue.reschedule(lease, error="cognify worker cancelled")
                 except Exception:  # noqa: BLE001 - preserve cancellation semantics
                     logger.exception("cognify retry cancellation reschedule failed")
-                raise
+                task = asyncio.current_task()
+                if task is not None and task.cancelling():
+                    raise
+                logger.error(
+                    "background cognify cancelled for datasets %s; retry persisted",
+                    lease.datasets,
+                )
+                self._schedule_cognify_retry()
+                return
             except Exception as exc:  # noqa: BLE001 - retry after the lease expires
                 try:
                     self.cognify_queue.reschedule(
@@ -869,6 +927,7 @@ class CogneePublicClient:
                     "cognify retry acknowledgement failed for datasets %s",
                     lease.datasets,
                 )
+                self._schedule_cognify_retry()
                 return
             logger.info("background cognify finished for datasets %s", lease.datasets)
 

--- a/kb/cognify_queue.py
+++ b/kb/cognify_queue.py
@@ -50,6 +50,7 @@ def _after_fork_child() -> None:
             try:
                 handle.close()
             except OSError:
+                # Child cleanup is best-effort; continue closing other handles.
                 pass
         _EXECUTION_HANDLES.clear()
     finally:
@@ -269,14 +270,15 @@ class CognifyRetryQueue:
                 raise
             try:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                guard = CognifyExecutionGuard(handle)
+                _EXECUTION_HANDLES[handle.fileno()] = handle
             except BlockingIOError:
                 handle.close()
                 return None
             except BaseException:
                 handle.close()
                 raise
-            _EXECUTION_HANDLES[handle.fileno()] = handle
-        return CognifyExecutionGuard(handle)
+        return guard
 
     @staticmethod
     def _positive_duration(value: float, field_name: str) -> float:
@@ -301,7 +303,7 @@ class CognifyRetryQueue:
         current_text = _timestamp(current)
         with self._exclusive():
             state = self._load()
-            changed = self._recover_stale_in_state(state, current)
+            self._recover_stale_in_state(state, current)
             jobs = state["jobs"]
             unleased = [record for record in jobs.values() if record["lease_id"] is None]
             leased_overlaps = [
@@ -331,7 +333,6 @@ class CognifyRetryQueue:
                 for job_id in remove_ids:
                     jobs.pop(job_id, None)
                 target["updated_at"] = current_text
-                changed = True
                 result = self._job_from_record(target)
             elif unleased:
                 target = min(unleased, key=self._record_order)
@@ -350,7 +351,6 @@ class CognifyRetryQueue:
                         "updated_at": current_text,
                     }
                 )
-                changed = True
                 result = self._job_from_record(target)
             else:
                 job_id = f"cognify_{uuid4().hex}"
@@ -367,11 +367,9 @@ class CognifyRetryQueue:
                     "last_error": None,
                 }
                 jobs[job_id] = record
-                changed = True
                 result = self._job_from_record(record)
 
-            if changed:
-                self._save(state)
+            self._save(state)
             return result
 
     def claim(self, *, now: datetime | None = None, lease_seconds: float | None = None) -> CognifyLease | None:

--- a/kb/cognify_queue.py
+++ b/kb/cognify_queue.py
@@ -346,6 +346,34 @@ class CognifyRetryQueue:
                 self._save(state)
             return leases
 
+    def renew(
+        self,
+        lease: CognifyLease,
+        *,
+        now: datetime | None = None,
+        lease_seconds: float | None = None,
+    ) -> CognifyLease:
+        """Extend one active lease without changing its dataset snapshot."""
+        duration = (
+            self.lease_seconds
+            if lease_seconds is None
+            else self._positive_duration(lease_seconds, "lease_seconds")
+        )
+        current = self._resolve_now(now)
+        renewed_until = _timestamp(current + timedelta(seconds=duration))
+        with self._exclusive():
+            state = self._load()
+            record = self._leased_record(state, lease, current)
+            record.update({"leased_until": renewed_until, "updated_at": _timestamp(current)})
+            self._save(state)
+            return CognifyLease(
+                job_id=record["job_id"],
+                lease_id=record["lease_id"],
+                datasets=tuple(record["lease_datasets"]),
+                attempt=record["attempt"],
+                leased_until=renewed_until,
+            )
+
     def acknowledge(self, lease: CognifyLease, *, now: datetime | None = None) -> None:
         """Acknowledge one lease without losing datasets enqueued mid-lease."""
         current = self._resolve_now(now)
@@ -411,6 +439,18 @@ class CognifyRetryQueue:
             if count:
                 self._save(state)
             return count
+
+    def next_wakeup_delay(self, *, now: datetime | None = None) -> float | None:
+        """Return seconds until the next queued job can be claimed."""
+        current = self._resolve_now(now)
+        with self._exclusive():
+            state = self._load()
+            delays: list[float] = []
+            for record in state["jobs"].values():
+                field_name = "available_at" if record["lease_id"] is None else "leased_until"
+                timestamp = _parse_timestamp(record[field_name], field_name=field_name)
+                delays.append(max(0.0, (timestamp - current).total_seconds()))
+            return min(delays) if delays else None
 
     def snapshot(self) -> tuple[CognifyJob, ...]:
         """Return all records without changing their lease state."""

--- a/kb/cognify_queue.py
+++ b/kb/cognify_queue.py
@@ -1,0 +1,631 @@
+"""Durable, content-free queue for deferred Cognee cognify work.
+
+The queue stores dataset names and execution metadata only. It deliberately has
+no Cognee or service dependency so a later integration can choose how to run a
+claimed dataset set without making the queue responsible for that work.
+
+State mutations use a sidecar ``flock`` across the complete read-modify-write
+and an atomic, fsynced replacement. Existing state is validated strictly;
+corruption raises instead of being interpreted as an empty queue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import fcntl
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+import threading
+from typing import Any
+from uuid import uuid4
+
+
+STATE_VERSION = 1
+DEFAULT_LEASE_SECONDS = 300.0
+DEFAULT_BACKOFF_SECONDS = 5.0
+DEFAULT_MAX_BACKOFF_SECONDS = 3600.0
+MAX_ERROR_LENGTH = 512
+
+_RECORD_FIELDS = frozenset(
+    {
+        "job_id",
+        "datasets",
+        "created_at",
+        "updated_at",
+        "available_at",
+        "attempt",
+        "lease_id",
+        "leased_until",
+        "lease_datasets",
+        "last_error",
+    }
+)
+
+
+class CognifyQueueError(RuntimeError):
+    """Base error for queue and lease failures."""
+
+
+class CognifyQueueStateError(CognifyQueueError):
+    """The queue file exists but is not a valid queue state."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(
+            f"Cognify queue state {path} is invalid ({reason}); "
+            "refusing to treat it as an empty queue."
+        )
+        self.path = path
+        self.reason = reason
+
+
+class CognifyLeaseError(CognifyQueueError):
+    """A lease is unknown, stale, or does not match its queue record."""
+
+
+@dataclass(frozen=True, slots=True)
+class CognifyJob:
+    """A content-free queued dataset set and its retry metadata."""
+
+    job_id: str
+    datasets: tuple[str, ...]
+    created_at: str
+    updated_at: str
+    available_at: str
+    attempt: int
+    lease_id: str | None
+    leased_until: str | None
+    last_error: str | None
+
+    @property
+    def id(self) -> str:
+        """Short alias for callers that name queue records by ``id``."""
+        return self.job_id
+
+    @property
+    def leased(self) -> bool:
+        return self.lease_id is not None
+
+
+@dataclass(frozen=True, slots=True)
+class CognifyLease:
+    """A claim token and immutable dataset snapshot for one worker attempt."""
+
+    job_id: str
+    lease_id: str
+    datasets: tuple[str, ...]
+    attempt: int
+    leased_until: str
+
+
+Clock = Callable[[], datetime]
+
+
+def _default_clock() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_utc(value: datetime, *, field_name: str = "timestamp") -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be a timezone-aware datetime")
+    return value.astimezone(UTC)
+
+
+def _timestamp(value: datetime) -> str:
+    return _as_utc(value).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any, *, field_name: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} must be a non-empty ISO-8601 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field_name} is not a valid ISO-8601 timestamp") from exc
+    return _as_utc(parsed, field_name=field_name)
+
+
+def _normalize_datasets(value: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)):
+        raise ValueError("datasets must be an iterable of names, not one string")
+    try:
+        values = list(value)
+    except TypeError as exc:
+        raise ValueError("datasets must be an iterable of names") from exc
+    normalized: set[str] = set()
+    for item in values:
+        if not isinstance(item, str):
+            raise ValueError("dataset names must be strings")
+        name = item.strip()
+        if not name:
+            raise ValueError("dataset names must be non-empty")
+        if any(ord(character) < 0x20 for character in name):
+            raise ValueError("dataset names must not contain control characters")
+        normalized.add(name)
+    if not normalized:
+        raise ValueError("at least one dataset name is required")
+    return tuple(sorted(normalized))
+
+
+def _bounded_error(error: str) -> str:
+    if not isinstance(error, str):
+        raise ValueError("error must be a string")
+    normalized = " ".join(error.split())
+    if not normalized:
+        normalized = "unspecified cognify failure"
+    return normalized[:MAX_ERROR_LENGTH]
+
+
+def _empty_state() -> dict[str, Any]:
+    return {"version": STATE_VERSION, "jobs": {}}
+
+
+class CognifyRetryQueue:
+    """Cross-process durable queue for dataset-level cognify retries."""
+
+    def __init__(
+        self,
+        path: Path | str,
+        *,
+        lease_seconds: float = DEFAULT_LEASE_SECONDS,
+        backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
+        max_backoff_seconds: float = DEFAULT_MAX_BACKOFF_SECONDS,
+        clock: Clock | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.lease_seconds = self._positive_duration(lease_seconds, "lease_seconds")
+        self.backoff_seconds = self._positive_duration(backoff_seconds, "backoff_seconds")
+        self.max_backoff_seconds = self._positive_duration(
+            max_backoff_seconds, "max_backoff_seconds"
+        )
+        if self.max_backoff_seconds < self.backoff_seconds:
+            raise ValueError("max_backoff_seconds must be >= backoff_seconds")
+        self._clock = clock or _default_clock
+        self._thread_lock = threading.RLock()
+        self._lock_depth = 0
+        self._lock_file: Any | None = None
+
+    @staticmethod
+    def _positive_duration(value: float, field_name: str) -> float:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value <= 0
+        ):
+            raise ValueError(f"{field_name} must be a positive number")
+        return float(value)
+
+    def enqueue(self, datasets: Iterable[str], *, now: datetime | None = None) -> CognifyJob:
+        """Add dataset names, merging them into existing unleased work.
+
+        A dataset set currently leased by a worker is extended only when the
+        new enqueue overlaps that leased set. The lease keeps its original
+        snapshot, and acknowledgement leaves any newly added names pending.
+        """
+        names = _normalize_datasets(datasets)
+        current = self._resolve_now(now)
+        current_text = _timestamp(current)
+        with self._exclusive():
+            state = self._load()
+            changed = self._recover_stale_in_state(state, current)
+            jobs = state["jobs"]
+            unleased = [record for record in jobs.values() if record["lease_id"] is None]
+            leased_overlaps = [
+                record
+                for record in jobs.values()
+                if record["lease_id"] is not None
+                and set(record["datasets"]).intersection(names)
+            ]
+
+            if leased_overlaps:
+                target = min(leased_overlaps, key=self._record_order)
+                merged = set(target["datasets"]) | set(names)
+                remove_ids: set[str] = set()
+                # Absorb unleased records that became part of this same dataset
+                # set, preventing duplicates around an active lease.
+                absorbed = True
+                while absorbed:
+                    absorbed = False
+                    for record in unleased:
+                        if record["job_id"] in remove_ids:
+                            continue
+                        if set(record["datasets"]).intersection(merged):
+                            merged.update(record["datasets"])
+                            remove_ids.add(record["job_id"])
+                            absorbed = True
+                target["datasets"] = sorted(merged)
+                for job_id in remove_ids:
+                    jobs.pop(job_id, None)
+                target["updated_at"] = current_text
+                changed = True
+                result = self._job_from_record(target)
+            elif unleased:
+                target = min(unleased, key=self._record_order)
+                merged = set(names)
+                for record in unleased:
+                    merged.update(record["datasets"])
+                for record in unleased:
+                    if record is not target:
+                        jobs.pop(record["job_id"], None)
+                target.update(
+                    {
+                        "datasets": sorted(merged),
+                        "available_at": current_text,
+                        "attempt": max(record["attempt"] for record in unleased),
+                        "last_error": None,
+                        "updated_at": current_text,
+                    }
+                )
+                changed = True
+                result = self._job_from_record(target)
+            else:
+                job_id = f"cognify_{uuid4().hex}"
+                record = {
+                    "job_id": job_id,
+                    "datasets": list(names),
+                    "created_at": current_text,
+                    "updated_at": current_text,
+                    "available_at": current_text,
+                    "attempt": 0,
+                    "lease_id": None,
+                    "leased_until": None,
+                    "lease_datasets": None,
+                    "last_error": None,
+                }
+                jobs[job_id] = record
+                changed = True
+                result = self._job_from_record(record)
+
+            if changed:
+                self._save(state)
+            return result
+
+    def claim(self, *, now: datetime | None = None, lease_seconds: float | None = None) -> CognifyLease | None:
+        """Claim the oldest due record, or return ``None`` when none is due."""
+        leases = self.claim_due(now=now, limit=1, lease_seconds=lease_seconds)
+        return leases[0] if leases else None
+
+    def claim_due(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 1,
+        lease_seconds: float | None = None,
+    ) -> list[CognifyLease]:
+        """Claim up to ``limit`` due records with unique lease tokens."""
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+            raise ValueError("limit must be a positive integer")
+        duration = (
+            self.lease_seconds
+            if lease_seconds is None
+            else self._positive_duration(lease_seconds, "lease_seconds")
+        )
+        current = self._resolve_now(now)
+        current_text = _timestamp(current)
+        leased_until = _timestamp(current + timedelta(seconds=duration))
+        with self._exclusive():
+            state = self._load()
+            changed = self._recover_stale_in_state(state, current)
+            due = [
+                record
+                for record in state["jobs"].values()
+                if record["lease_id"] is None
+                and _parse_timestamp(record["available_at"], field_name="available_at") <= current
+            ]
+            due.sort(key=self._record_order)
+            leases: list[CognifyLease] = []
+            for record in due[:limit]:
+                lease_id = f"lease_{uuid4().hex}"
+                dataset_snapshot = tuple(record["datasets"])
+                record.update(
+                    {
+                        "attempt": record["attempt"] + 1,
+                        "lease_id": lease_id,
+                        "leased_until": leased_until,
+                        "lease_datasets": list(dataset_snapshot),
+                        "updated_at": current_text,
+                    }
+                )
+                leases.append(
+                    CognifyLease(
+                        job_id=record["job_id"],
+                        lease_id=lease_id,
+                        datasets=dataset_snapshot,
+                        attempt=record["attempt"],
+                        leased_until=leased_until,
+                    )
+                )
+                changed = True
+            if changed:
+                self._save(state)
+            return leases
+
+    def acknowledge(self, lease: CognifyLease, *, now: datetime | None = None) -> None:
+        """Acknowledge one lease without losing datasets enqueued mid-lease."""
+        current = self._resolve_now(now)
+        with self._exclusive():
+            state = self._load()
+            record = self._leased_record(state, lease, current)
+            claimed = set(record["lease_datasets"])
+            remaining = [dataset for dataset in record["datasets"] if dataset not in claimed]
+            if remaining:
+                record.update(
+                    {
+                        "datasets": remaining,
+                        "available_at": _timestamp(current),
+                        "attempt": 0,
+                        "lease_id": None,
+                        "leased_until": None,
+                        "lease_datasets": None,
+                        "last_error": None,
+                        "updated_at": _timestamp(current),
+                    }
+                )
+            else:
+                state["jobs"].pop(record["job_id"])
+            self._save(state)
+
+    def ack(self, lease: CognifyLease, *, now: datetime | None = None) -> None:
+        """Alias for :meth:`acknowledge`."""
+        self.acknowledge(lease, now=now)
+
+    def reschedule(
+        self,
+        lease: CognifyLease,
+        *,
+        error: str,
+        now: datetime | None = None,
+    ) -> CognifyJob:
+        """Return a failed lease to the queue with bounded exponential backoff."""
+        failure = _bounded_error(error)
+        current = self._resolve_now(now)
+        with self._exclusive():
+            state = self._load()
+            record = self._leased_record(state, lease, current)
+            delay = self._backoff(record["attempt"])
+            record.update(
+                {
+                    "available_at": _timestamp(current + timedelta(seconds=delay)),
+                    "lease_id": None,
+                    "leased_until": None,
+                    "lease_datasets": None,
+                    "last_error": failure,
+                    "updated_at": _timestamp(current),
+                }
+            )
+            self._save(state)
+            return self._job_from_record(record)
+
+    def recover_stale_leases(self, *, now: datetime | None = None) -> int:
+        """Make expired leases due again and return the number recovered."""
+        current = self._resolve_now(now)
+        with self._exclusive():
+            state = self._load()
+            count = self._recover_stale_in_state(state, current)
+            if count:
+                self._save(state)
+            return count
+
+    def snapshot(self) -> tuple[CognifyJob, ...]:
+        """Return all records without changing their lease state."""
+        state = self._load()
+        records = sorted(state["jobs"].values(), key=self._record_order)
+        return tuple(self._job_from_record(record) for record in records)
+
+    def list_jobs(self) -> tuple[CognifyJob, ...]:
+        """Alias for :meth:`snapshot`."""
+        return self.snapshot()
+
+    def _resolve_now(self, value: datetime | None) -> datetime:
+        return _as_utc(self._clock() if value is None else value, field_name="now")
+
+    @staticmethod
+    def _record_order(record: dict[str, Any]) -> tuple[str, str]:
+        return str(record["available_at"]), str(record["job_id"])
+
+    def _backoff(self, attempt: int) -> float:
+        delay = self.backoff_seconds
+        remaining_doublings = max(0, attempt - 1)
+        while remaining_doublings and delay < self.max_backoff_seconds:
+            delay = min(self.max_backoff_seconds, delay * 2)
+            remaining_doublings -= 1
+        return delay
+
+    @staticmethod
+    def _recover_stale_in_state(state: dict[str, Any], now: datetime) -> int:
+        now_text = _timestamp(now)
+        recovered = 0
+        for record in state["jobs"].values():
+            leased_until = record["leased_until"]
+            if (
+                record["lease_id"] is not None
+                and leased_until is not None
+                and _parse_timestamp(leased_until, field_name="leased_until") <= now
+            ):
+                record.update(
+                    {
+                        "available_at": now_text,
+                        "lease_id": None,
+                        "leased_until": None,
+                        "lease_datasets": None,
+                        "updated_at": now_text,
+                    }
+                )
+                recovered += 1
+        return recovered
+
+    def _leased_record(
+        self,
+        state: dict[str, Any],
+        lease: CognifyLease,
+        now: datetime,
+    ) -> dict[str, Any]:
+        if not isinstance(lease, CognifyLease):
+            raise TypeError("lease must be a CognifyLease")
+        record = state["jobs"].get(lease.job_id)
+        if record is None or record["lease_id"] != lease.lease_id:
+            raise CognifyLeaseError(f"lease {lease.lease_id} is no longer active")
+        leased_until = record["leased_until"]
+        if leased_until is None or _parse_timestamp(leased_until, field_name="leased_until") <= now:
+            raise CognifyLeaseError(f"lease {lease.lease_id} has expired")
+        if tuple(record["lease_datasets"]) != lease.datasets:
+            raise CognifyLeaseError(f"lease {lease.lease_id} dataset snapshot does not match")
+        return record
+
+    @staticmethod
+    def _job_from_record(record: dict[str, Any]) -> CognifyJob:
+        return CognifyJob(
+            job_id=record["job_id"],
+            datasets=tuple(record["datasets"]),
+            created_at=record["created_at"],
+            updated_at=record["updated_at"],
+            available_at=record["available_at"],
+            attempt=record["attempt"],
+            lease_id=record["lease_id"],
+            leased_until=record["leased_until"],
+            last_error=record["last_error"],
+        )
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return _empty_state()
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CognifyQueueStateError(self.path, exc.__class__.__name__) from exc
+        try:
+            self._validate_state(data)
+        except ValueError as exc:
+            raise CognifyQueueStateError(self.path, str(exc)) from exc
+        return data
+
+    @classmethod
+    def _validate_state(cls, data: Any) -> None:
+        if not isinstance(data, dict):
+            raise ValueError("expected a JSON object")
+        if set(data) != {"version", "jobs"}:
+            raise ValueError("expected exactly version and jobs fields")
+        if data["version"] != STATE_VERSION:
+            raise ValueError(f"unsupported version {data['version']!r}")
+        jobs = data["jobs"]
+        if not isinstance(jobs, dict):
+            raise ValueError("jobs must be an object")
+        for job_id, record in jobs.items():
+            if not isinstance(job_id, str) or not job_id:
+                raise ValueError("job keys must be non-empty strings")
+            if not isinstance(record, dict):
+                raise ValueError(f"job {job_id!r} must be an object")
+            if set(record) != _RECORD_FIELDS:
+                raise ValueError(f"job {job_id!r} has an invalid field set")
+            if record["job_id"] != job_id:
+                raise ValueError(f"job {job_id!r} has a mismatched job_id")
+            datasets = record["datasets"]
+            if not isinstance(datasets, list):
+                raise ValueError(f"job {job_id!r} datasets must be a list")
+            if tuple(datasets) != _normalize_datasets(datasets):
+                raise ValueError(f"job {job_id!r} datasets are not canonical")
+            if not isinstance(record["attempt"], int) or isinstance(record["attempt"], bool):
+                raise ValueError(f"job {job_id!r} attempt must be an integer")
+            if record["attempt"] < 0:
+                raise ValueError(f"job {job_id!r} attempt cannot be negative")
+            for field_name in ("created_at", "updated_at", "available_at"):
+                _parse_timestamp(record[field_name], field_name=field_name)
+            lease_id = record["lease_id"]
+            leased_until = record["leased_until"]
+            lease_datasets = record["lease_datasets"]
+            if lease_id is not None and (not isinstance(lease_id, str) or not lease_id):
+                raise ValueError(f"job {job_id!r} lease_id must be null or a string")
+            if lease_id is None:
+                if leased_until is not None or lease_datasets is not None:
+                    raise ValueError(f"job {job_id!r} has lease metadata without a lease")
+            else:
+                _parse_timestamp(leased_until, field_name="leased_until")
+                if not isinstance(lease_datasets, list):
+                    raise ValueError(f"job {job_id!r} lease datasets must be a list")
+                if tuple(lease_datasets) != _normalize_datasets(lease_datasets):
+                    raise ValueError(f"job {job_id!r} lease datasets are not canonical")
+                if not set(lease_datasets).issubset(set(datasets)):
+                    raise ValueError(f"job {job_id!r} lease datasets exceed job datasets")
+            error = record["last_error"]
+            if error is not None and (
+                not isinstance(error, str) or len(error) > MAX_ERROR_LENGTH
+            ):
+                raise ValueError(f"job {job_id!r} last_error is invalid")
+
+    def _save(self, data: dict[str, Any]) -> None:
+        self._validate_state(data)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle_fd, temp_name = tempfile.mkstemp(
+            dir=self.path.parent,
+            prefix=f"{self.path.name}.",
+            suffix=".tmp",
+        )
+        temp_path = Path(temp_name)
+        descriptor_open = True
+        try:
+            with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+                descriptor_open = False
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.path)
+            directory_fd = os.open(
+                self.path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except BaseException:
+            if descriptor_open:
+                os.close(handle_fd)
+            temp_path.unlink(missing_ok=True)
+            raise
+
+    @contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Lock a sidecar across every read-modify-write operation."""
+        with self._thread_lock:
+            if self._lock_depth:
+                self._lock_depth += 1
+                try:
+                    yield
+                finally:
+                    self._lock_depth -= 1
+                return
+            lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            handle = self._lock_handle(lock_path)
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            self._lock_depth = 1
+            try:
+                yield
+            finally:
+                self._lock_depth = 0
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _lock_handle(self, lock_path: Path) -> Any:
+        existing = self._lock_file
+        if existing is not None and not existing.closed:
+            return existing
+        self._lock_file = lock_path.open("a+")
+        return self._lock_file
+
+
+__all__ = [
+    "CognifyJob",
+    "CognifyLease",
+    "CognifyLeaseError",
+    "CognifyQueueError",
+    "CognifyQueueStateError",
+    "CognifyRetryQueue",
+]

--- a/kb/cognify_queue.py
+++ b/kb/cognify_queue.py
@@ -32,6 +32,37 @@ DEFAULT_BACKOFF_SECONDS = 5.0
 DEFAULT_MAX_BACKOFF_SECONDS = 3600.0
 MAX_ERROR_LENGTH = 512
 
+_EXECUTION_HANDLES_LOCK = threading.Lock()
+_EXECUTION_HANDLES: dict[int, Any] = {}
+
+
+def _before_fork() -> None:
+    _EXECUTION_HANDLES_LOCK.acquire()
+
+
+def _after_fork_parent() -> None:
+    _EXECUTION_HANDLES_LOCK.release()
+
+
+def _after_fork_child() -> None:
+    try:
+        for handle in _EXECUTION_HANDLES.values():
+            try:
+                handle.close()
+            except OSError:
+                pass
+        _EXECUTION_HANDLES.clear()
+    finally:
+        _EXECUTION_HANDLES_LOCK.release()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        before=_before_fork,
+        after_in_parent=_after_fork_parent,
+        after_in_child=_after_fork_child,
+    )
+
 _RECORD_FIELDS = frozenset(
     {
         "job_id",
@@ -66,6 +97,34 @@ class CognifyQueueStateError(CognifyQueueError):
 
 class CognifyLeaseError(CognifyQueueError):
     """A lease is unknown, stale, or does not match its queue record."""
+
+
+@dataclass(slots=True)
+class CognifyExecutionGuard:
+    """Owned cross-process execution lock for one queue drain."""
+
+    _handle: Any
+    _released: bool = False
+
+    def release(self) -> None:
+        """Release the execution lock and close its owned descriptor once."""
+        if self._released:
+            return
+        self._released = True
+        with _EXECUTION_HANDLES_LOCK:
+            if self._handle.closed:
+                return
+            _EXECUTION_HANDLES.pop(self._handle.fileno(), None)
+            try:
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                self._handle.close()
+
+    def __enter__(self) -> CognifyExecutionGuard:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.release()
 
 
 @dataclass(frozen=True, slots=True)
@@ -177,7 +236,7 @@ class CognifyRetryQueue:
         max_backoff_seconds: float = DEFAULT_MAX_BACKOFF_SECONDS,
         clock: Clock | None = None,
     ) -> None:
-        self.path = Path(path)
+        self.path = Path(path).expanduser().resolve(strict=False)
         self.lease_seconds = self._positive_duration(lease_seconds, "lease_seconds")
         self.backoff_seconds = self._positive_duration(backoff_seconds, "backoff_seconds")
         self.max_backoff_seconds = self._positive_duration(
@@ -189,6 +248,35 @@ class CognifyRetryQueue:
         self._thread_lock = threading.RLock()
         self._lock_depth = 0
         self._lock_file: Any | None = None
+
+    def try_acquire_execution(self) -> CognifyExecutionGuard | None:
+        """Acquire queue-wide execution ownership without waiting.
+
+        This lock is separate from the short state-mutation lock. Callers must
+        acquire it before claiming work and retain it until active cognify work
+        and its child-task cleanup have stopped.
+        """
+        lock_path = self.path.with_suffix(f"{self.path.suffix}.execute.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        with _EXECUTION_HANDLES_LOCK:
+            descriptor = os.open(lock_path, flags, 0o600)
+            try:
+                handle = os.fdopen(descriptor, "a+")
+            except BaseException:
+                os.close(descriptor)
+                raise
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                handle.close()
+                return None
+            except BaseException:
+                handle.close()
+                raise
+            _EXECUTION_HANDLES[handle.fileno()] = handle
+        return CognifyExecutionGuard(handle)
 
     @staticmethod
     def _positive_duration(value: float, field_name: str) -> float:
@@ -662,6 +750,7 @@ class CognifyRetryQueue:
 
 
 __all__ = [
+    "CognifyExecutionGuard",
     "CognifyJob",
     "CognifyLease",
     "CognifyLeaseError",

--- a/kb/config.py
+++ b/kb/config.py
@@ -80,6 +80,12 @@ def _repair_journal_path(value: str | None) -> str:
     return str(Path(_state_root()) / "repair_journal.jsonl")
 
 
+def _cognify_queue_path(value: str | None) -> str:
+    if value:
+        return value
+    return str(Path(_state_root()) / "cognify_queue.json")
+
+
 def _repo_stats_state_path(value: str | None) -> str:
     if value:
         return value
@@ -247,6 +253,7 @@ class CitadelConfig:
     repo_content_sync_state_path: str = ".citadel/repo_content_sync_state.json"
     evolve_state_path: str = ".citadel/evolve_state.json"
     repair_journal_path: str = ".citadel/repair_journal.jsonl"
+    cognify_queue_path: str = ".citadel/cognify_queue.json"
     repo_content_sync_repos: tuple[str, ...] = field(default_factory=tuple)
     repo_content_sync_root_paths: tuple[str, ...] = field(default_factory=tuple)
     repo_content_sync_tree_prefixes: tuple[str, ...] = field(default_factory=tuple)
@@ -455,6 +462,7 @@ class CitadelConfig:
             repair_journal_path=_repair_journal_path(
                 os.getenv("CITADEL_REPAIR_JOURNAL_PATH")
             ),
+            cognify_queue_path=_cognify_queue_path(os.getenv("CITADEL_COGNIFY_QUEUE_PATH")),
             repo_content_sync_repos=tuple(
                 _csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_REPOS"))
             ),

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -666,8 +666,8 @@ class LinearSyncer:
             else:
                 # On-demand endpoint / evolve: background it so the request returns
                 # without waiting on the graph write.
-                self.citadel.cognee.schedule_cognify(cognify_datasets)
-                cognify_observed = "queued_not_confirmed"
+                queued = self.citadel.cognee.schedule_cognify(cognify_datasets)
+                cognify_observed = "queued_not_confirmed" if queued else "not_scheduled"
         elif touched_datasets:
             # Evolve Phase-1 subprocess (CITADEL_SUPPRESS_INLINE_COGNIFY): add-only
             # by design; the web cognifies in Phase 2 as the sole Kuzu writer.
@@ -770,6 +770,7 @@ class LinearSyncer:
             #   "cognify_failed"        awaited coalesced cognify raised
             #   "queued_not_confirmed"  background cognify scheduled; outcome
             #                           not observed by this pass
+            #   "not_scheduled"        durable background queue rejected the work
             #   "suppressed"            add-only mode; evolve Phase 2 cognifies
             #   None                    no accepted Central write this pass
             "central_ingested": (

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -659,6 +659,7 @@ class LinearSyncer:
                     await self.citadel.cognee.cognify(datasets=cognify_datasets)
                 except Exception:  # noqa: BLE001 - writes succeeded; cognify is a follow-on
                     logger.exception("Linear sync coalesced cognify failed")
+                    self.citadel.cognee.schedule_cognify(cognify_datasets)
                     cognify_observed = "cognify_failed"
                 else:
                     cognify_observed = "cognified"

--- a/kb/server.py
+++ b/kb/server.py
@@ -492,7 +492,7 @@ async def _stop_cognify_queue() -> None:
     if callable(stop):
         result = stop()
         if isawaitable(result):
-            await result
+            _ = await result
 
 
 @asynccontextmanager

--- a/kb/server.py
+++ b/kb/server.py
@@ -6581,8 +6581,12 @@ async def share_session(body: ShareSessionBody, request: Request) -> Any:
         for target, item in zip(write_targets, all_outcomes, strict=True)
         if item.ingest.accepted
     ]
+    cognify_queued = False
     if cognify_datasets:
-        citadel.cognee.schedule_cognify(list(dict.fromkeys(cognify_datasets)))
+        cognify_queued = citadel.cognee.schedule_cognify(
+            list(dict.fromkeys(cognify_datasets))
+        )
+    cognify_state = "deferred" if cognify_queued else "not_scheduled"
 
     record_mcp_audit(
         request,
@@ -6594,6 +6598,7 @@ async def share_session(body: ShareSessionBody, request: Request) -> Any:
             "accepted": outcome.ingest.accepted,
             "write_targets": [target.dataset for target in write_targets],
             "has_tool_errors": body.has_tool_errors,
+            "cognify": cognify_state,
         },
     )
     get_access_store().record_event(
@@ -6604,6 +6609,7 @@ async def share_session(body: ShareSessionBody, request: Request) -> Any:
         detail={
             "write_targets": [target.dataset for target in write_targets],
             "author_seat": actor.seat_slug,
+            "cognify": cognify_state,
         },
     )
     return jsonable_encoder(
@@ -6612,8 +6618,12 @@ async def share_session(body: ShareSessionBody, request: Request) -> Any:
             "accepted": outcome.ingest.accepted,
             "dataset": SESSION_TRACES_DATASET,
             "write_targets": [target.dataset for target in write_targets],
-            "cognify": "deferred",
-            "message": "Shared Session Trace accepted; searchable after coalesced cognify.",
+            "cognify": cognify_state,
+            "message": (
+                "Shared Session Trace accepted; searchable after coalesced cognify."
+                if cognify_queued
+                else "Shared Session Trace accepted, but indexing was not scheduled."
+            ),
         }
     )
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -4,6 +4,7 @@ import asyncio
 from contextlib import asynccontextmanager
 import hashlib
 import hmac
+from inspect import isawaitable
 import json
 import logging
 import os
@@ -480,6 +481,20 @@ async def _stop_evolve_scheduler(task: "asyncio.Task[Any] | None") -> None:
         pass
 
 
+def _start_cognify_queue() -> None:
+    resume = getattr(getattr(get_citadel(), "cognee", None), "resume_cognify_queue", None)
+    if callable(resume):
+        resume()
+
+
+async def _stop_cognify_queue() -> None:
+    stop = getattr(getattr(get_citadel(), "cognee", None), "stop_cognify_queue", None)
+    if callable(stop):
+        result = stop()
+        if isawaitable(result):
+            await result
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> Any:
     # Refuse to serve with a guessable env access key (M4). Deliberately at
@@ -530,11 +545,13 @@ async def lifespan(app: FastAPI) -> Any:
                 "Seat dataset backfill failed; seats created before provisioning "
                 "may still fail every search (#147)"
             )
+        _start_cognify_queue()
         evolve_task = _start_evolve_scheduler()
         repo_stats_task = _start_repo_stats_scheduler()
         try:
             yield
         finally:
+            await _stop_cognify_queue()
             await _stop_evolve_scheduler(evolve_task)
             # Same cancel-and-await shutdown; the helper is not evolve specific.
             await _stop_evolve_scheduler(repo_stats_task)

--- a/kb/service.py
+++ b/kb/service.py
@@ -48,7 +48,7 @@ class Citadel:
         cognee: CogneeGateway | None = None,
     ) -> None:
         self.config = config or CitadelConfig.from_env()
-        self.cognee = cognee or CogneePublicClient()
+        self.cognee = cognee or CogneePublicClient(queue_path=self.config.cognify_queue_path)
         self.repair_journal = RepairJournal(self.config.repair_journal_path)
         self.filter = PreIngestFilter(
             min_chars=self.config.min_chars,

--- a/kb/service.py
+++ b/kb/service.py
@@ -139,6 +139,8 @@ class Citadel:
                 reason = "queued_not_confirmed"
             elif cognify_state == "not_scheduled":
                 reason = "not_scheduled"
+            elif result.get("background_cognify") is False:
+                reason = "not_scheduled"
         return IngestResult(True, reason, target_dataset, merged_tags, result)
 
     def _guard_content(self, data: str, dataset: str) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -1381,6 +1381,119 @@ async def test_failed_background_cognify_is_rescheduled(
 
 
 @pytest.mark.asyncio
+async def test_failed_background_cognify_retries_without_new_ingest(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(path, backoff_seconds=0.01, max_backoff_seconds=0.05)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    calls: list[list[str]] = []
+    retried = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        calls.append(list(datasets))
+        if len(calls) == 1:
+            raise RuntimeError("temporary failure")
+        retried.set()
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+
+    await asyncio.wait_for(retried.wait(), timeout=1)
+
+    async def wait_for_queue_empty() -> None:
+        while queue.snapshot():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(wait_for_queue_empty(), timeout=1)
+
+    assert calls == [["central"], ["central"]]
+    assert queue.snapshot() == ()
+    await client.stop_cognify_queue()
+
+
+@pytest.mark.asyncio
+async def test_long_cognify_renews_queue_lease(monkeypatch: Any, tmp_path: Any) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(path, lease_seconds=0.3)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    started = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        started.set()
+        await asyncio.sleep(0.5)
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+    task = client._cognify_queue_task
+    assert task is not None
+
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.wait_for(asyncio.shield(task), timeout=1)
+
+    assert queue.snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_stop_cognify_queue_reschedules_cancelled_work(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(path, lease_seconds=30, backoff_seconds=0.01)
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    started = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        started.set()
+        await blocked.wait()
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await client.stop_cognify_queue()
+
+    jobs = queue.snapshot()
+    assert len(jobs) == 1
+    assert jobs[0].leased is False
+    assert jobs[0].last_error == "cognify worker cancelled"
+
+
+@pytest.mark.asyncio
 async def test_resume_cognify_queue_drains_pending_work(
     monkeypatch: Any, tmp_path: Any
 ) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -1457,6 +1457,323 @@ async def test_long_cognify_renews_queue_lease(monkeypatch: Any, tmp_path: Any) 
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_failure_wins_same_turn_cognify_completion(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json")
+    queue.enqueue(["central"])
+    lease = queue.claim()
+    assert lease is not None
+    client = CogneePublicClient(retry_queue=queue)
+
+    async def cognify(*, datasets: list[str], force: bool = False) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def fail_heartbeat(lease: Any) -> None:
+        raise OSError("queue volume unavailable")
+
+    monkeypatch.setattr(client, "cognify", cognify)
+    monkeypatch.setattr(client, "_renew_cognify_lease", fail_heartbeat)
+
+    with pytest.raises(OSError, match="queue volume unavailable"):
+        await client._cognify_with_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_failed_lease_renewal_cancels_cognify_before_retry(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(
+        path,
+        lease_seconds=1,
+        backoff_seconds=30,
+        max_backoff_seconds=30,
+    )
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        started.set()
+        try:
+            await blocked.wait()
+        finally:
+            cancelled.set()
+        return {"ok": True}
+
+    def fail_renewal(lease: Any) -> None:
+        raise OSError("queue volume unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    monkeypatch.setattr(queue, "renew", fail_renewal)
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+    task = client._cognify_queue_task
+    assert task is not None
+
+    await asyncio.wait_for(started.wait(), timeout=2)
+    await asyncio.wait_for(cancelled.wait(), timeout=2)
+    await asyncio.wait_for(asyncio.shield(task), timeout=2)
+
+    jobs = queue.snapshot()
+    assert len(jobs) == 1
+    assert jobs[0].leased is False
+    assert jobs[0].last_error == "OSError: queue volume unavailable"
+    assert client._cognify_queue_retry_handle is not None
+    await client.stop_cognify_queue()
+
+
+@pytest.mark.asyncio
+async def test_execution_guard_blocks_reclaim_until_cancellation_cleanup_stops(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    first_queue = CognifyRetryQueue(
+        path,
+        lease_seconds=0.05,
+        backoff_seconds=0.01,
+        max_backoff_seconds=0.05,
+    )
+    second_queue = CognifyRetryQueue(
+        path,
+        lease_seconds=0.05,
+        backoff_seconds=0.01,
+        max_backoff_seconds=0.05,
+    )
+    first_queue.enqueue(["central"])
+    first_client = CogneePublicClient(retry_queue=first_queue)
+    second_client = CogneePublicClient(retry_queue=second_queue)
+    first_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    replacement_started = asyncio.Event()
+    active_cognify = 0
+    max_active_cognify = 0
+
+    async def first_cognify(*, datasets: list[str], force: bool = False) -> None:
+        nonlocal active_cognify, max_active_cognify
+        active_cognify += 1
+        max_active_cognify = max(max_active_cognify, active_cognify)
+        first_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            raise
+        finally:
+            active_cognify -= 1
+
+    async def fail_heartbeat(lease: Any) -> None:
+        await first_started.wait()
+        raise OSError("queue volume unavailable")
+
+    async def replacement_cognify(*, datasets: list[str], force: bool = False) -> None:
+        nonlocal active_cognify, max_active_cognify
+        active_cognify += 1
+        max_active_cognify = max(max_active_cognify, active_cognify)
+        replacement_started.set()
+        active_cognify -= 1
+
+    monkeypatch.setattr(first_client, "cognify", first_cognify)
+    monkeypatch.setattr(first_client, "_renew_cognify_lease", fail_heartbeat)
+    monkeypatch.setattr(
+        first_client,
+        "_schedule_cognify_retry",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(second_client, "cognify", replacement_cognify)
+
+    first_client.resume_cognify_queue()
+    first_task = first_client._cognify_queue_task
+    assert first_task is not None
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    await asyncio.sleep(0.08)
+
+    second_client.resume_cognify_queue()
+    contending_task = second_client._cognify_queue_task
+    assert contending_task is not None
+    await asyncio.wait_for(asyncio.shield(contending_task), timeout=1)
+
+    assert replacement_started.is_set() is False
+    pending = second_queue.snapshot()
+    assert len(pending) == 1
+    assert pending[0].attempt == 1
+    assert max_active_cognify == 1
+
+    release_cleanup.set()
+    await asyncio.wait_for(asyncio.shield(first_task), timeout=1)
+    second_client._cancel_cognify_retry()
+    second_client.resume_cognify_queue()
+    replacement_task = second_client._cognify_queue_task
+    assert replacement_task is not None
+    await asyncio.wait_for(replacement_started.wait(), timeout=1)
+    await asyncio.wait_for(asyncio.shield(replacement_task), timeout=1)
+
+    assert max_active_cognify == 1
+    assert second_queue.snapshot() == ()
+    await first_client.stop_cognify_queue()
+    await second_client.stop_cognify_queue()
+
+
+@pytest.mark.asyncio
+async def test_execution_lock_contention_uses_bounded_poll(tmp_path: Any) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    owner_queue = CognifyRetryQueue(path, lease_seconds=300)
+    contender_queue = CognifyRetryQueue(path, lease_seconds=300)
+    owner_queue.enqueue(["central"])
+    owner_guard = owner_queue.try_acquire_execution()
+    assert owner_guard is not None
+    lease = owner_queue.claim()
+    assert lease is not None
+    contender = CogneePublicClient(retry_queue=contender_queue)
+
+    contender.resume_cognify_queue()
+    task = contender._cognify_queue_task
+    assert task is not None
+    await asyncio.wait_for(asyncio.shield(task), timeout=1)
+
+    handle = contender._cognify_queue_retry_handle
+    assert handle is not None
+    remaining = handle.when() - asyncio.get_running_loop().time()
+    assert 0 < remaining <= 1.0
+    assert contender_queue.snapshot()[0].attempt == 1
+
+    await contender.stop_cognify_queue()
+    owner_guard.release()
+@pytest.mark.asyncio
+async def test_failed_acknowledgement_retries_without_external_activity(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(
+        path,
+        lease_seconds=0.05,
+        backoff_seconds=0.01,
+        max_backoff_seconds=0.05,
+    )
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    cognify_calls: list[list[str]] = []
+    acknowledgement_calls = 0
+    wakeup_calls = 0
+    retried = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        cognify_calls.append(list(datasets))
+        if len(cognify_calls) == 2:
+            retried.set()
+        return {"ok": True}
+
+    acknowledge = queue.acknowledge
+    next_wakeup_delay = queue.next_wakeup_delay
+
+    def fail_first_acknowledgement(lease: Any) -> None:
+        nonlocal acknowledgement_calls
+        acknowledgement_calls += 1
+        if acknowledgement_calls == 1:
+            raise OSError("queue volume unavailable")
+        acknowledge(lease)
+
+    def fail_first_wakeup_read() -> float | None:
+        nonlocal wakeup_calls
+        wakeup_calls += 1
+        if wakeup_calls == 1:
+            raise OSError("queue volume unavailable")
+        return next_wakeup_delay()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    monkeypatch.setattr(queue, "acknowledge", fail_first_acknowledgement)
+    monkeypatch.setattr(queue, "next_wakeup_delay", fail_first_wakeup_read)
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+
+    await asyncio.wait_for(retried.wait(), timeout=1)
+
+    async def wait_for_queue_empty() -> None:
+        while queue.snapshot():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(wait_for_queue_empty(), timeout=1)
+
+    assert cognify_calls == [["central"], ["central"]]
+    assert acknowledgement_calls == 2
+    assert wakeup_calls >= 2
+    assert queue.snapshot() == ()
+    await client.stop_cognify_queue()
+
+
+@pytest.mark.asyncio
+async def test_child_cognify_cancellation_retries_without_external_activity(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(
+        path,
+        backoff_seconds=0.01,
+        max_backoff_seconds=0.05,
+    )
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    cognify_calls: list[list[str]] = []
+    retried = asyncio.Event()
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        cognify_calls.append(list(datasets))
+        if len(cognify_calls) == 1:
+            raise asyncio.CancelledError
+        retried.set()
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient(retry_queue=queue)
+    client.schedule_cognify(["central"])
+
+    await asyncio.wait_for(retried.wait(), timeout=1)
+
+    async def wait_for_queue_empty() -> None:
+        while queue.snapshot():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(wait_for_queue_empty(), timeout=1)
+
+    assert cognify_calls == [["central"], ["central"]]
+    assert queue.snapshot() == ()
+    await client.stop_cognify_queue()
+
+
+@pytest.mark.asyncio
 async def test_stop_cognify_queue_reschedules_cancelled_work(
     monkeypatch: Any, tmp_path: Any
 ) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping
 import pytest
 
 from kb import chunk_window
+from kb.cognify_queue import CognifyRetryQueue
 from kb.cognee_client import CogneePublicClient
 
 
@@ -1256,7 +1257,9 @@ async def test_durable_writes_bypass_session_cache(monkeypatch: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: Any) -> None:
+async def test_remember_schedules_lock_guarded_background_cognify(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
     # #47: outside the suppress flag, remember adds then schedules OUR background
     # cognify (lock-guarded), not cognee's fire-and-forget run_in_background.
     import asyncio
@@ -1265,6 +1268,7 @@ async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: A
 
     monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
     monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(tmp_path / "queue.json"))
     cognified: list[Any] = []
 
     async def run_startup_migrations() -> None:
@@ -1292,7 +1296,9 @@ async def test_remember_schedules_lock_guarded_background_cognify(monkeypatch: A
 
 
 @pytest.mark.asyncio
-async def test_schedule_cognify_runs_one_cognify_over_all_datasets(monkeypatch: Any) -> None:
+async def test_schedule_cognify_runs_one_cognify_over_all_datasets(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
     # #46/#52: the coalesced cognify is ONE background task over every dataset the
     # bulk write touched (de-duplicated), not one-per-write.
     import asyncio
@@ -1300,6 +1306,7 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(monkeypatch: 
     import kb.cognee_client as cc
 
     monkeypatch.setenv("LLM_API_KEY", "k")
+    monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(tmp_path / "queue.json"))
     cognified: list[list[str]] = []
 
     async def run_startup_migrations() -> None:
@@ -1325,6 +1332,111 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(monkeypatch: 
     client.schedule_cognify([])
     await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == []
+
+
+def test_schedule_cognify_persists_without_a_running_loop(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    path = tmp_path / "queue.json"
+    monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(path))
+
+    CogneePublicClient().schedule_cognify(["central"])
+
+    jobs = CognifyRetryQueue(path).snapshot()
+    assert len(jobs) == 1
+    assert jobs[0].datasets == ("central",)
+
+
+@pytest.mark.asyncio
+async def test_failed_background_cognify_is_rescheduled(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    import kb.cognee_client as cc
+
+    path = tmp_path / "queue.json"
+    monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(path))
+    monkeypatch.setenv("LLM_API_KEY", "k")
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        raise RuntimeError("node unavailable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient()
+    client.schedule_cognify(["central"])
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+
+    jobs = CognifyRetryQueue(path).snapshot()
+    assert len(jobs) == 1
+    assert jobs[0].leased is False
+    assert jobs[0].last_error == "RuntimeError: node unavailable"
+
+
+@pytest.mark.asyncio
+async def test_resume_cognify_queue_drains_pending_work(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    import asyncio
+
+    import kb.cognee_client as cc
+
+    path = tmp_path / "queue.json"
+    CognifyRetryQueue(path).enqueue(["central"])
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    cognified: list[list[str]] = []
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    async def cognify(*, datasets: Any, incremental_loading: bool) -> dict[str, Any]:
+        cognified.append(list(datasets))
+        return {"ok": True}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient(queue_path=path)
+    client.resume_cognify_queue()
+    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+
+    assert cognified == [["central"]]
+    assert CognifyRetryQueue(path).snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_remember_reports_false_when_durable_queue_cannot_accept_work(
+    monkeypatch: Any,
+) -> None:
+    class BrokenQueue:
+        def enqueue(self, datasets: list[str]) -> None:
+            raise OSError("queue volume unavailable")
+
+    async def add(data: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def run_startup_migrations() -> None:
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_startup_migrations=run_startup_migrations, add=add),
+    )
+    result = await CogneePublicClient(retry_queue=BrokenQueue()).remember(
+        "note", dataset_name="central"
+    )
+
+    assert result == {"added": {"ok": True}, "background_cognify": False}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -11,7 +11,7 @@ import pytest
 
 from kb import chunk_window
 from kb.cognify_queue import CognifyRetryQueue
-from kb.cognee_client import CogneePublicClient
+from kb.cognee_client import CogneePublicClient, _BACKGROUND_COGNIFY_TASKS
 
 
 COGNEE_ENV_KEYS = (
@@ -1147,8 +1147,6 @@ async def test_node_dataset_map_times_out_and_caches_the_failure(
 @pytest.mark.asyncio
 async def test_cognify_serializes_on_writer_lock(monkeypatch: Any) -> None:
     # #47: Kuzu is single-writer, so two overlapping cognify calls must serialize.
-    import asyncio
-
     monkeypatch.setenv("LLM_API_KEY", "k")
     concurrent = 0
     max_seen = 0
@@ -1262,10 +1260,6 @@ async def test_remember_schedules_lock_guarded_background_cognify(
 ) -> None:
     # #47: outside the suppress flag, remember adds then schedules OUR background
     # cognify (lock-guarded), not cognee's fire-and-forget run_in_background.
-    import asyncio
-
-    import kb.cognee_client as cc
-
     monkeypatch.delenv("CITADEL_SUPPRESS_INLINE_COGNIFY", raising=False)
     monkeypatch.setenv("LLM_API_KEY", "k")
     monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(tmp_path / "queue.json"))
@@ -1291,7 +1285,7 @@ async def test_remember_schedules_lock_guarded_background_cognify(
     result = await client.remember("note", dataset_name="seat:sarthi", tags=())
     assert result == {"added": {"ok": True}, "background_cognify": True}
     # Drain the scheduled background cognify and confirm it ran via cognify().
-    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    await asyncio.gather(*list(_BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == [["seat:sarthi"]]
 
 
@@ -1301,10 +1295,6 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(
 ) -> None:
     # #46/#52: the coalesced cognify is ONE background task over every dataset the
     # bulk write touched (de-duplicated), not one-per-write.
-    import asyncio
-
-    import kb.cognee_client as cc
-
     monkeypatch.setenv("LLM_API_KEY", "k")
     monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(tmp_path / "queue.json"))
     cognified: list[list[str]] = []
@@ -1324,13 +1314,13 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(
     client = CogneePublicClient()
 
     client.schedule_cognify(["central", "seat:a", "central"])  # duplicate central
-    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    await asyncio.gather(*list(_BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == [["central", "seat:a"]]  # one cognify, de-duplicated
 
     # No datasets → no task scheduled.
     cognified.clear()
     client.schedule_cognify([])
-    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    await asyncio.gather(*list(_BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
     assert cognified == []
 
 
@@ -1351,10 +1341,6 @@ def test_schedule_cognify_persists_without_a_running_loop(
 async def test_failed_background_cognify_is_rescheduled(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
-    import kb.cognee_client as cc
-
     path = tmp_path / "queue.json"
     monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(path))
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1372,7 +1358,7 @@ async def test_failed_background_cognify_is_rescheduled(
     )
     client = CogneePublicClient()
     client.schedule_cognify(["central"])
-    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    await asyncio.gather(*list(_BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
 
     jobs = CognifyRetryQueue(path).snapshot()
     assert len(jobs) == 1
@@ -1384,8 +1370,6 @@ async def test_failed_background_cognify_is_rescheduled(
 async def test_failed_background_cognify_retries_without_new_ingest(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(path, backoff_seconds=0.01, max_backoff_seconds=0.05)
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1425,8 +1409,6 @@ async def test_failed_background_cognify_retries_without_new_ingest(
 
 @pytest.mark.asyncio
 async def test_long_cognify_renews_queue_lease(monkeypatch: Any, tmp_path: Any) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(path, lease_seconds=0.3)
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1483,8 +1465,6 @@ async def test_heartbeat_failure_wins_same_turn_cognify_completion(
 async def test_failed_lease_renewal_cancels_cognify_before_retry(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(
         path,
@@ -1538,8 +1518,6 @@ async def test_failed_lease_renewal_cancels_cognify_before_retry(
 async def test_execution_guard_blocks_reclaim_until_cancellation_cleanup_stops(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     first_queue = CognifyRetryQueue(
         path,
@@ -1623,7 +1601,6 @@ async def test_execution_guard_blocks_reclaim_until_cancellation_cleanup_stops(
     await asyncio.wait_for(replacement_started.wait(), timeout=1)
     await asyncio.wait_for(asyncio.shield(replacement_task), timeout=1)
 
-    assert max_active_cognify == 1
     assert second_queue.snapshot() == ()
     await first_client.stop_cognify_queue()
     await second_client.stop_cognify_queue()
@@ -1631,8 +1608,6 @@ async def test_execution_guard_blocks_reclaim_until_cancellation_cleanup_stops(
 
 @pytest.mark.asyncio
 async def test_execution_lock_contention_uses_bounded_poll(tmp_path: Any) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     owner_queue = CognifyRetryQueue(path, lease_seconds=300)
     contender_queue = CognifyRetryQueue(path, lease_seconds=300)
@@ -1656,12 +1631,12 @@ async def test_execution_lock_contention_uses_bounded_poll(tmp_path: Any) -> Non
 
     await contender.stop_cognify_queue()
     owner_guard.release()
+
+
 @pytest.mark.asyncio
 async def test_failed_acknowledgement_retries_without_external_activity(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(
         path,
@@ -1730,8 +1705,6 @@ async def test_failed_acknowledgement_retries_without_external_activity(
 async def test_child_cognify_cancellation_retries_without_external_activity(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(
         path,
@@ -1777,8 +1750,6 @@ async def test_child_cognify_cancellation_retries_without_external_activity(
 async def test_stop_cognify_queue_reschedules_cancelled_work(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(path, lease_seconds=30, backoff_seconds=0.01)
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1814,10 +1785,6 @@ async def test_stop_cognify_queue_reschedules_cancelled_work(
 async def test_resume_cognify_queue_drains_pending_work(
     monkeypatch: Any, tmp_path: Any
 ) -> None:
-    import asyncio
-
-    import kb.cognee_client as cc
-
     path = tmp_path / "queue.json"
     CognifyRetryQueue(path).enqueue(["central"])
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1837,7 +1804,7 @@ async def test_resume_cognify_queue_drains_pending_work(
     )
     client = CogneePublicClient(queue_path=path)
     client.resume_cognify_queue()
-    await asyncio.gather(*list(cc._BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
+    await asyncio.gather(*list(_BACKGROUND_COGNIFY_TASKS), return_exceptions=True)
 
     assert cognified == [["central"]]
     assert CognifyRetryQueue(path).snapshot() == ()

--- a/tests/test_cognify_queue.py
+++ b/tests/test_cognify_queue.py
@@ -1,0 +1,238 @@
+"""Focused contract tests for the standalone cognify retry queue."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+from kb.cognify_queue import (
+    CognifyLeaseError,
+    CognifyQueueStateError,
+    CognifyRetryQueue,
+)
+
+
+T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _at(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _enqueue_from_process(path: str, datasets: tuple[str, ...], start: object) -> None:
+    start.wait()
+    CognifyRetryQueue(path).enqueue(datasets, now=T0)
+
+
+def test_enqueue_is_content_free_and_merges_duplicate_dataset_sets(tmp_path: Path) -> None:
+    path = tmp_path / "cognify-queue.json"
+    queue = CognifyRetryQueue(path)
+
+    first = queue.enqueue(("seat:alice", "central", "central"), now=T0)
+    second = queue.enqueue(("seat:bob", "central"), now=T0)
+
+    assert second.job_id == first.job_id
+    assert second.datasets == ("central", "seat:alice", "seat:bob")
+    assert len(queue.snapshot()) == 1
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    record = next(iter(persisted["jobs"].values()))
+    assert record["datasets"] == ["central", "seat:alice", "seat:bob"]
+    assert "content" not in record
+    assert "document_ids" not in record
+
+
+def test_claim_and_acknowledge_remove_completed_work(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=30)
+    queue.enqueue(("central",), now=T0)
+
+    lease = queue.claim(now=T0)
+
+    assert lease is not None
+    assert lease.datasets == ("central",)
+    assert lease.attempt == 1
+    assert queue.claim(now=T0) is None
+
+    queue.acknowledge(lease, now=T0 + timedelta(seconds=1))
+
+    assert queue.snapshot() == ()
+
+
+def test_enqueue_during_lease_survives_acknowledgement(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=30)
+    queue.enqueue(("central",), now=T0)
+    lease = queue.claim(now=T0)
+    assert lease is not None
+
+    queue.enqueue(("seat:alice",), now=T0 + timedelta(seconds=1))
+    queue.acknowledge(lease, now=T0 + timedelta(seconds=2))
+
+    pending = queue.snapshot()
+    assert len(pending) == 1
+    assert pending[0].datasets == ("seat:alice",)
+    assert pending[0].leased is False
+
+
+def test_failure_reschedules_with_bounded_exponential_backoff(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(
+        tmp_path / "queue.json",
+        backoff_seconds=5,
+        max_backoff_seconds=12,
+    )
+    queue.enqueue(("central",), now=T0)
+
+    first = queue.claim(now=T0)
+    assert first is not None
+    failed = queue.reschedule(first, error="temporary graph failure", now=T0)
+    assert failed.attempt == 1
+    assert failed.last_error == "temporary graph failure"
+    assert _at(failed.available_at) == T0 + timedelta(seconds=5)
+    assert queue.claim(now=T0 + timedelta(seconds=4)) is None
+
+    second = queue.claim(now=T0 + timedelta(seconds=5))
+    assert second is not None
+    failed_again = queue.reschedule(second, error="still unavailable", now=T0 + timedelta(seconds=5))
+    assert _at(failed_again.available_at) == T0 + timedelta(seconds=15)
+
+    third = queue.claim(now=T0 + timedelta(seconds=15))
+    assert third is not None
+    bounded = queue.reschedule(third, error="again", now=T0 + timedelta(seconds=15))
+    assert _at(bounded.available_at) == T0 + timedelta(seconds=27)
+
+
+def test_expired_lease_is_recovered_and_old_ack_is_rejected(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=10)
+    queue.enqueue(("central",), now=T0)
+    old_lease = queue.claim(now=T0)
+    assert old_lease is not None
+
+    assert queue.recover_stale_leases(now=T0 + timedelta(seconds=11)) == 1
+    recovered = queue.snapshot()[0]
+    assert recovered.leased is False
+    assert recovered.available_at == recovered.updated_at
+
+    with pytest.raises(CognifyLeaseError, match="no longer active"):
+        queue.acknowledge(old_lease, now=T0 + timedelta(seconds=11))
+
+
+def test_expired_lease_can_be_reclaimed(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=10)
+    queue.enqueue(("central",), now=T0)
+    first = queue.claim(now=T0)
+    assert first is not None
+
+    second = queue.claim(now=T0 + timedelta(seconds=11))
+
+    assert second is not None
+    assert second.job_id == first.job_id
+    assert second.lease_id != first.lease_id
+    assert second.attempt == 2
+
+
+def test_malformed_state_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    path.write_text("{\"version\": 1,", encoding="utf-8")
+    queue = CognifyRetryQueue(path)
+
+    with pytest.raises(CognifyQueueStateError, match="refusing to treat"):
+        queue.enqueue(("central",), now=T0)
+
+
+@pytest.mark.parametrize(
+    "record_update",
+    [
+        {"datasets": None},
+        {"lease_id": "lease", "leased_until": None, "lease_datasets": None},
+    ],
+)
+def test_malformed_record_types_fail_closed(tmp_path: Path, record_update: dict[str, object]) -> None:
+    path = tmp_path / "queue.json"
+    timestamp = T0.isoformat().replace("+00:00", "Z")
+    record: dict[str, object] = {
+        "job_id": "job",
+        "datasets": ["central"],
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "available_at": timestamp,
+        "attempt": 0,
+        "lease_id": None,
+        "leased_until": None,
+        "lease_datasets": None,
+        "last_error": None,
+    }
+    record.update(record_update)
+    path.write_text(json.dumps({"version": 1, "jobs": {"job": record}}), encoding="utf-8")
+
+    with pytest.raises(CognifyQueueStateError):
+        CognifyRetryQueue(path).snapshot()
+
+
+def test_state_with_unknown_content_field_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    timestamp = T0.isoformat().replace("+00:00", "Z")
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "jobs": {
+                    "job": {
+                        "job_id": "job",
+                        "datasets": ["central"],
+                        "created_at": timestamp,
+                        "updated_at": timestamp,
+                        "available_at": timestamp,
+                        "attempt": 0,
+                        "lease_id": None,
+                        "leased_until": None,
+                        "lease_datasets": None,
+                        "last_error": None,
+                        "content": "must never be persisted",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CognifyQueueStateError):
+        CognifyRetryQueue(path).snapshot()
+
+
+def test_atomic_write_failure_keeps_previous_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(path)
+    queue.enqueue(("central",), now=T0)
+    before = path.read_text(encoding="utf-8")
+
+    def fail_replace(source: Path, target: Path) -> None:
+        raise OSError("rename interrupted")
+
+    monkeypatch.setattr("kb.cognify_queue.os.replace", fail_replace)
+    with pytest.raises(OSError, match="rename interrupted"):
+        queue.enqueue(("seat:alice",), now=T0)
+
+    assert path.read_text(encoding="utf-8") == before
+    assert not list(tmp_path.glob("queue.json.*.tmp"))
+
+
+def test_cross_process_enqueue_does_not_lose_updates(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    processes = [
+        context.Process(target=_enqueue_from_process, args=(str(path), (dataset,), start))
+        for dataset in ("central", "seat:alice")
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    jobs = CognifyRetryQueue(path).snapshot()
+    assert len(jobs) == 1
+    assert jobs[0].datasets == ("central", "seat:alice")

--- a/tests/test_cognify_queue.py
+++ b/tests/test_cognify_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 import json
 import multiprocessing
+import os
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,40 @@ def _at(value: str) -> datetime:
 def _enqueue_from_process(path: str, datasets: tuple[str, ...], start: object) -> None:
     start.wait()
     CognifyRetryQueue(path).enqueue(datasets, now=T0)
+
+
+def _hold_execution_guard(path: str, acquired: object, exit_now: object) -> None:
+    guard = CognifyRetryQueue(path).try_acquire_execution()
+    if guard is None:
+        raise RuntimeError("execution guard was already held")
+    acquired.set()
+    exit_now.wait()
+    os._exit(0)
+
+
+def _check_forked_child_closes_guard(path: str) -> None:
+    queue = CognifyRetryQueue(path)
+    guard = queue.try_acquire_execution()
+    assert guard is not None
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_fd)
+        os.write(write_fd, b"closed" if guard._handle.closed else b"open")
+        os.close(write_fd)
+        os._exit(0)
+
+    os.close(write_fd)
+    inherited_state = os.read(read_fd, 16)
+    os.close(read_fd)
+    _, child_status = os.waitpid(child_pid, 0)
+    assert inherited_state == b"closed"
+    assert os.waitstatus_to_exitcode(child_status) == 0
+    assert CognifyRetryQueue(path).try_acquire_execution() is None
+    guard.release()
+    recovered = CognifyRetryQueue(path).try_acquire_execution()
+    assert recovered is not None
+    recovered.release()
 
 
 def test_enqueue_is_content_free_and_merges_duplicate_dataset_sets(tmp_path: Path) -> None:
@@ -253,3 +288,55 @@ def test_cross_process_enqueue_does_not_lose_updates(tmp_path: Path) -> None:
     jobs = CognifyRetryQueue(path).snapshot()
     assert len(jobs) == 1
     assert jobs[0].datasets == ("central", "seat:alice")
+
+
+def test_execution_guard_blocks_other_process_without_claiming_work(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "queue.json"
+    queue = CognifyRetryQueue(path)
+    queue.enqueue(("central",), now=T0)
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    exit_now = context.Event()
+    process = context.Process(
+        target=_hold_execution_guard,
+        args=(str(path), acquired, exit_now),
+    )
+    process.start()
+    assert acquired.wait(timeout=10)
+
+    assert queue.try_acquire_execution() is None
+    pending = queue.snapshot()
+    assert len(pending) == 1
+    assert pending[0].attempt == 0
+    assert pending[0].leased is False
+
+    exit_now.set()
+    process.join(timeout=10)
+    assert process.exitcode == 0
+
+    recovered = queue.try_acquire_execution()
+    assert recovered is not None
+    recovered.release()
+    recovered.release()
+
+
+def test_forked_child_does_not_inherit_execution_guard(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(target=_check_forked_child_closes_guard, args=(str(path),))
+    process.start()
+    process.join(timeout=10)
+    assert process.exitcode == 0
+
+
+def test_execution_guard_refuses_symlink_lock_file(tmp_path: Path) -> None:
+    path = tmp_path / "queue.json"
+    lock_path = tmp_path / "queue.json.execute.lock"
+    target = tmp_path / "other.lock"
+    target.touch()
+    lock_path.symlink_to(target)
+
+    with pytest.raises(OSError):
+        CognifyRetryQueue(path).try_acquire_execution()

--- a/tests/test_cognify_queue.py
+++ b/tests/test_cognify_queue.py
@@ -61,6 +61,23 @@ def test_claim_and_acknowledge_remove_completed_work(tmp_path: Path) -> None:
     assert queue.snapshot() == ()
 
 
+def test_renew_extends_lease_and_delays_reclaim(tmp_path: Path) -> None:
+    queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=10)
+    queue.enqueue(("central",), now=T0)
+    lease = queue.claim(now=T0)
+    assert lease is not None
+
+    renewed = queue.renew(lease, now=T0 + timedelta(seconds=5))
+
+    assert _at(renewed.leased_until) == T0 + timedelta(seconds=15)
+    assert queue.claim(now=T0 + timedelta(seconds=12)) is None
+    assert queue.next_wakeup_delay(now=T0 + timedelta(seconds=12)) == pytest.approx(3)
+
+    reclaimed = queue.claim(now=T0 + timedelta(seconds=16))
+    assert reclaimed is not None
+    assert reclaimed.attempt == 2
+
+
 def test_enqueue_during_lease_survives_acknowledgement(tmp_path: Path) -> None:
     queue = CognifyRetryQueue(tmp_path / "queue.json", lease_seconds=30)
     queue.enqueue(("central",), now=T0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,19 @@ def test_from_env_env_vars_still_override(monkeypatch) -> None:
     assert config.default_dataset == "explicit-dataset"
 
 
+def test_cognify_queue_path_defaults_to_state_root_and_honors_override(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("CITADEL_STATE_DIRECTORY", str(tmp_path / "state"))
+    monkeypatch.delenv("CITADEL_COGNIFY_QUEUE_PATH", raising=False)
+    config = CitadelConfig.from_env(env_file=None)
+    assert config.cognify_queue_path == str(tmp_path / "state" / "cognify_queue.json")
+
+    explicit = tmp_path / "explicit-queue.json"
+    monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(explicit))
+    assert CitadelConfig.from_env(env_file=None).cognify_queue_path == str(explicit)
+
+
 def test_repo_content_autojoin_env(monkeypatch) -> None:
     monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_ENABLED", "true")
     monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_AUTOJOIN_MARKERS", "AGENTS.md, SKILL.md")

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -148,7 +148,9 @@ async def test_linear_sync_ingests_central_and_mirror(
     # (Central + mirrors) instead of one-per-issue — capture it here.
     scheduled: list[list[str]] = []
     monkeypatch.setattr(
-        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+        citadel.cognee,
+        "schedule_cognify",
+        lambda datasets: scheduled.append(list(datasets)) or True,
     )
 
     syncer = LinearSyncer(
@@ -196,7 +198,7 @@ async def test_linear_sync_writes_each_issue_to_central(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
-    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: True)
     syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
 
     result = await syncer.run(force=True)
@@ -255,7 +257,7 @@ async def test_linear_sync_auto_maps_assignee_by_member_email(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
-    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: True)
     syncer = LinearSyncer(
         citadel, client=FakeLinearClient(issues, users=members), access_store=store
     )
@@ -294,7 +296,9 @@ async def test_linear_sync_defers_coalesced_cognify_when_inline_suppressed(
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
     scheduled: list[list[str]] = []
     monkeypatch.setattr(
-        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+        citadel.cognee,
+        "schedule_cognify",
+        lambda datasets: scheduled.append(list(datasets)) or True,
     )
     syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
 
@@ -337,7 +341,9 @@ async def test_linear_sync_awaits_coalesced_cognify_when_requested(
 
     monkeypatch.setattr(citadel.cognee, "cognify", fake_cognify)
     monkeypatch.setattr(
-        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+        citadel.cognee,
+        "schedule_cognify",
+        lambda datasets: scheduled.append(list(datasets)) or True,
     )
     syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues))
 
@@ -366,6 +372,26 @@ async def test_linear_sync_reports_queued_not_confirmed_on_background_cognify(
     assert scheduled  # the background cognify was requested...
     # ...and the report claims no more than the request:
     assert result["central_ingested"] == "queued_not_confirmed"
+
+
+@pytest.mark.asyncio
+async def test_linear_sync_reports_not_scheduled_when_retry_queue_rejects(
+    tmp_path: Any, sample_issues: list[dict[str, Any]], monkeypatch: Any
+) -> None:
+    syncer, ingests, scheduled = _incremental_syncer(tmp_path, sample_issues, monkeypatch)
+
+    def reject_schedule(datasets: Any) -> bool:
+        scheduled.append(list(datasets))
+        return False
+
+    monkeypatch.setattr(syncer.citadel.cognee, "schedule_cognify", reject_schedule)
+
+    result = await syncer.run(force=True)
+
+    assert result["ok"] is True
+    assert ingests
+    assert scheduled
+    assert result["central_ingested"] == "not_scheduled"
 
 
 @pytest.mark.asyncio
@@ -513,7 +539,7 @@ async def test_member_fetch_failure_is_carried_not_a_neutral_zero(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
-    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: True)
 
     class MemberFetchFails(FakeLinearClient):
         def fetch_users(self, *, max_users: int = 250) -> list[dict[str, Any]]:
@@ -572,7 +598,7 @@ async def test_linear_sync_counts_unresolved_assignee_without_name_guessing(
         return Outcome()
 
     monkeypatch.setattr("kb.linear_sync.LearningProcess.learn", fake_learn)
-    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: None)
+    monkeypatch.setattr(citadel.cognee, "schedule_cognify", lambda datasets: True)
     syncer = LinearSyncer(
         citadel,
         client=FakeLinearClient(issues, users=[]),
@@ -635,7 +661,9 @@ def _incremental_syncer(
     _capture_learn(monkeypatch, ingests)
     scheduled: list[list[str]] = []
     monkeypatch.setattr(
-        citadel.cognee, "schedule_cognify", lambda datasets: scheduled.append(list(datasets))
+        citadel.cognee,
+        "schedule_cognify",
+        lambda datasets: scheduled.append(list(datasets)) or True,
     )
     syncer = LinearSyncer(
         citadel, client=FakeLinearClient(sample_issues), access_store=store
@@ -839,8 +867,9 @@ class FakeCogneeForScanTest:
     async def cognify(self, **kwargs: Any) -> dict[str, Any]:
         return {"cognified": True}
 
-    def schedule_cognify(self, datasets: Any) -> None:
+    def schedule_cognify(self, datasets: Any) -> bool:
         self.scheduled_datasets.append(list(datasets))
+        return True
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6274,7 +6274,9 @@ class ShareCitadel(FakeCitadel):
         self.ingest_calls: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled = []
-        self.cognee.schedule_cognify = lambda datasets: self.cognee.scheduled.append(list(datasets))
+        self.cognee.schedule_cognify = (
+            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
         self.ingest_calls.append({"data": data, **kwargs})
@@ -6290,7 +6292,9 @@ class CrossSeatTraceCitadel(FakeCitadel):
         self.traces: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = lambda datasets: self.cognee.scheduled.append(list(datasets))
+        self.cognee.schedule_cognify = (
+            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
         self.ingest_calls.append({"data": data, **kwargs})
@@ -6339,6 +6343,42 @@ def test_share_session_dual_writes_and_schedules_cognify(tmp_path: Any) -> None:
     datasets = [call["dataset"] for call in app.state.citadel.ingest_calls]
     assert datasets == ["seat:alice", SESSION_TRACES_DATASET]
     assert app.state.citadel.cognee.scheduled == [["seat:alice", SESSION_TRACES_DATASET]]
+
+
+def test_share_session_surfaces_rejected_durable_queue(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
+    ).json()["token"]
+    citadel = ShareCitadel()
+    citadel.cognee.schedule_cognify = lambda datasets: False
+    app.state.citadel = citadel
+    client = TestClient(app, base_url="https://testserver")
+    root = str(tmp_path)
+    register_seat_capture_roots(admin, "alice", [root])
+
+    response = client.post(
+        "/api/share-session",
+        json={"data": "Task: queue failure", "cwd": root, "capture_roots": [root]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["accepted"] is True
+    assert payload["cognify"] == "not_scheduled"
+    assert payload["message"] == (
+        "Shared Session Trace accepted, but indexing was not scheduled."
+    )
+    events = app.state.access_store.snapshot()["audit_events"]
+    successful = [
+        event
+        for event in events
+        if event["action"] == "share_session" and event["success"]
+    ]
+    assert successful[-1]["detail"]["cognify"] == "not_scheduled"
 
 
 def test_share_session_trace_visible_to_other_seat(tmp_path: Any) -> None:
@@ -6526,7 +6566,9 @@ class PartialSessionTraceWriteCitadel(FakeCitadel):
         self.ingest_calls: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = lambda datasets: self.cognee.scheduled.append(list(datasets))
+        self.cognee.schedule_cognify = (
+            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
         self.ingest_calls.append({"data": data, **kwargs})
@@ -6544,7 +6586,9 @@ class FlakySessionTraceWriteCitadel(FakeCitadel):
         self.session_traces_attempts = 0
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = lambda datasets: self.cognee.scheduled.append(list(datasets))
+        self.cognee.schedule_cognify = (
+            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
         self.ingest_calls.append({"data": data, **kwargs})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4755,6 +4755,24 @@ def test_backfill_seat_datasets_is_wired_into_boot() -> None:
     assert "backfill_seat_datasets" in source, "boot no longer backfills seat datasets"
 
 
+def test_start_cognify_queue_resumes_due_work(monkeypatch: Any) -> None:
+    from kb import server
+
+    calls: list[str] = []
+
+    class FakeCognee:
+        def resume_cognify_queue(self) -> None:
+            calls.append("resume")
+
+    class FakeCitadel:
+        cognee = FakeCognee()
+
+    monkeypatch.setattr(server, "get_citadel", lambda: FakeCitadel())
+    server._start_cognify_queue()
+
+    assert calls == ["resume"]
+
+
 async def test_backfill_seat_datasets_is_a_noop_without_a_cognee_client(tmp_path: Any) -> None:
     """Boot must not break where the client has no ensure_dataset to call."""
     from kb.server import backfill_seat_datasets

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -74,6 +74,22 @@ class EmptyCognee(FakeCognee):
         return []
 
 
+def test_default_cognee_client_receives_configured_retry_queue_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class ConstructedClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(service, "CogneePublicClient", ConstructedClient)
+    path = tmp_path / "cognify-queue.json"
+    Citadel(CitadelConfig(cognify_queue_path=str(path)))
+
+    assert captured == {"queue_path": str(path)}
+
+
 @pytest.mark.asyncio
 async def test_ingest_applies_tags_and_dataset() -> None:
     fake = FakeCognee()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1907,6 +1907,22 @@ async def test_ingest_reports_queued_not_confirmed_until_cognify_finishes() -> N
 
 
 @pytest.mark.asyncio
+async def test_ingest_reports_not_scheduled_when_retry_queue_rejects() -> None:
+    class RejectedQueueCognee(FakeCognee):
+        async def remember(self, data: Any, **kwargs: Any) -> dict[str, Any]:
+            self.remember_calls.append({"data": data, **kwargs})
+            return {"added": {"ok": True}, "background_cognify": False}
+
+    fake = RejectedQueueCognee()
+    kb = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)
+
+    result = await kb.ingest("a note whose retry was rejected")
+
+    assert result.accepted is True
+    assert result.reason == "not_scheduled"
+
+
+@pytest.mark.asyncio
 async def test_feedback_can_auto_improve() -> None:
     fake = FakeCognee()
     kb = Citadel(CitadelConfig(auto_improve=True), cognee=fake)


### PR DESCRIPTION
## Summary

- Persist deferred dataset-level cognify work on the configured state volume.
- Resume queued work after restart and retry failures with bounded backoff.
- Renew active leases during long cognify operations.
- Return cancelled work to the queue during shutdown.
- Fail closed when retry state is corrupt or unavailable.

Relates to #228. This PR does not claim the historical zero-chunk census or production repair is closed. A production census, repair run, and post-repair benchmark remain required.

## Verification

- `.venv/bin/pytest -q`: `1715 passed, 1 skipped, 11 warnings in 18.80s`
- `.venv/bin/ruff check .`: `All checks passed!`
- `git diff --check origin/main...HEAD`: clean

## Deployment

Not deployed. No production data was changed.