### PR TITLE
chore(graph): rename kb/mesh.py to kb/vault_activity.py

### DIFF
--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -1,9 +1,9 @@
 """Knowledge Mesh: the real Cognee-backed relationship graph.
 
-This is intentionally separate from :class:`kb.mesh.MeshState`, which is a
-wrapper-level dashboard projection of runtime activity. The Knowledge Mesh
-exposes what the Organization Vault actually knows: nodes and relationships
-read from Cognee's graph engine (Kuzu in the v1 deployment).
+This is intentionally separate from :class:`kb.vault_activity.MeshState`,
+which is a wrapper-level dashboard projection of runtime activity. The
+Knowledge Mesh exposes what the Organization Vault actually knows: nodes and
+relationships read from Cognee's graph engine (Kuzu in the v1 deployment).
 
 The endpoint contract never fails hard: when Cognee has no data, the graph
 engine is unavailable, or the gateway does not expose graph access, callers

--- a/kb/learning.py
+++ b/kb/learning.py
@@ -18,7 +18,7 @@ from typing import Any, Literal
 
 from kb.conflicts import KnowledgeConflictStore, detect_contribution_conflict
 from kb.llm_enrichment import EnrichedChunk, EnrichmentOutcome, enrich_source_material
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.security_scan import SecretContentError, SecurityScanEntry, scan_text_entries
 from kb.models import IngestResult
 from kb.service import Citadel

--- a/kb/self_improve.py
+++ b/kb/self_improve.py
@@ -26,7 +26,7 @@ from kb.llm_enrichment import (
     parse_json_payload,
     redacted_preview,
 )
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.service import Citadel
 
 logger = logging.getLogger(__name__)

--- a/kb/server.py
+++ b/kb/server.py
@@ -69,7 +69,7 @@ from kb.mcp_server import (
     create_mcp_server,
     set_tools_list_session_resolver,
 )
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import FeedbackRequest
 from kb.obsidian_sync import ObsidianSyncStore, SyncPushDocument, normalize_path
 from kb.promotion import PromotionEngine

--- a/kb/vault_activity.py
+++ b/kb/vault_activity.py
@@ -1,3 +1,12 @@
+"""Vault Activity: the live, ephemeral projection of vault operations.
+
+Tracks source syncs, searches, ingests, and index updates as they happen,
+surfaced on the Operations Dashboard and the dev CLI (``citadel activity``,
+``--watch``). This is operational signal only — it is not Structured
+Knowledge and not the Knowledge Mesh (see :mod:`kb.knowledge_mesh`), and it
+resets with the service.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/scripts/run_self_improve.py
+++ b/scripts/run_self_improve.py
@@ -102,7 +102,7 @@ def _post_json(
 
 async def _run_local(*, dry_run: bool) -> dict[str, Any]:
     from kb.access import AccessStore
-    from kb.mesh import MeshState
+    from kb.vault_activity import MeshState
     from kb.self_improve import SelfImprovement
     from kb.service import Citadel
 

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -16,7 +16,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from kb.access import AccessStore, now_iso
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.promotion_queue import build_pending_item, scan_candidate
 from kb.promotion_refs import ReferenceAssessment
 from kb.server import app

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -9,7 +9,7 @@ import pytest
 from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
 from kb.learning import LearningProcess
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import IngestResult
 
 

--- a/tests/test_llm_enrichment.py
+++ b/tests/test_llm_enrichment.py
@@ -18,7 +18,7 @@ from kb.llm_enrichment import (
     parse_json_payload,
     redacted_preview,
 )
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import IngestResult
 
 

--- a/tests/test_search_feedback.py
+++ b/tests/test_search_feedback.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from kb.config import CitadelConfig
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.search_feedback import (
     SCHEMA_VERSION,
     build_search_telemetry,
@@ -230,7 +230,7 @@ async def test_capture_search_feedback_attempts_write_on_every_call() -> None:
 def test_search_endpoint_records_telemetry_and_survives_feedback_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from kb.mesh import MeshState as LiveMesh
+    from kb.vault_activity import MeshState as LiveMesh
     from test_server import authed_client
 
     client = authed_client()

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 
 from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.search_format import (
     apply_query_ranking,
     filter_hits,

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -7,7 +7,7 @@ import pytest
 
 from kb import self_improve as self_improve_module
 from kb.config import CitadelConfig
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import IngestResult
 from kb.self_improve import SelfImprovement, propose_optimizations
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,7 +21,7 @@ from kb.access import AccessIdentity, AccessStore, SESSION_TRACES_DATASET
 from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
 from kb.knowledge_mesh import KnowledgeMesh
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import FeedbackResult, IngestResult
 from kb.obsidian_sync import ObsidianSyncStore
 from kb.server import app

--- a/tests/test_vault_activity.py
+++ b/tests/test_vault_activity.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from kb.config import CitadelConfig
-from kb.mesh import MeshState
+from kb.vault_activity import MeshState
 from kb.models import FeedbackResult, IngestResult
 
 CONFIG = CitadelConfig(tenant_id="test", default_dataset="notes")


### PR DESCRIPTION
## Summary
- `kb/mesh.py` and `kb/knowledge_mesh.py` competed for the name "mesh": `mesh.py` held `MeshState`, the live **Vault Activity** projection (per `CONTEXT.md`), while `knowledge_mesh.py` held the actual **Knowledge Mesh**. `kb/mesh.py` also had no module docstring.
- Renamed `kb/mesh.py` -> `kb/vault_activity.py` (matches the `CONTEXT.md` vocabulary suggested in the issue), leaving `knowledge_mesh.py` as the unambiguous owner of "mesh".
- Renamed `tests/test_mesh.py` -> `tests/test_vault_activity.py` to match.
- Added a module docstring to `vault_activity.py` describing it as the Vault Activity projection, and fixed `knowledge_mesh.py`'s docstring cross-reference from `kb.mesh.MeshState` to `kb.vault_activity.MeshState`.
- Updated every importer: `kb/self_improve.py`, `kb/server.py`, `kb/learning.py`, `scripts/run_self_improve.py`, and 8 test files.
- Route paths (`/api/mesh`, `/api/mesh/graph`) are unchanged, as the issue asked — this is a module-naming change only.

Fixes #121

## Test plan
- [x] `uv run pytest tests/ -q` — 1727 passed, 1 skipped (unchanged from baseline)
- [x] `uv run ruff check .` — clean
- [x] `python -c "from kb.vault_activity import MeshState; from kb.knowledge_mesh import *; import kb.server"` — imports resolve correctly