### PR TITLE
fix(cli): expose corpus readiness evidence

### DIFF
--- a/kb/cli.py
+++ b/kb/cli.py
@@ -2081,8 +2081,13 @@ async def _doctor(args: argparse.Namespace) -> int:
     # unresolved so doctor exits nonzero.
     corpus = checks.get("corpus")
     if node and node.ok and auth and auth.ok and corpus and not corpus.ok:
-        issues.append({"problem": f"data plane broken ({corpus.detail}) — Node up but retrieval is empty",
-                       "fix": "check the evolve scheduler / cognify; run `citadel cognify --verify`"})
+        issues.append({
+            "problem": f"data plane not ready ({corpus.detail}); Node and auth are healthy",
+            "fix": (
+                "inspect the corpus probe in `citadel status --json`; "
+                "check the evolve scheduler / cognify; run `citadel cognify --verify`"
+            ),
+        })
 
     mcp_node = _mcp_node_url(repo / ".mcp.json")
     if mcp_node and cap_node and mcp_node.rstrip("/") != cap_node.rstrip("/"):

--- a/kb/status.py
+++ b/kb/status.py
@@ -359,8 +359,35 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
     indexed = corpus.get("indexed_docs")
     tracked = corpus.get("tracked_sources")
     ok = bool(corpus.get("ok", True)) and (canary is None or bool(canary.get("ok", True)))
-    detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
-    return Check("corpus", ok=ok, detail=detail, latency_ms=latency, data={"canary": canary})
+    probe_documents = corpus.get("probe_documents")
+    relational_documents = corpus.get("relational_documents")
+    fully_indexed = corpus.get("probe_fully_indexed_documents")
+    if all(isinstance(value, int) and not isinstance(value, bool) for value in (
+        probe_documents,
+        relational_documents,
+        fully_indexed,
+    )):
+        if corpus.get("probe_complete") is False:
+            probe_state = "incomplete"
+        elif corpus.get("probe_ok") is False:
+            probe_state = "failed"
+        else:
+            probe_state = "complete"
+        detail = (
+            f"corpus probe {probe_state}: {fully_indexed}/{probe_documents} sampled "
+            f"documents fully indexed ({probe_documents}/{relational_documents} sampled)"
+        )
+    elif corpus.get("degraded"):
+        detail = f"corpus probe unavailable: {corpus['degraded']}"
+    else:
+        detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
+    return Check(
+        "corpus",
+        ok=ok,
+        detail=detail,
+        latency_ms=latency,
+        data={"canary": canary, "corpus": dict(corpus)},
+    )
 
 
 def search_node(
@@ -930,12 +957,12 @@ def render_verdict(report: StatusReport, *, color: bool = False) -> str:
                 )
             )
         elif corpus_fail is not None:
-            # The Node is up, but the data plane is broken (sources tracked, graph
-            # empty, or the cognify canary failed) — the exact #27 failure mode.
+            # The Node is up, but its readiness gate is RED. Search availability
+            # is a separate check and must not be inferred from this gate.
             lines.append(
                 paint(
-                    f"Data plane broken — {corpus_fail.detail}. The Node is up but search "
-                    "returns nothing; ingested data is not being indexed.",
+                    f"Data plane not ready: {corpus_fail.detail}. The Node is up; "
+                    "search availability is reported separately.",
                     "red",
                     enable=color,
                 )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -359,6 +359,52 @@ def test_check_corpus_ok_when_readyz_healthy(monkeypatch) -> None:
     assert "280 indexed / 200 tracked" in check.detail
 
 
+def test_check_corpus_reports_bounded_probe_and_preserves_payload(monkeypatch) -> None:
+    body = {
+        "ok": False,
+        "corpus": {
+            "ok": False,
+            "tracked_sources": 330,
+            "indexed_docs": 33788,
+            "relational_documents": 2867,
+            "probe_documents": 64,
+            "probe_complete": False,
+            "probe_ok": False,
+            "probe_fully_indexed_documents": 0,
+        },
+        "canary": None,
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/readyz": body}))
+
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+
+    assert check is not None and check.ok is False
+    assert check.detail == (
+        "corpus probe incomplete: 0/64 sampled documents fully indexed (64/2867 sampled)"
+    )
+    assert check.data["corpus"]["relational_documents"] == 2867
+
+
+def test_render_verdict_does_not_infer_empty_search_from_corpus_failure() -> None:
+    report = StatusReport(
+        node_url="https://node.example",
+        healthy=False,
+        identity={},
+        checks=[
+            Check("node", ok=True, detail="healthy"),
+            Check("auth", ok=True, detail="valid"),
+            Check("corpus", ok=False, detail="corpus probe incomplete: 0/64 sampled"),
+        ],
+        recent=[],
+    )
+
+    out = status_mod.render_verdict(report)
+
+    assert "Data plane not ready" in out
+    assert "search availability is reported separately" in out
+    assert "search returns nothing" not in out
+
+
 def test_gather_status_node_down(tmp_path: Path) -> None:
     import kb.status as s
 


### PR DESCRIPTION
Refs #228

## Summary

This PR fixes a diagnostics mismatch found against the deployed 0.4.1 node.

- [VERIFIED] citadel status --check-search --json reported search healthy with 1 result(s).
- [VERIFIED] The same readiness probe reported 3,371 relational documents and 2,422 fully indexed documents, so the corpus gate is red.
- Preserve the full /readyz corpus payload in status JSON.
- Report bounded probe coverage in human output.
- Stop doctor and status from claiming retrieval is empty when only corpus readiness has failed.

## Verification

- [VERIFIED] uv run pytest -q -> 1694 passed, 1 skipped, 11 warnings.
- [VERIFIED] uv run pytest -q tests/test_status.py -> 48 passed.
- [VERIFIED] uv run ruff check kb/status.py kb/cli.py tests/test_status.py -> All checks passed.
- [VERIFIED] Reverted-source negative proof -> 2 failed, 46 passed.
- [VERIFIED] citadel doctor --json exits 1 and reports the bounded corpus failure with node and auth healthy.

## Scope

No ingest, repair, deploy, merge, tag, or release action is included. This PR makes the existing readiness failure observable and keeps search availability separate.