### PR TITLE
style: adopt ruff format across the tree

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Formatting-only commits — excluded from git blame.
+# See https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+
+# style: adopt ruff format across the tree (#127)
+ed3c1b6be1f0fe39ec5ad0555bbb3291b941983e

--- a/kb/access.py
+++ b/kb/access.py
@@ -192,9 +192,7 @@ def validate_role_scopes(role: str, scopes: tuple[str, ...] | list[str]) -> tupl
     allowed = set(default_scopes(role))
     extra = sorted(set(normalized) - allowed)
     if extra:
-        raise ValueError(
-            f"Scopes exceed {role} role: {', '.join(extra)}"
-        )
+        raise ValueError(f"Scopes exceed {role} role: {', '.join(extra)}")
     return normalized
 
 
@@ -252,9 +250,7 @@ def validate_expires_at(value: str | None) -> str | None:
     if not text:
         return None
     if _parse_time(text) is None:
-        raise ValueError(
-            f"expires_at is not an ISO 8601 timestamp: {value!r}"
-        )
+        raise ValueError(f"expires_at is not an ISO 8601 timestamp: {value!r}")
     return text
 
 
@@ -562,7 +558,9 @@ class AccessStore:
             if scopes is not None
             else validate_role_scopes(
                 resolved_role,
-                principal.scopes if resolved_role == principal.role else default_scopes(resolved_role),
+                principal.scopes
+                if resolved_role == principal.role
+                else default_scopes(resolved_role),
             )
         )
         token = new_api_token()
@@ -631,7 +629,9 @@ class AccessStore:
         next_tokens: list[ApiToken] = []
         for api_token in tokens:
             if api_token.id == token_id:
-                revoked = ApiToken(**{**asdict(api_token), "revoked_at": api_token.revoked_at or now_iso()})
+                revoked = ApiToken(
+                    **{**asdict(api_token), "revoked_at": api_token.revoked_at or now_iso()}
+                )
                 next_tokens.append(revoked)
             else:
                 next_tokens.append(api_token)

--- a/kb/access_client.py
+++ b/kb/access_client.py
@@ -126,7 +126,9 @@ def create_seat(
         payload["email"] = email
     if token_name:
         payload["token_name"] = token_name
-    return _request("POST", "/api/access/seats", base_url=base_url, key=key or admin_key(), payload=payload)
+    return _request(
+        "POST", "/api/access/seats", base_url=base_url, key=key or admin_key(), payload=payload
+    )
 
 
 def issue_seat_token(
@@ -164,7 +166,9 @@ def create_token(
         payload["allowed_datasets"] = allowed_datasets
     if expires_at:
         payload["expires_at"] = expires_at
-    return _request("POST", "/api/access/tokens", base_url=base_url, key=key or admin_key(), payload=payload)
+    return _request(
+        "POST", "/api/access/tokens", base_url=base_url, key=key or admin_key(), payload=payload
+    )
 
 
 def revoke_token(token_id: str, *, base_url: str, key: str | None = None) -> dict[str, Any]:

--- a/kb/agent_workflows.py
+++ b/kb/agent_workflows.py
@@ -140,7 +140,9 @@ def _doc_shaped_sources(hits: list[dict[str, Any]], *, limit: int = 8) -> list[d
     return out
 
 
-def _known_overlaps(file_text: str, hits: list[dict[str, Any]], *, limit: int = 6) -> list[dict[str, Any]]:
+def _known_overlaps(
+    file_text: str, hits: list[dict[str, Any]], *, limit: int = 6
+) -> list[dict[str, Any]]:
     """Surface vault hits that share tokens with the local file (overlap pointers)."""
     file_tokens = {t.lower() for t in extract_verify_cues(file_text, limit=40)}
     overlaps: list[dict[str, Any]] = []

--- a/kb/backup_mirror.py
+++ b/kb/backup_mirror.py
@@ -164,9 +164,7 @@ class GitHubMirrorPublisher:
             detail = redact_secrets(exc.read().decode("utf-8", errors="replace")[:300], self.token)
             if exc.code != 404:
                 logger.error("Backup mirror GitHub request %s failed: HTTPError %s", path, exc.code)
-            raise BackupMirrorPublishError(
-                f"GitHub API returned {exc.code}: {detail}"
-            ) from exc
+            raise BackupMirrorPublishError(f"GitHub API returned {exc.code}: {detail}") from exc
         except URLError as exc:
             logger.error(
                 "Backup mirror GitHub request %s failed: %s: %s",
@@ -261,7 +259,9 @@ class BackupMirror:
         self._write_json(self.latest_manifest_path, manifest)
         result["snapshot_manifest_path"] = str(snapshot_path)
         result["written"] = True
-        logger.info("Backup mirror manifest %s written to %s", manifest["snapshot_id"], snapshot_path)
+        logger.info(
+            "Backup mirror manifest %s written to %s", manifest["snapshot_id"], snapshot_path
+        )
         publisher = self._publisher()
         if self.config.backup_mirror_push_enabled and publisher:
             publish_result = publisher.publish_manifest(

--- a/kb/banner.py
+++ b/kb/banner.py
@@ -21,13 +21,55 @@ from typing import IO, Iterator
 # the brand SVGs; the CLI draws the same one so there is a single fortress.
 PIXEL_SIZE = 7
 PIXEL_FLAGS: tuple[int, ...] = (
-    1, 0, 1, 0, 1, 0, 1,
-    1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1,
-    1, 1, 0, 1, 0, 1, 1,
-    1, 1, 0, 1, 0, 1, 1,
-    1, 1, 0, 1, 0, 1, 1,
+    1,
+    0,
+    1,
+    0,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    0,
+    1,
+    1,
 )
 # Iris Flower magenta stepped to its deep stop. The web mark runs the same two
 # stops as a per-cell gradient, which a terminal cannot do, so the ramp is laid
@@ -77,9 +119,7 @@ def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
     return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
 
 
-PIXEL_COLS_RGB: tuple[tuple[int, int, int], ...] = tuple(
-    _hex_to_rgb(c) for c in PIXEL_COLS_HEX
-)
+PIXEL_COLS_RGB: tuple[tuple[int, int, int], ...] = tuple(_hex_to_rgb(c) for c in PIXEL_COLS_HEX)
 
 
 def supports_truecolor() -> bool:
@@ -244,9 +284,7 @@ def render_pixel_mark(
                     parts.append(_CELL_OFF)
                     continue
             is_window = index in WINDOW_INDICES
-            lit = (bool(PIXEL_FLAGS[index]) or is_window) and not (
-                blank_windows and is_window
-            )
+            lit = (bool(PIXEL_FLAGS[index]) or is_window) and not (blank_windows and is_window)
             if lit:
                 parts.append(
                     _paint_cell(

--- a/kb/capture.py
+++ b/kb/capture.py
@@ -93,10 +93,9 @@ def capture_token() -> str:
     Only seat-scoped tokens are accepted: the admin-key fallback is intentionally
     omitted so capture never routes to Central with elevated privileges.
     """
-    return (
-        (os.getenv("CITADEL_MCP_ACCESS_TOKEN") or "").strip()
-        or os.getenv("CITADEL_WRITER_KEYS", "").split(",")[0].strip()
-    )
+    return (os.getenv("CITADEL_MCP_ACCESS_TOKEN") or "").strip() or os.getenv(
+        "CITADEL_WRITER_KEYS", ""
+    ).split(",")[0].strip()
 
 
 def _redact_url_userinfo(url: str) -> str:

--- a/kb/chunk_window.py
+++ b/kb/chunk_window.py
@@ -639,9 +639,7 @@ def check_stored_chunk_payload(
     )
 
 
-def _iter_cognee_final_chunks(
-    text: str, budget: int
-) -> Iterable[tuple[int, str, int]]:
+def _iter_cognee_final_chunks(text: str, budget: int) -> Iterable[tuple[int, str, int]]:
     """Mirror Cognee 1.2.x TextChunker output before its storage fan-out.
 
     Cognee's paragraph chunker returns intermediate chunks, then TextChunker
@@ -652,9 +650,7 @@ def _iter_cognee_final_chunks(
     try:
         from cognee.tasks.chunks.chunk_by_paragraph import chunk_by_paragraph
     except Exception as exc:  # pragma: no cover - dependency pin/import failure
-        raise ChunkBudgetValidationError(
-            "cannot import Cognee's pinned paragraph chunker"
-        ) from exc
+        raise ChunkBudgetValidationError("cannot import Cognee's pinned paragraph chunker") from exc
 
     paragraph_chunks: list[dict[str, Any]] = []
     current_size = 0
@@ -766,9 +762,7 @@ def split_cognee_words(text: str) -> list[str]:
 
 _BPE_ENCODING: Any | None = None
 _BPE_ENCODING_UNAVAILABLE = object()
-_TIKTOKEN_CACHE_FILENAME = "".join(
-    ("fb374d41", "9588a463", "2f3f557e", "76b4b70a", "ebbca790")
-)
+_TIKTOKEN_CACHE_FILENAME = "".join(("fb374d41", "9588a463", "2f3f557e", "76b4b70a", "ebbca790"))
 _TIKTOKEN_CACHE_ARCHIVE = _TIKTOKEN_CACHE_FILENAME + ".gz"
 _TIKTOKEN_CACHE_SHA256 = "".join(
     (
@@ -805,18 +799,12 @@ def _seed_bundled_tiktoken_cache() -> None:
     global _BUNDLED_TIKTOKEN_CACHE_READY
     if "TIKTOKEN_CACHE_DIR" in os.environ:
         return
-    bundled_archive = (
-        Path(__file__).with_name("data")
-        / "tiktoken-cache"
-        / _TIKTOKEN_CACHE_ARCHIVE
-    )
+    bundled_archive = Path(__file__).with_name("data") / "tiktoken-cache" / _TIKTOKEN_CACHE_ARCHIVE
     if not bundled_archive.is_file():
         return
     configured = os.getenv("CITADEL_TIKTOKEN_CACHE_DIR")
     cache_dir = (
-        Path(configured)
-        if configured
-        else Path(tempfile.gettempdir()) / "citadel-tiktoken-cache"
+        Path(configured) if configured else Path(tempfile.gettempdir()) / "citadel-tiktoken-cache"
     )
     target = cache_dir / _TIKTOKEN_CACHE_FILENAME
     temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
@@ -863,8 +851,7 @@ def _bpe_encoding() -> Any | None:
     if not cache_available:
         _BPE_ENCODING = _BPE_ENCODING_UNAVAILABLE
         logger.error(
-            "No valid gpt-4o tokenizer cache is available; "
-            "exact chunk measurement is unavailable"
+            "No valid gpt-4o tokenizer cache is available; exact chunk measurement is unavailable"
         )
         return None
     try:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -352,7 +352,9 @@ async def _ingest(args: argparse.Namespace) -> int:
     accepted = result.get("accepted", True)
     # A duplicate is a benign, idempotent no-op — not a failure.
     duplicate = (not accepted) and "duplicate" in str(result.get("reason") or "")
-    cognified = result.get("cognified")  # True/False from the Node, or None (not requested / old Node)
+    cognified = result.get(
+        "cognified"
+    )  # True/False from the Node, or None (not requested / old Node)
     color = supports_color()
     dataset = result.get("dataset") or "your node"
     scope = "your private seat" if str(dataset).startswith("seat:") else "shared org vault"
@@ -369,7 +371,9 @@ async def _ingest(args: argparse.Namespace) -> int:
         if cognified is True:
             print(f"  {mark(True, enable=color)} cognified — now searchable")
         elif cognified is False:
-            print(f"  {paint(SKIP, 'yellow', enable=color)} ingested, but cognify didn't finish — the next Node sync will pick it up")
+            print(
+                f"  {paint(SKIP, 'yellow', enable=color)} ingested, but cognify didn't finish — the next Node sync will pick it up"
+            )
         elif cognify:
             # Requested cognify but the Node didn't report it (older Node, pre inline-cognify).
             print(paint("  (graph update will happen on the next Node sync)", "dim", enable=color))
@@ -409,8 +413,12 @@ _SEARCH_SECTION_ORDER = ("central", "session_traces", "node")
 def _search_item_text(item: Any) -> str:
     if isinstance(item, dict):
         text = (
-            item.get("text") or item.get("content") or item.get("summary")
-            or item.get("title") or item.get("name") or json.dumps(item, default=str)
+            item.get("text")
+            or item.get("content")
+            or item.get("summary")
+            or item.get("title")
+            or item.get("name")
+            or json.dumps(item, default=str)
         )
     else:
         text = str(item)
@@ -453,7 +461,9 @@ def _render_search(payload: dict[str, Any], query: str) -> None:
             print(paint(_SEARCH_SECTION_LABELS[key], "bold", enable=color))
             for item in items:
                 meta = _search_item_meta(item, color=color) if isinstance(item, dict) else ""
-                print(f"  {paint(f'{index}.', 'cyan', enable=color)} {meta}{_search_item_text(item)}")
+                print(
+                    f"  {paint(f'{index}.', 'cyan', enable=color)} {meta}{_search_item_text(item)}"
+                )
                 index += 1
             print()
         return
@@ -633,7 +643,13 @@ async def _search(args: argparse.Namespace) -> int:
             code="HTTP_ERROR",
             extra={"http_status": exc.code},
         )
-    except (TimeoutError, urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
+    except (
+        TimeoutError,
+        urllib.error.URLError,
+        OSError,
+        ValueError,
+        http.client.HTTPException,
+    ) as exc:
         # TimeoutError and urllib URLError("timed out") share one soft-fail path.
         if _is_timeout_exc(exc):
             return _emit_search_timeout(args, note=str(exc) or "search timed out")
@@ -650,7 +666,9 @@ async def _search(args: argparse.Namespace) -> int:
             return 0
         for warning in shaped.get("warnings") or []:
             print(paint(f"warning: {warning}", "yellow"), file=sys.stderr)
-        display_results = shaped["results"] if filters_on or shaped.get("spec_mode") else raw.get("results")
+        display_results = (
+            shaped["results"] if filters_on or shaped.get("spec_mode") else raw.get("results")
+        )
         _render_search({**raw, "results": display_results or [], "sections": None}, args.query)
         return 0
 
@@ -736,7 +754,13 @@ async def _verify(args: argparse.Namespace) -> int:
                 top_k,
                 timeout=_search_timeout_seconds(args),
             )
-    except (TimeoutError, urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
+    except (
+        TimeoutError,
+        urllib.error.URLError,
+        OSError,
+        ValueError,
+        http.client.HTTPException,
+    ) as exc:
         if _is_timeout_exc(exc):
             report = shape_verify_report(
                 path=path,
@@ -798,7 +822,13 @@ async def _prepare_pr_context(args: argparse.Namespace) -> int:
                 top_k,
                 timeout=_search_timeout_seconds(args),
             )
-    except (TimeoutError, urllib.error.URLError, OSError, ValueError, http.client.HTTPException) as exc:
+    except (
+        TimeoutError,
+        urllib.error.URLError,
+        OSError,
+        ValueError,
+        http.client.HTTPException,
+    ) as exc:
         if _is_timeout_exc(exc):
             brief = shape_prepare_pr_context(
                 repo=repo,
@@ -942,11 +972,15 @@ async def _learn(args: argparse.Namespace) -> None:
     from kb.learning_agent import LearningAgent
 
     agent = LearningAgent.from_env()
-    result = await agent.status() if args.status else await agent.run(
-        force=args.force,
-        dry_run=args.dry_run,
-        post_to_chat=args.post_to_chat,
-        include_digest_preview=not args.hide_digest_preview,
+    result = (
+        await agent.status()
+        if args.status
+        else await agent.run(
+            force=args.force,
+            dry_run=args.dry_run,
+            post_to_chat=args.post_to_chat,
+            include_digest_preview=not args.hide_digest_preview,
+        )
     )
     _print_json(result)
     return _result_exit(result)
@@ -1000,9 +1034,11 @@ def _wizard_roots(config: CaptureConfig, default_root: str | None = None) -> Cap
             # recording a root that will never capture anything.
             guess = Path.home() / raw.lstrip("/") if raw.startswith("/") else None
             if guess is not None and guess.exists():
-                answer = _prompt(
-                    f"  ! {normalized} does not exist — did you mean {guess}? [Y/n]: "
-                ).strip().lower()
+                answer = (
+                    _prompt(f"  ! {normalized} does not exist — did you mean {guess}? [Y/n]: ")
+                    .strip()
+                    .lower()
+                )
                 if answer in ("", "y", "yes"):
                     normalized = normalize_path(str(guess))
                 else:
@@ -1316,7 +1352,13 @@ def _access_exit(exc: AccessClientError, *, as_json: bool) -> int:
 def _print_minted_token(token: str, api_token: dict[str, Any], *, color: bool) -> None:
     """Print a freshly minted token once, with its write-scope + adopt steps."""
     print()
-    print(paint("  Token (shown once — copy it now, it cannot be retrieved later):", "yellow", enable=color))
+    print(
+        paint(
+            "  Token (shown once — copy it now, it cannot be retrieved later):",
+            "yellow",
+            enable=color,
+        )
+    )
     print("    " + paint(token, "bold", enable=color))
     dataset = api_token.get("default_dataset")
     if dataset and str(dataset).startswith("seat:"):
@@ -1326,7 +1368,13 @@ def _print_minted_token(token: str, api_token: dict[str, Any], *, color: bool) -
     else:
         scope = "ingests go to the org default dataset — NOT a private seat"
     print(paint(f"  scope: {scope}  ·  role={api_token.get('role')}", "dim", enable=color))
-    print(paint("  Adopt:  citadel onboard --token <token-above>   ·   share over a private channel", "dim", enable=color))
+    print(
+        paint(
+            "  Adopt:  citadel onboard --token <token-above>   ·   share over a private channel",
+            "dim",
+            enable=color,
+        )
+    )
 
 
 async def _seat_list(args: argparse.Namespace) -> int:
@@ -1495,7 +1543,10 @@ async def _token_create(args: argparse.Namespace) -> int:
         if seat_slug:
             known = {seat.get("seat_slug") for seat in _active_seats(base_url)}
             if seat_slug not in known:
-                listing = ", ".join(sorted(str(slug) for slug in known)) or "none yet — `citadel seat create`"
+                listing = (
+                    ", ".join(sorted(str(slug) for slug in known))
+                    or "none yet — `citadel seat create`"
+                )
                 print(
                     f"citadel token create: no seat '{seat_slug}'. Seats: {listing}",
                     file=sys.stderr,
@@ -1518,13 +1569,13 @@ async def _token_create(args: argparse.Namespace) -> int:
                 if slug in known:
                     print(
                         f"citadel token create: '{dataset}' is a seat — mint a seat-bound token: "
-                        f"citadel token create \"{args.name}\" --seat {slug}",
+                        f'citadel token create "{args.name}" --seat {slug}',
                         file=sys.stderr,
                     )
                 else:
                     print(
                         f"citadel token create: no seat '{slug}' — create it first: "
-                        f"citadel seat create \"Name\" {slug}",
+                        f'citadel seat create "Name" {slug}',
                         file=sys.stderr,
                     )
                 return 1
@@ -1543,7 +1594,13 @@ async def _token_create(args: argparse.Namespace) -> int:
         _print_json(result)
         return 0
     color = supports_color()
-    print(paint(f"Token created  (principal {result.get('principal', {}).get('id')})", "green", enable=color))
+    print(
+        paint(
+            f"Token created  (principal {result.get('principal', {}).get('id')})",
+            "green",
+            enable=color,
+        )
+    )
     if result.get("token"):
         _print_minted_token(result["token"], result.get("api_token", {}), color=color)
     # Standalone tokens are NOT seat-scoped — steer teammate tokens to seats.
@@ -1552,7 +1609,7 @@ async def _token_create(args: argparse.Namespace) -> int:
         print(
             paint(
                 "  Note: this is a standalone token (not a private seat). For a teammate, use "
-                "`citadel seat create \"Name\" slug` so their writes land in their own seat.",
+                '`citadel seat create "Name" slug` so their writes land in their own seat.',
                 "yellow",
                 enable=color,
             )
@@ -1588,7 +1645,10 @@ async def _token_set(args: argparse.Namespace) -> int:
     token = (args.token or "").strip()
     if not token:
         if not sys.stdin.isatty():
-            print("citadel token set: pass the token as an argument (no TTY to prompt on).", file=sys.stderr)
+            print(
+                "citadel token set: pass the token as an argument (no TTY to prompt on).",
+                file=sys.stderr,
+            )
             return 2
         token = _prompt_hidden("Paste the new seat token (ctdl_…): ")
     if not token:
@@ -1605,7 +1665,10 @@ async def _token_set(args: argparse.Namespace) -> int:
                 f"  {mark(False, enable=color)} token not verified ({auth.detail}) — nothing written.",
                 file=sys.stderr,
             )
-            print(paint("  (pass --skip-verify to write it anyway)", "dim", enable=color), file=sys.stderr)
+            print(
+                paint("  (pass --skip-verify to write it anyway)", "dim", enable=color),
+                file=sys.stderr,
+            )
             return 1
         print()
         print(_render_identity(auth, node_url, color))
@@ -1613,11 +1676,19 @@ async def _token_set(args: argparse.Namespace) -> int:
 
     previous = read_token_from_rc(rc_path)
     status = ensure_token_in_rc(rc_path, token)
-    detail = status + (f" · replaced {mask_token(previous)}" if previous and previous != token else "")
-    print(f"  {mark(True, enable=color)} token {mask_token(token)} → {rc_path}  {paint(detail, 'dim', enable=color)}")
+    detail = status + (
+        f" · replaced {mask_token(previous)}" if previous and previous != token else ""
+    )
+    print(
+        f"  {mark(True, enable=color)} token {mask_token(token)} → {rc_path}  {paint(detail, 'dim', enable=color)}"
+    )
     if (os.environ.get(TOKEN_ENV) or "").strip() != token:
         print(
-            paint(f"  ! this shell still has the old value — run `source {rc_path}` or open a new shell.", "yellow", enable=color)
+            paint(
+                f"  ! this shell still has the old value — run `source {rc_path}` or open a new shell.",
+                "yellow",
+                enable=color,
+            )
         )
     return 0
 
@@ -1647,10 +1718,16 @@ def _wire_detected_tools(node_url: str, *, color: bool) -> None:
     if selectable:
         labels = [
             tool_detect.SPECS[name].label
-            + (paint("  (paste-in snippet)", "dim", enable=color) if tool_detect.SPECS[name].mode == "snippet" else "")
+            + (
+                paint("  (paste-in snippet)", "dim", enable=color)
+                if tool_detect.SPECS[name].mode == "snippet"
+                else ""
+            )
             for name in selectable
         ]
-        preselected = {i for i, name in enumerate(selectable) if tool_detect.SPECS[name].mode == "write"}
+        preselected = {
+            i for i, name in enumerate(selectable) if tool_detect.SPECS[name].mode == "write"
+        }
         print()
         picked = checkbox_select(
             paint("Coding tools", "bold", enable=color)
@@ -1668,14 +1745,20 @@ def _wire_detected_tools(node_url: str, *, color: bool) -> None:
         spec = tool_detect.SPECS[name]
         if spec.mode == "write":
             sigil = mark(result.action != "error", enable=color)
-            print(f"  {sigil} {spec.label}  {paint(f'{result.action} · {result.detail}', 'dim', enable=color)}")
+            print(
+                f"  {sigil} {spec.label}  {paint(f'{result.action} · {result.detail}', 'dim', enable=color)}"
+            )
         else:  # snippet
-            print(f"  {paint(spec.label, 'bold', enable=color)} — paste into {paint(spec.config_hint, 'dim', enable=color)}:")
+            print(
+                f"  {paint(spec.label, 'bold', enable=color)} — paste into {paint(spec.config_hint, 'dim', enable=color)}:"
+            )
             print(_indent(result.snippet or ""))
     for name in notes:
         result = tool_detect.apply(name, node_url=node_url)
         spec = tool_detect.SPECS[name]
-        print(f"  {paint('•', 'dim', enable=color)} {spec.label}: {paint(result.detail, 'dim', enable=color)}")
+        print(
+            f"  {paint('•', 'dim', enable=color)} {spec.label}: {paint(result.detail, 'dim', enable=color)}"
+        )
 
 
 async def _mcp_add(args: argparse.Namespace) -> int:
@@ -1687,8 +1770,11 @@ async def _mcp_add(args: argparse.Namespace) -> int:
     rc = 0
     for name in targets:
         if name not in tool_detect.SPECS:
-            print(f"citadel mcp add: unknown tool {name!r} "
-                  f"(choose from: {', '.join(tool_detect.ALL_TOOLS)}, all)", file=sys.stderr)
+            print(
+                f"citadel mcp add: unknown tool {name!r} "
+                f"(choose from: {', '.join(tool_detect.ALL_TOOLS)}, all)",
+                file=sys.stderr,
+            )
             rc = 1
             continue
         spec = tool_detect.SPECS[name]
@@ -1696,8 +1782,10 @@ async def _mcp_add(args: argparse.Namespace) -> int:
         if spec.mode == "write":
             ok = result.action != "error"
             rc = rc or (0 if ok else 1)
-            print(f"  {mark(ok, enable=color)} {spec.label}  "
-                  f"{paint(f'{result.action} · {result.detail}', 'dim', enable=color)}")
+            print(
+                f"  {mark(ok, enable=color)} {spec.label}  "
+                f"{paint(f'{result.action} · {result.detail}', 'dim', enable=color)}"
+            )
         elif spec.mode == "snippet":
             print(paint(f"{spec.label} — paste into {spec.config_hint}:", "bold", enable=color))
             print(_indent(result.snippet or ""))
@@ -1718,7 +1806,9 @@ async def _mcp_list(args: argparse.Namespace) -> int:
     for name in detected:
         spec = tool_detect.SPECS[name]
         mode = {"write": "auto-write", "snippet": "snippet", "note": "note"}[spec.mode]
-        print(f"  {paint(name.ljust(9), 'cyan', enable=color)} {mode:<10} {paint(spec.config_hint, 'dim', enable=color)}")
+        print(
+            f"  {paint(name.ljust(9), 'cyan', enable=color)} {mode:<10} {paint(spec.config_hint, 'dim', enable=color)}"
+        )
     return 0
 
 
@@ -1819,11 +1909,7 @@ def _render_mesh(mesh: dict[str, Any], color: bool) -> str:
     last = stats.get("last_indexed_at")
     if last:
         parts.append(paint(f"last indexed {str(last)[:16].replace('T', ' ')}", "dim", enable=color))
-    return (
-        paint("Knowledge mesh", "bold", enable=color)
-        + "\n  "
-        + " · ".join(parts)
-    )
+    return paint("Knowledge mesh", "bold", enable=color) + "\n  " + " · ".join(parts)
 
 
 def _render_event(event: dict[str, Any], color: bool) -> str:
@@ -2029,8 +2115,13 @@ async def _doctor(args: argparse.Namespace) -> int:
 
     async def _gather() -> Any:
         return await asyncio.to_thread(
-            gather_status, node_url, token, repo=repo, config_path=config_path,
-            with_search=False, with_recent=False,
+            gather_status,
+            node_url,
+            token,
+            repo=repo,
+            config_path=config_path,
+            with_search=False,
+            with_recent=False,
         )
 
     if as_json:
@@ -2065,15 +2156,23 @@ async def _doctor(args: argparse.Namespace) -> int:
 
     node = checks.get("node")
     if node and not node.ok:
-        issues.append({"problem": f"Node unreachable at {node_url} ({node.detail})",
-                       "fix": "check the Node URL / network"})
+        issues.append(
+            {
+                "problem": f"Node unreachable at {node_url} ({node.detail})",
+                "fix": "check the Node URL / network",
+            }
+        )
     auth = checks.get("auth")
     # Only call it a token rejection when the Node is actually reachable — when
     # the Node is down, auth fails too, and we must not tell the user to rotate
     # a perfectly valid token.
     if node and node.ok and token and auth and not auth.ok:
-        issues.append({"problem": f"Node rejected the token ({auth.detail})",
-                       "fix": "token revoked/expired or wrong Node — re-mint (`citadel seat create`) or re-onboard"})
+        issues.append(
+            {
+                "problem": f"Node rejected the token ({auth.detail})",
+                "fix": "token revoked/expired or wrong Node — re-mint (`citadel seat create`) or re-onboard",
+            }
+        )
 
     # Data-plane gate: a reachable, authenticated Node whose corpus check is RED
     # (sources tracked but graph empty, or the cognify canary failed) is a real
@@ -2081,27 +2180,49 @@ async def _doctor(args: argparse.Namespace) -> int:
     # unresolved so doctor exits nonzero.
     corpus = checks.get("corpus")
     if node and node.ok and auth and auth.ok and corpus and not corpus.ok:
-        issues.append({"problem": f"data plane broken ({corpus.detail}) — Node up but retrieval is empty",
-                       "fix": "check the evolve scheduler / cognify; run `citadel cognify --verify`"})
+        issues.append(
+            {
+                "problem": f"data plane broken ({corpus.detail}) — Node up but retrieval is empty",
+                "fix": "check the evolve scheduler / cognify; run `citadel cognify --verify`",
+            }
+        )
 
     mcp_node = _mcp_node_url(repo / ".mcp.json")
     if mcp_node and cap_node and mcp_node.rstrip("/") != cap_node.rstrip("/"):
-        issues.append({"problem": f".mcp.json Node ({mcp_node}) disagrees with capture config ({cap_node})",
-                       "fix": f"citadel onboard --node-url {cap_node}"})
+        issues.append(
+            {
+                "problem": f".mcp.json Node ({mcp_node}) disagrees with capture config ({cap_node})",
+                "fix": f"citadel onboard --node-url {cap_node}",
+            }
+        )
 
     hook_check = checks.get("pre_push_hook")
     if hook_check and not hook_check.ok:
         if (hook_check.data or {}).get("git_repo") is False:
             # Not a git repo here — "hook missing" would read as "your hook is
             # gone" when there was simply nothing to inspect at this cwd.
-            issues.append({
-                "problem": f"pre-push hook not checked — {hook_check.detail}",
-                "fix": "run `citadel doctor` from inside a git repo (or pass --repo)",
-            })
+            issues.append(
+                {
+                    "problem": f"pre-push hook not checked — {hook_check.detail}",
+                    "fix": "run `citadel doctor` from inside a git repo (or pass --repo)",
+                }
+            )
         else:
-            issues.append({"problem": "git pre-push autosync hook missing", "fix": "citadel doctor --fix", "kind": "pre_push"})
+            issues.append(
+                {
+                    "problem": "git pre-push autosync hook missing",
+                    "fix": "citadel doctor --fix",
+                    "kind": "pre_push",
+                }
+            )
     if checks.get("session_hook") and not checks["session_hook"].ok:
-        issues.append({"problem": "Claude SessionEnd/SessionStart hooks missing", "fix": "citadel doctor --fix", "kind": "session"})
+        issues.append(
+            {
+                "problem": "Claude SessionEnd/SessionStart hooks missing",
+                "fix": "citadel doctor --fix",
+                "kind": "session",
+            }
+        )
     if checks.get("mcp") and not checks["mcp"].ok:
         mcp_check = checks["mcp"]
         state = (mcp_check.data or {}).get("state") or MCP_STATE_MISSING
@@ -2118,8 +2239,7 @@ async def _doctor(args: argparse.Namespace) -> int:
                 mcp_issue["fix"] = "citadel doctor --fix"
         elif state == MCP_STATE_NEEDS_AUTH:
             mcp_issue["fix"] = (
-                f"set {TOKEN_ENV} in the environment Cursor was launched from, "
-                "then restart Cursor"
+                f"set {TOKEN_ENV} in the environment Cursor was launched from, then restart Cursor"
             )
         issues.append(mcp_issue)
     for mcp_issue in diagnose_mcp_config(repo):
@@ -2152,9 +2272,7 @@ async def _doctor(args: argparse.Namespace) -> int:
                         # Demote so --fix does not claim "all clear".
                         fixed.append("MCP server (hosted HTTP)")
                         issue.pop("kind", None)
-                        issue["problem"] = (
-                            f"MCP not ready ({after_state}): {after.detail}"
-                        )
+                        issue["problem"] = f"MCP not ready ({after_state}): {after.detail}"
                         issue["fix"] = (
                             f"set {TOKEN_ENV} in the environment Cursor was "
                             "launched from, then restart Cursor"
@@ -2169,13 +2287,15 @@ async def _doctor(args: argparse.Namespace) -> int:
     rc = 1 if unresolved else 0
 
     if as_json:
-        _print_json({
-            "ok": not issues,
-            "node_url": node_url,
-            "issues": [{k: v for k, v in i.items() if k != "kind"} for i in issues],
-            "fixed": fixed,
-            "resolved": not unresolved,
-        })
+        _print_json(
+            {
+                "ok": not issues,
+                "node_url": node_url,
+                "issues": [{k: v for k, v in i.items() if k != "kind"} for i in issues],
+                "fixed": fixed,
+                "resolved": not unresolved,
+            }
+        )
         return rc
 
     if sys.stdout.isatty():
@@ -2196,10 +2316,18 @@ async def _doctor(args: argparse.Namespace) -> int:
         print(paint(f"✓ Fixed: {', '.join(fixed)}. All clear.", "green", enable=color))
     elif fixed:
         print()
-        print(paint(f"Applied: {', '.join(fixed)}. Remaining items need you (see above).", "yellow", enable=color))
+        print(
+            paint(
+                f"Applied: {', '.join(fixed)}. Remaining items need you (see above).",
+                "yellow",
+                enable=color,
+            )
+        )
     elif any(i.get("kind") for i in issues):
         print()
-        print(paint("Run `citadel doctor --fix` to apply the auto-fixable ones.", "dim", enable=color))
+        print(
+            paint("Run `citadel doctor --fix` to apply the auto-fixable ones.", "dim", enable=color)
+        )
     return rc
 
 
@@ -2238,9 +2366,18 @@ def _render_identity(auth: Any, node_url: str, color: bool) -> str:
     ident = getattr(auth, "data", None) or {}
     seat = ident.get("seat_slug") or ident.get("actor") or "—"
     caps = ident.get("capabilities") or {}
-    access = " · ".join(
-        flag for flag, on in (("read", caps.get("read")), ("write", caps.get("write")), ("admin", caps.get("admin"))) if on
-    ) or "—"
+    access = (
+        " · ".join(
+            flag
+            for flag, on in (
+                ("read", caps.get("read")),
+                ("write", caps.get("write")),
+                ("admin", caps.get("admin")),
+            )
+            if on
+        )
+        or "—"
+    )
     writes = f"seat:{seat}" if ident.get("seat_slug") else "shared org dataset"
     lines = [
         paint(f"  {mark(True, enable=color)} authenticated", "green", enable=color),
@@ -2311,7 +2448,11 @@ async def _resolve_onboard_token(
             if answer in ("n", "no"):
                 token = _prompt_hidden("  Paste the new seat token (ctdl_…): ") or existing
                 if token == existing:
-                    print(paint("  (nothing pasted — keeping the existing token)", "dim", enable=color))
+                    print(
+                        paint(
+                            "  (nothing pasted — keeping the existing token)", "dim", enable=color
+                        )
+                    )
         else:
             token = existing
     if not token and interactive:
@@ -2343,13 +2484,23 @@ async def _resolve_onboard_token(
                 # Node unreachable / network error — a new token won't help.
                 print(
                     f"  {paint('!', 'yellow', enable=color)} "
-                    + paint(f"could not verify the token ({detail}) — continuing; run `citadel status` later.", "yellow", enable=color)
+                    + paint(
+                        f"could not verify the token ({detail}) — continuing; run `citadel status` later.",
+                        "yellow",
+                        enable=color,
+                    )
                 )
                 break
             print(f"  {mark(False, enable=color)} the Node rejected this token ({detail})")
             answer = _prompt("  Paste a different token? [y/N]: ").strip().lower()
             if answer not in ("y", "yes"):
-                print(paint("  (keeping it anyway — fix it later with `citadel token set`)", "dim", enable=color))
+                print(
+                    paint(
+                        "  (keeping it anyway — fix it later with `citadel token set`)",
+                        "dim",
+                        enable=color,
+                    )
+                )
                 break
             new_token = _prompt_hidden("  Paste the new seat token (ctdl_…): ")
             if not new_token:
@@ -2422,9 +2573,7 @@ async def _onboard(args: argparse.Namespace) -> int:
     # and proactive-ingest work out of the box (#35). Interactive-only; written
     # to the shell rc next to the seat token.
     if interactive:
-        llm_key = _prompt_hidden(
-            "\nOpenRouter API key for local cognify — Enter to skip: "
-        )
+        llm_key = _prompt_hidden("\nOpenRouter API key for local cognify — Enter to skip: ")
         if llm_key:
             steps.append(
                 (
@@ -2438,9 +2587,7 @@ async def _onboard(args: argparse.Namespace) -> int:
                 )
             )
             # Only relevant once a key exists — noise for everyone who skipped.
-            print(
-                "  (local cognify also needs: pipx install 'citadel-archive[server]')"
-            )
+            print("  (local cognify also needs: pipx install 'citadel-archive[server]')")
 
     # Capture roots (unless --no-capture): the wizard asks about the repo
     # toplevel explicitly (declinable); if the config still ends up empty, it
@@ -2456,9 +2603,7 @@ async def _onboard(args: argparse.Namespace) -> int:
             cfg = _wizard_roots(cfg, default_root=str(repo))
         if not cfg.roots:
             cfg = cfg.with_root(str(repo), (DEFAULT_ROOT_TAG,))  # 'personal' never promotes
-        save_capture_config(
-            cfg, path=cfg_path, updated_at=datetime.now(timezone.utc).isoformat()
-        )
+        save_capture_config(cfg, path=cfg_path, updated_at=datetime.now(timezone.utc).isoformat())
         steps.append((f"capture roots → {cfg_path}", f"{len(cfg.roots)} root(s)"))
         sync_result = sync_local_capture_roots_to_server(
             cfg,
@@ -2525,8 +2670,8 @@ async def _onboard(args: argparse.Namespace) -> int:
     print(
         f"\nNext: restart your shell (or `source {rc_path}`), then in your agent:\n"
         '  • at task start — "use citadel_search before we code on <topic>"\n'
-        '  • proactive capture — see /skills/proactive-ingest for mid-session ingest + autosync\n'
-        '  • when a route is worth reusing — ask the user, then `citadel_share_session` '
+        "  • proactive capture — see /skills/proactive-ingest for mid-session ingest + autosync\n"
+        "  • when a route is worth reusing — ask the user, then `citadel_share_session` "
         "(Shared Session Traces are reference-only, not org truth)\n"
         '  • smoke test — "use citadel_search to find what we decided about the vault"'
     )
@@ -2610,27 +2755,42 @@ async def _update(args: argparse.Namespace) -> int:
 
 
 _HOME_MENU = (
-    ("Get started", (
-        ("onboard", "one-command setup — token · hooks · MCP · capture roots"),
-        ("status", "connection · identity · local setup (--json for agents)"),
-        ("doctor", "diagnose setup problems · --fix to repair"),
-        ("update", "update citadel to the latest release"),
-    )),
-    ("Capture", (
-        ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
-        ("capture", "push summaries of approved roots to your Node"),
-        ("promotion", "list · approve · reject · run the Promotion Agent queue"),
-    )),
-    ("Knowledge", (
-        ("search", "search the Organization Vault"),
-        ("ingest", "add a durable note to your Node"),
-        ("activity", "recent vault activity — captures · syncs · searches (--global for the team)"),
-    )),
-    ("Connect & admin", (
-        ("mcp", "add Citadel MCP to Claude · Cursor · Codex · …"),
-        ("seat", "create · list seats and mint tokens (admin)"),
-        ("token", "set this machine's seat token · admin create/revoke"),
-    )),
+    (
+        "Get started",
+        (
+            ("onboard", "one-command setup — token · hooks · MCP · capture roots"),
+            ("status", "connection · identity · local setup (--json for agents)"),
+            ("doctor", "diagnose setup problems · --fix to repair"),
+            ("update", "update citadel to the latest release"),
+        ),
+    ),
+    (
+        "Capture",
+        (
+            ("setup", "declare Approved Capture Roots (~/.citadel/capture.json)"),
+            ("capture", "push summaries of approved roots to your Node"),
+            ("promotion", "list · approve · reject · run the Promotion Agent queue"),
+        ),
+    ),
+    (
+        "Knowledge",
+        (
+            ("search", "search the Organization Vault"),
+            ("ingest", "add a durable note to your Node"),
+            (
+                "activity",
+                "recent vault activity — captures · syncs · searches (--global for the team)",
+            ),
+        ),
+    ),
+    (
+        "Connect & admin",
+        (
+            ("mcp", "add Citadel MCP to Claude · Cursor · Codex · …"),
+            ("seat", "create · list seats and mint tokens (admin)"),
+            ("token", "set this machine's seat token · admin create/revoke"),
+        ),
+    ),
 )
 
 
@@ -2732,12 +2892,18 @@ class CitadelParser(argparse.ArgumentParser):
                 ]
                 lines.append("")
             elif choices:
-                lines.append("  available: " + ", ".join(paint(c, "cyan", enable=color) for c in choices))
+                lines.append(
+                    "  available: " + ", ".join(paint(c, "cyan", enable=color) for c in choices)
+                )
                 lines.append("")
             if top:
-                lines.append("  run " + paint("citadel", "cyan", enable=color) + " to see all commands.")
+                lines.append(
+                    "  run " + paint("citadel", "cyan", enable=color) + " to see all commands."
+                )
             else:
-                lines.append("  run " + paint(f"{self.prog} --help", "cyan", enable=color) + " for options.")
+                lines.append(
+                    "  run " + paint(f"{self.prog} --help", "cyan", enable=color) + " for options."
+                )
             sys.stderr.write("\n".join(lines) + "\n")
             raise SystemExit(2)
 
@@ -2757,10 +2923,18 @@ class CitadelParser(argparse.ArgumentParser):
                 lines = [paint(f"✗ {self.prog} needs a subcommand:", "red", enable=color), ""]
                 for name in sub_action.choices:
                     label = paint(name.ljust(pad), "cyan", enable=color)
-                    lines.append(f"  {label}{paint(help_by_name.get(name, ''), 'dim', enable=color)}")
+                    lines.append(
+                        f"  {label}{paint(help_by_name.get(name, ''), 'dim', enable=color)}"
+                    )
                 lines.append("")
                 lines.append(
-                    "  e.g. " + paint(f"{self.prog} {next(iter(sub_action.choices))}", "bold", "cyan", enable=color)
+                    "  e.g. "
+                    + paint(
+                        f"{self.prog} {next(iter(sub_action.choices))}",
+                        "bold",
+                        "cyan",
+                        enable=color,
+                    )
                 )
                 sys.stderr.write("\n".join(lines) + "\n")
                 raise SystemExit(2)
@@ -2817,7 +2991,9 @@ def build_parser() -> argparse.ArgumentParser:
         "activity",
         help="Show your Node's vault activity — captures, syncs, promotions, searches",
     )
-    activity.add_argument("--watch", action="store_true", help="Live-tail new activity (Ctrl-C to stop)")
+    activity.add_argument(
+        "--watch", action="store_true", help="Live-tail new activity (Ctrl-C to stop)"
+    )
     activity.add_argument(
         "--global",
         dest="global_broadcast",
@@ -2829,8 +3005,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show local capture receipts from ~/.citadel/activity.log (offline, no server)",
     )
-    activity.add_argument("--limit", type=int, default=20, help="How many recent events to show (default 20)")
-    activity.add_argument("--type", help="Filter by event type (ingest, search, promotion, github_sync, …)")
+    activity.add_argument(
+        "--limit", type=int, default=20, help="How many recent events to show (default 20)"
+    )
+    activity.add_argument(
+        "--type", help="Filter by event type (ingest, search, promotion, github_sync, …)"
+    )
     activity.add_argument("--json", action="store_true", help="Machine-readable output")
     activity.add_argument("--node-url", help="Override Node URL (default: from config)")
     activity.add_argument("--config", help="Override capture config path")
@@ -2840,7 +3020,9 @@ def build_parser() -> argparse.ArgumentParser:
         "doctor",
         help="Diagnose setup problems and suggest (or --fix) repairs",
     )
-    doctor.add_argument("--fix", action="store_true", help="Apply safe auto-fixes (hooks, .mcp.json)")
+    doctor.add_argument(
+        "--fix", action="store_true", help="Apply safe auto-fixes (hooks, .mcp.json)"
+    )
     doctor.add_argument("--json", action="store_true", help="Machine-readable output")
     doctor.add_argument("--node-url", help="Override Node URL")
     doctor.add_argument("--repo", help="Repo to check (default: git toplevel or cwd)")
@@ -2911,9 +3093,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Capture only this configured root (repeatable; default: all)",
     )
-    capture.add_argument(
-        "--dry-run", action="store_true", help="Print payloads without posting"
-    )
+    capture.add_argument("--dry-run", action="store_true", help="Print payloads without posting")
     capture.add_argument("--json", action="store_true", help="Machine-readable output")
     capture.add_argument("--config", help="Override config path (testing)")
     capture.set_defaults(handler=_capture)
@@ -3017,7 +3197,9 @@ def build_parser() -> argparse.ArgumentParser:
     token_set.add_argument("--shell-rc", help="Shell rc file for the token export")
     token_set.add_argument("--node-url", help="Override Node URL")
     token_set.add_argument(
-        "--skip-verify", action="store_true", help="Write without checking the token against the Node"
+        "--skip-verify",
+        action="store_true",
+        help="Write without checking the token against the Node",
     )
     token_set.set_defaults(handler=_token_set)
 
@@ -3030,11 +3212,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--seat", help="Bind the token to an EXISTING seat by slug (omit for an interactive picker)"
     )
     token_create.add_argument(
-        "--role", default=None, choices=("reader", "writer", "admin"),
+        "--role",
+        default=None,
+        choices=("reader", "writer", "admin"),
         help="Standalone-token role (default: reader; seat tokens inherit the seat's role)",
     )
     token_create.add_argument(
-        "--kind", default=None, choices=("service_account", "user"),
+        "--kind",
+        default=None,
+        choices=("service_account", "user"),
         help="Standalone-token principal kind (default: service_account)",
     )
     token_create.add_argument(
@@ -3194,8 +3380,12 @@ def build_parser() -> argparse.ArgumentParser:
         dest="top_k",
         help="Max vault hits (default: 12)",
     )
-    prepare_pr.add_argument("--timeout", type=float, default=None, help="Client soft-timeout seconds")
-    prepare_pr.add_argument("--budget-ms", type=int, default=None, help="Soft-timeout in milliseconds")
+    prepare_pr.add_argument(
+        "--timeout", type=float, default=None, help="Client soft-timeout seconds"
+    )
+    prepare_pr.add_argument(
+        "--budget-ms", type=int, default=None, help="Soft-timeout in milliseconds"
+    )
     prepare_pr.add_argument("--node-url", help="Override Node URL")
     prepare_pr.set_defaults(handler=_prepare_pr_context)
 
@@ -3215,8 +3405,13 @@ def build_parser() -> argparse.ArgumentParser:
     improve = subcommands.add_parser("improve", help="Run Cognee improvement")
     improve.add_argument("--dataset", help="Dataset to improve")
     # Accept --session as an alias for parity with ingest/search/feedback.
-    improve.add_argument("--session-id", "--session", action="append", dest="session_id",
-                         help="Session id to improve (repeatable)")
+    improve.add_argument(
+        "--session-id",
+        "--session",
+        action="append",
+        dest="session_id",
+        help="Session id to improve (repeatable)",
+    )
     improve.set_defaults(handler=_improve)
 
     cognify = subcommands.add_parser(

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -29,6 +29,7 @@ _BACKGROUND_COGNIFY_TASKS: set[Any] = set()
 DEFAULT_COGNIFY_QUEUE_PATH = Path(".citadel/cognify_queue.json")
 COGNIFY_EXECUTION_LOCK_POLL_SECONDS = 1.0
 
+
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
     if raw is None:
@@ -57,9 +58,7 @@ def _corpus_health_max_documents() -> int:
             "CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS must be a positive integer"
         ) from exc
     if value < 1:
-        raise RuntimeError(
-            "CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS must be a positive integer"
-        )
+        raise RuntimeError("CITADEL_CORPUS_HEALTH_MAX_DOCUMENTS must be a positive integer")
     return value
 
 
@@ -86,7 +85,9 @@ def _cognify_data_ids(result: Any) -> list[str]:
         if not isinstance(info, (list, tuple)):
             continue
         for item in info:
-            data_id = item.get("data_id") if isinstance(item, Mapping) else getattr(item, "data_id", None)
+            data_id = (
+                item.get("data_id") if isinstance(item, Mapping) else getattr(item, "data_id", None)
+            )
             if data_id is not None:
                 data_ids.append(str(data_id))
     return list(dict.fromkeys(data_ids))
@@ -139,9 +140,7 @@ def _parse_citadel_tags(external_metadata: Any) -> list[str]:
 # degrades to "no attribution" instead of stalling the endpoint. All three are
 # env-overridable so a live node can be tuned without a redeploy.
 NODE_DATASET_MAP_TTL_SECONDS = _float_env("CITADEL_NODE_DATASET_MAP_TTL_SECONDS", 60.0)
-NODE_DATASET_MAP_TIMEOUT_SECONDS = _float_env(
-    "CITADEL_NODE_DATASET_MAP_TIMEOUT_SECONDS", 5.0
-)
+NODE_DATASET_MAP_TIMEOUT_SECONDS = _float_env("CITADEL_NODE_DATASET_MAP_TIMEOUT_SECONDS", 5.0)
 # A failed/timed-out read is cached only briefly (NOT the full content TTL): a
 # transient stall must re-read quickly instead of latching a 60s content
 # blackout for every scoped caller (#50). On failure we also prefer the last
@@ -438,9 +437,7 @@ class CogneeGateway(Protocol):
     async def restore_document_chunks(self, deleted: Mapping[str, Any]) -> bool:
         raise NotImplementedError
 
-    async def discard_document_chunk_snapshot(
-        self, deleted: Mapping[str, Any]
-    ) -> bool:
+    async def discard_document_chunk_snapshot(self, deleted: Mapping[str, Any]) -> bool:
         raise NotImplementedError
 
 
@@ -835,9 +832,7 @@ class CogneePublicClient:
             )
             if heartbeat in done:
                 heartbeat.result()
-                raise RuntimeError(
-                    f"cognify retry lease heartbeat stopped for {lease.job_id}"
-                )
+                raise RuntimeError(f"cognify retry lease heartbeat stopped for {lease.job_id}")
             return await cognify
         finally:
             for task in (cognify, heartbeat):
@@ -1072,10 +1067,7 @@ class CogneePublicClient:
             return cached[1]
         async with self._graph_data_lock:
             cached = self._graph_data_cache
-            if (
-                cached is not None
-                and monotonic() - cached[0] < GRAPH_DATA_CACHE_TTL_SECONDS
-            ):
+            if cached is not None and monotonic() - cached[0] < GRAPH_DATA_CACHE_TTL_SECONDS:
                 return cached[1]
             result = await self._read_graph_data()
             self._graph_data_cache = (monotonic(), result)
@@ -1157,9 +1149,7 @@ class CogneePublicClient:
         if cached is None:
             return None
         ts, mapping, ok = cached
-        ttl = (
-            NODE_DATASET_MAP_TTL_SECONDS if ok else NODE_DATASET_MAP_FAILURE_TTL_SECONDS
-        )
+        ttl = NODE_DATASET_MAP_TTL_SECONDS if ok else NODE_DATASET_MAP_FAILURE_TTL_SECONDS
         if monotonic() - ts < ttl:
             return mapping
         return None
@@ -1229,9 +1219,7 @@ class CogneePublicClient:
             if not dataset_ids:
                 return []
             rows = await session.execute(
-                select(DatasetData.data_id).where(
-                    DatasetData.dataset_id.in_(dataset_ids)
-                )
+                select(DatasetData.data_id).where(DatasetData.dataset_id.in_(dataset_ids))
             )
         return sorted({str(data_id) for (data_id,) in rows.all() if data_id is not None})
 
@@ -1355,9 +1343,7 @@ class CogneePublicClient:
                 membership = await session.execute(
                     select(DatasetData.data_id, Dataset.name)
                     .join(Dataset, Dataset.id == DatasetData.dataset_id)
-                    .where(
-                        DatasetData.data_id.in_([UUID(row["id"]) for row in rows])
-                    )
+                    .where(DatasetData.data_id.in_([UUID(row["id"]) for row in rows]))
                 )
                 names_by_id: dict[str, list[str]] = {}
                 for data_id, dataset_name in membership.all():
@@ -1388,22 +1374,19 @@ class CogneePublicClient:
         engine = get_relational_engine()
         async with engine.get_async_session() as session:
             documents = int(
-                (await session.execute(select(func.count()).select_from(Data))).scalar()
-                or 0
+                (await session.execute(select(func.count()).select_from(Data))).scalar() or 0
             )
             documents_default_owner = int(
                 (
                     await session.execute(
-                        select(func.count())
-                        .select_from(Data)
-                        .where(Data.owner_id == user.id)
+                        select(func.count()).select_from(Data).where(Data.owner_id == user.id)
                     )
                 ).scalar()
                 or 0
             )
-            by_dataset_query = select(
-                Dataset.name, func.count(DatasetData.data_id)
-            ).join(Dataset, Dataset.id == DatasetData.dataset_id)
+            by_dataset_query = select(Dataset.name, func.count(DatasetData.data_id)).join(
+                Dataset, Dataset.id == DatasetData.dataset_id
+            )
             by_dataset = {
                 str(name): int(total or 0)
                 for name, total in (
@@ -1414,9 +1397,7 @@ class CogneePublicClient:
                 str(name): int(total or 0)
                 for name, total in (
                     await session.execute(
-                        by_dataset_query.where(Dataset.owner_id == user.id).group_by(
-                            Dataset.name
-                        )
+                        by_dataset_query.where(Dataset.owner_id == user.id).group_by(Dataset.name)
                     )
                 ).all()
             }
@@ -1493,9 +1474,7 @@ class CogneePublicClient:
                     raise RuntimeError("corpus page returned a row without an id")
                 document_id = str(row["id"])
                 if document_id in document_ids_seen:
-                    raise RuntimeError(
-                        f"corpus page returned duplicate document {document_id}"
-                    )
+                    raise RuntimeError(f"corpus page returned duplicate document {document_id}")
                 document_ids_seen.add(document_id)
                 document_ids.append(document_id)
             if len(document_ids_seen) > total_documents:
@@ -1530,9 +1509,7 @@ class CogneePublicClient:
                 for document_id in document_ids
                 if int(chunk_counts.get(document_id, 0)) > 0
             }
-            graph_ids_seen = set(document_ids) & {
-                str(document_id) for document_id in graph_ids
-            }
+            graph_ids_seen = set(document_ids) & {str(document_id) for document_id in graph_ids}
             fully_indexed_ids = chunked_ids & graph_ids_seen
 
         return {
@@ -1547,15 +1524,10 @@ class CogneePublicClient:
             "probe_graph_documents": len(graph_ids_seen),
             "probe_fully_indexed_documents": len(fully_indexed_ids),
             "probe_ok": probe_complete
-            and (
-                total_documents == 0
-                or len(fully_indexed_ids) == len(document_ids_seen)
-            ),
+            and (total_documents == 0 or len(fully_indexed_ids) == len(document_ids_seen)),
         }
 
-    async def corpus_chunk_counts(
-        self, document_ids: list[str]
-    ) -> dict[str, int] | None:
+    async def corpus_chunk_counts(self, document_ids: list[str]) -> dict[str, int] | None:
         """Chunk rows per document from the vector store; None when not measured.
 
         None and 0 are different answers: 0 claims cognee accepted a document
@@ -1706,9 +1678,7 @@ class CogneePublicClient:
         try:
             wanted_ids = [UUID(document_id) for document_id in wanted]
         except (TypeError, ValueError) as exc:
-            raise RuntimeError(
-                "dataset membership requested a non-UUID document id"
-            ) from exc
+            raise RuntimeError("dataset membership requested a non-UUID document id") from exc
 
         engine = get_relational_engine()
         names_by_id: dict[str, set[str]] = {document_id: set() for document_id in wanted}
@@ -1725,9 +1695,7 @@ class CogneePublicClient:
                 if document_id not in names_by_id:
                     raise RuntimeError("dataset membership returned an unexpected document")
                 names_by_id[document_id].add(dataset_name)
-        return {
-            document_id: sorted(names_by_id[document_id]) for document_id in wanted
-        }
+        return {document_id: sorted(names_by_id[document_id]) for document_id in wanted}
 
     async def corpus_zero_chunk_documents(
         self,
@@ -1816,9 +1784,7 @@ class CogneePublicClient:
                     raise RuntimeError("corpus page returned a row without an id")
                 document_id = str(row["id"])
                 if document_id in seen_ids:
-                    raise RuntimeError(
-                        f"corpus page returned duplicate document {document_id}"
-                    )
+                    raise RuntimeError(f"corpus page returned duplicate document {document_id}")
                 seen_ids.add(document_id)
                 page_ids.append(document_id)
 
@@ -1996,9 +1962,7 @@ class CogneePublicClient:
             "violations_truncated": violation_count > len(violations),
         }
 
-    async def stored_chunk_ids_for_documents(
-        self, document_ids: list[str]
-    ) -> list[str] | None:
+    async def stored_chunk_ids_for_documents(self, document_ids: list[str]) -> list[str] | None:
         """Return every persisted chunk id for ``document_ids``.
 
         A repair must delete the complete old projection before Cognee rebuilds
@@ -2112,9 +2076,7 @@ class CogneePublicClient:
                     raise RuntimeError("corpus page returned a row without an id")
                 document_id = str(row["id"])
                 if document_id in seen_ids:
-                    raise RuntimeError(
-                        f"corpus page returned duplicate document {document_id}"
-                    )
+                    raise RuntimeError(f"corpus page returned duplicate document {document_id}")
                 seen_ids.add(document_id)
                 corpus_rows_by_id[document_id] = row
 
@@ -2149,9 +2111,7 @@ class CogneePublicClient:
         if not isinstance(violation_counts, dict):
             raise RuntimeError("stored chunk budget returned invalid document counts")
         violation_count = check.get("violation_count")
-        missing_document_id_violation_count = check.get(
-            "missing_document_id_violation_count", 0
-        )
+        missing_document_id_violation_count = check.get("missing_document_id_violation_count", 0)
         if (
             isinstance(violation_count, bool)
             or not isinstance(violation_count, int)
@@ -2161,9 +2121,7 @@ class CogneePublicClient:
             or missing_document_id_violation_count < 0
         ):
             raise RuntimeError("stored chunk budget returned invalid violation totals")
-        grouped_violation_count = sum(
-            int(value) for value in violation_counts.values()
-        )
+        grouped_violation_count = sum(int(value) for value in violation_counts.values())
         if grouped_violation_count + missing_document_id_violation_count != violation_count:
             raise RuntimeError("stored chunk budget violation totals do not reconcile")
 
@@ -2238,8 +2196,7 @@ class CogneePublicClient:
             "oversized_document_count": len(oversized_ids),
             "oversized_chunk_count": oversized_chunk_count,
             "oversized_documents": oversized_documents,
-            "oversized_documents_truncated": len(oversized_ids)
-            > len(oversized_documents),
+            "oversized_documents_truncated": len(oversized_ids) > len(oversized_documents),
             "repair_document_ids": sorted(repair_ids),
             "repair_datasets": sorted(repair_datasets),
             "unassigned_oversized_document_count": unassigned + orphan_count,
@@ -2345,9 +2302,7 @@ class CogneePublicClient:
                     raise RuntimeError("corpus page returned a row without an id")
                 document_id = str(row["id"])
                 if document_id in seen_ids:
-                    raise RuntimeError(
-                        f"corpus page returned duplicate document {document_id}"
-                    )
+                    raise RuntimeError(f"corpus page returned duplicate document {document_id}")
                 seen_ids.add(document_id)
                 page_ids.append(document_id)
                 corpus_rows_by_id[document_id] = row
@@ -2550,11 +2505,7 @@ class CogneePublicClient:
             "repair_document_ids": sorted(repair_ids),
             "repair_document_datasets": repair_document_datasets,
             "repair_datasets": sorted(
-                {
-                    name
-                    for names in repair_document_datasets.values()
-                    for name in names
-                }
+                {name for names in repair_document_datasets.values() for name in names}
             ),
             "unassigned_zero_chunk_document_count": zero_unassigned,
             "unassigned_oversized_document_count": oversized_unassigned,
@@ -2564,9 +2515,7 @@ class CogneePublicClient:
             "census_complete": True,
         }
 
-    async def graph_chunk_ids_for_documents(
-        self, document_ids: list[str]
-    ) -> set[str] | None:
+    async def graph_chunk_ids_for_documents(self, document_ids: list[str]) -> set[str] | None:
         """Return graph node ids for ``DocumentChunk`` properties by source id."""
         if not document_ids:
             return set()
@@ -2789,9 +2738,7 @@ class CogneePublicClient:
             try:
                 vector_uuids.append(UUID(str(vector_id)))
             except (ValueError, TypeError, AttributeError) as exc:
-                raise RuntimeError(
-                    "stored chunk collection returned a non-UUID row id"
-                ) from exc
+                raise RuntimeError("stored chunk collection returned a non-UUID row id") from exc
 
         graph_engine = await get_graph_engine()
         vector_engine = get_vector_engine()
@@ -2806,9 +2753,7 @@ class CogneePublicClient:
             snapshot_token = self._store_repair_snapshot(snapshot)
             try:
                 if vector_uuids:
-                    await vector_engine.delete_data_points(
-                        "DocumentChunk_text", vector_uuids
-                    )
+                    await vector_engine.delete_data_points("DocumentChunk_text", vector_uuids)
                 if graph_ids:
                     await graph_engine.delete_nodes(sorted(graph_ids))
                 self._invalidate_graph_data_cache()
@@ -2890,9 +2835,7 @@ class CogneePublicClient:
         expected = {str(vector_id) for vector_id in vector_ids}
         actual = {str(row[0]) for row in rows if row[0] is not None}
         if actual != expected:
-            raise RuntimeError(
-                "vector projection changed while preparing repair snapshot"
-            )
+            raise RuntimeError("vector projection changed while preparing repair snapshot")
         return [
             {
                 "id": row[0],
@@ -2932,9 +2875,7 @@ class CogneePublicClient:
                 }
             )
         if {node["id"] for node in nodes} != set(graph_ids):
-            raise RuntimeError(
-                "graph projection changed while preparing repair snapshot"
-            )
+            raise RuntimeError("graph projection changed while preparing repair snapshot")
 
         edge_rows = await query(
             """
@@ -2976,9 +2917,7 @@ class CogneePublicClient:
             "graph": await self._snapshot_graph_projection(graph_engine, graph_ids),
         }
 
-    async def _restore_vector_rows(
-        self, vector_engine: Any, rows: list[dict[str, Any]]
-    ) -> None:
+    async def _restore_vector_rows(self, vector_engine: Any, rows: list[dict[str, Any]]) -> None:
         if not rows:
             return
         from sqlalchemy.dialects.postgresql import insert
@@ -3004,9 +2943,7 @@ class CogneePublicClient:
             await session.execute(statement)
             await session.commit()
 
-    async def _restore_graph_projection(
-        self, graph_engine: Any, graph: Mapping[str, Any]
-    ) -> None:
+    async def _restore_graph_projection(self, graph_engine: Any, graph: Mapping[str, Any]) -> None:
         query = getattr(graph_engine, "query", None)
         if not callable(query):
             raise RuntimeError("graph projection restore is unavailable")
@@ -3065,9 +3002,7 @@ class CogneePublicClient:
             except (TypeError, ValueError, AttributeError) as exc:
                 raise RuntimeError("current vector projection has a non-UUID id") from exc
         if current_vector_uuids:
-            await vector_engine.delete_data_points(
-                "DocumentChunk_text", current_vector_uuids
-            )
+            await vector_engine.delete_data_points("DocumentChunk_text", current_vector_uuids)
         if graph_ids:
             await graph_engine.delete_nodes(sorted(graph_ids))
         await self._restore_vector_rows(vector_engine, list(snapshot.get("vector_rows") or []))
@@ -3248,9 +3183,7 @@ class CogneePublicClient:
             if not self._is_no_data_error(exc):
                 raise
             nodes, edges = [], []
-        props, props_by_id, part_neighbor_ids = self._graph_projection(
-            doc_id, nodes, edges
-        )
+        props, props_by_id, part_neighbor_ids = self._graph_projection(doc_id, nodes, edges)
         if props is not None:
             text, _ = self._extract_text(props)
             if text is not None:
@@ -3292,18 +3225,14 @@ class CogneePublicClient:
             if not callable(retrieve):
                 return None
             seed_rows = await retrieve(self._CHUNK_VECTOR_COLLECTION, [requested])
-            seed_payload = (
-                self._retrieved_payload(seed_rows[0]) if seed_rows else None
-            )
+            seed_payload = self._retrieved_payload(seed_rows[0]) if seed_rows else None
             if seed_payload is not None:
                 # Chunk hit: the parent document id rides in the payload —
                 # exactly the owner attribution the full assembly reports.
                 if self._extract_text(seed_payload)[0] is None:
                     return None
                 parent_raw = seed_payload.get("document_id")
-                if not parent_raw and isinstance(
-                    seed_payload.get("is_part_of"), dict
-                ):
+                if not parent_raw and isinstance(seed_payload.get("is_part_of"), dict):
                     parent_raw = seed_payload["is_part_of"].get("id")
                 try:
                     parent_id = str(UUID(str(parent_raw))) if parent_raw else None
@@ -3318,9 +3247,7 @@ class CogneePublicClient:
                 self._CHUNK_VECTOR_COLLECTION,
                 [str(uuid5(NAMESPACE_OID, f"{requested}-0"))],
             )
-            probe_payload = (
-                self._retrieved_payload(probe_rows[0]) if probe_rows else None
-            )
+            probe_payload = self._retrieved_payload(probe_rows[0]) if probe_rows else None
             if probe_payload is None or self._extract_text(probe_payload)[0] is None:
                 return None
             owner_ids = [requested]
@@ -3413,9 +3340,7 @@ class CogneePublicClient:
                 return None
             raise
 
-        props, props_by_id, part_neighbor_ids = self._graph_projection(
-            doc_id, nodes, edges
-        )
+        props, props_by_id, part_neighbor_ids = self._graph_projection(doc_id, nodes, edges)
         if props is None:
             return None
         text, text_key = self._extract_text(props)
@@ -3431,9 +3356,7 @@ class CogneePublicClient:
                 # cannot be assembled (never worse than before).
                 parent_id = self._textless_neighbor_id(props_by_id, part_neighbor_ids)
                 if parent_id is not None:
-                    parent = await self._document_from_graph(
-                        parent_id, follow_parent=False
-                    )
+                    parent = await self._document_from_graph(parent_id, follow_parent=False)
                     if parent is not None and parent.get("body"):
                         owner_ids = list(parent.get("dataset_node_ids") or [parent_id])
                         if doc_id not in owner_ids:
@@ -3545,16 +3468,12 @@ class CogneePublicClient:
             if not callable(retrieve):
                 return None
             seed_rows = await retrieve(self._CHUNK_VECTOR_COLLECTION, [requested])
-            seed_payload = (
-                self._retrieved_payload(seed_rows[0]) if seed_rows else None
-            )
+            seed_payload = self._retrieved_payload(seed_rows[0]) if seed_rows else None
             document_id: str | None
             if seed_payload is not None:
                 # Chunk hit: the parent document id rides in the payload.
                 parent_raw = seed_payload.get("document_id")
-                if not parent_raw and isinstance(
-                    seed_payload.get("is_part_of"), dict
-                ):
+                if not parent_raw and isinstance(seed_payload.get("is_part_of"), dict):
                     parent_raw = seed_payload["is_part_of"].get("id")
                 document_id = str(parent_raw) if parent_raw else None
             else:
@@ -3573,9 +3492,7 @@ class CogneePublicClient:
                     str(uuid5(NAMESPACE_OID, f"{document_id}-{index}"))
                     for index in range(self._CHUNK_SIBLING_PROBE_LIMIT)
                 ]
-                for row in await retrieve(
-                    self._CHUNK_VECTOR_COLLECTION, sibling_ids
-                ):
+                for row in await retrieve(self._CHUNK_VECTOR_COLLECTION, sibling_ids):
                     payload = self._retrieved_payload(row)
                     if payload is None:
                         continue
@@ -3616,9 +3533,7 @@ class CogneePublicClient:
                 "id": document_id or doc_id,
                 "source_type": "cognee",
                 "title": title,
-                "body": "\n\n".join(
-                    self._extract_text(payload)[0] or "" for _, payload in chunks
-                ),
+                "body": "\n\n".join(self._extract_text(payload)[0] or "" for _, payload in chunks),
                 "chunk_count": len(chunks),
                 "metadata": metadata,
                 "dataset_node_ids": owner_ids,
@@ -3647,9 +3562,7 @@ class CogneePublicClient:
         async with self.maintenance():
             return await self._cognify_unlocked(datasets=datasets, force=force)
 
-    async def _cognify_unlocked(
-        self, *, datasets: list[str], force: bool = False
-    ) -> Any:
+    async def _cognify_unlocked(self, *, datasets: list[str], force: bool = False) -> Any:
         """Cognify already-added data in ``datasets``.
 
         ``cognee.cognify`` defaults to ``incremental_loading=True``, so this only
@@ -3680,9 +3593,7 @@ class CogneePublicClient:
         # Single Kuzu writer: serialize the graph write against any other in-process
         # cognify so they cannot collide on the lock (#47).
         async with self.writer_lock:
-            result = await cognee.cognify(
-                datasets=datasets, incremental_loading=not force
-            )
+            result = await cognee.cognify(datasets=datasets, incremental_loading=not force)
             self._invalidate_graph_data_cache()
         # The graph writer lock protects Kuzu only. Run the vector payload census
         # after releasing it so a slow SQL scan cannot block another cognify.
@@ -3691,13 +3602,10 @@ class CogneePublicClient:
             missing_ids = sorted(set(expected_ids) - set(processed_ids))
             if missing_ids:
                 raise RuntimeError(
-                    "forced cognify receipt omitted "
-                    f"{len(missing_ids)} expected source id(s)"
+                    f"forced cognify receipt omitted {len(missing_ids)} expected source id(s)"
                 )
         if processed_ids:
-            stored_check = await self.stored_chunk_budget_check(
-                document_ids=processed_ids
-            )
+            stored_check = await self.stored_chunk_budget_check(document_ids=processed_ids)
             if stored_check is None:
                 logger.warning(
                     "stored chunk budget was not measured after cognify: "
@@ -3749,8 +3657,7 @@ class CogneePublicClient:
         # success while doing nothing (false-green exit 0, #41).
         if not os.getenv("LLM_API_KEY"):
             raise RuntimeError(
-                "LLM_API_KEY (or OPENROUTER_API_KEY) is not set; improve requires an "
-                "LLM key."
+                "LLM_API_KEY (or OPENROUTER_API_KEY) is not set; improve requires an LLM key."
             )
         import cognee
 

--- a/kb/cognify_queue.py
+++ b/kb/cognify_queue.py
@@ -309,8 +309,7 @@ class CognifyRetryQueue:
             leased_overlaps = [
                 record
                 for record in jobs.values()
-                if record["lease_id"] is not None
-                and set(record["datasets"]).intersection(names)
+                if record["lease_id"] is not None and set(record["datasets"]).intersection(names)
             ]
 
             if leased_overlaps:
@@ -372,7 +371,9 @@ class CognifyRetryQueue:
             self._save(state)
             return result
 
-    def claim(self, *, now: datetime | None = None, lease_seconds: float | None = None) -> CognifyLease | None:
+    def claim(
+        self, *, now: datetime | None = None, lease_seconds: float | None = None
+    ) -> CognifyLease | None:
         """Claim the oldest due record, or return ``None`` when none is due."""
         leases = self.claim_due(now=now, limit=1, lease_seconds=lease_seconds)
         return leases[0] if leases else None
@@ -680,9 +681,7 @@ class CognifyRetryQueue:
                 if not set(lease_datasets).issubset(set(datasets)):
                     raise ValueError(f"job {job_id!r} lease datasets exceed job datasets")
             error = record["last_error"]
-            if error is not None and (
-                not isinstance(error, str) or len(error) > MAX_ERROR_LENGTH
-            ):
+            if error is not None and (not isinstance(error, str) or len(error) > MAX_ERROR_LENGTH):
                 raise ValueError(f"job {job_id!r} last_error is invalid")
 
     def _save(self, data: dict[str, Any]) -> None:

--- a/kb/config.py
+++ b/kb/config.py
@@ -11,6 +11,7 @@ from kb.access import CENTRAL_DATASET
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - exercised only before dependencies are installed.
+
     def load_dotenv(*args: object, **kwargs: object) -> bool:
         return False
 
@@ -199,9 +200,7 @@ class CitadelConfig:
     # 429). It gets its own dedicated cap. graph_data() is TTL-cached +
     # single-flight, so concurrent mesh reads mostly hit cache and are cheap —
     # a small cpu-based cap is plenty.
-    mesh_graph_max_concurrency: int = field(
-        default_factory=lambda: max(4, os.cpu_count() or 4)
-    )
+    mesh_graph_max_concurrency: int = field(default_factory=lambda: max(4, os.cpu_count() or 4))
     default_session: str = "personal-session"
     default_tags: tuple[str, ...] = field(default_factory=tuple)
     min_chars: int = 3
@@ -319,9 +318,7 @@ class CitadelConfig:
             obsidian_sync_state_path=_obsidian_sync_state_path(
                 os.getenv("CITADEL_OBSIDIAN_SYNC_STATE_PATH")
             ),
-            conflicts_store_path=_conflicts_store_path(
-                os.getenv("CITADEL_CONFLICTS_STORE_PATH")
-            ),
+            conflicts_store_path=_conflicts_store_path(os.getenv("CITADEL_CONFLICTS_STORE_PATH")),
             conflicts_max_records=_int(
                 os.getenv("CITADEL_CONFLICTS_MAX_RECORDS"),
                 default=500,
@@ -336,9 +333,7 @@ class CitadelConfig:
             search_timeout_seconds=_float(
                 os.getenv("CITADEL_SEARCH_TIMEOUT_SECONDS"), default=20.0
             ),
-            search_max_concurrency=_int(
-                os.getenv("CITADEL_SEARCH_MAX_CONCURRENCY"), default=8
-            ),
+            search_max_concurrency=_int(os.getenv("CITADEL_SEARCH_MAX_CONCURRENCY"), default=8),
             mesh_graph_max_concurrency=_int(
                 os.getenv("CITADEL_MESH_GRAPH_MAX_CONCURRENCY"),
                 default=max(4, os.cpu_count() or 4),
@@ -370,7 +365,9 @@ class CitadelConfig:
                 os.getenv("CITADEL_GITHUB_SYNC_INCLUDE_COMMITS"),
                 default=True,
             ),
-            github_sync_run_improve=_bool(os.getenv("CITADEL_GITHUB_SYNC_RUN_IMPROVE"), default=True),
+            github_sync_run_improve=_bool(
+                os.getenv("CITADEL_GITHUB_SYNC_RUN_IMPROVE"), default=True
+            ),
             github_sync_ingest_unchanged=_bool(
                 os.getenv("CITADEL_GITHUB_SYNC_INGEST_UNCHANGED"),
                 default=True,
@@ -379,12 +376,8 @@ class CitadelConfig:
                 os.getenv("CITADEL_GITHUB_SYNC_INCLUDE_PRIVATE"),
                 default=True,
             ),
-            github_sync_repo_allowlist=tuple(
-                _csv(os.getenv("CITADEL_GITHUB_SYNC_REPO_ALLOWLIST"))
-            ),
-            github_sync_repo_denylist=tuple(
-                _csv(os.getenv("CITADEL_GITHUB_SYNC_REPO_DENYLIST"))
-            ),
+            github_sync_repo_allowlist=tuple(_csv(os.getenv("CITADEL_GITHUB_SYNC_REPO_ALLOWLIST"))),
+            github_sync_repo_denylist=tuple(_csv(os.getenv("CITADEL_GITHUB_SYNC_REPO_DENYLIST"))),
             github_sync_security_scan_enabled=_bool(
                 os.getenv("CITADEL_GITHUB_SYNC_SECURITY_SCAN_ENABLED"),
                 default=True,
@@ -459,13 +452,9 @@ class CitadelConfig:
                 os.getenv("CITADEL_REPO_CONTENT_SYNC_STATE_PATH")
             ),
             evolve_state_path=_evolve_state_path(os.getenv("CITADEL_EVOLVE_STATE_PATH")),
-            repair_journal_path=_repair_journal_path(
-                os.getenv("CITADEL_REPAIR_JOURNAL_PATH")
-            ),
+            repair_journal_path=_repair_journal_path(os.getenv("CITADEL_REPAIR_JOURNAL_PATH")),
             cognify_queue_path=_cognify_queue_path(os.getenv("CITADEL_COGNIFY_QUEUE_PATH")),
-            repo_content_sync_repos=tuple(
-                _csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_REPOS"))
-            ),
+            repo_content_sync_repos=tuple(_csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_REPOS"))),
             repo_content_sync_root_paths=tuple(
                 _csv(os.getenv("CITADEL_REPO_CONTENT_SYNC_ROOT_PATHS"))
             ),
@@ -532,9 +521,7 @@ class CitadelConfig:
             webhook_max_message_bytes=_int(
                 os.getenv("CITADEL_WEBHOOK_MAX_MESSAGE_BYTES"), default=30000
             ),
-            webhook_timeout_seconds=_int(
-                os.getenv("CITADEL_WEBHOOK_TIMEOUT_SECONDS"), default=20
-            ),
+            webhook_timeout_seconds=_int(os.getenv("CITADEL_WEBHOOK_TIMEOUT_SECONDS"), default=20),
             google_chat_enabled=_bool(os.getenv("CITADEL_GOOGLE_CHAT_ENABLED"), default=False),
             google_chat_space_name=os.getenv("CITADEL_GOOGLE_CHAT_SPACE_NAME") or None,
             google_chat_service_account_json=(
@@ -578,7 +565,9 @@ class CitadelConfig:
                 or os.getenv("CITADEL_BACKUP_MIRROR_GITHUB_TOKEN")
                 or None
             ),
-            linear_api_key=os.getenv("CITADEL_LINEAR_API_KEY") or os.getenv("LINEAR_API_KEY") or None,
+            linear_api_key=os.getenv("CITADEL_LINEAR_API_KEY")
+            or os.getenv("LINEAR_API_KEY")
+            or None,
             linear_sync_dataset=os.getenv("CITADEL_LINEAR_SYNC_DATASET", "masumi-network"),
             linear_sync_session=os.getenv("CITADEL_LINEAR_SYNC_SESSION", "masumi-linear"),
             linear_sync_state_path=_linear_sync_state_path(

--- a/kb/conflicts.py
+++ b/kb/conflicts.py
@@ -103,9 +103,7 @@ class KnowledgeConflictStore:
         data["conflicts"][conflict_id] = asdict(record)
         self._prune(data)
         self._save(data)
-        logger.warning(
-            "Knowledge conflict recorded: %s (%s)", conflict_id, candidate.kind
-        )
+        logger.warning("Knowledge conflict recorded: %s (%s)", conflict_id, candidate.kind)
         return data["conflicts"][conflict_id]
 
     def list(self, *, status: str | None = None) -> list[dict[str, Any]]:

--- a/kb/github_sync.py
+++ b/kb/github_sync.py
@@ -63,11 +63,7 @@ def utc_now() -> str:
 
 def _matches_any(name: str, patterns: tuple[str, ...]) -> bool:
     candidates = {name, name.split("/")[-1]}
-    return any(
-        fnmatchcase(candidate, pattern)
-        for pattern in patterns
-        for candidate in candidates
-    )
+    return any(fnmatchcase(candidate, pattern) for pattern in patterns for candidate in candidates)
 
 
 class GitHubAPIError(RuntimeError):
@@ -258,7 +254,9 @@ class GitHubOrgSyncer:
             if ingest_unchanged is None
             else ingest_unchanged
         )
-        self.run_improve = self.config.github_sync_run_improve if run_improve is None else run_improve
+        self.run_improve = (
+            self.config.github_sync_run_improve if run_improve is None else run_improve
+        )
         self.include_private = self.config.github_sync_include_private
         self.repo_allowlist = self.config.github_sync_repo_allowlist
         self.repo_denylist = self.config.github_sync_repo_denylist
@@ -381,7 +379,9 @@ class GitHubOrgSyncer:
         if not dry_run:
             tracked_commits = dict(previous_commits)
             for repo_name, repo_commits in commits_by_repo.items():
-                tracked_commits[repo_name] = [commit.sha for commit in repo_commits if commit.sha][:500]
+                tracked_commits[repo_name] = [commit.sha for commit in repo_commits if commit.sha][
+                    :500
+                ]
             state.update(
                 {
                     "version": STATE_VERSION,
@@ -389,9 +389,7 @@ class GitHubOrgSyncer:
                     "last_checked_at": checked_at,
                     "repos": {repo.full_name: repo.state() for repo in repos},
                     "commits": tracked_commits,
-                    "seen_event_ids": [
-                        event.id for event in events if event.id
-                    ][:500],
+                    "seen_event_ids": [event.id for event in events if event.id][:500],
                 }
             )
             if should_ingest:

--- a/kb/google_chat.py
+++ b/kb/google_chat.py
@@ -89,7 +89,9 @@ class GoogleChatDelivery:
             lambda: self._post_once(url, body),
             operation="google_chat.post_digest",
             max_attempts=self.retry_count + 1,
-            should_retry_result=lambda outcome: not outcome["ok"] and bool(outcome.get("retryable")),
+            should_retry_result=lambda outcome: (
+                not outcome["ok"] and bool(outcome.get("retryable"))
+            ),
             retry_after_from_result=lambda outcome: outcome.get("retry_after"),
         )
         if result["ok"]:

--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -160,9 +160,7 @@ def load_capture_roots() -> list[dict[str, Any]]:
             {
                 "path": _norm_path(raw_path),
                 "tags": [
-                    str(tag).strip().lower()
-                    for tag in (item.get("tags") or [])
-                    if str(tag).strip()
+                    str(tag).strip().lower() for tag in (item.get("tags") or []) if str(tag).strip()
                 ],
             }
         )

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -202,7 +202,6 @@ def _text_of(block: Any) -> str:
     return ""
 
 
-
 def build_tags(cwd: str) -> list[str]:
     tags = ["dev-session"]
     branch = git_branch(cwd)

--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -465,9 +465,7 @@ def build_graph_payload(
     # Kept nodes still wearing a cognee-internal label (``text_<md5>`` or the
     # bare node id) get a human label derived from their chunk text below.
     internal_nodes: dict[str, dict[str, Any]] = {
-        node["id"]: node
-        for node in nodes
-        if _is_internal_label(node["id"], node["label"])
+        node["id"]: node for node in nodes if _is_internal_label(node["id"], node["label"])
     }
     doc_chunk_ids: dict[str, list[str]] = {}
 
@@ -506,11 +504,7 @@ def build_graph_payload(
                 chunk_id, properties = str(raw[0]), raw[1]
             except (TypeError, IndexError, KeyError):
                 continue
-            if (
-                chunk_id in wanted
-                and chunk_id not in chunk_props
-                and isinstance(properties, dict)
-            ):
+            if chunk_id in wanted and chunk_id not in chunk_props and isinstance(properties, dict):
                 chunk_props[chunk_id] = properties
         for doc_id, chunk_ids in doc_chunk_ids.items():
             best: tuple[tuple[int, float, int], str] | None = None
@@ -554,9 +548,7 @@ def build_graph_payload(
         # visibility filtering (KnowledgeMesh.graph), so it is display-only and
         # never widens what a scoped caller can see.
         nodeset_ids = {
-            node["id"]
-            for node in nodes
-            if "nodeset" in str(node.get("type", "")).lower()
+            node["id"] for node in nodes if "nodeset" in str(node.get("type", "")).lower()
         }
         collapse_into: dict[str, str] = {}
         if nodeset_ids:
@@ -712,9 +704,7 @@ def build_graph_payload(
     }
 
 
-def fallback_graph(
-    reason: str, presence: list[dict[str, Any]] | None = None
-) -> dict[str, Any]:
+def fallback_graph(reason: str, presence: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     """Empty-graph payload; ``presence`` still appends Seat Presence hubs.
 
     ADR-0009: every seat is ALWAYS visible, so fallback payloads carry the
@@ -772,9 +762,7 @@ class KnowledgeMesh:
                 "Knowledge mesh graph read failed with %s; returning fallback graph",
                 exc.__class__.__name__,
             )
-            return fallback_graph(
-                f"graph_engine_error:{exc.__class__.__name__}", presence
-            )
+            return fallback_graph(f"graph_engine_error:{exc.__class__.__name__}", presence)
         raw_nodes = list(raw_nodes)
         raw_edges = list(raw_edges)
         dataset_map: dict[str, list[str]] = {}
@@ -784,8 +772,7 @@ class KnowledgeMesh:
                 dataset_map = await node_dataset_map() or {}
             except Exception as exc:
                 logger.warning(
-                    "Knowledge mesh dataset map read failed with %s; "
-                    "omitting dataset attribution",
+                    "Knowledge mesh dataset map read failed with %s; omitting dataset attribution",
                     exc.__class__.__name__,
                 )
                 dataset_map = {}

--- a/kb/learning.py
+++ b/kb/learning.py
@@ -139,9 +139,7 @@ class LearningProcess:
                 result = await self.citadel.ingest(chunk_data, **ingest_kwargs)
             except Exception as exc:
                 if self.mesh:
-                    await self.mesh.record_error(
-                        self.config, operation=operation, error=str(exc)
-                    )
+                    await self.mesh.record_error(self.config, operation=operation, error=str(exc))
                 raise
             results.append(result)
             if self.mesh:

--- a/kb/learning_agent.py
+++ b/kb/learning_agent.py
@@ -104,10 +104,8 @@ class LearningAgent:
                 "repo_content": repo_content_result,
                 "vault": vault_context,
             },
-            "ingested": bool(github_result.get("ingested")) or int(
-                repo_content_result.get("files_ingested") or 0
-            )
-            > 0,
+            "ingested": bool(github_result.get("ingested"))
+            or int(repo_content_result.get("files_ingested") or 0) > 0,
             "improved": bool(github_result.get("improved"))
             or bool(repo_content_result.get("improved")),
             "dry_run": dry_run,
@@ -143,7 +141,9 @@ class LearningAgent:
         config = self.citadel.config
         if not config.organization_digest_enabled:
             return {"ok": True, "dataset": None, "recent_context": [], "reason": "digest_disabled"}
-        dataset = config.search_default_dataset or config.github_sync_dataset or config.default_dataset
+        dataset = (
+            config.search_default_dataset or config.github_sync_dataset or config.default_dataset
+        )
         query = (
             "meaningful source-linked decisions ongoing work blockers features architecture "
             f"repository momentum last {config.organization_digest_window_hours} hours"
@@ -198,7 +198,10 @@ class LearningAgent:
             return self._skip_gateway_results("dry_run")
         if not digest.get("enabled"):
             return self._skip_gateway_results("digest_disabled")
-        if not digest.get("meaningful") and not self.citadel.config.organization_digest_post_on_no_updates:
+        if (
+            not digest.get("meaningful")
+            and not self.citadel.config.organization_digest_post_on_no_updates
+        ):
             return self._skip_gateway_results("no_meaningful_updates")
 
         gateway_items = sorted(self.gateways.items())
@@ -213,8 +216,7 @@ class LearningAgent:
             )
         )
         results = {
-            name: posted
-            for (name, _), posted in zip(gateway_items, posted_gateways, strict=True)
+            name: posted for (name, _), posted in zip(gateway_items, posted_gateways, strict=True)
         }
 
         if "google_chat" not in results:
@@ -239,9 +241,7 @@ class LearningAgent:
                 message_id=message_id,
             )
         except Exception as exc:
-            logger.error(
-                "Gateway digest delivery failed with %s", exc.__class__.__name__
-            )
+            logger.error("Gateway digest delivery failed with %s", exc.__class__.__name__)
             return {
                 "enabled": True,
                 "ok": False,
@@ -276,8 +276,10 @@ class LearningAgent:
                 "gateway": gateway_name,
                 "reason": reason,
             }
-        text = message or default_message or (
-            f"Citadel {gateway_name} delivery gateway test - configuration check only."
+        text = (
+            message
+            or default_message
+            or (f"Citadel {gateway_name} delivery gateway test - configuration check only.")
         )
         message_id = f"{gateway_name}-test-{datetime.now(timezone.utc).isoformat()}"
         try:

--- a/kb/linear_sync.py
+++ b/kb/linear_sync.py
@@ -232,9 +232,7 @@ def format_workspace_digest(issues: list[LinearIssue]) -> str:
     lines = ["# Linear workspace sync", "", f"Synced {len(issues)} issues.", ""]
     for issue in issues[:120]:
         assignee = issue.assignee_name or "unassigned"
-        lines.append(
-            f"- **{issue.identifier}** [{issue.state_name}] {issue.title} — {assignee}"
-        )
+        lines.append(f"- **{issue.identifier}** [{issue.state_name}] {issue.title} — {assignee}")
     if len(issues) > 120:
         lines.append(f"- … and {len(issues) - 120} more")
     return "\n".join(lines).strip()
@@ -383,11 +381,7 @@ class LinearSyncer:
             self._save_state(state)
             logger.error("Linear sync failed: %s", exc)
             return {"ok": False, "enabled": True, "reason": "linear_api_error", "error": str(exc)}
-        email_index = (
-            seat_email_index(self.access_store)
-            if self.access_store
-            else {}
-        )
+        email_index = seat_email_index(self.access_store) if self.access_store else {}
         # Auto-resolve assignee_id -> seat by matching Linear members' emails to
         # seat emails, using the node's own Linear key (#46). This populates seat
         # mirrors without a manual CITADEL_LINEAR_USER_MAP, and works even when the

--- a/kb/llm_enrichment.py
+++ b/kb/llm_enrichment.py
@@ -85,10 +85,13 @@ def enrichment_enabled() -> bool:
 
 
 def enrichment_threshold_chars() -> int:
-    return max(1, _int_env(
-        "CITADEL_LLM_ENRICHMENT_THRESHOLD_CHARS",
-        default=DEFAULT_THRESHOLD_CHARS,
-    ))
+    return max(
+        1,
+        _int_env(
+            "CITADEL_LLM_ENRICHMENT_THRESHOLD_CHARS",
+            default=DEFAULT_THRESHOLD_CHARS,
+        ),
+    )
 
 
 def redacted_preview(text: str, *, length: int = LOG_PREVIEW_CHARS) -> str:
@@ -202,9 +205,7 @@ class EnrichmentOutcome:
 
     @property
     def chunked(self) -> bool:
-        return len(self.chunks) > 1 or any(
-            chunk.summary or chunk.tags for chunk in self.chunks
-        )
+        return len(self.chunks) > 1 or any(chunk.summary or chunk.tags for chunk in self.chunks)
 
 
 def paragraph_chunks(data: str, *, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> list[str]:
@@ -321,9 +322,7 @@ def enrich_source_material(data: str) -> EnrichmentOutcome:
     if len(data) < enrichment_threshold_chars():
         return _passthrough(data, "below_threshold")
     if content_flagged_by_security_scan(data):
-        logger.warning(
-            "LLM enrichment skipped: security scan flagged the source material"
-        )
+        logger.warning("LLM enrichment skipped: security scan flagged the source material")
         return _fallback(data, "security_flagged")
     if not openrouter_api_key():
         return _fallback(data, "no_api_key")

--- a/kb/logging_utils.py
+++ b/kb/logging_utils.py
@@ -56,9 +56,7 @@ def resolve_log_level(value: str | None = None) -> str:
 
 
 def resolve_cognee_log_level(value: str | None = None) -> str:
-    level = (
-        value or os.getenv(COGNEE_LOG_LEVEL_ENV) or DEFAULT_COGNEE_LOG_LEVEL
-    ).strip().upper()
+    level = (value or os.getenv(COGNEE_LOG_LEVEL_ENV) or DEFAULT_COGNEE_LOG_LEVEL).strip().upper()
     return level if level in VALID_LEVELS else DEFAULT_COGNEE_LOG_LEVEL
 
 

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -453,7 +453,6 @@ def _max_ingest_bytes() -> int:
     return max(1, value)
 
 
-
 def _self_base_url() -> str:
     """Base URL the hosted MCP uses to reach the Citadel HTTP API in-process."""
     configured = os.getenv("CITADEL_MCP_SELF_BASE_URL")
@@ -472,7 +471,11 @@ def _transport_security() -> TransportSecuritySettings:
     hosts via ``CITADEL_MCP_ALLOWED_HOSTS`` (comma-separated; origins optional via
     ``CITADEL_MCP_ALLOWED_ORIGINS``).
     """
-    hosts = [host.strip() for host in os.getenv("CITADEL_MCP_ALLOWED_HOSTS", "").split(",") if host.strip()]
+    hosts = [
+        host.strip()
+        for host in os.getenv("CITADEL_MCP_ALLOWED_HOSTS", "").split(",")
+        if host.strip()
+    ]
     origins = [
         origin.strip()
         for origin in os.getenv("CITADEL_MCP_ALLOWED_ORIGINS", "").split(",")
@@ -544,11 +547,7 @@ def _public_url_headers_from_context(ctx: Context | None) -> dict[str, str]:
     if request is None:
         return {}
     try:
-        host = (
-            request.headers.get("x-forwarded-host")
-            or request.headers.get("host")
-            or ""
-        )
+        host = request.headers.get("x-forwarded-host") or request.headers.get("host") or ""
         proto = request.headers.get("x-forwarded-proto") or urlparse(str(request.url)).scheme
     except Exception:
         return {}
@@ -670,16 +669,12 @@ def _compact_search_for_agent(payload: Any) -> Any:
 def _audit_query(view: str, limit: int) -> str:
     normalized_view = view.strip().lower() or "mcp"
     if normalized_view not in AUDIT_VIEWS:
-        raise CitadelMcpError(
-            f"view must be one of: {', '.join(sorted(AUDIT_VIEWS))}."
-        )
+        raise CitadelMcpError(f"view must be one of: {', '.join(sorted(AUDIT_VIEWS))}.")
     normalized_limit = min(max(int(limit), 1), MAX_AUDIT_LIMIT)
     return f"/api/audit?{urlencode({'view': normalized_view, 'limit': normalized_limit})}"
 
 
-def _filter_tools_for_session(
-    all_tools: list[Any], session: dict[str, Any] | None
-) -> list[Any]:
+def _filter_tools_for_session(all_tools: list[Any], session: dict[str, Any] | None) -> list[Any]:
     """Drop tools the caller's role/seat cannot use (#33).
 
     Hides tools whose required role exceeds the caller (so reader/writer seats
@@ -827,9 +822,7 @@ class CitadelHttpClient:
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
-        return self._request(
-            "GET", path, require_token=False, extra_headers=extra_headers
-        )
+        return self._request("GET", path, require_token=False, extra_headers=extra_headers)
 
     def post(
         self,
@@ -892,9 +885,7 @@ class CitadelHttpClient:
                 exc.read().decode("utf-8", errors="replace")[:500],
                 self.access_token,
             )
-            logger.warning(
-                "Citadel API call %s %s returned HTTP %s", method, path, exc.code
-            )
+            logger.warning("Citadel API call %s %s returned HTTP %s", method, path, exc.code)
             raise CitadelMcpError(
                 f"Citadel returned HTTP {exc.code}: {detail}", status_code=exc.code
             ) from exc
@@ -1002,9 +993,7 @@ def create_mcp_server(
 
     def public_manifest(extra_headers: dict[str, str] | None = None) -> dict[str, Any]:
         if fallback is not None and hasattr(fallback, "get_public"):
-            return fallback.get_public(
-                "/.well-known/citadel.json", extra_headers=extra_headers
-            )
+            return fallback.get_public("/.well-known/citadel.json", extra_headers=extra_headers)
         return resolve_public_client().get_public(
             "/.well-known/citadel.json", extra_headers=extra_headers
         )
@@ -1200,6 +1189,7 @@ def create_mcp_server(
         candidates the scope kept. The Linear workspace DIGEST carries no
         per-issue header and is excluded; use citadel_search for it.
         """
+
         def search_linear() -> dict[str, Any]:
             payload = resolve_client(ctx).post(
                 "/search",
@@ -1220,9 +1210,7 @@ def create_mcp_server(
             # never the one the request asked for.
             filtering = payload.get("filtering") if isinstance(payload, dict) else None
             applied = filtering.get("applied") if isinstance(filtering, dict) else None
-            confirmed = (
-                isinstance(applied, dict) and applied.get("source") == LINEAR_ISSUE_SOURCE
-            )
+            confirmed = isinstance(applied, dict) and applied.get("source") == LINEAR_ISSUE_SOURCE
             scoped: dict[str, Any] = {**payload, "scope_applied": confirmed}
             if not confirmed:
                 warnings = [w for w in (payload.get("warnings") or []) if w]
@@ -1285,9 +1273,7 @@ def create_mcp_server(
                 # retry a write that had landed, duplicating it. Report what is
                 # known instead: submitted, outcome unconfirmed, here is how to
                 # settle it.
-                return _unconfirmed_ingest(
-                    normalized_data, tags or [], dataset, exc.timeout_s
-                )
+                return _unconfirmed_ingest(normalized_data, tags or [], dataset, exc.timeout_s)
 
         return await _call_async(
             "citadel_ingest",
@@ -1322,9 +1308,7 @@ def create_mcp_server(
                 except ValueError:
                     roots = []
             if not roots:
-                raise ToolError(
-                    "capture_roots is required when no local capture config exists."
-                )
+                raise ToolError("capture_roots is required when no local capture config exists.")
 
             payload_data = (data or "").strip()
             tool_errors = has_tool_errors

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -86,9 +86,7 @@ class MeshState:
             self._rehydrated = True
             try:
                 self._ensure_base_graph(config)
-                baselines = (
-                    sources if sources is not None else self._read_source_baselines(config)
-                )
+                baselines = sources if sources is not None else self._read_source_baselines(config)
                 latest_ts: str | None = None
                 for source in baselines:
                     ts = source.get("last_indexed_at")
@@ -176,9 +174,7 @@ class MeshState:
         so this projection is intentionally decoupled from any cognee read.
         """
         dataset_id = self._dataset_node(source.get("dataset") or config.default_dataset)
-        source_id = stable_id(
-            "source", f"rehydrate:{source.get('type')}:{source.get('label')}"
-        )
+        source_id = stable_id("source", f"rehydrate:{source.get('type')}:{source.get('label')}")
         self.nodes[source_id] = {
             "id": source_id,
             "label": source.get("label") or "Source",
@@ -292,15 +288,9 @@ class MeshState:
                 "tenant_id": config.tenant_id,
                 "default_dataset": config.default_dataset,
                 "stats": {
-                    "nodes": (
-                        corpus_total(authoritative_nodes, len(self.nodes))
-                    ),
-                    "edges": (
-                        corpus_total(authoritative_edges, len(self.edges))
-                    ),
-                    "tracked_sources": (
-                        corpus_total(authoritative_docs, self.documents)
-                    ),
+                    "nodes": (corpus_total(authoritative_nodes, len(self.nodes))),
+                    "edges": (corpus_total(authoritative_edges, len(self.edges))),
+                    "tracked_sources": (corpus_total(authoritative_docs, self.documents)),
                     "last_indexed_at": self.last_indexed_at,
                     "latest_event_id": self.revision,
                     "since_restart": since_restart,
@@ -336,9 +326,7 @@ class MeshState:
                 events = [event for event in events if event.get("type") == event_type]
             if kind:
                 events = [
-                    event
-                    for event in events
-                    if event.get("timeline", {}).get("kind") == kind
+                    event for event in events if event.get("timeline", {}).get("kind") == kind
                 ]
             if visible is not None:
                 events = [
@@ -461,11 +449,7 @@ class MeshState:
         """
         async with self._lock:
             self._ensure_base_graph(config)
-            target_dataset = (
-                dataset
-                or telemetry.get("primary_dataset")
-                or config.default_dataset
-            )
+            target_dataset = dataset or telemetry.get("primary_dataset") or config.default_dataset
             search_id = str(telemetry.get("search_id") or f"search:{self.feedback_items}")
             feedback_id = stable_id(
                 "feedback", f"search_telemetry:{target_dataset}:{search_id}:{self.feedback_items}"
@@ -622,7 +606,9 @@ class MeshState:
             dataset_id = self._dataset_node(
                 result.get("dataset") or config.repo_content_sync_dataset
             )
-            source_id = stable_id("source", f"github-repo-content:{result.get('org') or config.github_org}")
+            source_id = stable_id(
+                "source", f"github-repo-content:{result.get('org') or config.github_org}"
+            )
             self.nodes[source_id] = {
                 "id": source_id,
                 "label": f"Repo content / {result.get('org') or config.github_org}",
@@ -870,9 +856,7 @@ class MeshState:
         corpus: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         corpus = corpus or {}
-        graph_records = len(
-            [node for node in self.nodes.values() if node["type"] != "index"]
-        )
+        graph_records = len([node for node in self.nodes.values() if node["type"] != "index"])
         authoritative_nodes = corpus.get("indexed_docs")
         corpus_degraded = bool(corpus.get("degraded"))
         graph_status = "active"

--- a/kb/obsidian_sync.py
+++ b/kb/obsidian_sync.py
@@ -240,7 +240,11 @@ class ObsidianSyncStore:
                 conflicts.append(conflict)
                 continue
 
-            if current and incoming_hash == remote_hash and bool(current.get("deleted_at")) == incoming.deleted:
+            if (
+                current
+                and incoming_hash == remote_hash
+                and bool(current.get("deleted_at")) == incoming.deleted
+            ):
                 skipped.append(
                     {
                         "document_id": document_id,
@@ -336,7 +340,8 @@ class ObsidianSyncStore:
         changes = [
             change
             for change in data.get("changes", [])
-            if change.get("source_id") == vault_id and int(change.get("sequence", 0)) > resolved_cursor
+            if change.get("source_id") == vault_id
+            and int(change.get("sequence", 0)) > resolved_cursor
         ]
         documents: list[dict[str, Any]] = []
         for change in changes:
@@ -363,7 +368,11 @@ class ObsidianSyncStore:
             if revision.get("document_id") == document_id
         ]
         revisions.sort(key=lambda item: int(item.get("rev", 0)), reverse=True)
-        return {**document, "body": revisions[0]["body"] if revisions else "", "revisions": revisions}
+        return {
+            **document,
+            "body": revisions[0]["body"] if revisions else "",
+            "revisions": revisions,
+        }
 
     def resolve_conflict(
         self,

--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -223,7 +223,7 @@ def read_token_from_rc(rc_path: Path) -> str:
         stripped = raw.strip()
         for prefix in (f"export {TOKEN_ENV}=", f"{TOKEN_ENV}="):
             if stripped.startswith(prefix):
-                value = stripped[len(prefix):].strip()
+                value = stripped[len(prefix) :].strip()
                 try:
                     parts = shlex.split(value, comments=True)
                 except ValueError:  # unbalanced quotes — treat as unreadable
@@ -375,7 +375,9 @@ def install_windsurf_agent_policy_rule(repo: Path) -> str:
     return _write_text_file_idempotent(dst, windsurf_agent_policy_rule_text())
 
 
-def install_agent_policies(repo: Path, *, detected: list[str] | None = None) -> list[tuple[str, str]]:
+def install_agent_policies(
+    repo: Path, *, detected: list[str] | None = None
+) -> list[tuple[str, str]]:
     """Install Citadel agent policy for every supported coding agent.
 
     * **AGENTS.md** — Codex (CLI + app), Cursor (fallback), Pi, Cline, Zed, and
@@ -394,7 +396,10 @@ def install_agent_policies(repo: Path, *, detected: list[str] | None = None) -> 
         detected = detect()
 
     steps: list[tuple[str, str]] = [
-        (f"Agent policy ({AGENTS_MD_FILENAME})", install_markdown_policy_file(repo / AGENTS_MD_FILENAME)),
+        (
+            f"Agent policy ({AGENTS_MD_FILENAME})",
+            install_markdown_policy_file(repo / AGENTS_MD_FILENAME),
+        ),
     ]
     if "cursor" in detected:
         steps.append(
@@ -406,7 +411,10 @@ def install_agent_policies(repo: Path, *, detected: list[str] | None = None) -> 
         )
     if "gemini" in detected:
         steps.append(
-            (f"Gemini agent policy ({GEMINI_MD_FILENAME})", install_markdown_policy_file(repo / GEMINI_MD_FILENAME))
+            (
+                f"Gemini agent policy ({GEMINI_MD_FILENAME})",
+                install_markdown_policy_file(repo / GEMINI_MD_FILENAME),
+            )
         )
     return steps
 
@@ -459,7 +467,7 @@ def read_citadel_mcp_block(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        servers = (_load_json_object(path).get("mcpServers") or {})
+        servers = _load_json_object(path).get("mcpServers") or {}
     except ValueError:
         return None
     if not isinstance(servers, dict):

--- a/kb/organization_digest.py
+++ b/kb/organization_digest.py
@@ -62,7 +62,9 @@ def organization_digest_summary(result: dict[str, Any]) -> dict[str, Any]:
         "open_pull_requests": int(github.get("open_pull_request_count") or 0),
         "merged_pull_requests": int(github.get("merged_pull_request_count") or 0),
         "vault_context_items": len(_items(vault.get("recent_context"))),
-        "active_repositories": [row.get("repo") for row in active_repositories[:5] if row.get("repo")],
+        "active_repositories": [
+            row.get("repo") for row in active_repositories[:5] if row.get("repo")
+        ],
     }
 
 
@@ -171,9 +173,7 @@ def resolve_openrouter_model() -> tuple[str, str]:
     (no second slash, e.g. "openrouter/auto") is left untouched.
     """
     configured = (
-        os.getenv("CITADEL_ORG_DIGEST_LLM_MODEL")
-        or os.getenv("LLM_MODEL")
-        or default_llm_model()
+        os.getenv("CITADEL_ORG_DIGEST_LLM_MODEL") or os.getenv("LLM_MODEL") or default_llm_model()
     ).strip()
     sent = configured
     if sent.lower().startswith(LITELLM_OPENROUTER_PREFIX):
@@ -310,9 +310,7 @@ def llm_agent_read(packet: dict[str, Any]) -> list[str] | None:
         timeout=30,
     )
     if message is None:
-        logger.warning(
-            "Organization digest LLM read failed; falling back to deterministic read"
-        )
+        logger.warning("Organization digest LLM read failed; falling back to deterministic read")
         return None
     lines = []
     for raw_line in message.splitlines():

--- a/kb/promotion.py
+++ b/kb/promotion.py
@@ -41,7 +41,11 @@ from kb.promotion_queue import (
     build_pending_item,
     candidate_hash,
 )
-from kb.promotion_refs import ReferenceAssessment, assess_org_reference, parse_capture_tags_from_text
+from kb.promotion_refs import (
+    ReferenceAssessment,
+    assess_org_reference,
+    parse_capture_tags_from_text,
+)
 from kb.security_scan import SecurityScanEntry, scan_text_entries
 from kb.service import Citadel
 
@@ -137,9 +141,7 @@ def _candidate_from_result(result: Any) -> PromotionCandidate | None:
             if isinstance(meta_tags, list):
                 tags.extend(str(tag) for tag in meta_tags)
     tags.extend(parse_capture_tags_from_text(text))
-    normalized_tags = tuple(
-        dict.fromkeys(tag.strip().lower() for tag in tags if tag.strip())
-    )
+    normalized_tags = tuple(dict.fromkeys(tag.strip().lower() for tag in tags if tag.strip()))
     return PromotionCandidate(text=text, tags=normalized_tags)
 
 
@@ -276,9 +278,7 @@ class PromotionEngine:
                 break
             attempted += 1
             try:
-                results = await self.citadel.search(
-                    query, dataset=seat_dataset, top_k=cap
-                )
+                results = await self.citadel.search(query, dataset=seat_dataset, top_k=cap)
             except Exception as exc:  # pragma: no cover - depends on Cognee runtime.
                 logger.warning(
                     "promotion.enumerate search failed for %s: %s",
@@ -326,8 +326,7 @@ class PromotionEngine:
                     "dataset provisioning at creation; backfill it (#147)."
                 )
             raise PromotionEnumerationError(
-                f"all {attempted} seed queries failed for {seat_dataset}: "
-                f"{', '.join(distinct)}"
+                f"all {attempted} seed queries failed for {seat_dataset}: {', '.join(distinct)}"
             )
         return candidates[:cap]
 
@@ -367,11 +366,7 @@ class PromotionEngine:
         """True when the candidate trips the blocking-severity secret scanner."""
         try:
             scan = scan_text_entries(
-                [
-                    SecurityScanEntry(
-                        source="promotion", location=seat_dataset, text=text
-                    )
-                ],
+                [SecurityScanEntry(source="promotion", location=seat_dataset, text=text)],
                 block_severity=self.config.content_scan_block_severity,
             )
         except Exception:  # pragma: no cover - scan is best-effort; fail closed.
@@ -449,11 +444,7 @@ class PromotionEngine:
             )
 
         threshold = self.config.promotion_relevance_threshold
-        qualifies = (
-            verdict.relevant
-            and not verdict.sensitive
-            and verdict.score >= threshold
-        )
+        qualifies = verdict.relevant and not verdict.sensitive and verdict.score >= threshold
         base_kwargs = {
             "candidate": candidate.text,
             "relevant": verdict.relevant,
@@ -563,17 +554,14 @@ class PromotionEngine:
         attestation_identity = attested_by or identity
         attestation = {
             "promoted_by": (
-                attestation_identity.actor_id.strip()
-                or attestation_identity.actor_name.strip()
+                attestation_identity.actor_id.strip() or attestation_identity.actor_name.strip()
             ),
             "promoted_at": now_iso(),
         }
 
         central = None
         try:
-            targets = resolve_write_targets(
-                identity, None, promotion_tags, self.config
-            )
+            targets = resolve_write_targets(identity, None, promotion_tags, self.config)
             central = next(
                 (t.dataset for t in targets if t.tier == "full"),
                 targets[-1].dataset,
@@ -781,9 +769,7 @@ class PromotionEngine:
             "max_items": cap,
             "candidates": len(candidates),
             "proposed": sum(1 for p in proposals if p.decision == "promote"),
-            "pending_approval": sum(
-                1 for p in proposals if p.decision == "pending_approval"
-            ),
+            "pending_approval": sum(1 for p in proposals if p.decision == "pending_approval"),
             "promoted": promoted,
             "queued": queued,
             "proposals": [p.to_dict() for p in proposals],

--- a/kb/promotion_client.py
+++ b/kb/promotion_client.py
@@ -102,9 +102,7 @@ def resolve_seat_dataset(base_url: str, token: str, explicit: str | None) -> str
         return explicit
     slug = resolve_seat_slug(base_url, token)
     if not slug:
-        raise PromotionClientError(
-            "could not resolve seat dataset — pass --dataset seat:<slug>"
-        )
+        raise PromotionClientError("could not resolve seat dataset — pass --dataset seat:<slug>")
     return f"seat:{slug}"
 
 

--- a/kb/promotion_refs.py
+++ b/kb/promotion_refs.py
@@ -156,8 +156,4 @@ def parse_capture_tags_from_text(text: str) -> tuple[str, ...]:
     match = CAPTURE_TAGS_RE.search(text)
     if not match:
         return ()
-    return tuple(
-        tag.strip().lower()
-        for tag in match.group(1).split(",")
-        if tag.strip()
-    )
+    return tuple(tag.strip().lower() for tag in match.group(1).split(",") if tag.strip())

--- a/kb/prompt.py
+++ b/kb/prompt.py
@@ -53,7 +53,9 @@ def _clip(text: str, budget: int) -> str:
     return text if len(text) <= budget else text[: max(budget - 1, 0)] + "…"
 
 
-def _render_rows(options: list[str], checked: set[int], cursor: int, *, color: bool, width: int) -> list[str]:
+def _render_rows(
+    options: list[str], checked: set[int], cursor: int, *, color: bool, width: int
+) -> list[str]:
     rows = []
     for index, label in enumerate(options):
         box = paint(f"[{OK}]", "green", enable=color) if index in checked else "[ ]"
@@ -81,8 +83,11 @@ def _select_raw(header: str, options: list[str], checked: set[int]) -> set[int] 
         nonlocal drawn
         if drawn:
             out.write(f"\033[{drawn}A")  # jump back to the top of our block
-        rows = [header, *_render_rows(options, checked, cursor, color=color, width=width),
-                "  " + paint(_clip(_HELP, width - 4), "dim", enable=color)]
+        rows = [
+            header,
+            *_render_rows(options, checked, cursor, color=color, width=width),
+            "  " + paint(_clip(_HELP, width - 4), "dim", enable=color),
+        ]
         for row in rows:
             out.write("\033[2K" + row + "\n")
         drawn = len(rows)
@@ -127,7 +132,11 @@ def _select_lines(header: str, options: list[str], checked: set[int]) -> set[int
             box = paint(f"[{OK}]", "green", enable=color) if index - 1 in checked else "[ ]"
             print(f"    {box} {index}. {label}")
         try:
-            raw = input("  Toggle by number (e.g. 1 3), a all, n none, q skip — Enter to apply: ").strip().lower()
+            raw = (
+                input("  Toggle by number (e.g. 1 3), a all, n none, q skip — Enter to apply: ")
+                .strip()
+                .lower()
+            )
         except EOFError:
             print()
             return checked
@@ -155,11 +164,7 @@ def checkbox_select(header: str, options: list[str], checked: set[int]) -> set[i
     if not options:
         return set()
     checked = {i for i in checked if 0 <= i < len(options)}
-    raw_capable = (
-        os.getenv("TERM", "") != "dumb"
-        and sys.stdin.isatty()
-        and sys.stdout.isatty()
-    )
+    raw_capable = os.getenv("TERM", "") != "dumb" and sys.stdin.isatty() and sys.stdout.isatty()
     if raw_capable:
         try:
             return _select_raw(header, options, set(checked))

--- a/kb/repair_journal.py
+++ b/kb/repair_journal.py
@@ -153,9 +153,7 @@ class RepairJournal:
             "repair_document_ids": sorted({str(item) for item in repair_document_ids}),
             "repair_datasets": sorted({str(item) for item in repair_datasets}),
         }
-        normalized_repair_mapping = _normalize_repair_document_datasets(
-            repair_document_datasets
-        )
+        normalized_repair_mapping = _normalize_repair_document_datasets(repair_document_datasets)
         if normalized_repair_mapping:
             record["repair_document_datasets"] = normalized_repair_mapping
         deleted = sorted({str(item) for item in deleted_document_ids})
@@ -212,9 +210,7 @@ class RepairJournal:
                     f"repair journal contains invalid JSON at line {line_number}"
                 ) from exc
             if not isinstance(record, dict):
-                raise RuntimeError(
-                    f"repair journal record at line {line_number} is not an object"
-                )
+                raise RuntimeError(f"repair journal record at line {line_number} is not an object")
             operation_id = record.get("operation_id")
             if not isinstance(operation_id, str) or not operation_id:
                 raise RuntimeError(
@@ -250,10 +246,7 @@ class RepairJournal:
                 continue
             if "source_manifest" not in record and operation_id in source_manifests:
                 record = {**record, "source_manifest": source_manifests[operation_id]}
-            if (
-                "repair_document_datasets" not in record
-                and operation_id in repair_mappings
-            ):
+            if "repair_document_datasets" not in record and operation_id in repair_mappings:
                 record = {
                     **record,
                     "repair_document_datasets": repair_mappings[operation_id],

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -60,9 +60,7 @@ TERMINAL_INGEST_REJECTIONS = frozenset(
 # ``accepted=True`` confirms source storage, not necessarily the projection.
 # These reasons mean the caller only requested cognification, so the state
 # entry must remain retryable until a later pass observes completion.
-PROJECTION_PENDING_INGEST_REASONS = frozenset(
-    {"queued_not_confirmed", "not_scheduled"}
-)
+PROJECTION_PENDING_INGEST_REASONS = frozenset({"queued_not_confirmed", "not_scheduled"})
 
 # One lock per state file, NOT per syncer instance. ``get_repo_content_syncer``
 # in kb.server builds a fresh ``RepoContentSyncer`` on every call (app.state
@@ -165,9 +163,7 @@ def _cognee_data_ids(outcome: Any) -> list[str]:
             info_list = added.get("data_ingestion_info")
         for info in info_list or ():
             data_id = (
-                info.get("data_id")
-                if isinstance(info, Mapping)
-                else getattr(info, "data_id", None)
+                info.get("data_id") if isinstance(info, Mapping) else getattr(info, "data_id", None)
             )
             if data_id:
                 ids.append(str(data_id))
@@ -250,14 +246,10 @@ class RepoContentGitHubClient(GitHubOrgClient):
             {"path": path, "sha": ref, "per_page": 1},
         )
         if not isinstance(data, list) or not data or not isinstance(data[0], dict):
-            raise GitHubAPIError(
-                f"Could not resolve the last commit for {full_name}/{path}."
-            )
+            raise GitHubAPIError(f"Could not resolve the last commit for {full_name}/{path}.")
         commit_sha = data[0].get("sha")
         if not isinstance(commit_sha, str) or not commit_sha:
-            raise GitHubAPIError(
-                f"Could not resolve the last commit for {full_name}/{path}."
-            )
+            raise GitHubAPIError(f"Could not resolve the last commit for {full_name}/{path}.")
         return commit_sha
 
     def fetch_tree(self, full_name: str, *, ref: str) -> tuple[list[str], bool] | None:
@@ -562,7 +554,11 @@ class RepoContentSyncer:
         files = data.get("files")
         if not isinstance(files, dict):
             files = {}
-        return {"version": STATE_VERSION, "files": files, **{k: v for k, v in data.items() if k != "files"}}
+        return {
+            "version": STATE_VERSION,
+            "files": files,
+            **{k: v for k, v in data.items() if k != "files"},
+        }
 
     def _save_state(self, state: dict[str, Any]) -> None:
         # Atomic (temp file + rename) so a restart mid-write cannot leave the
@@ -575,8 +571,7 @@ class RepoContentSyncer:
         if not self.config.repo_content_sync_autojoin_enabled:
             return resolved
         markers = (
-            self.config.repo_content_sync_autojoin_markers
-            or DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS
+            self.config.repo_content_sync_autojoin_markers or DEFAULT_REPO_CONTENT_AUTOJOIN_MARKERS
         )
         discovered = discover_org_repos(
             self.client,
@@ -634,7 +629,8 @@ class RepoContentSyncer:
                 self.config.repo_content_sync_tree_prefixes or DEFAULT_REPO_CONTENT_TREE_PREFIXES
             ),
             "tree_extensions": list(
-                self.config.repo_content_sync_tree_extensions or DEFAULT_REPO_CONTENT_TREE_EXTENSIONS
+                self.config.repo_content_sync_tree_extensions
+                or DEFAULT_REPO_CONTENT_TREE_EXTENSIONS
             ),
             "max_files_per_repo": self.config.repo_content_sync_max_files_per_repo,
             "max_bytes_per_file": self.config.repo_content_sync_max_bytes_per_file,
@@ -710,7 +706,9 @@ class RepoContentSyncer:
         state = self._load_state()
         tracked: dict[str, Any] = dict(state.get("files") or {})
         root_paths = self.config.repo_content_sync_root_paths or DEFAULT_REPO_CONTENT_ROOT_PATHS
-        tree_prefixes = self.config.repo_content_sync_tree_prefixes or DEFAULT_REPO_CONTENT_TREE_PREFIXES
+        tree_prefixes = (
+            self.config.repo_content_sync_tree_prefixes or DEFAULT_REPO_CONTENT_TREE_PREFIXES
+        )
         tree_extensions = (
             self.config.repo_content_sync_tree_extensions or DEFAULT_REPO_CONTENT_TREE_EXTENSIONS
         )
@@ -890,10 +888,7 @@ class RepoContentSyncer:
                         # re-implementing the scan by hand. Categories and
                         # severities are already redacted by public_dict().
                         categories = sorted(
-                            {
-                                str(finding.get("category"))
-                                for finding in scan.get("findings", [])
-                            }
+                            {str(finding.get("category")) for finding in scan.get("findings", [])}
                         )
                         for category in categories:
                             blocked_reasons[category] = blocked_reasons.get(category, 0) + 1
@@ -971,9 +966,7 @@ class RepoContentSyncer:
                         detect_conflicts=False,
                     )
                     ingest_results = tuple(outcome.all_ingests)
-                    accepted_results = tuple(
-                        result for result in ingest_results if result.accepted
-                    )
+                    accepted_results = tuple(result for result in ingest_results if result.accepted)
                     pending_reasons = sorted(
                         {
                             result.reason
@@ -1015,9 +1008,7 @@ class RepoContentSyncer:
                         # it in a sync report cannot tell anyone whether a human
                         # has to look at the file or whether the same bytes were
                         # merely already in flight, so carry what ingest said.
-                        reasons = sorted(
-                            {result.reason for result in outcome.all_ingests}
-                        )
+                        reasons = sorted({result.reason for result in outcome.all_ingests})
                         reason = reasons[0] if len(reasons) == 1 else "+".join(reasons)
                         if reasons and all(
                             value in TERMINAL_INGEST_REJECTIONS for value in reasons
@@ -1071,9 +1062,7 @@ class RepoContentSyncer:
 
         repos_errored = [result for result in repo_results if result["errors"]]
         all_repos_errored = (
-            bool(repo_results)
-            and len(repos_errored) == len(repo_results)
-            and ingested_files == 0
+            bool(repo_results) and len(repos_errored) == len(repo_results) and ingested_files == 0
         )
 
         logger.info(
@@ -1107,7 +1096,9 @@ class RepoContentSyncer:
 
 
 async def _cli_main() -> None:
-    parser = argparse.ArgumentParser(description="Sync allowlisted repository content into Citadel.")
+    parser = argparse.ArgumentParser(
+        description="Sync allowlisted repository content into Citadel."
+    )
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/kb/repo_stats.py
+++ b/kb/repo_stats.py
@@ -144,11 +144,7 @@ def count_adr_records() -> int | None:
         adr_dir = _repo_root() / "docs" / "adr"
         if not adr_dir.is_dir():
             return None
-        return sum(
-            1
-            for path in adr_dir.glob("*.md")
-            if path.name[:4].isdigit()
-        )
+        return sum(1 for path in adr_dir.glob("*.md") if path.name[:4].isdigit())
     except OSError:
         logger.debug("ADR count unavailable", exc_info=True)
         return None

--- a/kb/repository_update.py
+++ b/kb/repository_update.py
@@ -250,10 +250,7 @@ class RepositoryDailyUpdate:
     def meaningful(self) -> bool:
         """Whether the window contains any Meaningful Source Changes."""
         return bool(
-            self.changed_repos
-            or self.new_events
-            or self.new_commits
-            or self.recent_pull_requests
+            self.changed_repos or self.new_events or self.new_commits or self.recent_pull_requests
         )
 
     @property

--- a/kb/retrieval_eval.py
+++ b/kb/retrieval_eval.py
@@ -43,6 +43,7 @@ installed ``citadel`` command does not depend on the repository layout.
 Write run JSONs only under scripts/bench/runs/ (gitignored): a run JSON
 enumerates every served hit identity and must never be committed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -74,9 +75,9 @@ HERE = REPO_BENCH_DIR if REPO_BENCH_DIR.is_dir() else PACKAGE_ROOT / "bench"
 GROUND_TRUTH = HERE / "ground_truth"
 DEFAULT_QUESTIONS = HERE / "golden_questions.json"
 
-K_ANSWER = 5          # answer_recall@5 / doc_recall@5 window
-K_DUP = 10            # duplicate_blob_rate@10 / distinct_files@10 window
-MIN_SPAN_CHARS = 15   # normalized; shorter spans match too promiscuously
+K_ANSWER = 5  # answer_recall@5 / doc_recall@5 window
+K_DUP = 10  # duplicate_blob_rate@10 / distinct_files@10 window
+MIN_SPAN_CHARS = 15  # normalized; shorter spans match too promiscuously
 MAX_SPANS = 4
 
 # Identity parsing is anchored at the START of the chunk. The old harness used
@@ -149,9 +150,7 @@ def is_window_question(question: dict[str, Any]) -> bool:
 def distinctive_terms(text: str) -> set[str]:
     """Lowercase content words used for the head/tail novelty control."""
     return {
-        word
-        for word in NOVEL_TERM_RE.findall(text.lower())
-        if word not in NOVEL_TERM_STOPWORDS
+        word for word in NOVEL_TERM_RE.findall(text.lower()) if word not in NOVEL_TERM_STOPWORDS
     }
 
 
@@ -223,9 +222,7 @@ def split_header_body(text: str) -> tuple[str, str]:
     # No separator (malformed or truncated chunk): strip the contiguous header
     # prefix (title line, blanks, known meta lines) and keep the rest as body.
     index = 1
-    while index < len(lines) and (
-        not lines[index].strip() or HEADER_META_LINE.match(lines[index])
-    ):
+    while index < len(lines) and (not lines[index].strip() or HEADER_META_LINE.match(lines[index])):
         index += 1
     return "\n".join(lines[:index]), "\n".join(lines[index:])
 
@@ -262,9 +259,7 @@ def parse_identity(hit: dict[str, Any]) -> Identity:
     doc_id = hit.get("document_id") or hit.get("id")
     if doc_id:
         return Identity("doc", str(doc_id))
-    return Identity(
-        "doc", "text:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
-    )
+    return Identity("doc", "text:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:16])
 
 
 def collapse_hits(hits: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -512,9 +507,7 @@ def score_question(
             bodies = [normalize(body) for body in entry["bodies"]]
             if any(span in body for body in bodies for span in spans):
                 answer_rank = entry["effective_rank"]
-                answer_from_expected = entry_matches_expected(
-                    entry, expected, gt_shingles
-                )
+                answer_from_expected = entry_matches_expected(entry, expected, gt_shingles)
                 break
 
     raw_page_pass = False
@@ -612,9 +605,7 @@ def score_question(
     # Baseline recorded 2026-07-31 by the path method: recall@5 was 0.93 while
     # the mean distinct-source ratio was 0.62, with 22 of 60 queries returning
     # only one or two distinct documents.
-    resolvable_slots = [
-        hit for hit in dup_slots if parse_identity(hit).kind in ("repo", "linear")
-    ]
+    resolvable_slots = [hit for hit in dup_slots if parse_identity(hit).kind in ("repo", "linear")]
     distinct_resolvable = len({parse_identity(hit).source for hit in resolvable_slots})
     # The ratio over ALL slots is the pessimistic bound: a hit whose source path
     # could not be resolved counts against diversity exactly like a duplicate
@@ -708,9 +699,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     # None of those is comparable across the v5 boundary. `compare` is what
     # enforces this: two runs answering different question sets differ in
     # `questions_pin` and are refused outright.
-    span_rows = [
-        row for row in positives if row["has_spans"] and row.get("window_role") is None
-    ]
+    span_rows = [row for row in positives if row["has_spans"] and row.get("window_role") is None]
     if not probes:
         raise BenchError(
             "The blocked-probe/negatives list is empty (no expected_recall=0 "
@@ -792,8 +781,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
     neither_pass = sum(
         1
         for pair in complete_pairs
-        if not head_by_pair[pair]["answer_pass_at_5"]
-        and not tail_by_pair[pair]["answer_pass_at_5"]
+        if not head_by_pair[pair]["answer_pass_at_5"] and not tail_by_pair[pair]["answer_pass_at_5"]
     )
     tail_only_pass = len(complete_pairs) - head_only_pass - both_pass - neither_pass
 
@@ -804,9 +792,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
         if row["answer_slot"] is not None and row["answer_term_coverage"] is not None
     ]
     inverted = [row for row in ranked if row["outranked_by_coverage"] is not None]
-    zero_coverage_inversions = sum(
-        1 for row in inverted if row["outranked_by_coverage"] == 0.0
-    )
+    zero_coverage_inversions = sum(1 for row in inverted if row["outranked_by_coverage"] == 0.0)
     # rank_inversion_rate blends two populations that answer_recall_at_5 keeps
     # apart: real questions and the 36 verbatim-sentence window queries, whose
     # exact-quote form is not how anyone searches. Report the split so a reader
@@ -843,8 +829,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             "answers_from_unexpected_documents": sum(
                 1
                 for row in positives
-                if row["answer_pass_at_5"]
-                and row.get("answer_from_expected_document") is False
+                if row["answer_pass_at_5"] and row.get("answer_from_expected_document") is False
             ),
         },
         "duplication": {
@@ -906,15 +891,11 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             # quoting one document used to report `documents: 2`, overstating
             # how much of the corpus the window measurement covers -- the
             # name-versus-what-it-attests failure this harness exists to catch.
-            "documents": len(
-                {doc for row in window_rows for doc in (row.get("expect_any") or [])}
-            ),
+            "documents": len({doc for row in window_rows for doc in (row.get("expect_any") or [])}),
         },
         "ranking": {
             "answers_ranked": len(ranked),
-            "rank_inversion_rate": (
-                round(len(inverted) / len(ranked), 4) if ranked else None
-            ),
+            "rank_inversion_rate": (round(len(inverted) / len(ranked), 4) if ranked else None),
             "inversions_by_zero_coverage": zero_coverage_inversions,
             "answer_worst_slot": max((row["answer_slot"] for row in ranked), default=None),
             # The split behind the headline rate. `answer_recall_at_5` excludes
@@ -926,9 +907,7 @@ def summarize(rows: list[dict[str, Any]], stability: list[float]) -> dict[str, A
             ),
             "answers_ranked_window_only": len(ranked_window),
             "rank_inversion_rate_window_only": (
-                round(len(inverted_window) / len(ranked_window), 4)
-                if ranked_window
-                else None
+                round(len(inverted_window) / len(ranked_window), 4) if ranked_window else None
             ),
         },
         "metadata_stability": {
@@ -1066,7 +1045,7 @@ def api_fingerprint(node_url: str, token: str, timeout: float) -> dict[str, Any]
 # --------------------------------------------------------------------------
 
 CENSUS_PAGE_LIMIT = 1000  # /api/corpus CORPUS_MAX_LIMIT
-CENSUS_MAX_PAGES = 100    # 100k documents; a ceiling, not an expectation
+CENSUS_MAX_PAGES = 100  # 100k documents; a ceiling, not an expectation
 
 
 def make_corpus_fetcher(
@@ -1120,9 +1099,7 @@ def corpus_census(
     while True:
         if pages >= max_pages:
             truncated = True
-            notes.append(
-                f"census stopped at the {max_pages}-page ceiling; counts are a floor"
-            )
+            notes.append(f"census stopped at the {max_pages}-page ceiling; counts are a floor")
             break
         try:
             body = fetch_page(cursor)
@@ -1138,8 +1115,7 @@ def corpus_census(
             return {
                 "error": exc.__class__.__name__,
                 "reason": (
-                    "corpus census failed mid-walk; the never-indexed share "
-                    "was not measured"
+                    "corpus census failed mid-walk; the never-indexed share was not measured"
                 ),
             }
         pages += 1
@@ -1363,11 +1339,7 @@ def compare_fingerprints(
     # count grows daily by design and gating on it would block every compare.
     current_total = (current.get("census") or {}).get("documents_total")
     baseline_total = (baseline.get("census") or {}).get("documents_total")
-    if (
-        current_total is not None
-        and baseline_total is not None
-        and current_total != baseline_total
-    ):
+    if current_total is not None and baseline_total is not None and current_total != baseline_total:
         verdicts.append(
             "note: corpus census document totals differ "
             f"({baseline_total} -> {current_total}); repo-content is unchanged "
@@ -1407,9 +1379,7 @@ def _first_content_line(text: str) -> str:
     return ""
 
 
-def lint_questions(
-    questions_path: Path, ground_truth_dir: Path
-) -> tuple[list[str], list[str]]:
+def lint_questions(questions_path: Path, ground_truth_dir: Path) -> tuple[list[str], list[str]]:
     """Validate every answer span. Returns (problems, notes).
 
     Rules per span: present in a cached expect_any body; absent from the
@@ -1499,8 +1469,7 @@ def lint_questions(
         expected_cached = [p for p in expected if p in cached_norm]
         if not expected_cached:
             problems.append(
-                f"{qid}: has answer_spans but no expect_any document is cached "
-                "in ground_truth/"
+                f"{qid}: has answer_spans but no expect_any document is cached in ground_truth/"
             )
             continue
 
@@ -1519,9 +1488,7 @@ def lint_questions(
                 problems.append(f"{label}: not found in any cached ground-truth body")
             for repo_path in expected_cached:
                 if norm_span in _synthetic_header(repo_path):
-                    problems.append(
-                        f"{label}: appears in the sync header block for {repo_path}"
-                    )
+                    problems.append(f"{label}: appears in the sync header block for {repo_path}")
                 first_line = normalize(_first_content_line(cached_raw[repo_path]))
                 if first_line and norm_span in first_line:
                     problems.append(
@@ -1541,9 +1508,7 @@ def lint_questions(
                 if other in expected:
                     continue
                 if norm_span in body:
-                    problems.append(
-                        f"{label}: not unique, also present in cached body {other}"
-                    )
+                    problems.append(f"{label}: not unique, also present in cached body {other}")
 
         if is_window_question(question):
             window_problems, window_notes = _lint_window_question(question, cached_raw)
@@ -1580,9 +1545,7 @@ def _lint_window_question(
     if role not in ("head", "tail"):
         return [f"{qid}: window question needs window_role of 'head' or 'tail'"], notes
 
-    expected_category = (
-        WINDOW_HEAD_CATEGORY if role == "head" else WINDOW_TAIL_CATEGORY
-    )
+    expected_category = WINDOW_HEAD_CATEGORY if role == "head" else WINDOW_TAIL_CATEGORY
     if str(question.get("category", "")) != expected_category:
         problems.append(
             f"{qid}: window_role {role!r} needs category {expected_category!r} "
@@ -1729,9 +1692,7 @@ def make_http_searcher(node_url: str, token: str, timeout: float) -> Searcher:
     return searcher
 
 
-def make_ci_searcher(
-    questions: list[dict[str, Any]], ground_truth_dir: Path
-) -> Searcher:
+def make_ci_searcher(questions: list[dict[str, Any]], ground_truth_dir: Path) -> Searcher:
     """Serve the tracked synthetic fixture through the real scoring path.
 
     This is a harness self-check, not a live retrieval measurement. It proves
@@ -1753,8 +1714,7 @@ def make_ci_searcher(
         fixture = ground_truth_dir / source.replace("/", "__")
         if not fixture.is_file():
             raise BenchError(
-                f"{question.get('id', '?')}: CI ground-truth fixture is missing: "
-                f"{fixture}"
+                f"{question.get('id', '?')}: CI ground-truth fixture is missing: {fixture}"
             )
         body = fixture.read_text(encoding="utf-8")
         text = "\n".join(
@@ -1856,18 +1816,16 @@ def execute_benchmark(
         rows.append(first)
         if repeats > 1:
             reference = attempt_outcome(first)
-            agreement = sum(
-                1 for row in attempt_rows if attempt_outcome(row) == reference
-            ) / len(attempt_rows)
+            agreement = sum(1 for row in attempt_rows if attempt_outcome(row) == reference) / len(
+                attempt_rows
+            )
             stability.append(agreement)
         if not quiet:
             if question.get("expected_recall", 1) == 0:
                 state = "PROBE HIT" if first["doc_rank"] is not None else "probe miss (good)"
             elif first["has_spans"]:
                 state = (
-                    f"answer rank {first['answer_rank']}"
-                    if first["answer_rank"]
-                    else "ANSWER MISS"
+                    f"answer rank {first['answer_rank']}" if first["answer_rank"] else "ANSWER MISS"
                 )
             else:
                 state = (
@@ -1970,9 +1928,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    fingerprint = build_fingerprint(
-        args.node_url, token, args.timeout, questions_path, repo_state
-    )
+    fingerprint = build_fingerprint(args.node_url, token, args.timeout, questions_path, repo_state)
     result["fingerprint"] = fingerprint
     result["node_url"] = args.node_url
     _print_summary(result["summary"])
@@ -2011,9 +1967,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     if args.baseline:
         baseline = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
-        comparable, verdicts = compare_fingerprints(
-            fingerprint, baseline.get("fingerprint") or {}
-        )
+        comparable, verdicts = compare_fingerprints(fingerprint, baseline.get("fingerprint") or {})
         print("\n--- baseline comparison ---")
         for verdict in verdicts:
             print(verdict)
@@ -2021,9 +1975,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             base_quality = (baseline.get("summary") or {}).get("quality") or {}
             for key, value in result["summary"]["quality"].items():
                 previous = base_quality.get(key)
-                delta = (
-                    round(value - previous, 4) if isinstance(previous, (int, float)) else "n/a"
-                )
+                delta = round(value - previous, 4) if isinstance(previous, (int, float)) else "n/a"
                 print(f"{key:>28}: {previous} -> {value} (delta {delta})")
         else:
             print("metric deltas withheld: the runs do not measure the same corpus.")
@@ -2056,9 +2008,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 
 def cmd_lint(args: argparse.Namespace) -> int:
-    problems, notes = lint_questions(
-        Path(args.questions), Path(args.ground_truth)
-    )
+    problems, notes = lint_questions(Path(args.questions), Path(args.ground_truth))
     for note in notes:
         print(note)
     if problems:
@@ -2070,9 +2020,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     questions = list(data.get("questions") or [])
     converted = sum(1 for q in questions if q.get("answer_spans"))
     unconverted = sum(
-        1
-        for q in questions
-        if q.get("expected_recall", 1) == 1 and not q.get("answer_spans")
+        1 for q in questions if q.get("expected_recall", 1) == 1 and not q.get("answer_spans")
     )
     print(
         f"lint OK: {converted} question(s) with validated answer_spans, "
@@ -2120,10 +2068,7 @@ def cmd_ci(args: argparse.Namespace) -> int:
     if failures:
         print("CI BENCH FAILED: " + "; ".join(failures), file=sys.stderr)
         return 1
-    print(
-        "ci benchmark OK: "
-        + " ".join(f"{key}={quality[key]}" for key in expected)
-    )
+    print("ci benchmark OK: " + " ".join(f"{key}={quality[key]}" for key in expected))
     return 0
 
 
@@ -2191,28 +2136,18 @@ def _enforce_run_evidence(
         failures.append(f"{label} census is missing; corpus coverage is unmeasured")
     else:
         if census.get("error"):
-            failures.append(
-                f"{label} census failed: {census.get('error')}"
-            )
+            failures.append(f"{label} census failed: {census.get('error')}")
         if census.get("truncated") is not False:
             failures.append(f"{label} census is incomplete or truncated")
         unmeasured = census.get("chunk_count_unmeasured")
         if not _nonnegative_count(unmeasured):
-            failures.append(
-                f"{label} census chunk_count_unmeasured is missing or invalid"
-            )
+            failures.append(f"{label} census chunk_count_unmeasured is missing or invalid")
         elif unmeasured:
-            failures.append(
-                f"{label} census has {unmeasured} unmeasured document(s)"
-            )
+            failures.append(f"{label} census has {unmeasured} unmeasured document(s)")
         documents_total = census.get("documents_total")
         documents_walked = census.get("documents_walked")
-        if not _nonnegative_count(documents_total) or not _nonnegative_count(
-            documents_walked
-        ):
-            failures.append(
-                f"{label} census total/walked document counts are missing or invalid"
-            )
+        if not _nonnegative_count(documents_total) or not _nonnegative_count(documents_walked):
+            failures.append(f"{label} census total/walked document counts are missing or invalid")
         elif documents_total != documents_walked:
             failures.append(
                 f"{label} census is incomplete: walked {documents_walked} of "
@@ -2220,16 +2155,12 @@ def _enforce_run_evidence(
             )
         zero_value = census.get("chunk_count_zero")
         if not _nonnegative_count(zero_value):
-            failures.append(
-                f"{label} census chunk_count_zero is missing or invalid"
-            )
+            failures.append(f"{label} census chunk_count_zero is missing or invalid")
         else:
             zero_chunks = zero_value
 
     ground_truth = fingerprint.get("ground_truth")
-    ground_truth_sha = (
-        ground_truth.get("sha256") if isinstance(ground_truth, dict) else None
-    )
+    ground_truth_sha = ground_truth.get("sha256") if isinstance(ground_truth, dict) else None
     if not isinstance(ground_truth_sha, str) or not ground_truth_sha:
         failures.append(f"{label} ground-truth fingerprint is missing")
 
@@ -2262,29 +2193,19 @@ def _enforce_run_evidence(
             metrics[key] = float(value)
 
     negative_hit_rate = quality.get("negative_hit_rate")
-    if not _finite_number(negative_hit_rate) or not 0.0 <= float(
-        negative_hit_rate
-    ) <= 1.0:
-        failures.append(
-            f"{label} negative_hit_rate is missing or invalid: {negative_hit_rate!r}"
-        )
+    if not _finite_number(negative_hit_rate) or not 0.0 <= float(negative_hit_rate) <= 1.0:
+        failures.append(f"{label} negative_hit_rate is missing or invalid: {negative_hit_rate!r}")
     elif negative_hit_rate:
-        failures.append(
-            f"{label} contains negative hits: negative_hit_rate={negative_hit_rate}"
-        )
+        failures.append(f"{label} contains negative hits: negative_hit_rate={negative_hit_rate}")
 
     metadata = summary.get("metadata_stability")
-    unstable = metadata.get("chunks_with_unstable_trust_tier") if isinstance(
-        metadata, dict
-    ) else None
+    unstable = (
+        metadata.get("chunks_with_unstable_trust_tier") if isinstance(metadata, dict) else None
+    )
     if not _nonnegative_count(unstable):
-        failures.append(
-            f"{label} unstable trust count is missing or invalid"
-        )
+        failures.append(f"{label} unstable trust count is missing or invalid")
     elif unstable:
-        failures.append(
-            f"{label} contains unstable trust metadata on {unstable} chunk(s)"
-        )
+        failures.append(f"{label} contains unstable trust metadata on {unstable} chunk(s)")
 
     return failures, metrics, zero_chunks
 
@@ -2300,22 +2221,14 @@ def enforce_acceptance(
     """
     baseline_fingerprint = baseline.get("fingerprint")
     candidate_fingerprint = candidate.get("fingerprint")
-    baseline_fingerprint = (
-        baseline_fingerprint if isinstance(baseline_fingerprint, dict) else {}
-    )
-    candidate_fingerprint = (
-        candidate_fingerprint if isinstance(candidate_fingerprint, dict) else {}
-    )
-    comparable, verdicts = compare_fingerprints(
-        candidate_fingerprint, baseline_fingerprint
-    )
+    baseline_fingerprint = baseline_fingerprint if isinstance(baseline_fingerprint, dict) else {}
+    candidate_fingerprint = candidate_fingerprint if isinstance(candidate_fingerprint, dict) else {}
+    comparable, verdicts = compare_fingerprints(candidate_fingerprint, baseline_fingerprint)
     failures: list[str] = []
     if not comparable:
         failures.append("fingerprints are not comparable")
 
-    baseline_failures, baseline_metrics, baseline_zero = _enforce_run_evidence(
-        baseline, "baseline"
-    )
+    baseline_failures, baseline_metrics, baseline_zero = _enforce_run_evidence(baseline, "baseline")
     candidate_failures, candidate_metrics, candidate_zero = _enforce_run_evidence(
         candidate, "candidate"
     )
@@ -2329,32 +2242,24 @@ def enforce_acceptance(
             if previous is None or current is None:
                 continue
             if current < previous:
-                failures.append(
-                    f"candidate {key} regressed: {previous:g} -> {current:g}"
-                )
+                failures.append(f"candidate {key} regressed: {previous:g} -> {current:g}")
         if baseline_zero is not None and candidate_zero is not None:
             if candidate_zero > baseline_zero:
                 failures.append(
-                    "candidate chunk_count_zero regressed: "
-                    f"{baseline_zero} -> {candidate_zero}"
+                    f"candidate chunk_count_zero regressed: {baseline_zero} -> {candidate_zero}"
                 )
         if candidate_zero != 0:
-            failures.append(
-                f"candidate chunk_count_zero must be 0, got {candidate_zero}"
-            )
+            failures.append(f"candidate chunk_count_zero must be 0, got {candidate_zero}")
         candidate_tail = candidate_metrics.get("tail_recall_given_head_at_5")
         if candidate_tail != 1.0:
             failures.append(
-                "candidate tail_recall_given_head_at_5 must be 1.0, "
-                f"got {candidate_tail}"
+                f"candidate tail_recall_given_head_at_5 must be 1.0, got {candidate_tail}"
             )
 
         baseline_gt = (baseline_fingerprint.get("ground_truth") or {}).get("sha256")
         candidate_gt = (candidate_fingerprint.get("ground_truth") or {}).get("sha256")
         if baseline_gt != candidate_gt:
-            failures.append(
-                "ground-truth fingerprints differ; benchmark scores are not comparable"
-            )
+            failures.append("ground-truth fingerprints differ; benchmark scores are not comparable")
 
     return comparable, verdicts, failures
 
@@ -2546,8 +2451,7 @@ def _census_paragraph(census: dict[str, Any] | None) -> str:
     unmeasured = census.get("chunk_count_unmeasured") or 0
     if unmeasured:
         text += (
-            f" {unmeasured} documents had no chunk_count measurement, so the "
-            "zero count is a floor."
+            f" {unmeasured} documents had no chunk_count measurement, so the zero count is a floor."
         )
     if census.get("truncated"):
         text += (
@@ -2643,8 +2547,7 @@ def build_markdown_report(run: dict[str, Any]) -> str:
         n = _metric_sample_count(run, n_source)
         n_cell = "n/a" if n is None else n
         lines.append(
-            f"| {key} | {value_cell} | {run_date} | `{short_sha}` | {n_cell} "
-            f"| {definition} |"
+            f"| {key} | {value_cell} | {run_date} | `{short_sha}` | {n_cell} | {definition} |"
         )
 
     lines += ["", _census_paragraph(fingerprint.get("census"))]
@@ -2730,9 +2633,7 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     run_parser = sub.add_parser("run", help="run the benchmark against a node")
-    run_parser.add_argument(
-        "--node-url", default=os.getenv("CITADEL_NODE_URL", DEFAULT_NODE)
-    )
+    run_parser.add_argument("--node-url", default=os.getenv("CITADEL_NODE_URL", DEFAULT_NODE))
     run_parser.add_argument("--questions", default=str(DEFAULT_QUESTIONS))
     run_parser.add_argument(
         "--repeats",
@@ -2766,12 +2667,8 @@ def main(argv: list[str] | None = None) -> int:
     ci_parser = sub.add_parser(
         "ci", help="Run the tracked, network-free benchmark harness self-check"
     )
-    ci_parser.add_argument(
-        "--questions", default=str(REPO_BENCH_DIR / "golden_questions_ci.json")
-    )
-    ci_parser.add_argument(
-        "--ground-truth", default=str(REPO_BENCH_DIR / "ground_truth_ci")
-    )
+    ci_parser.add_argument("--questions", default=str(REPO_BENCH_DIR / "golden_questions_ci.json"))
+    ci_parser.add_argument("--ground-truth", default=str(REPO_BENCH_DIR / "ground_truth_ci"))
     ci_parser.set_defaults(func=cmd_ci)
 
     compare_parser = sub.add_parser("compare", help="compare two saved runs")
@@ -2796,9 +2693,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="markdown is the only output format; the flag makes intent explicit",
     )
-    report_parser.add_argument(
-        "--out", default=None, help="write the block here instead of stdout"
-    )
+    report_parser.add_argument("--out", default=None, help="write the block here instead of stdout")
     report_parser.set_defaults(func=cmd_report)
 
     args = parser.parse_args(argv)

--- a/kb/retry.py
+++ b/kb/retry.py
@@ -105,9 +105,7 @@ def run_with_retries(
     base_delay = (
         base_delay_seconds if base_delay_seconds is not None else default_base_delay_seconds()
     )
-    max_delay = (
-        max_delay_seconds if max_delay_seconds is not None else default_max_delay_seconds()
-    )
+    max_delay = max_delay_seconds if max_delay_seconds is not None else default_max_delay_seconds()
     chooser = rng or random
     sleeper = sleep if sleep is not None else time.sleep
 
@@ -148,4 +146,3 @@ def run_with_retries(
         )
         sleeper(delay)
     return result
-

--- a/kb/search_feedback.py
+++ b/kb/search_feedback.py
@@ -116,9 +116,7 @@ def summarize_hit(item: Any, *, rank: int) -> dict[str, Any] | None:
     if not isinstance(item, dict):
         return None
     envelope = item.get("_citadel") if isinstance(item.get("_citadel"), dict) else {}
-    provenance = (
-        envelope.get("provenance") if isinstance(envelope.get("provenance"), dict) else {}
-    )
+    provenance = envelope.get("provenance") if isinstance(envelope.get("provenance"), dict) else {}
     result_id = _safe_str(
         envelope.get("result_id") or item.get("id") or item.get("url"),
         limit=MAX_ID_CHARS,
@@ -202,8 +200,10 @@ def build_search_telemetry(
             if key == "mode" and isinstance(value, str) and value.strip():
                 clean_filters[key] = value.strip().lower()[:32]
                 continue
-            if key in {"limit", "top_k"} and isinstance(value, (int, float)) and not isinstance(
-                value, bool
+            if (
+                key in {"limit", "top_k"}
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
             ):
                 clean_filters[key] = int(value)
                 continue
@@ -212,9 +212,7 @@ def build_search_telemetry(
                     continue
                 if isinstance(value, list):
                     cleaned_list = [
-                        item
-                        for item in (_safe_str(part, limit=64) for part in value)
-                        if item
+                        item for item in (_safe_str(part, limit=64) for part in value) if item
                     ]
                     if cleaned_list:
                         clean_filters["types"] = cleaned_list[:20]

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -231,18 +231,109 @@ def is_docs_mode_query(query: str, *, mode: str | None = None) -> bool:
 _QUERY_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_./-]*")
 _QUERY_STOPWORDS = frozenset(
     {
-        "the", "and", "for", "with", "this", "that", "these", "those", "from",
-        "what", "how", "where", "when", "which", "who", "whose", "why", "are",
-        "was", "were", "does", "did", "doing", "not", "you", "your", "has",
-        "have", "had", "can", "could", "should", "would", "will", "shall",
-        "may", "might", "must", "about", "into", "onto", "over", "under",
-        "between", "our", "their", "they", "them", "its", "his", "her",
-        "also", "but", "nor", "either", "any", "all", "some", "than", "then",
-        "there", "here", "been", "being", "because", "just", "only", "very",
-        "much", "more", "most", "such", "each", "per", "via", "own", "off",
-        "out", "too", "get", "got", "let", "see", "say", "said", "tell", "show",
-        "find", "use", "used", "using", "one", "two", "way", "make", "made",
-        "need", "want", "know", "like", "work", "works", "please",
+        "the",
+        "and",
+        "for",
+        "with",
+        "this",
+        "that",
+        "these",
+        "those",
+        "from",
+        "what",
+        "how",
+        "where",
+        "when",
+        "which",
+        "who",
+        "whose",
+        "why",
+        "are",
+        "was",
+        "were",
+        "does",
+        "did",
+        "doing",
+        "not",
+        "you",
+        "your",
+        "has",
+        "have",
+        "had",
+        "can",
+        "could",
+        "should",
+        "would",
+        "will",
+        "shall",
+        "may",
+        "might",
+        "must",
+        "about",
+        "into",
+        "onto",
+        "over",
+        "under",
+        "between",
+        "our",
+        "their",
+        "they",
+        "them",
+        "its",
+        "his",
+        "her",
+        "also",
+        "but",
+        "nor",
+        "either",
+        "any",
+        "all",
+        "some",
+        "than",
+        "then",
+        "there",
+        "here",
+        "been",
+        "being",
+        "because",
+        "just",
+        "only",
+        "very",
+        "much",
+        "more",
+        "most",
+        "such",
+        "each",
+        "per",
+        "via",
+        "own",
+        "off",
+        "out",
+        "too",
+        "get",
+        "got",
+        "let",
+        "see",
+        "say",
+        "said",
+        "tell",
+        "show",
+        "find",
+        "use",
+        "used",
+        "using",
+        "one",
+        "two",
+        "way",
+        "make",
+        "made",
+        "need",
+        "want",
+        "know",
+        "like",
+        "work",
+        "works",
+        "please",
     }
 )
 MAX_QUERY_TERMS = 12
@@ -283,9 +374,7 @@ def text_term_matches(text: str, terms: list[str]) -> list[str]:
     return [term for term in terms if _term_pattern(term).search(lowered)]
 
 
-def best_match_window(
-    text: str, terms: list[str], *, width: int = 400
-) -> tuple[int, str] | None:
+def best_match_window(text: str, terms: list[str], *, width: int = 400) -> tuple[int, str] | None:
     """(offset, window) around the densest cluster of query terms.
 
     Returns None when no term occurs. Exists because truncating a long document
@@ -554,6 +643,7 @@ def apply_query_ranking(
         return list(results)
     dict_hits = [item for item in results if isinstance(item, dict)]
     other = [item for item in results if not isinstance(item, dict)]
+
     # Class boost first, then lexical term coverage as the tie-breaker. Without
     # the second key a page of same-class hits (ten repo-content chunks, all
     # `canonical-docs`) sorted into exactly its input order and mode=docs was
@@ -812,9 +902,7 @@ def repo_filter_matches(identity: str | None, wanted: str) -> bool:
     if not needle:
         return True
     return (
-        identity == needle
-        or identity.endswith("/" + needle)
-        or identity.startswith(needle + "/")
+        identity == needle or identity.endswith("/" + needle) or identity.startswith(needle + "/")
     )
 
 
@@ -922,9 +1010,7 @@ def filter_hits(
         # whole blob made path= another body-text filter.
         needle = path.replace("**/", "").replace("/**", "").replace("*", "").lower()
         if needle:
-            filtered = [
-                h for h in filtered if needle in (_hit_path_identity(h) or "").lower()
-            ]
+            filtered = [h for h in filtered if needle in (_hit_path_identity(h) or "").lower()]
     if canonical_only:
         # Content-shaped, NOT a trust filter: it keeps hits whose text reads like
         # documentation. It cannot vouch for any of them — the tier that could
@@ -970,7 +1056,12 @@ def shape_search_payload(
         exclude_ambient = True
     if apply_spec_ranking is None:
         apply_spec_ranking = is_spec_mode_query(query) and not docs_mode
-    if docs_mode or extract_hex_needles(query) or apply_spec_ranking or len(query_terms(query)) == 1:
+    if (
+        docs_mode
+        or extract_hex_needles(query)
+        or apply_spec_ranking
+        or len(query_terms(query)) == 1
+    ):
         ordered = apply_query_ranking(raw_results, query, mode=mode)
     else:
         ordered = list(raw_results)

--- a/kb/security_scan.py
+++ b/kb/security_scan.py
@@ -39,9 +39,7 @@ SECRET_PATTERNS: tuple[tuple[str, str, re.Pattern[str]], ...] = (
     (
         "database_connection_url",
         "critical",
-        re.compile(
-            r"(?i)\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^\s'\"`<>]+"
-        ),
+        re.compile(r"(?i)\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^\s'\"`<>]+"),
     ),
     (
         "github_token",
@@ -94,11 +92,7 @@ REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
     re.compile(r"(?i)(token[\"'\s:=]+)[A-Za-z0-9._~+/=-]+"),
     re.compile(r"(?i)(api[_-]?key[\"'\s:=]+)[A-Za-z0-9._~+/=-]+"),
-    *(
-        pattern
-        for category, _, pattern in SECRET_PATTERNS
-        if category != "secret_assignment"
-    ),
+    *(pattern for category, _, pattern in SECRET_PATTERNS if category != "secret_assignment"),
     re.compile(
         r"(?i)(\b(?:api[_-]?key|secret|token|password|passwd|pwd)\s*[:=]\s*['\"]?)[^\s'\"]{4,}"
     ),
@@ -172,9 +166,7 @@ def redact_secrets(value: str, *known_secrets: str | None) -> str:
             redacted = redacted.replace(secret, "[REDACTED]")
     for pattern in REDACTION_PATTERNS:
         redacted = pattern.sub(
-            lambda match: f"{match.group(1)}[REDACTED]"
-            if match.groups()
-            else "[REDACTED]",
+            lambda match: f"{match.group(1)}[REDACTED]" if match.groups() else "[REDACTED]",
             redacted,
         )
     return redacted

--- a/kb/server.py
+++ b/kb/server.py
@@ -140,9 +140,8 @@ def _forget_background_task(task: "asyncio.Task[Any]") -> None:
         return
     exc = task.exception()
     if exc is not None:
-        logger.error(
-            "Background task %s died: %s", task.get_name(), exc, exc_info=exc
-        )
+        logger.error("Background task %s died: %s", task.get_name(), exc, exc_info=exc)
+
 
 # Most recent evolve-scheduler cognify canary verdict (verify=True), surfaced via
 # /readyz so an always-on health probe goes RED when end-to-end ingest+cognify+
@@ -238,6 +237,7 @@ async def _search_within_budget(
     except asyncio.TimeoutError:
         return [], True
 
+
 mcp_server = create_mcp_server()
 mcp_app = mcp_server.streamable_http_app()
 
@@ -314,7 +314,9 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
     delay = first_sleep_seconds(interval_seconds, last)
     logger.info(
         "Evolve scheduler: first pass in %.0fs of a %ss interval (last pass: %s)",
-        delay, interval_seconds, last or "none recorded",
+        delay,
+        interval_seconds,
+        last or "none recorded",
     )
     while True:
         await asyncio.sleep(delay)
@@ -581,9 +583,7 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 @app.exception_handler(RequestValidationError)
-async def log_request_validation_error(
-    request: Request, exc: RequestValidationError
-) -> Any:
+async def log_request_validation_error(request: Request, exc: RequestValidationError) -> Any:
     """Say WHY a 422 happened, in the log, without echoing the payload.
 
     FastAPI answers the caller with the field-level detail but the server side
@@ -608,6 +608,7 @@ async def log_request_validation_error(
         "; ".join(problems) or "no detail",
     )
     return await request_validation_exception_handler(request, exc)
+
 
 # The Next.js static export (see docs/adr/0014-nextjs-frontend-static-export.md).
 # Its own directory rather than a corner of static/, which holds the fonts, the
@@ -653,6 +654,8 @@ PRIVATE_CACHE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
 PUBLIC_CACHE_PATHS = frozenset({"/.well-known/citadel.json", "/skills"})
 PUBLIC_CACHE_PREFIXES = ("/skills/", "/static/", "/next/_next/")
 PUBLIC_HOST_RE = re.compile(r"^(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?$")
+
+
 def _content_security_policy(style_src: str) -> str:
     """Build the policy from one template so only `style-src` can ever differ."""
     return (
@@ -824,7 +827,9 @@ def contact_rate_limit_ok(client_ip: str) -> bool:
         _contact_global_hits[:] = recent_global
         if len(recent_global) >= CONTACT_GLOBAL_LIMIT:
             return False
-        recent = [t for t in _contact_hits.get(client_ip, []) if now - t < CONTACT_PER_IP_WINDOW_SECONDS]
+        recent = [
+            t for t in _contact_hits.get(client_ip, []) if now - t < CONTACT_PER_IP_WINDOW_SECONDS
+        ]
         if len(recent) >= CONTACT_PER_IP_LIMIT:
             _contact_hits[client_ip] = recent
             return False
@@ -1088,9 +1093,7 @@ class CapturePolicyBody(BaseModel):
 
 
 class CaptureRootsBody(BaseModel):
-    roots: list[str] = Field(
-        default_factory=list, max_length=MAX_APPROVED_CAPTURE_ROOTS
-    )
+    roots: list[str] = Field(default_factory=list, max_length=MAX_APPROVED_CAPTURE_ROOTS)
 
 
 class ObsidianVaultBody(BaseModel):
@@ -1278,11 +1281,7 @@ def weak_access_keys() -> list[tuple[str, int]]:
         candidates.append(("CITADEL_ADMIN_KEY", config.admin_key))
     candidates.extend(("CITADEL_WRITER_KEYS", key) for key in config.writer_keys)
     candidates.extend(("CITADEL_READER_KEYS", key) for key in config.reader_keys)
-    return [
-        (name, len(key))
-        for name, key in candidates
-        if len(key) < WEAK_ACCESS_KEY_MIN_LENGTH
-    ]
+    return [(name, len(key)) for name, key in candidates if len(key) < WEAK_ACCESS_KEY_MIN_LENGTH]
 
 
 def allow_weak_access_keys() -> bool:
@@ -1450,9 +1449,7 @@ def record_auth_failure(client_ip: str) -> bool:
     try:
         with _auth_fail_lock:
             recent_global = [
-                hit
-                for hit in _auth_fail_global_hits
-                if now - hit < AUTH_FAIL_GLOBAL_WINDOW_SECONDS
+                hit for hit in _auth_fail_global_hits if now - hit < AUTH_FAIL_GLOBAL_WINDOW_SECONDS
             ]
             _auth_fail_global_hits[:] = recent_global
             recent = [
@@ -1460,7 +1457,10 @@ def record_auth_failure(client_ip: str) -> bool:
                 for hit in _auth_fail_hits.get(client_ip, [])
                 if now - hit < AUTH_FAIL_PER_IP_WINDOW_SECONDS
             ]
-            if len(recent) >= AUTH_FAIL_PER_IP_LIMIT or len(recent_global) >= AUTH_FAIL_GLOBAL_LIMIT:
+            if (
+                len(recent) >= AUTH_FAIL_PER_IP_LIMIT
+                or len(recent_global) >= AUTH_FAIL_GLOBAL_LIMIT
+            ):
                 _auth_fail_hits[client_ip] = recent
                 return False
             recent.append(now)
@@ -1493,9 +1493,7 @@ def _reject_unauthenticated(request: Request) -> None:
             detail="Too many failed authentication attempts. Try again later.",
             headers={"Retry-After": str(AUTH_FAIL_PER_IP_WINDOW_SECONDS)},
         )
-    logger.warning(
-        "Rejected unauthenticated request: %s %s", request.method, request.url.path
-    )
+    logger.warning("Rejected unauthenticated request: %s %s", request.method, request.url.path)
     raise HTTPException(status_code=401, detail="Access key required.")
 
 
@@ -1956,7 +1954,9 @@ def resolve_write_targets(
         dataset = requested
         guard_curated_central(identity, dataset, tags, config)
         enforce_dataset_allowlist(identity, dataset)
-        tier: IngestTier = "light" if is_seat_dataset(dataset) and not is_org_bound(tags) else "full"
+        tier: IngestTier = (
+            "light" if is_seat_dataset(dataset) and not is_org_bound(tags) else "full"
+        )
         return [WriteTarget(dataset, tier)]
 
     node_dataset = identity.default_dataset if is_seat_dataset(identity.default_dataset) else None
@@ -2097,11 +2097,7 @@ async def search_across_datasets(
             if key in seen:
                 continue
             seen.add(key)
-            if (
-                dataset != SESSION_TRACES_DATASET
-                and key in trace_keys
-                and isinstance(result, dict)
-            ):
+            if dataset != SESSION_TRACES_DATASET and key in trace_keys and isinstance(result, dict):
                 result = {**result, SHARED_TRACE_MARKER: True}
             merged.append((dataset, result))
             budget -= 1
@@ -2245,11 +2241,7 @@ def resolve_search_sessions(
     return {
         # The session scopes the caller's own node; for a caller with no node of
         # its own, a single-dataset search still scopes to that one dataset.
-        dataset: (
-            session
-            if dataset == owned or (owned is None and len(datasets) == 1)
-            else None
-        )
+        dataset: (session if dataset == owned or (owned is None and len(datasets) == 1) else None)
         for dataset in datasets
     }
 
@@ -2392,9 +2384,7 @@ async def capture_search_feedback(
         # is written presence-only. Scoping is by ``details.dataset`` alone
         # (mesh.timeline / scope_mesh_snapshot), so tagging a seat's search with
         # Central would publish their query to every reader.
-        node_dataset = (
-            actor.default_dataset if is_seat_dataset(actor.default_dataset) else None
-        )
+        node_dataset = actor.default_dataset if is_seat_dataset(actor.default_dataset) else None
         await mesh_state.record_search_telemetry(
             config,
             telemetry=telemetry if node_dataset else presence_only_telemetry(telemetry),
@@ -2529,10 +2519,7 @@ async def ensure_session_traces_dataset(citadel: Citadel) -> None:
         from cognee import datasets as cognee_datasets
 
         existing = await cognee_datasets.list_datasets()
-        names = {
-            str(getattr(item, "name", "") or "").strip()
-            for item in existing
-        }
+        names = {str(getattr(item, "name", "") or "").strip() for item in existing}
         if SESSION_TRACES_DATASET in names:
             return
     except Exception:
@@ -2697,9 +2684,7 @@ def result_provenance(result: dict[str, Any]) -> dict[str, str]:
     return {key: value for key, value in provenance.items() if value}
 
 
-def document_endpoint_for_result(
-    result_id: str, *, document_id: str | None = None
-) -> str | None:
+def document_endpoint_for_result(result_id: str, *, document_id: str | None = None) -> str | None:
     # Any real id is now drillable (#28): ghsync:/doc_ as before, plus native
     # cognee node/chunk UUIDs that /api/documents resolves via the graph engine.
     # Prefer a hit's document-level id when present. A chunk-level id can be
@@ -2812,9 +2797,7 @@ def with_result_metadata(
     result_id = str(normalized["id"])
     document_id = first_string(normalized.get("document_id"))
     drilldown_id = document_id or result_id
-    document_endpoint = document_endpoint_for_result(
-        result_id, document_id=document_id
-    )
+    document_endpoint = document_endpoint_for_result(result_id, document_id=document_id)
     if not document_endpoint:
         drilldown_available = False
     elif drilldown_predicate is None:
@@ -2967,7 +2950,9 @@ def request_is_https(request: Request) -> bool:
 
 
 def public_cacheable_path(path: str) -> bool:
-    return path in PUBLIC_CACHE_PATHS or any(path.startswith(prefix) for prefix in PUBLIC_CACHE_PREFIXES)
+    return path in PUBLIC_CACHE_PATHS or any(
+        path.startswith(prefix) for prefix in PUBLIC_CACHE_PREFIXES
+    )
 
 
 def public_skill_rows(request: Request) -> list[dict[str, Any]]:
@@ -3005,7 +2990,11 @@ async def add_security_headers(request: Request, call_next: Any) -> Response:
     for header, value in SECURITY_HEADERS.items():
         response.headers.setdefault(header, value)
     if "cache-control" not in response.headers:
-        cache_headers = PUBLIC_CACHE_HEADERS if public_cacheable_path(request.url.path) else PRIVATE_CACHE_HEADERS
+        cache_headers = (
+            PUBLIC_CACHE_HEADERS
+            if public_cacheable_path(request.url.path)
+            else PRIVATE_CACHE_HEADERS
+        )
         for header, value in cache_headers.items():
             response.headers.setdefault(header, value)
     if request_is_https(request):
@@ -3409,7 +3398,9 @@ def _captured_last_7d(node: str | None) -> int | None:
             action = str(audit_event.get("action") or "")
             if action != "ingest" and not action.endswith("citadel_ingest"):
                 continue
-            detail = audit_event.get("detail") if isinstance(audit_event.get("detail"), dict) else {}
+            detail = (
+                audit_event.get("detail") if isinstance(audit_event.get("detail"), dict) else {}
+            )
             if detail.get("accepted") is False:
                 continue
             created = audit_event.get("created_at")
@@ -3463,7 +3454,9 @@ async def me_summary(request: Request) -> dict[str, Any]:
                     continue
                 if mesh_node.get("type") != "document":
                     continue
-                meta = mesh_node.get("metadata") if isinstance(mesh_node.get("metadata"), dict) else {}
+                meta = (
+                    mesh_node.get("metadata") if isinstance(mesh_node.get("metadata"), dict) else {}
+                )
                 if meta.get("dataset") == node:
                     document_count += 1
         except Exception:
@@ -3508,7 +3501,9 @@ async def me_summary(request: Request) -> dict[str, Any]:
             action = str(audit_event.get("action") or "")
             if action != "ingest" and not action.endswith("citadel_ingest"):
                 continue
-            detail = audit_event.get("detail") if isinstance(audit_event.get("detail"), dict) else {}
+            detail = (
+                audit_event.get("detail") if isinstance(audit_event.get("detail"), dict) else {}
+            )
             if detail.get("accepted") is False:
                 continue
             audit_ingests.append(audit_event)
@@ -3544,9 +3539,7 @@ async def me_summary(request: Request) -> dict[str, Any]:
         counts_by_dataset = getattr(cognee_client, "document_counts_by_dataset", None)
         if callable(counts_by_dataset):
             counts = await counts_by_dataset()
-            readable_document_count = sum(
-                int(counts.get(name) or 0) for name in readable_datasets
-            )
+            readable_document_count = sum(int(counts.get(name) or 0) for name in readable_datasets)
             # Prefer the durable count for the Node total too. `document_count`
             # above walks the mesh projection, which is rebuilt in memory and
             # empties on every process restart, so on a service that redeploys
@@ -3645,7 +3638,9 @@ async def access_snapshot(
 
     # Gap 9, the other half: state the seat on the token instead of making every
     # consumer join tokens against principals to discover it is missing.
-    principals_by_id = {principal["id"]: principal for principal in snapshot.get("principals") or []}
+    principals_by_id = {
+        principal["id"]: principal for principal in snapshot.get("principals") or []
+    }
     tokens: list[dict[str, Any]] = []
     for token in snapshot.get("tokens") or []:
         principal = principals_by_id.get(token.get("principal_id")) or {}
@@ -3686,7 +3681,9 @@ async def access_snapshot(
         "audit_events_returned": len(page),
         # The oldest id on this page. Pass it back as `cursor` for the next,
         # older page. Null when there is nothing older left.
-        "next_cursor": (page[0].get("id") if start > 0 and page and isinstance(page[0], dict) else None),
+        "next_cursor": (
+            page[0].get("id") if start > 0 and page and isinstance(page[0], dict) else None
+        ),
     }
 
 
@@ -3706,9 +3703,7 @@ CORPUS_CURSOR_MAX_SKEW_SECONDS = 300.0
 def _encode_corpus_cursor(created_at_iso: str, document_id: str) -> str:
     import base64
 
-    payload = json.dumps(
-        {"t": created_at_iso, "id": document_id}, separators=(",", ":")
-    )
+    payload = json.dumps({"t": created_at_iso, "id": document_id}, separators=(",", ":"))
     return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii")
 
 
@@ -3737,9 +3732,7 @@ def _decode_corpus_cursor(cursor: str | None) -> "tuple[Any, str] | None":
 def _clamp_corpus_cursor_time(created_at: Any) -> Any:
     from datetime import datetime, timedelta, timezone
 
-    ceiling = datetime.now(timezone.utc) + timedelta(
-        seconds=CORPUS_CURSOR_MAX_SKEW_SECONDS
-    )
+    ceiling = datetime.now(timezone.utc) + timedelta(seconds=CORPUS_CURSOR_MAX_SKEW_SECONDS)
     return min(created_at, ceiling)
 
 
@@ -3772,9 +3765,7 @@ async def corpus_census(
     corpus_page = getattr(cognee_client, "corpus_page", None)
     corpus_totals = getattr(cognee_client, "corpus_totals", None)
     if not callable(corpus_page) or not callable(corpus_totals):
-        raise HTTPException(
-            status_code=503, detail="Corpus census is unavailable on this node."
-        )
+        raise HTTPException(status_code=503, detail="Corpus census is unavailable on this node.")
 
     if limit is None:
         page_size = CORPUS_DEFAULT_LIMIT
@@ -3844,12 +3835,8 @@ async def corpus_census(
 
         for row in rows:
             row_id = str(row.get("id"))
-            row["chunk_count"] = (
-                None if chunk_counts is None else int(chunk_counts.get(row_id, 0))
-            )
-            row["in_graph"] = (
-                None if in_graph_ids is None else (row_id in in_graph_ids)
-            )
+            row["chunk_count"] = None if chunk_counts is None else int(chunk_counts.get(row_id, 0))
+            row["in_graph"] = None if in_graph_ids is None else (row_id in in_graph_ids)
 
         next_cursor: str | None = None
         if has_more and rows:
@@ -3980,8 +3967,7 @@ async def list_access_seats(request: Request) -> dict[str, Any]:
                 "principal_name": principal.get("name"),
                 "principal_kind": principal.get("kind"),
                 "seat_slug": None,
-                "default_dataset": token.get("default_dataset")
-                or principal.get("default_dataset"),
+                "default_dataset": token.get("default_dataset") or principal.get("default_dataset"),
                 "revoked": bool(token.get("revoked_at")),
                 "revoked_at": token.get("revoked_at"),
                 "last_used_at": token.get("last_used_at"),
@@ -4409,9 +4395,7 @@ async def citadel_discovery_manifest(request: Request, response: Response) -> di
             },
             "tools": tools,
             "approval_recommended_for": [
-                row["name"]
-                for row in tools
-                if row["risk"] in {"additive_write", "admin_job"}
+                row["name"] for row in tools if row["risk"] in {"additive_write", "admin_job"}
             ],
             "audit": {
                 "event_action": "mcp.<tool_name>",
@@ -4476,7 +4460,7 @@ async def get_skill(slug: str) -> FileResponse:
     integrity = skill_integrity(path)
     headers = {
         **PUBLIC_CACHE_HEADERS,
-        "ETag": f"\"sha256-{integrity['sha256']}\"",
+        "ETag": f'"sha256-{integrity["sha256"]}"',
         "X-Citadel-Skill-SHA256": str(integrity["sha256"]),
         "X-Citadel-Skill-Integrity": str(integrity["integrity"]),
     }
@@ -4558,21 +4542,16 @@ async def _corpus_health_impl() -> dict[str, Any]:
             for field in ("probe_max_documents", "probe_pages"):
                 if field in measured:
                     value = measured[field]
-                    if (
-                        isinstance(value, bool)
-                        or not isinstance(value, int)
-                        or value < 0
-                    ):
+                    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                         raise RuntimeError(f"bounded corpus probe returned invalid {field}")
-            if "probe_max_documents" in measured and measured["probe_documents"] > measured[
-                "probe_max_documents"
-            ]:
+            if (
+                "probe_max_documents" in measured
+                and measured["probe_documents"] > measured["probe_max_documents"]
+            ):
                 raise RuntimeError("bounded corpus probe exceeded its hard cap")
             if "probe_cap_exceeded" in measured:
                 if type(measured["probe_cap_exceeded"]) is not bool:
-                    raise RuntimeError(
-                        "bounded corpus probe returned invalid probe_cap_exceeded"
-                    )
+                    raise RuntimeError("bounded corpus probe returned invalid probe_cap_exceeded")
                 if measured["probe_cap_exceeded"] and (
                     measured["probe_complete"] or measured["probe_ok"]
                 ):
@@ -4593,8 +4572,7 @@ async def _corpus_health_impl() -> dict[str, Any]:
                 "ok": measured["probe_complete"] is True
                 and measured["probe_ok"] is True
                 and not (
-                    tracked >= _MIN_TRACKED_FOR_CORPUS
-                    and measured["relational_documents"] == 0
+                    tracked >= _MIN_TRACKED_FOR_CORPUS and measured["relational_documents"] == 0
                 ),
                 "tracked_sources": tracked,
                 # Compatibility for MeshState: graph nodes are not relational
@@ -4713,9 +4691,7 @@ async def readyz(request: Request) -> Any:
     return JSONResponse(payload, status_code=200 if ok else 503)
 
 
-def _mesh_dataset_visible(
-    identity: AccessIdentity, dataset: Any, cache: dict[str, bool]
-) -> bool:
+def _mesh_dataset_visible(identity: AccessIdentity, dataset: Any, cache: dict[str, bool]) -> bool:
     if not isinstance(dataset, str) or not dataset:
         return True
     if dataset not in cache:
@@ -4723,9 +4699,7 @@ def _mesh_dataset_visible(
     return cache[dataset]
 
 
-def scope_mesh_snapshot(
-    snapshot: dict[str, Any], identity: AccessIdentity
-) -> dict[str, Any]:
+def scope_mesh_snapshot(snapshot: dict[str, Any], identity: AccessIdentity) -> dict[str, Any]:
     """Strip other seats' content from the runtime-activity projection (ADR-0009).
 
     The /api/mesh projection records each document's first line and each raw
@@ -4745,9 +4719,7 @@ def scope_mesh_snapshot(
     kept_nodes: list[dict[str, Any]] = []
     for node in snapshot.get("nodes", []):
         dataset = (node.get("metadata") or {}).get("dataset")
-        if node.get("type") != "dataset" and not _mesh_dataset_visible(
-            identity, dataset, cache
-        ):
+        if node.get("type") != "dataset" and not _mesh_dataset_visible(identity, dataset, cache):
             dropped.add(node.get("id"))
             continue
         kept_nodes.append(node)
@@ -4759,9 +4731,7 @@ def scope_mesh_snapshot(
     kept_events = [
         event
         for event in snapshot.get("events", [])
-        if _mesh_dataset_visible(
-            identity, (event.get("details") or {}).get("dataset"), cache
-        )
+        if _mesh_dataset_visible(identity, (event.get("details") or {}).get("dataset"), cache)
     ]
     return {
         **snapshot,
@@ -4784,9 +4754,7 @@ async def mesh(request: Request) -> Any:
     # `_corpus_health` is the same source /readyz and `citadel status` use, and
     # is fail-soft: on a transient read error it returns None totals and
     # `snapshot` falls back to the in-memory values rather than raising here.
-    snapshot = await get_mesh().snapshot(
-        citadel.config, corpus=await _bounded_corpus_health()
-    )
+    snapshot = await get_mesh().snapshot(citadel.config, corpus=await _bounded_corpus_health())
     return jsonable_encoder(scope_mesh_snapshot(snapshot, identity))
 
 
@@ -4952,9 +4920,7 @@ async def indexes(request: Request) -> Any:
     citadel = get_citadel()
     # Pass the authoritative corpus figures so the dashboard reports the vault's
     # real size rather than whatever has happened since the last deploy.
-    snapshot = await get_mesh().snapshot(
-        citadel.config, corpus=await _bounded_corpus_health()
-    )
+    snapshot = await get_mesh().snapshot(citadel.config, corpus=await _bounded_corpus_health())
     return jsonable_encoder({"indexes": snapshot["indexes"], "stats": snapshot["stats"]})
 
 
@@ -5158,7 +5124,7 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str) -> 
     prefix = "sha256="
     if not signature_header.startswith(prefix):
         return False
-    provided = signature_header[len(prefix):]
+    provided = signature_header[len(prefix) :]
     expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
     return hmac.compare_digest(provided, expected)
 
@@ -5189,9 +5155,7 @@ async def _run_webhook_reingest(syncer: GitHubOrgSyncer) -> None:
             exc.__class__.__name__,
             exc,
         )
-        await get_mesh().record_error(
-            get_citadel().config, operation="github_sync", error=str(exc)
-        )
+        await get_mesh().record_error(get_citadel().config, operation="github_sync", error=str(exc))
 
 
 @app.post("/api/webhooks/github")
@@ -5265,7 +5229,9 @@ async def linear_sync_issues(
 ) -> dict[str, Any]:
     identity = require_access(request, "reader", "kb:read")
     syncer = get_linear_syncer()
-    seat_dataset_name = identity.default_dataset if is_seat_dataset(identity.default_dataset) else None
+    seat_dataset_name = (
+        identity.default_dataset if is_seat_dataset(identity.default_dataset) else None
+    )
     if scope == "my" and not seat_dataset_name:
         return {"ok": True, "scope": scope, "issues": [], "count": 0}
     issues = syncer.issues_for_scope(scope=scope, seat_dataset_name=seat_dataset_name)
@@ -5601,9 +5567,7 @@ async def resolve_obsidian_conflict(
     return {"ok": True, "conflict": jsonable_encoder(result)}
 
 
-async def load_node_dataset_map(
-    *, warn_unavailable: bool = True
-) -> dict[str, list[str]] | None:
+async def load_node_dataset_map(*, warn_unavailable: bool = True) -> dict[str, list[str]] | None:
     """Fetch the gateway's cached node->dataset map ONCE for reuse across many
     ADR-0009 visibility checks in a single request.
 
@@ -5675,8 +5639,7 @@ async def cognee_document_visible(identity: AccessIdentity, node_ids: list[str])
         # The cached/timed-out lookup degrades to {} on failure (#50) —
         # indistinguishable from an empty store, so scoped callers are denied.
         logger.warning(
-            "Document drill-down denied: empty node dataset map "
-            "(fail-closed for scoped callers)"
+            "Document drill-down denied: empty node dataset map (fail-closed for scoped callers)"
         )
         return False
     return node_ids_visible_in_map(identity, node_ids, mapping)
@@ -6007,7 +5970,9 @@ async def run_learning_agent(body: LearningAgentRunBody, request: Request) -> An
             "ingested": result.get("ingested"),
             "improved": result.get("improved"),
             "files_ingested": (
-                repo_content_result.get("files_ingested") if isinstance(repo_content_result, dict) else None
+                repo_content_result.get("files_ingested")
+                if isinstance(repo_content_result, dict)
+                else None
             ),
             "digest_meaningful": (result.get("organization_digest") or {}).get("meaningful"),
             "google_chat_sent": google_chat_notification.get("sent"),
@@ -6040,7 +6005,9 @@ async def run_cognify(body: CognifyRunBody, request: Request) -> Any:
     citadel = get_citadel()
     dataset = body.dataset or citadel.config.default_dataset
     try:
-        result = await citadel.cognify_dataset(dataset=dataset, verify=body.verify, force=body.force)
+        result = await citadel.cognify_dataset(
+            dataset=dataset, verify=body.verify, force=body.force
+        )
     except Exception as exc:  # pragma: no cover - depends on Cognee config.
         logger.error("Cognify run failed: %s", exc.__class__.__name__)
         get_access_store().record_event(
@@ -6583,9 +6550,7 @@ async def share_session(body: ShareSessionBody, request: Request) -> Any:
     ]
     cognify_queued = False
     if cognify_datasets:
-        cognify_queued = citadel.cognee.schedule_cognify(
-            list(dict.fromkeys(cognify_datasets))
-        )
+        cognify_queued = citadel.cognee.schedule_cognify(list(dict.fromkeys(cognify_datasets)))
     cognify_state = "deferred" if cognify_queued else "not_scheduled"
 
     record_mcp_audit(
@@ -6650,9 +6615,7 @@ def share_session_tags_from_body(seat_slug: str, body: ShareSessionBody) -> list
 #
 # The MCP twins of contribute and share_session are excluded because their
 # non-MCP row is always written too, and listing both double-counts one write.
-CONTRIBUTION_ACTIONS = frozenset(
-    {"contribute", "ingest", "share_session", "mcp.citadel_ingest"}
-)
+CONTRIBUTION_ACTIONS = frozenset({"contribute", "ingest", "share_session", "mcp.citadel_ingest"})
 
 
 @app.get("/api/contributions/recent")
@@ -7081,9 +7044,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             # the flag never promises a 404 — textless entities and foreign-seat
             # docs/chunks fall out here.
             try:
-                owner_node_ids = await get_citadel().resolve_document_owner_ids(
-                    drilldown_id
-                )
+                owner_node_ids = await get_citadel().resolve_document_owner_ids(drilldown_id)
             except Exception:  # noqa: BLE001 - any failure fails closed, like a 404
                 return False
             if owner_node_ids is None:
@@ -7098,9 +7059,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             result_id = str(envelope.get("result_id") or "")
             document_id = first_string(item.get("document_id"))
             drilldown_id = document_id or result_id
-            document_endpoint = document_endpoint_for_result(
-                result_id, document_id=document_id
-            )
+            document_endpoint = document_endpoint_for_result(result_id, document_id=document_id)
             if not document_endpoint:
                 # Synthetic chunk:<hash> id with no backing store — honestly
                 # non-drillable, nothing to resolve.
@@ -7172,9 +7131,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         detail=audit_detail,
     )
     primary_dataset = search_datasets[0]
-    node_dataset = (
-        actor.default_dataset if is_seat_dataset(actor.default_dataset) else None
-    )
+    node_dataset = actor.default_dataset if is_seat_dataset(actor.default_dataset) else None
     telemetry = await capture_search_feedback(
         mesh_state=mesh_state,
         config=citadel.config,
@@ -7241,14 +7198,14 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         payload["timed_out"] = True
         payload["truncated"] = True
         payload["code"] = CODE_TIMEOUT
-    elif not normalized and body.dataset is None and (
-        not filters_active or candidates_fetched == 0
+    elif (
+        not normalized and body.dataset is None and (not filters_active or candidates_fetched == 0)
     ):
         # With filters active this fires only when retrieval itself came back
         # empty — an empty page whose candidates the filters excluded gets the
         # filter warning below instead, not dataset advice.
         payload["note"] = (
-            "No results in the default dataset. Pass an explicit \"dataset\" to search a "
+            'No results in the default dataset. Pass an explicit "dataset" to search a '
             "specific source; see known_datasets."
         )
         payload["known_datasets"] = known_datasets(citadel.config)

--- a/kb/service.py
+++ b/kb/service.py
@@ -193,8 +193,7 @@ class Citadel:
                 violation = chunk_window.validate_cognee_chunk_budget(data)
             except chunk_window.ChunkBudgetValidationError as exc:
                 logger.error(
-                    "Ingest refused for dataset %s: final chunk budget could not "
-                    "be verified (%s)",
+                    "Ingest refused for dataset %s: final chunk budget could not be verified (%s)",
                     safe_log_value(dataset),
                     safe_log_value(str(exc)),
                 )
@@ -202,8 +201,7 @@ class Citadel:
             if violation is None:
                 return None
             logger.warning(
-                "Ingest refused for dataset %s: final Cognee chunk violates its "
-                "budget (%s)",
+                "Ingest refused for dataset %s: final Cognee chunk violates its budget (%s)",
                 safe_log_value(dataset),
                 safe_log_value(violation.describe()),
             )
@@ -268,10 +266,7 @@ class Citadel:
         if not session_recorded:
             # Fall back to a durable, searchable feedback note so the signal is
             # never silently dropped.
-            note = (
-                f"Feedback for QA {request.qa_id}: score={request.score} | "
-                f"{request.text or ''}"
-            )
+            note = f"Feedback for QA {request.qa_id}: score={request.score} | {request.text or ''}"
             durable = await self.ingest(
                 note,
                 dataset=dataset,
@@ -358,11 +353,7 @@ class Citadel:
         required_ids = source_required_ids or set()
         get_document = getattr(self.cognee, "get_document", None)
         if not callable(get_document):
-            return (
-                {"reason": "repair_candidate_lookup_unavailable"}
-                if required_ids
-                else None
-            )
+            return {"reason": "repair_candidate_lookup_unavailable"} if required_ids else None
         for document_id in repair_ids:
             try:
                 document = await get_document(document_id)
@@ -382,10 +373,7 @@ class Citadel:
                     "reason": "repair_candidate_unavailable",
                 }
             body = document.get("body")
-            if (
-                document_id not in required_ids
-                and (not isinstance(body, str) or not body.strip())
-            ):
+            if document_id not in required_ids and (not isinstance(body, str) or not body.strip()):
                 continue
             datasets = repair_document_datasets.get(document_id) or []
             for target_dataset in datasets:
@@ -438,9 +426,7 @@ class Citadel:
             "after": None,
         }
 
-    async def _restore_repair_projections(
-        self, deleted: dict[str, Any] | None
-    ) -> bool:
+    async def _restore_repair_projections(self, deleted: dict[str, Any] | None) -> bool:
         restore = getattr(self.cognee, "restore_document_chunks", None)
         if not callable(restore) or deleted is None:
             return False
@@ -511,9 +497,7 @@ class Citadel:
         for document_id in document_ids:
             expected_entry = expected.get(document_id)
             current_entry = current.get(document_id)
-            if not isinstance(expected_entry, Mapping) or not isinstance(
-                current_entry, Mapping
-            ):
+            if not isinstance(expected_entry, Mapping) or not isinstance(current_entry, Mapping):
                 return {
                     "ok": False,
                     "reason": "repair_source_manifest_incomplete",
@@ -618,9 +602,7 @@ class Citadel:
             }
 
         scoped = [
-            record
-            for record in pending
-            if dataset is None or record.get("dataset") == dataset
+            record for record in pending if dataset is None or record.get("dataset") == dataset
         ]
         if len(scoped) != len(pending):
             return {
@@ -675,13 +657,9 @@ class Citadel:
                     "after": None,
                 }
 
-            verification = await self._verify_repair_source_manifest(
-                repair_ids, source_manifest
-            )
+            verification = await self._verify_repair_source_manifest(repair_ids, source_manifest)
             if verification.get("ok") is not True:
-                reason = str(
-                    verification.get("reason") or "repair_recovery_manifest_unavailable"
-                )
+                reason = str(verification.get("reason") or "repair_recovery_manifest_unavailable")
                 try:
                     self.repair_journal.append(
                         operation_id=operation_id,
@@ -715,8 +693,7 @@ class Citadel:
             )
             if membership_verification.get("ok") is not True:
                 reason = str(
-                    membership_verification.get("reason")
-                    or "repair_dataset_membership_unavailable"
+                    membership_verification.get("reason") or "repair_dataset_membership_unavailable"
                 )
                 try:
                     self.repair_journal.append(
@@ -985,9 +962,7 @@ class Citadel:
             await self._delete_marker_node(marker)
 
         after = await self._graph_counts()
-        graph_grew = (
-            after["nodes"] > before["nodes"] or after["edges"] > before["edges"]
-        )
+        graph_grew = after["nodes"] > before["nodes"] or after["edges"] > before["edges"]
         if verification is not None:
             verification["graph_grew"] = graph_grew
             # graph_grew is diagnostic detail, NOT a pass condition (#114). Any
@@ -1067,9 +1042,7 @@ class Citadel:
             try:
                 with self.repair_journal.lease():
                     if not recover:
-                        journal_gate = self._repair_journal_gate(
-                            dataset=dataset, force=force
-                        )
+                        journal_gate = self._repair_journal_gate(dataset=dataset, force=force)
                         if journal_gate is not None:
                             return journal_gate
                     async with maintenance():
@@ -1268,8 +1241,8 @@ class Citadel:
                 "after": None,
             }
 
-        source_manifest, source_manifest_failure = (
-            await self._capture_repair_source_manifest(repair_ids)
+        source_manifest, source_manifest_failure = await self._capture_repair_source_manifest(
+            repair_ids
         )
         if source_manifest_failure is not None:
             return {
@@ -1279,9 +1252,7 @@ class Citadel:
                 "force": force,
                 "reason": source_manifest_failure["reason"],
                 "error_type": source_manifest_failure.get("error_type"),
-                "missing_document_ids": source_manifest_failure.get(
-                    "missing_document_ids", []
-                ),
+                "missing_document_ids": source_manifest_failure.get("missing_document_ids", []),
                 "repair_required": True,
                 "before": before,
                 "after": None,
@@ -1421,18 +1392,10 @@ class Citadel:
                 repair_datasets=repair_datasets,
             )
             if oversized_repair_ids_set:
-                deleted = await self.cognee.delete_document_chunks(
-                    sorted(oversized_repair_ids_set)
-                )
+                deleted = await self.cognee.delete_document_chunks(sorted(oversized_repair_ids_set))
             if isinstance(deleted, dict) and deleted.get("ok") is False:
-                raise RuntimeError(
-                    str(deleted.get("reason") or "repair_delete_failed")
-                )
-            deleted_ids = (
-                deleted.get("document_ids", [])
-                if isinstance(deleted, dict)
-                else []
-            )
+                raise RuntimeError(str(deleted.get("reason") or "repair_delete_failed"))
+            deleted_ids = deleted.get("document_ids", []) if isinstance(deleted, dict) else []
             self.repair_journal.append(
                 operation_id=repair_operation_id,
                 dataset=dataset,
@@ -1500,14 +1463,9 @@ class Citadel:
                 )
         except Exception as exc:  # noqa: BLE001 - return recoverable repair state
             logger.exception("corpus reconciliation failed during %s", repair_phase)
-            deleted_ids = (
-                deleted.get("document_ids", [])
-                if isinstance(deleted, dict)
-                else []
-            )
+            deleted_ids = deleted.get("document_ids", []) if isinstance(deleted, dict) else []
             projections_preserved = (
-                isinstance(deleted, dict)
-                and deleted.get("projections_preserved") is True
+                isinstance(deleted, dict) and deleted.get("projections_preserved") is True
             )
             if deleted is not None and not projections_preserved:
                 projections_preserved = await self._restore_repair_projections(deleted)
@@ -1548,18 +1506,12 @@ class Citadel:
             }
 
         after_valid = isinstance(after, dict)
-        post_counts_valid = (
-            isinstance(post_counts, dict)
-            and all(
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and value > 0
-                for value in (post_counts.get(document_id) for document_id in repair_ids)
-            )
+        post_counts_valid = isinstance(post_counts, dict) and all(
+            isinstance(value, int) and not isinstance(value, bool) and value > 0
+            for value in (post_counts.get(document_id) for document_id in repair_ids)
         )
-        post_graph_valid = (
-            post_graph_ids is not None
-            and set(repair_ids).issubset({str(document_id) for document_id in post_graph_ids})
+        post_graph_valid = post_graph_ids is not None and set(repair_ids).issubset(
+            {str(document_id) for document_id in post_graph_ids}
         )
         stored_budget = after.get("stored_chunk_budget") if isinstance(after, dict) else None
         if dataset is not None:
@@ -1811,8 +1763,8 @@ class Citadel:
                 "after": None,
             }
 
-        source_manifest, source_manifest_failure = (
-            await self._capture_repair_source_manifest(repair_ids)
+        source_manifest, source_manifest_failure = await self._capture_repair_source_manifest(
+            repair_ids
         )
         if source_manifest_failure is not None:
             return {
@@ -1822,9 +1774,7 @@ class Citadel:
                 "force": force,
                 "reason": source_manifest_failure["reason"],
                 "error_type": source_manifest_failure.get("error_type"),
-                "missing_document_ids": source_manifest_failure.get(
-                    "missing_document_ids", []
-                ),
+                "missing_document_ids": source_manifest_failure.get("missing_document_ids", []),
                 "repair_required": True,
                 "before": before,
                 "after": None,
@@ -2169,8 +2119,8 @@ class Citadel:
             document_id: ([dataset] if dataset else list(repair_datasets))
             for document_id in repair_ids
         }
-        source_manifest, source_manifest_failure = (
-            await self._capture_repair_source_manifest(repair_ids)
+        source_manifest, source_manifest_failure = await self._capture_repair_source_manifest(
+            repair_ids
         )
         if source_manifest_failure is not None:
             return {
@@ -2180,9 +2130,7 @@ class Citadel:
                 "force": True,
                 "reason": source_manifest_failure["reason"],
                 "error_type": source_manifest_failure.get("error_type"),
-                "missing_document_ids": source_manifest_failure.get(
-                    "missing_document_ids", []
-                ),
+                "missing_document_ids": source_manifest_failure.get("missing_document_ids", []),
                 "repair_required": True,
                 "before": before,
                 "after": None,
@@ -2292,9 +2240,7 @@ class Citadel:
             )
             deleted = await self.cognee.delete_document_chunks(repair_ids)
             if isinstance(deleted, dict) and deleted.get("ok") is False:
-                raise RuntimeError(
-                    str(deleted.get("reason") or "repair_delete_failed")
-                )
+                raise RuntimeError(str(deleted.get("reason") or "repair_delete_failed"))
             self.repair_journal.append(
                 operation_id=repair_operation_id,
                 dataset=dataset,
@@ -2355,14 +2301,9 @@ class Citadel:
             post_graph_ids = await self.cognee.corpus_graph_presence(repair_ids)
         except Exception as exc:  # noqa: BLE001 - return recoverable repair state
             logger.exception("oversized reconciliation failed during %s", repair_phase)
-            deleted_ids = (
-                deleted.get("document_ids", [])
-                if isinstance(deleted, dict)
-                else []
-            )
+            deleted_ids = deleted.get("document_ids", []) if isinstance(deleted, dict) else []
             projections_preserved = (
-                isinstance(deleted, dict)
-                and deleted.get("projections_preserved") is True
+                isinstance(deleted, dict) and deleted.get("projections_preserved") is True
             )
             if deleted is not None and not projections_preserved:
                 projections_preserved = await self._restore_repair_projections(deleted)
@@ -2571,10 +2512,10 @@ def _is_dataitem_garbage(text: str) -> bool:
         line = raw_line.strip()
         if line.startswith("Answer:"):
             has_answer = True
-            if line[len("Answer:"):].strip() != "[DataItem]":
+            if line[len("Answer:") :].strip() != "[DataItem]":
                 return False
         elif line.startswith("Question:"):
-            if line[len("Question:"):].strip():
+            if line[len("Question:") :].strip():
                 return False
     return has_answer
 
@@ -2705,7 +2646,13 @@ def _legacy_garbage_kind(node_id: Any, properties: Any) -> str | None:
     classified — there is no substring-of-prose match.
     """
     props = properties if isinstance(properties, dict) else {}
-    for value in (props.get("text"), props.get("name"), props.get("title"), props.get("id"), node_id):
+    for value in (
+        props.get("text"),
+        props.get("name"),
+        props.get("title"),
+        props.get("id"),
+        node_id,
+    ):
         if isinstance(value, str) and _MARKER_RE.fullmatch(value.strip()):
             return "marker"
     text = props.get("text")

--- a/kb/session_trace.py
+++ b/kb/session_trace.py
@@ -11,6 +11,7 @@ from kb.llm_enrichment import (
     enrichment_enabled,
     openrouter_chat,
 )
+
 logger = logging.getLogger(__name__)
 
 __all__ = [

--- a/kb/session_trace_distill.py
+++ b/kb/session_trace_distill.py
@@ -15,9 +15,7 @@ _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bctdl_[A-Za-z0-9_-]{20,}\b"), "[REDACTED_TOKEN]"),
     (re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"), "[REDACTED_AWS_KEY]"),
     (
-        re.compile(
-            r"(?i)\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^\s'\"`<>]+"
-        ),
+        re.compile(r"(?i)\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^\s'\"`<>]+"),
         "[REDACTED_DATABASE_URL]",
     ),
     (re.compile(r"(?i)(?:--token=|--api-key=|--password=)[^\s]+"), "=[REDACTED]"),

--- a/kb/skills.py
+++ b/kb/skills.py
@@ -121,8 +121,7 @@ def refresh_skill_catalog(state_path: str | Path | None = None) -> dict[str, obj
             loaded = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(loaded, dict):
                 previous = {
-                    str(slug): str(digest)
-                    for slug, digest in (loaded.get("skills") or {}).items()
+                    str(slug): str(digest) for slug, digest in (loaded.get("skills") or {}).items()
                 }
         except (OSError, json.JSONDecodeError, AttributeError):
             previous = {}

--- a/kb/status.py
+++ b/kb/status.py
@@ -107,7 +107,11 @@ def _humanize_net_error(exc: Exception) -> str:
     lowered = text.lower()
     if isinstance(exc, urllib.error.HTTPError):
         return text
-    if "nodename nor servname" in lowered or "name or service not known" in lowered or "getaddrinfo" in lowered:
+    if (
+        "nodename nor servname" in lowered
+        or "name or service not known" in lowered
+        or "getaddrinfo" in lowered
+    ):
         return "cannot resolve host"
     if "connection refused" in lowered:
         return "connection refused"
@@ -150,7 +154,9 @@ class StatusReport:
             reason = detail
         elif not search_probed:
             reason = "search not probed; pass --check-search"
-        elif (search.data or {}).get("timed_out") or (search.data or {}).get("code") == CODE_TIMEOUT:
+        elif (search.data or {}).get("timed_out") or (search.data or {}).get(
+            "code"
+        ) == CODE_TIMEOUT:
             code = CODE_TIMEOUT
             reason = search.detail or "search timed out"
         elif not search_ok:
@@ -211,9 +217,7 @@ def check_auth(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -
         )
     started = time.monotonic()
     try:
-        data = _request(
-            "GET", f"{base_url.rstrip('/')}/api/session", token=token, timeout=timeout
-        )
+        data = _request("GET", f"{base_url.rstrip('/')}/api/session", token=token, timeout=timeout)
     except Exception as exc:
         detail = _humanize_net_error(exc)
         return Check("auth", ok=False, detail=detail, data={"code": CODE_AUTH_REQUIRED})
@@ -229,7 +233,13 @@ def check_auth(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -
     auth_data: dict[str, Any] = dict(identity)
     if not ok:
         auth_data["code"] = CODE_AUTH_REQUIRED
-    return Check("auth", ok=ok, detail="valid" if ok else "invalid session", latency_ms=latency, data=auth_data)
+    return Check(
+        "auth",
+        ok=ok,
+        detail="valid" if ok else "invalid session",
+        latency_ms=latency,
+        data=auth_data,
+    )
 
 
 def check_search(
@@ -452,7 +462,9 @@ def ingest_node(
     payload: dict[str, Any] = {"data": data, "tags": list(tags)}
     if cognify:
         payload["cognify"] = True
-    resolved = timeout if timeout is not None else (_COGNIFY_TIMEOUT if cognify else _INGEST_TIMEOUT)
+    resolved = (
+        timeout if timeout is not None else (_COGNIFY_TIMEOUT if cognify else _INGEST_TIMEOUT)
+    )
     return _request(
         "POST",
         f"{base_url.rstrip('/')}/ingest",
@@ -499,14 +511,19 @@ def fetch_events(
         query += f"&type={urllib.parse.quote(event_type)}"
     try:
         data = _request(
-            "GET", f"{base_url.rstrip('/')}/api/knowledge/events?{query}", token=token, timeout=timeout
+            "GET",
+            f"{base_url.rstrip('/')}/api/knowledge/events?{query}",
+            token=token,
+            timeout=timeout,
         )
     except Exception as exc:
         return {"error": _humanize_net_error(exc)}
     return data if isinstance(data, dict) else {}
 
 
-def fetch_presence(base_url: str, token: str | None, *, timeout: float = _TIMEOUT) -> dict[str, Any]:
+def fetch_presence(
+    base_url: str, token: str | None, *, timeout: float = _TIMEOUT
+) -> dict[str, Any]:
     """Best-effort org **Seat Presence** board (ADR-0009): every seat's slug and
     contribution count, org-visible by design.
 
@@ -653,9 +670,7 @@ def assess_mcp_setup(repo: Path) -> Check:
 
 def check_local_setup(repo: Path, config_path: Path | None = None) -> list[Check]:
     checks: list[Check] = []
-    checks.append(
-        Check("token", ok=bool(os.getenv(TOKEN_ENV)), detail=_mask(os.getenv(TOKEN_ENV)))
-    )
+    checks.append(Check("token", ok=bool(os.getenv(TOKEN_ENV)), detail=_mask(os.getenv(TOKEN_ENV))))
     checks.append(assess_mcp_setup(repo))
 
     # The hook is per-repo, so this check only ever sees the repo it was pointed
@@ -857,7 +872,9 @@ def render_text(report: StatusReport, *, color: bool = False, verdict: bool = Tr
         # Latencies form one aligned (and dimmed) column per section, so the
         # details read as a block instead of a ragged mix of text and numbers.
         width = min(max((len(c.detail) for c in checks), default=0), max(cols - 30, 8))
-        header = paint(title, "bold", enable=color) + (paint(note, "dim", enable=color) if note else "")
+        header = paint(title, "bold", enable=color) + (
+            paint(note, "dim", enable=color) if note else ""
+        )
         return [header, *(_row(c, width) for c in checks)]
 
     if conn:
@@ -913,15 +930,21 @@ def render_verdict(report: StatusReport, *, color: bool = False) -> str:
             )
             lines.append(paint("  Run `citadel doctor --fix` to repair.", "dim", enable=color))
         if search_warming:
-            lines.append(paint("  Search is still warming up — retry in a minute.", "dim", enable=color))
+            lines.append(
+                paint("  Search is still warming up — retry in a minute.", "dim", enable=color)
+            )
         elif search_degraded:
             detail = next((c.detail for c in search_fail), "")
-            lines.append(paint(f"  Search degraded — {detail}. Not blocking.", "yellow", enable=color))
+            lines.append(
+                paint(f"  Search degraded — {detail}. Not blocking.", "yellow", enable=color)
+            )
     else:
         node_auth_fail = [c for c in conn_fail if c.name in ("node", "auth")]
         corpus_fail = next((c for c in conn if c.name == "corpus" and not c.ok), None)
         if node_auth_fail:
-            labels = ", ".join(_CHECK_LABELS.get(c.name, c.name) for c in node_auth_fail) or "Node/Auth"
+            labels = (
+                ", ".join(_CHECK_LABELS.get(c.name, c.name) for c in node_auth_fail) or "Node/Auth"
+            )
             lines.append(
                 paint(
                     f"Not connected — {labels} failing. Check the Node URL / token, or run `citadel onboard`.",

--- a/kb/tool_detect.py
+++ b/kb/tool_detect.py
@@ -45,7 +45,12 @@ class ToolSpec:
 
 # Order here is the order tools are offered during onboarding.
 SPECS: dict[str, ToolSpec] = {
-    "claude": ToolSpec("claude", "Claude Code (user scope)", "write", "~/.claude.json (or `claude mcp add --scope user`)"),
+    "claude": ToolSpec(
+        "claude",
+        "Claude Code (user scope)",
+        "write",
+        "~/.claude.json (or `claude mcp add --scope user`)",
+    ),
     "cursor": ToolSpec("cursor", "Cursor", "write", "~/.cursor/mcp.json"),
     "codex": ToolSpec("codex", "Codex CLI", "write", "~/.codex/config.toml"),
     "gemini": ToolSpec("gemini", "Gemini CLI", "write", "~/.gemini/settings.json"),
@@ -153,7 +158,16 @@ def _wire_codex(url: str) -> ToolResult:
     if _which("codex"):
         try:
             subprocess.run(
-                ["codex", "mcp", "add", "citadel", "--url", url, "--bearer-token-env-var", TOKEN_ENV],
+                [
+                    "codex",
+                    "mcp",
+                    "add",
+                    "citadel",
+                    "--url",
+                    url,
+                    "--bearer-token-env-var",
+                    TOKEN_ENV,
+                ],
                 check=True,
                 capture_output=True,
                 timeout=30,
@@ -171,7 +185,7 @@ def _wire_codex(url: str) -> ToolResult:
             return ToolResult("codex", "error", f"{path}: {exc}")
     if marker in existing:
         return ToolResult("codex", "unchanged", str(path))
-    block = f"\n{marker}\nurl = \"{url}\"\nbearer_token_env_var = \"{TOKEN_ENV}\"\n"
+    block = f'\n{marker}\nurl = "{url}"\nbearer_token_env_var = "{TOKEN_ENV}"\n'
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
@@ -202,16 +216,26 @@ def _wire_claude(url: str, *, node_base: str) -> ToolResult:
         try:
             subprocess.run(
                 [
-                    "claude", "mcp", "add", "--transport", "http", "citadel", url,
-                    "--scope", "user",
-                    "--header", f"Authorization: Bearer ${{{TOKEN_ENV}}}",
+                    "claude",
+                    "mcp",
+                    "add",
+                    "--transport",
+                    "http",
+                    "citadel",
+                    url,
+                    "--scope",
+                    "user",
+                    "--header",
+                    f"Authorization: Bearer ${{{TOKEN_ENV}}}",
                 ],
                 check=True,
                 capture_output=True,
                 timeout=30,
             )
             _ensure_claude_project_mcp(node_base)
-            return ToolResult("claude", "wrote", "via `claude mcp add --scope user` + project .mcp.json")
+            return ToolResult(
+                "claude", "wrote", "via `claude mcp add --scope user` + project .mcp.json"
+            )
         except (OSError, subprocess.SubprocessError):
             pass  # fall back to editing ~/.claude.json directly
     result = _merge_json_mcp(
@@ -282,7 +306,14 @@ def apply(name: str, *, node_url: str = DEFAULT_NODE_URL) -> ToolResult:
     if name == "zed":
         # No header env-interpolation in Zed yet → literal token in settings.json.
         snippet = json.dumps(
-            {"context_servers": {"citadel": {"url": url, "headers": {"Authorization": "Bearer <paste your ctdl_ token>"}}}},
+            {
+                "context_servers": {
+                    "citadel": {
+                        "url": url,
+                        "headers": {"Authorization": "Bearer <paste your ctdl_ token>"},
+                    }
+                }
+            },
             indent=2,
         )
         return ToolResult("zed", "snippet", spec.config_hint, snippet)

--- a/kb/webhook_gateway.py
+++ b/kb/webhook_gateway.py
@@ -59,8 +59,6 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         raise WebhookConfigError(f"webhook endpoint attempted a {code} redirect")
 
 
-
-
 def _is_forbidden_address(candidate: str) -> bool:
     """True when *candidate* is an IP a webhook must never reach."""
     try:
@@ -116,9 +114,7 @@ def require_webhook_url(url: str) -> str:
     """
     parsed = urlparse(url)
     if parsed.scheme.lower() != "https":
-        raise WebhookConfigError(
-            f"webhook URL must be https, got {parsed.scheme or 'no scheme'}"
-        )
+        raise WebhookConfigError(f"webhook URL must be https, got {parsed.scheme or 'no scheme'}")
     host = (parsed.hostname or "").lower().rstrip(".")  # a trailing dot dodges suffixes
     if not host:
         raise WebhookConfigError("webhook URL has no host")
@@ -232,9 +228,7 @@ class WebhookDelivery:
             )
             if self.token:
                 request.add_header("Authorization", f"Bearer {self.token}")
-            opener = urllib.request.build_opener(
-                _NoRedirect, _PinnedHTTPSHandler(self.pinned_ip)
-            )
+            opener = urllib.request.build_opener(_NoRedirect, _PinnedHTTPSHandler(self.pinned_ip))
             with opener.open(request, timeout=self.timeout_seconds) as response:
                 status_code = response.status
         except WebhookConfigError as exc:

--- a/scripts/bench/cost_model.py
+++ b/scripts/bench/cost_model.py
@@ -21,6 +21,7 @@ Usage:
     python scripts/bench/cost_model.py --memory-gb 2.0       # what-if
     python scripts/bench/cost_model.py --json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -64,8 +65,9 @@ class CostLine:
     share_pct: float
 
 
-def service_cost(vcpu: float, memory_gb: float, volume_gb: float,
-                 egress_gb_per_hour: float) -> dict[str, float]:
+def service_cost(
+    vcpu: float, memory_gb: float, volume_gb: float, egress_gb_per_hour: float
+) -> dict[str, float]:
     return {
         "CPU": vcpu * PRICE_VCPU_SECOND * SECONDS_PER_MONTH,
         "Memory": memory_gb * PRICE_GB_RAM_SECOND * SECONDS_PER_MONTH,
@@ -99,8 +101,12 @@ def monthly_cost(
         "Egress": f"{sum(s[4] for s in services) * 720:.1f} GB/mo",
     }
     lines = [
-        CostLine(component=name, basis=bases[name], monthly_usd=round(value, 2),
-                 share_pct=round(100 * value / grand, 1))
+        CostLine(
+            component=name,
+            basis=bases[name],
+            monthly_usd=round(value, 2),
+            share_pct=round(100 * value / grand, 1),
+        )
         for name, value in totals.items()
     ]
     return lines, per_service
@@ -174,22 +180,29 @@ def main() -> int:
     per_search = cpu_cost + egress_cost
 
     if args.json:
-        print(json.dumps({
-            "monthly_total_usd": total,
-            "monthly_total_note": (
-                "24h-average basis. Memory dominates and moves with the window: a "
-                "trailing-7-day basis gives ~$61. Quote as 'about $55', not to the cent."
-            ),
-            "services": per_service,
-            "lines": [asdict(line) for line in lines],
-            "marginal_cost_per_search_usd": round(per_search, 8),
-            "marginal_cost_cpu_usd": round(cpu_cost, 8),
-            "marginal_cost_egress_usd": round(egress_cost, 8),
-            "marginal_cost_per_1k_searches_usd": round(per_search * 1000, 4),
-            "searches_per_month_to_double_cost": int(total / per_search) if per_search else None,
-            "search_response_bytes_median": MEASURED_SEARCH_RESPONSE_BYTES,
-            "price_source": "https://railway.com/pricing, fetched 2026-07-31",
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "monthly_total_usd": total,
+                    "monthly_total_note": (
+                        "24h-average basis. Memory dominates and moves with the window: a "
+                        "trailing-7-day basis gives ~$61. Quote as 'about $55', not to the cent."
+                    ),
+                    "services": per_service,
+                    "lines": [asdict(line) for line in lines],
+                    "marginal_cost_per_search_usd": round(per_search, 8),
+                    "marginal_cost_cpu_usd": round(cpu_cost, 8),
+                    "marginal_cost_egress_usd": round(egress_cost, 8),
+                    "marginal_cost_per_1k_searches_usd": round(per_search * 1000, 4),
+                    "searches_per_month_to_double_cost": int(total / per_search)
+                    if per_search
+                    else None,
+                    "search_response_bytes_median": MEASURED_SEARCH_RESPONSE_BYTES,
+                    "price_source": "https://railway.com/pricing, fetched 2026-07-31",
+                },
+                indent=2,
+            )
+        )
         return 0
 
     print("Citadel project: monthly cost from measured resource use")
@@ -199,7 +212,9 @@ def main() -> int:
         print(f"  {name:22} ${value:7.2f}")
     print()
     for line in lines:
-        print(f"  {line.component:8} {line.basis:24} ${line.monthly_usd:7.2f}  {line.share_pct:5.1f}%")
+        print(
+            f"  {line.component:8} {line.basis:24} ${line.monthly_usd:7.2f}  {line.share_pct:5.1f}%"
+        )
     print(f"  {'':33}{'-' * 8}")
     print(f"  {'TOTAL':8} {'':24} ${total:7.2f}\n")
 
@@ -210,8 +225,10 @@ def main() -> int:
     print("  a trailing-7-day basis gives ~$61. Two decimals would be false precision.\n")
     print(f"  Marginal cost per search : ${per_search:.8f}")
     print(f"    CPU                    : ${cpu_cost:.8f}  ({100 * cpu_cost / per_search:.0f}%)")
-    print(f"    Response egress        : ${egress_cost:.8f}  ({100 * egress_cost / per_search:.0f}%)"
-          f"  at a {MEASURED_SEARCH_RESPONSE_BYTES:,}-byte median response")
+    print(
+        f"    Response egress        : ${egress_cost:.8f}  ({100 * egress_cost / per_search:.0f}%)"
+        f"  at a {MEASURED_SEARCH_RESPONSE_BYTES:,}-byte median response"
+    )
     print(f"  Per 1,000 searches       : ${per_search * 1000:.4f}")
     if per_search:
         print(f"  Searches/month needed to double the bill: {int(total / per_search):,}")

--- a/scripts/bench/fetch_ground_truth.py
+++ b/scripts/bench/fetch_ground_truth.py
@@ -7,6 +7,7 @@ benchmark match a hit by content overlap instead, which survives chunking.
 Usage:
     GITHUB_TOKEN=... python scripts/bench/fetch_ground_truth.py
 """
+
 from __future__ import annotations
 
 import base64

--- a/scripts/bench/simulate_doc_cap.py
+++ b/scripts/bench/simulate_doc_cap.py
@@ -33,6 +33,7 @@ query time, and every forced sync multiplies the corpus again.
 Usage:
     python scripts/bench/simulate_doc_cap.py --pool 20 --repeats 2
 """
+
 from __future__ import annotations
 
 import argparse
@@ -143,8 +144,10 @@ def main() -> int:
             best = per_cap_best[str(cap)]
             ranks[str(cap)].append(min(best) if best else None)
 
-    print(f"questions={len(questions)} pool={args.pool} final_k={args.final_k} "
-          f"repeats={args.repeats}\n")
+    print(
+        f"questions={len(questions)} pool={args.pool} final_k={args.final_k} "
+        f"repeats={args.repeats}\n"
+    )
     print(f"{'cap':>6}  {'recall@5':>9}  {'MRR':>6}")
     summary = {}
     for cap in caps:
@@ -157,8 +160,10 @@ def main() -> int:
         summary[label] = {"recall_at_5": round(recall, 4), "mrr": round(mrr, 4)}
 
     if slot_share:
-        print(f"\nworst-case single-document share of the uncapped top-{args.final_k}: "
-              f"mean {statistics.fmean(slot_share):.2f}, max {max(slot_share):.2f}")
+        print(
+            f"\nworst-case single-document share of the uncapped top-{args.final_k}: "
+            f"mean {statistics.fmean(slot_share):.2f}, max {max(slot_share):.2f}"
+        )
 
     if args.out:
         Path(args.out).write_text(json.dumps(summary, indent=2), encoding="utf-8")

--- a/scripts/run_github_sync.py
+++ b/scripts/run_github_sync.py
@@ -170,11 +170,7 @@ def _gateway_delivery_summary(result: dict[str, Any]) -> str | None:
     if isinstance(google_chat, dict) and google_chat:
         if google_chat.get("sent") is True:
             return "google_chat:sent"
-        outcome = (
-            google_chat.get("reason")
-            or google_chat.get("status_category")
-            or "not_sent"
-        )
+        outcome = google_chat.get("reason") or google_chat.get("status_category") or "not_sent"
         return f"google_chat:{outcome}"
     return None
 

--- a/scripts/run_railway.py
+++ b/scripts/run_railway.py
@@ -537,9 +537,7 @@ def _run_stages(stages: list[tuple[str, bool, Callable[[], int]]], *, label: str
     return _stage_verdict(label, succeeded, failed, skipped)
 
 
-def _stage_verdict(
-    label: str, succeeded: list[str], failed: list[str], skipped: list[str]
-) -> int:
+def _stage_verdict(label: str, succeeded: list[str], failed: list[str], skipped: list[str]) -> int:
     """Log the pass summary and return its exit code.
 
     Shared by the sync and in-loop stage runners so the #89 rule (any failed

--- a/scripts/verify_package_artifacts.py
+++ b/scripts/verify_package_artifacts.py
@@ -31,9 +31,7 @@ def verify(dist_dir: Path) -> None:
     assert any(name.endswith("/kb/webui/index.html") for name in names)
     assert any(name.endswith("/kb/retrieval_eval.py") for name in names)
     tokenizer_prefix = "/kb/data/tiktoken-cache/"
-    assert any(
-        tokenizer_prefix in name and name.endswith(".gz") for name in names
-    )
+    assert any(tokenizer_prefix in name and name.endswith(".gz") for name in names)
     print("release artifact webui, benchmark, and tokenizer payload verified")
 
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -216,17 +216,13 @@ def test_concurrent_writers_do_not_lose_events(tmp_path: Path) -> None:
     import threading
 
     path = tmp_path / "access.json"
-    AccessStore(path).create_principal_token(
-        name="seed", kind="service_account", role="reader"
-    )
+    AccessStore(path).create_principal_token(name="seed", kind="service_account", role="reader")
 
     def writer(tag: str) -> None:
         # A separate instance per thread, which is the cross-process shape.
         local = AccessStore(path)
         for index in range(40):
-            local.record_event(
-                action=f"probe.{tag}", actor=None, success=True, detail={"i": index}
-            )
+            local.record_event(action=f"probe.{tag}", actor=None, success=True, detail={"i": index})
 
     threads = [threading.Thread(target=writer, args=(f"w{n}",)) for n in range(4)]
     for thread in threads:
@@ -251,9 +247,7 @@ def test_a_concurrent_write_cannot_resurrect_a_revoked_token(tmp_path: Path) -> 
 
     path = tmp_path / "access.json"
     store = AccessStore(path)
-    created = store.create_principal_token(
-        name="victim", kind="service_account", role="writer"
-    )
+    created = store.create_principal_token(name="victim", kind="service_account", role="writer")
 
     # Authenticate (loads a pre-revocation snapshot), revoke concurrently, then
     # let the stamp write land.
@@ -307,9 +301,7 @@ def test_last_used_is_stamped_but_not_on_every_request(tmp_path: Path) -> None:
     """
     path = tmp_path / "access.json"
     store = AccessStore(path)
-    created = store.create_principal_token(
-        name="hot", kind="service_account", role="reader"
-    )
+    created = store.create_principal_token(name="hot", kind="service_account", role="reader")
 
     assert store.authenticate_token(created.token) is not None
     stamped = store.snapshot()["tokens"][0]["last_used_at"]

--- a/tests/test_access_client.py
+++ b/tests/test_access_client.py
@@ -51,11 +51,18 @@ def test_create_seat_sends_payload_and_auth(monkeypatch) -> None:
         return _FakeResp({"ok": True, "token": "ctdl_new", "principal": {"seat_slug": "alice"}})
 
     monkeypatch.setattr(ac._OPENER, "open", fake_open)
-    out = ac.create_seat(base_url="https://node.example", name="Alice", slug="alice", key="owner-admin")
+    out = ac.create_seat(
+        base_url="https://node.example", name="Alice", slug="alice", key="owner-admin"
+    )
     assert out["token"] == "ctdl_new"
     assert captured["url"] == "https://node.example/api/access/seats"
     assert captured["method"] == "POST"
-    assert captured["body"] == {"name": "Alice", "slug": "alice", "role": "writer", "issue_token": True}
+    assert captured["body"] == {
+        "name": "Alice",
+        "slug": "alice",
+        "role": "writer",
+        "issue_token": True,
+    }
     assert captured["auth"] == "Bearer owner-admin"
 
 

--- a/tests/test_agent_canary.py
+++ b/tests/test_agent_canary.py
@@ -64,11 +64,7 @@ def test_canary_mcp_status_states(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     (tmp_path / ".mcp.json").write_text(
         json.dumps(
-            {
-                "mcpServers": {
-                    "citadel": {"type": "http", "url": "https://citadel.example/mcp/"}
-                }
-            }
+            {"mcpServers": {"citadel": {"type": "http", "url": "https://citadel.example/mcp/"}}}
         )
     )
     needs_auth = status_mod.assess_mcp_setup(tmp_path)
@@ -86,11 +82,7 @@ def test_canary_mcp_status_states(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_x")
     (tmp_path / ".mcp.json").write_text(
         json.dumps(
-            {
-                "mcpServers": {
-                    "citadel": {"type": "http", "url": "https://citadel.example/mcp/"}
-                }
-            }
+            {"mcpServers": {"citadel": {"type": "http", "url": "https://citadel.example/mcp/"}}}
         )
     )
     ready = status_mod.assess_mcp_setup(tmp_path)
@@ -221,9 +213,7 @@ def test_canary_live_node_optional() -> None:
     from kb.capture_config import DEFAULT_NODE_URL
 
     base = (os.getenv("CITADEL_NODE_URL") or DEFAULT_NODE_URL).rstrip("/")
-    payload = status_mod.search_node(
-        base, token, "MIP-003 endpoint schema", top_k=5, timeout=15.0
-    )
+    payload = status_mod.search_node(base, token, "MIP-003 endpoint schema", top_k=5, timeout=15.0)
     shaped = shape_search_payload(payload, query="MIP-003 endpoint schema")
     assert shaped["ok"] is True
     assert "results" in shaped

--- a/tests/test_agent_workflows.py
+++ b/tests/test_agent_workflows.py
@@ -48,6 +48,8 @@ def test_shape_verify_and_prepare() -> None:
     assert report["doc_shaped_sources"][0]["trust_tier"] == "unattested"
     assert report["doc_shaped_sources"][0]["content_hint"] == "looks-like-spec"
     assert report["known_overlaps"]
-    brief = shape_prepare_pr_context(repo="cardano-dev-skills", topic="masumi", search_payload=payload)
+    brief = shape_prepare_pr_context(
+        repo="cardano-dev-skills", topic="masumi", search_payload=payload
+    )
     assert brief["command"] == "prepare-pr-context"
     assert brief["agent_instruction"]

--- a/tests/test_backup_mirror.py
+++ b/tests/test_backup_mirror.py
@@ -106,7 +106,9 @@ def test_backup_mirror_write_requires_enabled_flag(tmp_path: Any) -> None:
 
 def test_backup_mirror_writes_latest_manifest_when_enabled(tmp_path: Any) -> None:
     config = mirror_config(tmp_path, enabled=True)
-    (tmp_path / "github.json").write_text('{"last_checked_at":"2026-06-03T00:00:00Z"}', encoding="utf-8")
+    (tmp_path / "github.json").write_text(
+        '{"last_checked_at":"2026-06-03T00:00:00Z"}', encoding="utf-8"
+    )
     mirror = BackupMirror(config)
 
     result = mirror.run(dry_run=False)
@@ -135,7 +137,9 @@ def test_backup_mirror_pushes_manifest_tree_when_enabled(tmp_path: Any) -> None:
         push_enabled=True,
         token="ghp_not_written_to_manifest",
     )
-    (tmp_path / "github.json").write_text('{"last_checked_at":"2026-06-03T00:00:00Z"}', encoding="utf-8")
+    (tmp_path / "github.json").write_text(
+        '{"last_checked_at":"2026-06-03T00:00:00Z"}', encoding="utf-8"
+    )
     publisher = FakePublisher()
     mirror = BackupMirror(config, publisher=publisher)
 

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -27,8 +27,8 @@ def test_tagline_is_brand_highlighted(monkeypatch) -> None:
 
 def test_banner_large_is_the_brand_wordmark(monkeypatch) -> None:
     plain = banner_large(color=False)
-    assert "____" in plain        # figlet CITADEL
-    assert "\033[" not in plain   # plain when piped
+    assert "____" in plain  # figlet CITADEL
+    assert "\033[" not in plain  # plain when piped
     assert len(plain.splitlines()) == 5  # just the wordmark, nothing else
 
     monkeypatch.delenv("COLORTERM", raising=False)
@@ -91,15 +91,7 @@ def test_cli_mark_matches_the_shipped_web_mark() -> None:
     narrowed) and nothing caught it, because no test compared the two. This
     pins the bitmask that kb/static/favicon.svg and info.js render.
     """
-    shipped = (
-        "1010101"
-        "1111111"
-        "1111111"
-        "1111111"
-        "1101011"
-        "1101011"
-        "1101011"
-    )
+    shipped = "1010101111111111111111111111110101111010111101011"
     assert "".join(str(flag) for flag in PIXEL_FLAGS) == shipped
 
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -83,9 +83,7 @@ def test_capture_no_roots_warns(tmp_path: Path, capsys) -> None:
 
 def test_capture_root_filter_no_match_message(tmp_path: Path, capsys) -> None:
     config_path = tmp_path / "capture.json"
-    save_capture_config(
-        CaptureConfig().with_root("/tmp/approved", ["personal"]), path=config_path
-    )
+    save_capture_config(CaptureConfig().with_root("/tmp/approved", ["personal"]), path=config_path)
     args = argparse.Namespace(config=str(config_path), root=["/tmp/nope"], dry_run=True)
     rc = asyncio.run(_capture(args))
     assert rc == 1
@@ -103,7 +101,9 @@ def test_capture_corrupt_config_exits_clean(tmp_path: Path, capsys) -> None:
     assert "corrupt capture config" in capsys.readouterr().err
 
 
-def test_capture_node_down_is_handled_and_exits_nonzero(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_capture_node_down_is_handled_and_exits_nonzero(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
     config_path = tmp_path / "capture.json"
     save_capture_config(
         CaptureConfig(node_url="https://node.example").with_root(str(tmp_path), ["personal"]),
@@ -125,9 +125,7 @@ def test_capture_node_down_is_handled_and_exits_nonzero(tmp_path: Path, monkeypa
 
 def test_capture_dry_run_returns_zero(tmp_path: Path) -> None:
     config_path = tmp_path / "capture.json"
-    save_capture_config(
-        CaptureConfig().with_root(str(tmp_path), ["personal"]), path=config_path
-    )
+    save_capture_config(CaptureConfig().with_root(str(tmp_path), ["personal"]), path=config_path)
     args = argparse.Namespace(config=str(config_path), root=None, dry_run=True)
     assert asyncio.run(_capture(args)) == 0
 
@@ -192,7 +190,9 @@ def test_truncate_utf8_does_not_split_codepoints() -> None:
 
 
 def test_redact_url_userinfo() -> None:
-    assert _redact_url_userinfo("https://user:tok@github.com/o/r.git") == "https://github.com/o/r.git"
+    assert (
+        _redact_url_userinfo("https://user:tok@github.com/o/r.git") == "https://github.com/o/r.git"
+    )
     assert _redact_url_userinfo("git@github.com:o/r.git") == "git@github.com:o/r.git"
 
 
@@ -231,9 +231,7 @@ def test_capture_duplicate_rejection_reports_ok_false_with_reason(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
-    monkeypatch.setattr(
-        "kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process")
-    )
+    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process"))
     rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
     out = json.loads(capsys.readouterr().out)
     entry = out["results"][0]
@@ -249,9 +247,7 @@ def test_capture_duplicate_human_output_says_nothing_stored(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
-    monkeypatch.setattr(
-        "kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process")
-    )
+    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: _rejection("duplicate_in_process"))
     rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=False)))
     captured = capsys.readouterr()
     assert rc == 0
@@ -259,9 +255,7 @@ def test_capture_duplicate_human_output_says_nothing_stored(
     assert "duplicate_in_process" in captured.out
 
 
-def test_capture_non_duplicate_rejection_is_a_failure(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_capture_non_duplicate_rejection_is_a_failure(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
     monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: _rejection("content_too_short"))
     rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=False)))

--- a/tests/test_capture_config.py
+++ b/tests/test_capture_config.py
@@ -123,10 +123,10 @@ def test_setup_interactive_wizard(tmp_path: Path, monkeypatch) -> None:
     answers = iter(
         [
             "https://wizard-node.example",  # Node URL prompt
-            "n",                             # decline the offered cwd default
-            str(repo),                       # first root path
-            "org-work, notes",               # tags
-            "",                              # empty path -> finish
+            "n",  # decline the offered cwd default
+            str(repo),  # first root path
+            "org-work, notes",  # tags
+            "",  # empty path -> finish
         ]
     )
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(answers))

--- a/tests/test_chunk_window.py
+++ b/tests/test_chunk_window.py
@@ -70,9 +70,7 @@ def test_bundled_gpt4o_tokenizer_is_available_without_network() -> None:
     cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
 
     assert cache_dir
-    assert (
-        Path(cache_dir) / chunk_window._TIKTOKEN_CACHE_FILENAME
-    ).is_file()
+    assert (Path(cache_dir) / chunk_window._TIKTOKEN_CACHE_FILENAME).is_file()
     assert chunk_window.require_bpe_encoding().name == "o200k_base"
 
 
@@ -134,9 +132,7 @@ def test_detector_fires_on_a_planted_over_window_chunk(caplog: Any) -> None:
     tokenizer = _FakeWordpieceTokenizer()
     planted = "x" * 1710  # the worst real chunk measured on this tree, in wordpieces
     with caplog.at_level(logging.WARNING, logger="kb.chunk_window"):
-        over = chunk_window.record_embed_batch(
-            [planted], count_tokens=tokenizer.count, window=512
-        )
+        over = chunk_window.record_embed_batch([planted], count_tokens=tokenizer.count, window=512)
 
     assert over == 1
     report = chunk_window.embed_window_report()
@@ -352,9 +348,10 @@ def test_newline_is_not_a_word_boundary() -> None:
 
 
 def test_final_cognee_chunk_validator_accepts_in_budget_text() -> None:
-    assert chunk_window.validate_cognee_chunk_budget(
-        "A short note with ordinary words.", budget=64
-    ) is None
+    assert (
+        chunk_window.validate_cognee_chunk_budget("A short note with ordinary words.", budget=64)
+        is None
+    )
 
 
 def test_final_cognee_chunk_validator_rejects_emitted_over_budget_chunk(
@@ -609,7 +606,7 @@ def test_the_arithmetic_floor_never_claims_more_tokens_than_there_are() -> None:
         "a" * 40_000,
         "한국어 텍스트 " * 3000,
         "🚀🔥💡" * 4000,
-        "{\"key\":\"value\"}," * 3000,
+        '{"key":"value"},' * 3000,
         "0123456789" * 4000,
         "The payment service escrows funds until the seller submits a result. " * 600,
     ]
@@ -622,9 +619,7 @@ def test_the_arithmetic_floor_never_claims_more_tokens_than_there_are() -> None:
 def test_max_token_bytes_is_read_from_the_encoding_not_asserted() -> None:
     """It must come off the vocabulary, because a cognee or tiktoken bump can move it."""
     encoding = chunk_window._bpe_encoding()
-    assert chunk_window.max_token_bytes() == max(
-        len(token) for token in encoding._mergeable_ranks
-    )
+    assert chunk_window.max_token_bytes() == max(len(token) for token in encoding._mergeable_ranks)
 
 
 # --------------------------------------------------------------------------
@@ -639,9 +634,7 @@ def test_applying_the_budget_twice_evicts_the_caches_once(monkeypatch: Any) -> N
     every cognee operation, so the second call has to be a no-op.
     """
     calls: list[int] = []
-    monkeypatch.setattr(
-        chunk_window, "_clear_cognee_budget_caches", lambda: calls.append(1)
-    )
+    monkeypatch.setattr(chunk_window, "_clear_cognee_budget_caches", lambda: calls.append(1))
     chunk_window.reset_applied_budget()
 
     chunk_window.apply_chunk_budget()
@@ -799,6 +792,6 @@ def test_word_segmentation_agrees_with_cognee() -> None:
         theirs = [word for word, _kind in chunk_by_word(sample)]
         mine = chunk_window.split_cognee_words(sample)
         assert "".join(mine) == sample, "segmentation must be lossless"
-        assert max((len(w) for w in mine), default=0) >= max(
-            (len(w) for w in theirs), default=0
-        ), "our longest segment must not be shorter than cognee's longest word"
+        assert max((len(w) for w in mine), default=0) >= max((len(w) for w in theirs), default=0), (
+            "our longest segment must not be shorter than cognee's longest word"
+        )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -16,8 +16,16 @@ from kb.status import Check, StatusReport
 
 
 def _ingest_args(**kw):
-    base = dict(data="a note", tag=[], json=True, node_url="https://node.example",
-                local=False, dataset=None, session=None, no_cognify=True)
+    base = dict(
+        data="a note",
+        tag=[],
+        json=True,
+        node_url="https://node.example",
+        local=False,
+        dataset=None,
+        session=None,
+        no_cognify=True,
+    )
     base.update(kw)
     return argparse.Namespace(**base)
 
@@ -48,8 +56,11 @@ def test_doctor_clean_reports_ok(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_x")
     monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(_all_ok()))
     args = argparse.Namespace(
-        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
-        node_url=None, json=True, fix=False,
+        repo=str(tmp_path),
+        config=str(tmp_path / "cap.json"),
+        node_url=None,
+        json=True,
+        fix=False,
     )
     rc = asyncio.run(_doctor(args))
     assert rc == 0
@@ -64,8 +75,11 @@ def test_doctor_warns_when_token_in_rc_not_env(tmp_path: Path, monkeypatch, caps
     monkeypatch.setattr("kb.cli.detect_shell_rc", lambda: rc)
     monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(_all_ok()))
     args = argparse.Namespace(
-        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
-        node_url=None, json=True, fix=False,
+        repo=str(tmp_path),
+        config=str(tmp_path / "cap.json"),
+        node_url=None,
+        json=True,
+        fix=False,
     )
     rc = asyncio.run(_doctor(args))
     assert rc == 1
@@ -81,8 +95,11 @@ def test_doctor_flags_legacy_stdio_mcp(tmp_path: Path, monkeypatch, capsys) -> N
     )
     monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(_all_ok()))
     args = argparse.Namespace(
-        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
-        node_url=None, json=True, fix=False,
+        repo=str(tmp_path),
+        config=str(tmp_path / "cap.json"),
+        node_url=None,
+        json=True,
+        fix=False,
     )
     rc = asyncio.run(_doctor(args))
     assert rc == 1
@@ -102,8 +119,11 @@ def test_doctor_fix_installs_missing_local_setup(tmp_path: Path, monkeypatch, ca
     ]
     monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(broken))
     args = argparse.Namespace(
-        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
-        node_url="https://node.example", json=True, fix=True,
+        repo=str(tmp_path),
+        config=str(tmp_path / "cap.json"),
+        node_url="https://node.example",
+        json=True,
+        fix=True,
     )
     rc = asyncio.run(_doctor(args))
     out = json.loads(capsys.readouterr().out)
@@ -174,12 +194,21 @@ def test_search_http_renders_results(monkeypatch, capsys) -> None:
     }
     monkeypatch.setattr("kb.status.search_node", lambda *a, **k: payload)
     args = argparse.Namespace(
-        query="hi", top_k=10, json=True, node_url="https://node.example",
-        local=False, dataset=None, session=None,
-        type=None, repo=None, path=None, canonical_only=False,
+        query="hi",
+        top_k=10,
+        json=True,
+        node_url="https://node.example",
+        local=False,
+        dataset=None,
+        session=None,
+        type=None,
+        repo=None,
+        path=None,
+        canonical_only=False,
         exclude_ambient=False,
         mode=None,
-        timeout=None, budget_ms=None,
+        timeout=None,
+        budget_ms=None,
     )
     rc = asyncio.run(_search(args))
     assert rc == 0
@@ -192,10 +221,21 @@ def test_search_http_renders_results(monkeypatch, capsys) -> None:
 
 def _search_args(**kw):
     base = dict(
-        query="hi", top_k=10, json=True, node_url="https://node.example",
-        local=False, dataset=None, session=None,
-        type=None, repo=None, path=None, canonical_only=False,
-        exclude_ambient=False, mode=None, timeout=None, budget_ms=None,
+        query="hi",
+        top_k=10,
+        json=True,
+        node_url="https://node.example",
+        local=False,
+        dataset=None,
+        session=None,
+        type=None,
+        repo=None,
+        path=None,
+        canonical_only=False,
+        exclude_ambient=False,
+        mode=None,
+        timeout=None,
+        budget_ms=None,
     )
     base.update(kw)
     return argparse.Namespace(**base)
@@ -300,12 +340,21 @@ def test_search_http_renders_trace_sections(monkeypatch, capsys) -> None:
     }
     monkeypatch.setattr("kb.status.search_node", lambda *a, **k: payload)
     args = argparse.Namespace(
-        query="kuzu lock", top_k=10, json=False, node_url="https://node.example",
-        local=False, dataset=None, session=None,
-        type=None, repo=None, path=None, canonical_only=False,
+        query="kuzu lock",
+        top_k=10,
+        json=False,
+        node_url="https://node.example",
+        local=False,
+        dataset=None,
+        session=None,
+        type=None,
+        repo=None,
+        path=None,
+        canonical_only=False,
         exclude_ambient=False,
         mode=None,
-        timeout=None, budget_ms=None,
+        timeout=None,
+        budget_ms=None,
     )
     rc = asyncio.run(_search(args))
     assert rc == 0
@@ -337,12 +386,21 @@ def test_search_human_literal_query_flattens_ranked_results(monkeypatch, capsys)
 def test_search_no_token_exits_one(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: None)
     args = argparse.Namespace(
-        query="hi", top_k=10, json=False, node_url=None,
-        local=False, dataset=None, session=None,
-        type=None, repo=None, path=None, canonical_only=False,
+        query="hi",
+        top_k=10,
+        json=False,
+        node_url=None,
+        local=False,
+        dataset=None,
+        session=None,
+        type=None,
+        repo=None,
+        path=None,
+        canonical_only=False,
         exclude_ambient=False,
         mode=None,
-        timeout=None, budget_ms=None,
+        timeout=None,
+        budget_ms=None,
     )
     rc = asyncio.run(_search(args))
     assert rc == 1
@@ -352,12 +410,21 @@ def test_search_no_token_exits_one(monkeypatch, capsys) -> None:
 def test_search_no_token_json_auth_required(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: None)
     args = argparse.Namespace(
-        query="hi", top_k=10, json=True, node_url=None,
-        local=False, dataset=None, session=None,
-        type=None, repo=None, path=None, canonical_only=False,
+        query="hi",
+        top_k=10,
+        json=True,
+        node_url=None,
+        local=False,
+        dataset=None,
+        session=None,
+        type=None,
+        repo=None,
+        path=None,
+        canonical_only=False,
         exclude_ambient=False,
         mode=None,
-        timeout=None, budget_ms=None,
+        timeout=None,
+        budget_ms=None,
     )
     rc = asyncio.run(_search(args))
     assert rc == 1
@@ -565,7 +632,9 @@ def test_verify_and_prepare_pr_context(monkeypatch, tmp_path, capsys) -> None:
 
 def test_ingest_http_accepted(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
-    monkeypatch.setattr("kb.status.ingest_node", lambda *a, **k: {"accepted": True, "dataset": "seat:alice"})
+    monkeypatch.setattr(
+        "kb.status.ingest_node", lambda *a, **k: {"accepted": True, "dataset": "seat:alice"}
+    )
     rc = asyncio.run(_ingest(_ingest_args()))
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["accepted"] is True
@@ -573,14 +642,19 @@ def test_ingest_http_accepted(monkeypatch, capsys) -> None:
 
 def test_ingest_http_rejected_exits_one(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
-    monkeypatch.setattr("kb.status.ingest_node", lambda *a, **k: {"accepted": False, "reason": "secret_content"})
+    monkeypatch.setattr(
+        "kb.status.ingest_node", lambda *a, **k: {"accepted": False, "reason": "secret_content"}
+    )
     rc = asyncio.run(_ingest(_ingest_args()))
     assert rc == 1  # a hard rejection must not exit 0
 
 
 def test_ingest_duplicate_is_benign(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
-    monkeypatch.setattr("kb.status.ingest_node", lambda *a, **k: {"accepted": False, "reason": "duplicate_in_process"})
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: {"accepted": False, "reason": "duplicate_in_process"},
+    )
     # A duplicate is idempotent: exit 0, friendly message, not a scary failure.
     rc = asyncio.run(_ingest(_ingest_args(json=False)))
     assert rc == 0
@@ -626,7 +700,9 @@ def _token_set_args(tmp_path: Path, **kw) -> argparse.Namespace:
 def test_token_set_verifies_then_writes_rc(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         "kb.status.check_auth",
-        lambda *a, **k: Check("auth", True, "valid", data={"seat_slug": "sarthi", "role": "writer"}),
+        lambda *a, **k: Check(
+            "auth", True, "valid", data={"seat_slug": "sarthi", "role": "writer"}
+        ),
     )
     rc = asyncio.run(_token_set(_token_set_args(tmp_path)))
     assert rc == 0
@@ -745,8 +821,10 @@ def test_wire_detected_tools_applies_only_selection(monkeypatch, capsys) -> None
     monkeypatch.setattr("kb.tool_detect.detect", lambda: ["cursor", "codex", "zed", "pi"])
     monkeypatch.setattr(
         "kb.tool_detect.apply",
-        lambda name, node_url: applied.append(name)
-        or ToolResult(name, "note" if name == "pi" else "wrote", "ok", snippet="{}"),
+        lambda name, node_url: (
+            applied.append(name)
+            or ToolResult(name, "note" if name == "pi" else "wrote", "ok", snippet="{}")
+        ),
     )
     # The checkbox returns cursor + zed; codex (preselected) was deselected.
     monkeypatch.setattr("kb.prompt.checkbox_select", lambda header, options, checked: {0, 2})
@@ -798,7 +876,9 @@ def test_stale_env_hint_points_at_shell_rc(tmp_path: Path, monkeypatch) -> None:
 # ---- capture-roots wizard -----------------------------------------------------
 
 
-def test_wizard_offers_home_relative_guess_for_missing_root(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_wizard_offers_home_relative_guess_for_missing_root(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
     # "/masumi" for ~/masumi is the common typo — the wizard should offer the
     # home-relative dir that actually exists instead of recording a dead root.
     from kb.capture_config import CaptureConfig
@@ -820,7 +900,9 @@ def test_wizard_enter_accepts_default_root(tmp_path: Path, monkeypatch) -> None:
     answers = iter(["", "", ""])  # accept default → default tags → finish
     monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
 
-    config = _wizard_roots(CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path))
+    config = _wizard_roots(
+        CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path)
+    )
     assert [root.path for root in config.roots] == [str(tmp_path)]
     assert "personal" in config.roots[0].tags
 
@@ -832,7 +914,9 @@ def test_wizard_default_root_is_declinable(tmp_path: Path, monkeypatch) -> None:
 
     answers = iter(["n", ""])
     monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
-    config = _wizard_roots(CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path))
+    config = _wizard_roots(
+        CaptureConfig(node_url="https://node.example"), default_root=str(tmp_path)
+    )
     assert config.roots == ()
 
 
@@ -859,7 +943,9 @@ def test_read_key_handles_bare_escape_and_csi_tails() -> None:
 def test_wizard_default_suppressed_when_already_approved(tmp_path: Path, monkeypatch) -> None:
     from kb.capture_config import CaptureConfig
 
-    existing = CaptureConfig(node_url="https://node.example").with_root(str(tmp_path), ("personal",))
+    existing = CaptureConfig(node_url="https://node.example").with_root(
+        str(tmp_path), ("personal",)
+    )
     answers = iter([""])  # no default on offer → Enter just finishes
     monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
 
@@ -878,8 +964,14 @@ SEATS = [
 
 def _token_create_args(**kw):
     base = dict(
-        name="ci-bot", seat=None, dataset=None, role=None, kind=None,
-        expires_at=None, json=True, node_url="https://node.example",
+        name="ci-bot",
+        seat=None,
+        dataset=None,
+        role=None,
+        kind=None,
+        expires_at=None,
+        json=True,
+        node_url="https://node.example",
     )
     base.update(kw)
     return argparse.Namespace(**base)
@@ -896,7 +988,9 @@ def _wire_access(monkeypatch, *, seats=None):
         calls["standalone"] = k
         return {"ok": True, "token": "ctdl_standalone", "principal": {"id": "p1"}, "api_token": k}
 
-    monkeypatch.setattr("kb.cli.list_seats", lambda **k: {"seats": seats if seats is not None else SEATS})
+    monkeypatch.setattr(
+        "kb.cli.list_seats", lambda **k: {"seats": seats if seats is not None else SEATS}
+    )
     monkeypatch.setattr("kb.cli.issue_seat_token", fake_issue_seat_token)
     monkeypatch.setattr("kb.cli.create_token", fake_create_token)
     return calls
@@ -1128,8 +1222,11 @@ def test_doctor_pre_push_from_non_repo_says_so(tmp_path: Path, monkeypatch, caps
     ]
     monkeypatch.setattr("kb.cli.gather_status", lambda *a, **k: _report(checks))
     args = argparse.Namespace(
-        repo=str(tmp_path), config=str(tmp_path / "cap.json"),
-        node_url=None, json=True, fix=False,
+        repo=str(tmp_path),
+        config=str(tmp_path / "cap.json"),
+        node_url=None,
+        json=True,
+        fix=False,
     )
     rc = asyncio.run(_doctor(args))
     out = json.loads(capsys.readouterr().out)
@@ -1140,8 +1237,14 @@ def test_doctor_pre_push_from_non_repo_says_so(tmp_path: Path, monkeypatch, caps
 
 def _activity_args(**kw):
     base = dict(
-        local=False, config=None, node_url="https://node.example",
-        watch=False, type=None, limit=20, json=True, global_broadcast=True,
+        local=False,
+        config=None,
+        node_url="https://node.example",
+        watch=False,
+        type=None,
+        limit=20,
+        json=True,
+        global_broadcast=True,
     )
     base.update(kw)
     return argparse.Namespace(**base)

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -235,9 +235,7 @@ class _FakeGraphEngine:
         self, nodes: list[tuple[str, dict[str, Any]]], edges: list[tuple[Any, ...]]
     ) -> None:
         self._nodes = {str(nid): dict(props or {}) for nid, props in nodes}
-        self._edges = [
-            (str(src), str(tgt), rel) for src, tgt, rel, *_ in edges
-        ]
+        self._edges = [(str(src), str(tgt), rel) for src, tgt, rel, *_ in edges]
 
     async def get_node(self, node_id: str) -> dict[str, Any] | None:
         props = self._nodes.get(str(node_id))
@@ -544,9 +542,7 @@ async def test_read_node_dataset_map_joined_query_over_real_models(
     async def get_default_user() -> Any:
         return SimpleNamespace(id=user_id, tenant_id=tenant_id)
 
-    monkeypatch.setattr(
-        relational_module, "get_relational_engine", lambda: _FakeRelEngine()
-    )
+    monkeypatch.setattr(relational_module, "get_relational_engine", lambda: _FakeRelEngine())
     monkeypatch.setattr(users_methods, "get_default_user", get_default_user)
 
     client = CogneePublicClient()
@@ -617,9 +613,7 @@ async def test_source_manifest_requires_readable_matching_raw_source(
             async with maker() as session:
                 yield session
 
-    monkeypatch.setattr(
-        relational_module, "get_relational_engine", lambda: _FakeRelEngine()
-    )
+    monkeypatch.setattr(relational_module, "get_relational_engine", lambda: _FakeRelEngine())
     client = CogneePublicClient()
     monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
 
@@ -646,9 +640,24 @@ async def test_source_manifest_requires_readable_matching_raw_source(
 async def test_zero_chunk_census_walks_pages_and_filters_datasets(monkeypatch: Any) -> None:
     client = CogneePublicClient()
     rows = [
-        {"id": "doc-a", "name": "a", "created_at": "2026-01-01T00:00:00+00:00", "datasets": ["alpha"]},
-        {"id": "doc-b", "name": "b", "created_at": "2026-01-02T00:00:00+00:00", "datasets": ["beta"]},
-        {"id": "doc-c", "name": "c", "created_at": "2026-01-03T00:00:00+00:00", "datasets": ["alpha", "beta"]},
+        {
+            "id": "doc-a",
+            "name": "a",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "datasets": ["alpha"],
+        },
+        {
+            "id": "doc-b",
+            "name": "b",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "datasets": ["beta"],
+        },
+        {
+            "id": "doc-c",
+            "name": "c",
+            "created_at": "2026-01-03T00:00:00+00:00",
+            "datasets": ["alpha", "beta"],
+        },
     ]
     page_cursors: list[tuple[str | None, str | None, int]] = []
 
@@ -656,9 +665,7 @@ async def test_zero_chunk_census_walks_pages_and_filters_datasets(monkeypatch: A
         return {"documents": 3}
 
     async def corpus_page(**kwargs: Any) -> list[dict[str, Any]]:
-        page_cursors.append(
-            (kwargs["after_created_at"], kwargs["after_id"], kwargs["limit"])
-        )
+        page_cursors.append((kwargs["after_created_at"], kwargs["after_id"], kwargs["limit"]))
         return rows[:2] if kwargs["after_id"] is None else rows[2:]
 
     async def corpus_chunk_counts(document_ids: list[str]) -> dict[str, int]:
@@ -765,14 +772,10 @@ async def test_ensure_dataset_creates_a_missing_row_and_is_idempotent(
         await conn.run_sync(Dataset.__table__.create)
     maker = async_sessionmaker(engine, expire_on_commit=False)
     async with maker() as session:
-        session.add(
-            Dataset(id=uuid4(), name="seat:alice", owner_id=user_id, tenant_id=tenant_id)
-        )
+        session.add(Dataset(id=uuid4(), name="seat:alice", owner_id=user_id, tenant_id=tenant_id))
         # Same NAME, different tenant. Must not read as already provisioned,
         # because the read path matches on tenant too.
-        session.add(
-            Dataset(id=uuid4(), name="seat:carol", owner_id=user_id, tenant_id=uuid4())
-        )
+        session.add(Dataset(id=uuid4(), name="seat:carol", owner_id=user_id, tenant_id=uuid4()))
         await session.commit()
 
     class _FakeRelEngine:
@@ -789,9 +792,7 @@ async def test_ensure_dataset_creates_a_missing_row_and_is_idempotent(
     async def fake_create_authorized_dataset(name: str, user: Any) -> Any:
         created.append(name)
         async with maker() as session:
-            session.add(
-                Dataset(id=uuid4(), name=name, owner_id=user.id, tenant_id=user.tenant_id)
-            )
+            session.add(Dataset(id=uuid4(), name=name, owner_id=user.id, tenant_id=user.tenant_id))
             await session.commit()
 
     # get_datasets binds get_relational_engine at ITS module import, so patching
@@ -802,9 +803,7 @@ async def test_ensure_dataset_creates_a_missing_row_and_is_idempotent(
         lambda: _FakeRelEngine(),
     )
     monkeypatch.setattr(users_methods, "get_default_user", get_default_user)
-    monkeypatch.setattr(
-        methods_pkg, "create_authorized_dataset", fake_create_authorized_dataset
-    )
+    monkeypatch.setattr(methods_pkg, "create_authorized_dataset", fake_create_authorized_dataset)
 
     client = CogneePublicClient()
     monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
@@ -979,18 +978,16 @@ async def test_ensure_dataset_repairs_a_row_that_has_no_acl(
     dataset_id = await get_unique_dataset_id(dataset_name=name, user=user)
     engine = get_relational_engine()
     async with engine.get_async_session() as session:
-        session.add(
-            Dataset(id=dataset_id, name=name, owner_id=user.id, tenant_id=user.tenant_id)
-        )
+        session.add(Dataset(id=dataset_id, name=name, owner_id=user.id, tenant_id=user.tenant_id))
         await session.commit()
 
     assert await get_authorized_dataset_by_name(name, user, "read") is None
 
     await _real_cognee_client(monkeypatch).ensure_dataset(name)
 
-    assert (
-        await get_authorized_dataset_by_name(name, user, "read")
-    ) is not None, "seat still unsearchable after ensure_dataset"
+    assert (await get_authorized_dataset_by_name(name, user, "read")) is not None, (
+        "seat still unsearchable after ensure_dataset"
+    )
 
 
 def test_assert_cognee_dataset_api_imports_real_symbols() -> None:
@@ -1063,9 +1060,7 @@ async def test_node_dataset_map_single_flight_collapses_cold_burst(
 
     monkeypatch.setattr(client, "_read_node_dataset_map", fake_read)
 
-    results = await asyncio.gather(
-        *[client.node_dataset_map() for _ in range(10)]
-    )
+    results = await asyncio.gather(*[client.node_dataset_map() for _ in range(10)])
     assert all(result == {"doc": ["seat:alice"]} for result in results)
     assert reads == 1
 
@@ -1324,9 +1319,7 @@ async def test_schedule_cognify_runs_one_cognify_over_all_datasets(
     assert cognified == []
 
 
-def test_schedule_cognify_persists_without_a_running_loop(
-    monkeypatch: Any, tmp_path: Any
-) -> None:
+def test_schedule_cognify_persists_without_a_running_loop(monkeypatch: Any, tmp_path: Any) -> None:
     path = tmp_path / "queue.json"
     monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(path))
 
@@ -1338,9 +1331,7 @@ def test_schedule_cognify_persists_without_a_running_loop(
 
 
 @pytest.mark.asyncio
-async def test_failed_background_cognify_is_rescheduled(
-    monkeypatch: Any, tmp_path: Any
-) -> None:
+async def test_failed_background_cognify_is_rescheduled(monkeypatch: Any, tmp_path: Any) -> None:
     path = tmp_path / "queue.json"
     monkeypatch.setenv("CITADEL_COGNIFY_QUEUE_PATH", str(path))
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -1782,9 +1773,7 @@ async def test_stop_cognify_queue_reschedules_cancelled_work(
 
 
 @pytest.mark.asyncio
-async def test_resume_cognify_queue_drains_pending_work(
-    monkeypatch: Any, tmp_path: Any
-) -> None:
+async def test_resume_cognify_queue_drains_pending_work(monkeypatch: Any, tmp_path: Any) -> None:
     path = tmp_path / "queue.json"
     CognifyRetryQueue(path).enqueue(["central"])
     monkeypatch.setenv("LLM_API_KEY", "k")
@@ -2466,7 +2455,9 @@ async def test_delete_document_chunks_deletes_independent_graph_and_vector_ids(
         return None
 
     monkeypatch.setenv("VECTOR_DB_PROVIDER", "pgvector")
-    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations))
+    monkeypatch.setitem(
+        sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations)
+    )
     monkeypatch.setitem(sys.modules, "cognee.infrastructure", SimpleNamespace())
     monkeypatch.setitem(sys.modules, "cognee.infrastructure.databases", SimpleNamespace())
     monkeypatch.setitem(
@@ -2564,7 +2555,9 @@ async def test_delete_document_chunks_reports_partial_delete_failure(
         return None
 
     monkeypatch.setenv("VECTOR_DB_PROVIDER", "pgvector")
-    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations))
+    monkeypatch.setitem(
+        sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations)
+    )
     monkeypatch.setitem(sys.modules, "cognee.infrastructure", SimpleNamespace())
     monkeypatch.setitem(sys.modules, "cognee.infrastructure.databases", SimpleNamespace())
     monkeypatch.setitem(
@@ -2606,7 +2599,9 @@ async def test_delete_document_chunks_reports_partial_delete_failure(
     ) -> dict[str, list[dict[str, Any]]]:
         del graph_engine, graph_ids
         return {
-            "nodes": [{"id": graph_id, "name": "chunk", "type": "DocumentChunk", "properties": "{}"}],
+            "nodes": [
+                {"id": graph_id, "name": "chunk", "type": "DocumentChunk", "properties": "{}"}
+            ],
             "edges": [],
         }
 
@@ -2655,7 +2650,9 @@ async def test_restore_document_chunks_uses_private_snapshot_once(monkeypatch: A
         return None
 
     monkeypatch.setenv("VECTOR_DB_PROVIDER", "pgvector")
-    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations))
+    monkeypatch.setitem(
+        sys.modules, "cognee", SimpleNamespace(run_startup_migrations=run_startup_migrations)
+    )
     monkeypatch.setitem(sys.modules, "cognee.infrastructure", SimpleNamespace())
     monkeypatch.setitem(sys.modules, "cognee.infrastructure.databases", SimpleNamespace())
     monkeypatch.setitem(
@@ -2707,9 +2704,12 @@ async def test_restore_document_chunks_uses_private_snapshot_once(monkeypatch: A
     assert result is True
     assert captured["vectors"][0]["payload"]["text"] == "private"
     assert "opaque-token" not in client._repair_snapshots
-    assert await client.restore_document_chunks(
-        {"document_ids": ["doc-a"], "snapshot_token": "opaque-token"}
-    ) is False
+    assert (
+        await client.restore_document_chunks(
+            {"document_ids": ["doc-a"], "snapshot_token": "opaque-token"}
+        )
+        is False
+    )
 
 
 @pytest.mark.asyncio
@@ -2865,12 +2865,8 @@ async def _seed_corpus(user: Any) -> dict[str, Any]:
     other_owner = uuid4()
     other_data_id = uuid4()
 
-    central = Dataset(
-        id=uuid4(), name="masumi-network", owner_id=user.id, tenant_id=user.tenant_id
-    )
-    ghost = Dataset(
-        id=uuid4(), name="seat:ghost", owner_id=other_owner, tenant_id=user.tenant_id
-    )
+    central = Dataset(id=uuid4(), name="masumi-network", owner_id=user.id, tenant_id=user.tenant_id)
+    ghost = Dataset(id=uuid4(), name="seat:ghost", owner_id=other_owner, tenant_id=user.tenant_id)
     engine = get_relational_engine()
     async with engine.get_async_session() as session:
         session.add(central)
@@ -2976,9 +2972,7 @@ async def test_corpus_page_enumerates_the_real_store_with_keyset_pages(
 
 
 @pytest.mark.asyncio
-async def test_corpus_totals_reports_the_owner_split(
-    cognee_sqlite: Any, monkeypatch: Any
-) -> None:
+async def test_corpus_totals_reports_the_owner_split(cognee_sqlite: Any, monkeypatch: Any) -> None:
     """Both counts, so a row under another owner_id shows up as a difference
     instead of silently missing from an owner-scoped number."""
     from cognee.infrastructure.databases.relational import create_db_and_tables
@@ -3036,9 +3030,7 @@ async def test_corpus_health_walks_keyset_pages_and_unions_projection_checks(
         return {"documents": 3}
 
     async def corpus_page(**kwargs: Any) -> list[dict[str, Any]]:
-        page_calls.append(
-            (kwargs["after_created_at"], kwargs["after_id"], kwargs["limit"])
-        )
+        page_calls.append((kwargs["after_created_at"], kwargs["after_id"], kwargs["limit"]))
         return pages[len(page_calls) - 1]
 
     async def corpus_chunk_counts(document_ids: list[str]) -> dict[str, int]:
@@ -3157,7 +3149,9 @@ async def test_standard_cognee_document_graph_contains_relational_data_id() -> N
     nodes, edges = await get_graph_from_model(chunk)
 
     assert str(data_id) in {str(node.id) for node in nodes}
-    assert any(str(source) == str(chunk.id) and str(target) == str(data_id) for source, target, *_ in edges)
+    assert any(
+        str(source) == str(chunk.id) and str(target) == str(data_id) for source, target, *_ in edges
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_cognify_queue.py
+++ b/tests/test_cognify_queue.py
@@ -146,7 +146,9 @@ def test_failure_reschedules_with_bounded_exponential_backoff(tmp_path: Path) ->
 
     second = queue.claim(now=T0 + timedelta(seconds=5))
     assert second is not None
-    failed_again = queue.reschedule(second, error="still unavailable", now=T0 + timedelta(seconds=5))
+    failed_again = queue.reschedule(
+        second, error="still unavailable", now=T0 + timedelta(seconds=5)
+    )
     assert _at(failed_again.available_at) == T0 + timedelta(seconds=15)
 
     third = queue.claim(now=T0 + timedelta(seconds=15))
@@ -186,7 +188,7 @@ def test_expired_lease_can_be_reclaimed(tmp_path: Path) -> None:
 
 def test_malformed_state_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "queue.json"
-    path.write_text("{\"version\": 1,", encoding="utf-8")
+    path.write_text('{"version": 1,', encoding="utf-8")
     queue = CognifyRetryQueue(path)
 
     with pytest.raises(CognifyQueueStateError, match="refusing to treat"):
@@ -200,7 +202,9 @@ def test_malformed_state_fails_closed(tmp_path: Path) -> None:
         {"lease_id": "lease", "leased_until": None, "lease_datasets": None},
     ],
 )
-def test_malformed_record_types_fail_closed(tmp_path: Path, record_update: dict[str, object]) -> None:
+def test_malformed_record_types_fail_closed(
+    tmp_path: Path, record_update: dict[str, object]
+) -> None:
     path = tmp_path / "queue.json"
     timestamp = T0.isoformat().replace("+00:00", "Z")
     record: dict[str, object] = {
@@ -253,7 +257,9 @@ def test_state_with_unknown_content_field_fails_closed(tmp_path: Path) -> None:
         CognifyRetryQueue(path).snapshot()
 
 
-def test_atomic_write_failure_keeps_previous_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_atomic_write_failure_keeps_previous_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = tmp_path / "queue.json"
     queue = CognifyRetryQueue(path)
     queue.enqueue(("central",), now=T0)

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -554,9 +554,7 @@ def test_home_reads_the_readable_corpus_count_not_the_node_only_one() -> None:
     assert "document_count" not in source.replace("readable_document_count", ""), (
         "Home fell back to the Node-only document_count; that number excludes Central"
     )
-    assert "tracked_sources" not in source, (
-        "Home read a source count for a document tile"
-    )
+    assert "tracked_sources" not in source, "Home read a source count for a document tile"
     # Null renders as a dash plus a reason, not as zero.
     assert "return null" in source, "a missing count must be null, never 0"
     assert 'id="homeReadableNote"' in index_html, "no element to render why the count is missing"

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -31,9 +31,7 @@ def test_evolve_scheduler_config_defaults(monkeypatch: Any) -> None:
 # --- scheduler wiring ------------------------------------------------------
 
 
-def _fake_citadel(
-    *, enabled: bool, interval: int = 21600, state_path: str = ""
-) -> SimpleNamespace:
+def _fake_citadel(*, enabled: bool, interval: int = 21600, state_path: str = "") -> SimpleNamespace:
     return SimpleNamespace(
         config=SimpleNamespace(
             evolve_scheduler_enabled=enabled,
@@ -136,7 +134,9 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
     monkeypatch.setattr(server.asyncio, "create_subprocess_exec", forbidden_exec)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
-    task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+    )
     try:
         for _ in range(300):
             if len(cognify_calls) >= 2:
@@ -189,7 +189,9 @@ async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(
     _patch_phase1(monkeypatch, raises=True)
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
-    task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+    )
     try:
         for _ in range(300):
             if len(cognify_calls) >= 2:
@@ -222,7 +224,9 @@ async def test_evolve_scheduler_logs_error_when_stages_exit_nonzero(
     monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
 
     with caplog.at_level(logging.ERROR, logger=server.logger.name):
-        task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
+        task = asyncio.create_task(
+            server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+        )
         try:
             for _ in range(300):
                 if cognify_calls:

--- a/tests/test_get_document_drilldown.py
+++ b/tests/test_get_document_drilldown.py
@@ -50,9 +50,7 @@ CHUNK_IDS = [str(uuid5(NAMESPACE_OID, f"{DOC_ID}-{index}")) for index in range(3
 ENTITY_ID = str(uuid5(NAMESPACE_OID, "drilldown-entity"))
 # In the chunk store but never written to the graph (the measured 404 class).
 ORPHAN_DOC_ID = str(uuid5(NAMESPACE_OID, "orphan-doc"))
-ORPHAN_CHUNK_IDS = [
-    str(uuid5(NAMESPACE_OID, f"{ORPHAN_DOC_ID}-{index}")) for index in range(4)
-]
+ORPHAN_CHUNK_IDS = [str(uuid5(NAMESPACE_OID, f"{ORPHAN_DOC_ID}-{index}")) for index in range(4)]
 FULL_BODY = "part zero\n\npart one\n\npart two"
 
 
@@ -78,9 +76,7 @@ def real_graph(tmp_path_factory: pytest.TempPathFactory) -> Any:
     direction unobservable, so the assembly must not care), and a textless
     Entity reachable from a chunk via ``contains``.
     """
-    ladybug = pytest.importorskip(
-        "cognee.infrastructure.databases.graph.ladybug.adapter"
-    )
+    ladybug = pytest.importorskip("cognee.infrastructure.databases.graph.ladybug.adapter")
     import asyncio
 
     adapter = ladybug.LadybugAdapter(
@@ -199,9 +195,7 @@ class _ChunkStore:
     async def retrieve(self, collection_name: str, data_point_ids: list[Any]) -> list[Any]:
         for row_id in data_point_ids:
             if not isinstance(row_id, str):
-                raise RuntimeError(
-                    "lance error: Invalid user input: Error optimizing sql filter"
-                )
+                raise RuntimeError("lance error: Invalid user input: Error optimizing sql filter")
         self.calls.append((collection_name, list(data_point_ids)))
         if collection_name != "DocumentChunk_text":
             return []
@@ -213,9 +207,7 @@ class _ChunkStore:
         return out
 
 
-def _install_chunk_store(
-    client: CogneePublicClient, store: _ChunkStore
-) -> None:
+def _install_chunk_store(client: CogneePublicClient, store: _ChunkStore) -> None:
     async def _engine() -> _ChunkStore:
         return store
 
@@ -325,9 +317,7 @@ async def test_graph_missing_chunk_id_resolves_from_chunk_store(
     assert document["dataset_node_ids"][0] == ORPHAN_DOC_ID
     assert ORPHAN_CHUNK_IDS[2] in document["dataset_node_ids"]
     # The fallback read the SAME collection search reads.
-    assert store.calls and all(
-        collection == "DocumentChunk_text" for collection, _ in store.calls
-    )
+    assert store.calls and all(collection == "DocumentChunk_text" for collection, _ in store.calls)
 
 
 async def test_graph_missing_document_id_resolves_from_chunk_store(

--- a/tests/test_github_sync_job.py
+++ b/tests/test_github_sync_job.py
@@ -115,12 +115,8 @@ def test_scheduled_sync_redacts_private_metadata_from_default_output(
                         "commit_count": 4,
                         "open_pull_request_count": 1,
                         "merged_pull_request_count": 1,
-                        "changed_repositories": [
-                            {"full_name": "private-org/private-repo"}
-                        ],
-                        "recent_commits": [
-                            {"message": "private customer incident details"}
-                        ],
+                        "changed_repositories": [{"full_name": "private-org/private-repo"}],
+                        "recent_commits": [{"message": "private customer incident details"}],
                         "digest": "private repo digest body",
                     }
                 },
@@ -181,15 +177,10 @@ def test_gateway_delivery_summary_prefers_generic_gateways() -> None:
 
 def test_gateway_delivery_summary_falls_back_to_google_chat() -> None:
     result = {
-        "notifications": {
-            "google_chat": {"sent": False, "status_category": "delivery_error"}
-        }
+        "notifications": {"google_chat": {"sent": False, "status_category": "delivery_error"}}
     }
 
-    assert (
-        run_github_sync._gateway_delivery_summary(result)
-        == "google_chat:delivery_error"
-    )
+    assert run_github_sync._gateway_delivery_summary(result) == "google_chat:delivery_error"
 
 
 def test_post_json_converts_read_timeout_to_clean_result(monkeypatch: Any) -> None:

--- a/tests/test_gitleaks_config.py
+++ b/tests/test_gitleaks_config.py
@@ -109,9 +109,7 @@ def test_target_rules_reference_rules_that_exist(config: dict[str, Any]) -> None
     known = local | KNOWN_BUILTIN_RULES
     unknown: dict[int, list[str]] = {}
     for index, block in enumerate(_allowlists(config)):
-        missing = [
-            name for name in (block.get("targetRules") or ()) if str(name) not in known
-        ]
+        missing = [name for name in (block.get("targetRules") or ()) if str(name) not in known]
         if missing:
             unknown[index] = missing
     assert not unknown, (
@@ -122,7 +120,5 @@ def test_target_rules_reference_rules_that_exist(config: dict[str, Any]) -> None
 
 def test_every_rule_has_an_id(config: dict[str, Any]) -> None:
     """``targetRules`` addresses rules by id, so a rule without one cannot be scoped."""
-    missing = [
-        index for index, rule in enumerate(config.get("rules") or ()) if not rule.get("id")
-    ]
+    missing = [index for index, rule in enumerate(config.get("rules") or ()) if not rule.get("id")]
     assert not missing, f"rule(s) {missing} have no id, so no allowlist can target them"

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -24,10 +24,15 @@ def test_setup_json_emits_pure_config(tmp_path: Path, capsys) -> None:
     cfg = tmp_path / "cap.json"
     rc = _run(
         [
-            "setup", "--non-interactive", "--json",
-            "--node-url", "https://node.example",
-            "--root", f"{tmp_path}=org-work",
-            "--config", str(cfg),
+            "setup",
+            "--non-interactive",
+            "--json",
+            "--node-url",
+            "https://node.example",
+            "--root",
+            f"{tmp_path}=org-work",
+            "--config",
+            str(cfg),
         ]
     )
     assert rc == 0
@@ -44,12 +49,12 @@ def test_bare_citadel_shows_home_screen(monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     # Strip ANSI so colored Pixel Bastion / labels still match.
     plain = re.sub(r"\x1b\[[0-9;]*m", "", out)
-    assert "the organization vault" in plain         # tagline beside the mark
-    assert "██" in plain                              # Pixel Bastion mark
-    assert "CITADEL" in plain                         # wordmark label beside mark
-    assert "____" not in plain                        # no figlet hero on home
-    assert "onboard" in plain and "status" in plain     # curated command menu
-    assert "Get started" in plain                     # grouped menu
+    assert "the organization vault" in plain  # tagline beside the mark
+    assert "██" in plain  # Pixel Bastion mark
+    assert "CITADEL" in plain  # wordmark label beside mark
+    assert "____" not in plain  # no figlet hero on home
+    assert "onboard" in plain and "status" in plain  # curated command menu
+    assert "Get started" in plain  # grouped menu
 
 
 def test_unknown_command_suggests_closest(capsys) -> None:
@@ -201,7 +206,17 @@ def test_setup_json_never_prompts_even_on_tty(tmp_path: Path, monkeypatch, capsy
 def test_capture_json_dry_run_is_clean(tmp_path: Path, capsys) -> None:
     cfg = tmp_path / "cap.json"
     (tmp_path / "README.md").write_text("a summary line\n")
-    _run(["setup", "--non-interactive", "--json", "--root", f"{tmp_path}=personal", "--config", str(cfg)])
+    _run(
+        [
+            "setup",
+            "--non-interactive",
+            "--json",
+            "--root",
+            f"{tmp_path}=personal",
+            "--config",
+            str(cfg),
+        ]
+    )
     capsys.readouterr()
 
     rc = _run(["capture", "--dry-run", "--json", "--config", str(cfg)])
@@ -213,8 +228,19 @@ def test_capture_json_dry_run_is_clean(tmp_path: Path, capsys) -> None:
 
 def test_capture_json_real_post_shape(tmp_path: Path, monkeypatch, capsys) -> None:
     cfg = tmp_path / "cap.json"
-    _run(["setup", "--non-interactive", "--json", "--node-url", "https://node.example",
-          "--root", f"{tmp_path}=personal", "--config", str(cfg)])
+    _run(
+        [
+            "setup",
+            "--non-interactive",
+            "--json",
+            "--node-url",
+            "https://node.example",
+            "--root",
+            f"{tmp_path}=personal",
+            "--config",
+            str(cfg),
+        ]
+    )
     capsys.readouterr()
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_headless_token")
     monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: {"status": "ok"})
@@ -235,9 +261,13 @@ def test_onboard_json_no_prompts(tmp_path: Path, monkeypatch, capsys) -> None:
 
     rc = _run(
         [
-            "onboard", "--non-interactive", "--json",
-            "--repo", str(repo),
-            "--shell-rc", str(tmp_path / ".zshrc"),
+            "onboard",
+            "--non-interactive",
+            "--json",
+            "--repo",
+            str(repo),
+            "--shell-rc",
+            str(tmp_path / ".zshrc"),
             "--no-capture",
         ]
     )

--- a/tests/test_knowledge_mesh.py
+++ b/tests/test_knowledge_mesh.py
@@ -78,9 +78,7 @@ async def test_graph_caps_nodes_and_drops_edges_outside_the_cap() -> None:
     graph = await mesh.graph(limit=2)
 
     assert [node["id"] for node in graph["nodes"]] == ["node-1", "node-2"]
-    assert graph["edges"] == [
-        {"source": "node-1", "target": "node-2", "relationship": "uses"}
-    ]
+    assert graph["edges"] == [{"source": "node-1", "target": "node-2", "relationship": "uses"}]
     assert graph["truncated"] is True
     assert graph["total_nodes"] == 3
 
@@ -124,9 +122,7 @@ def test_build_graph_payload_skips_malformed_rows() -> None:
     )
 
     assert [node["id"] for node in payload["nodes"]] == ["ok-node", "dupe"]
-    assert payload["edges"] == [
-        {"source": "ok-node", "target": "dupe", "relationship": "links"}
-    ]
+    assert payload["edges"] == [{"source": "ok-node", "target": "dupe", "relationship": "links"}]
 
 
 def test_fallback_graph_shape() -> None:
@@ -307,9 +303,7 @@ def test_dataset_hub_survives_node_cap_without_edges_to_dropped_nodes() -> None:
             "relationship": "belongs_to",
         }
     ]
-    assert all(
-        "chunk-1" not in (edge["source"], edge["target"]) for edge in payload["edges"]
-    )
+    assert all("chunk-1" not in (edge["source"], edge["target"]) for edge in payload["edges"])
     assert payload["truncated"] is True
     assert payload["total_nodes"] == 2
 
@@ -336,9 +330,7 @@ def test_two_datasets_on_one_document_yield_two_hubs_and_edges() -> None:
 
 async def test_graph_attributes_datasets_through_gateway() -> None:
     mesh = KnowledgeMesh(
-        FakeDatasetGateway(
-            DOC_NODES, DOC_EDGES, dataset_map={"doc-1": ["seat:alice"]}
-        )
+        FakeDatasetGateway(DOC_NODES, DOC_EDGES, dataset_map={"doc-1": ["seat:alice"]})
     )
 
     graph = await mesh.graph()
@@ -395,7 +387,14 @@ def test_internal_document_name_replaced_by_lowest_chunk_index_text() -> None:
     nodes = [
         ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
         ("chunk-b", {"text": "second chunk body", "chunk_index": 1, "type": "DocumentChunk"}),
-        ("chunk-a", {"text": "# Release checklist\nrest of the body", "chunk_index": 0, "type": "DocumentChunk"}),
+        (
+            "chunk-a",
+            {
+                "text": "# Release checklist\nrest of the body",
+                "chunk_index": 0,
+                "type": "DocumentChunk",
+            },
+        ),
     ]
     # Edge order and direction must not matter: chunk_index 0 always wins.
     for edges in (
@@ -584,9 +583,7 @@ async def test_is_a_edge_to_plain_entity_never_leaks_hidden_only_entity_name() -
     # so a hidden-only plain Entity stays hidden even across an is_a edge
     # to a visible ring-1 entity (in either direction).
     for source, target in (("ent-isa-leak", "ent-shared"), ("ent-shared", "ent-isa-leak")):
-        nodes = ISOLATION_NODES + [
-            ("ent-isa-leak", {"name": "SecretKuzuFork", "type": "Entity"})
-        ]
+        nodes = ISOLATION_NODES + [("ent-isa-leak", {"name": "SecretKuzuFork", "type": "Entity"})]
         edges = ISOLATION_EDGES + [
             ("chunk-hidden", "ent-isa-leak", "contains", {}),
             (source, target, "is_a", {}),
@@ -624,15 +621,11 @@ async def test_visible_nodes_field_reports_caller_scope() -> None:
 async def test_graph_without_dataset_visible_matches_unfiltered_payload() -> None:
     # None = bypass/admin callers: byte-identical to the unfiltered shaping,
     # no visible_nodes field, hidden content fully present.
-    gateway = FakeDatasetGateway(
-        ISOLATION_NODES, ISOLATION_EDGES, dataset_map=ISOLATION_MAP
-    )
+    gateway = FakeDatasetGateway(ISOLATION_NODES, ISOLATION_EDGES, dataset_map=ISOLATION_MAP)
 
     graph = await KnowledgeMesh(gateway).graph()
 
-    expected = build_graph_payload(
-        ISOLATION_NODES, ISOLATION_EDGES, dataset_map=ISOLATION_MAP
-    )
+    expected = build_graph_payload(ISOLATION_NODES, ISOLATION_EDGES, dataset_map=ISOLATION_MAP)
     assert graph == {"ok": True, "fallback": False, **expected}
     assert "visible_nodes" not in graph
     assert any(node["id"] == "doc-hidden" for node in graph["nodes"])
@@ -642,9 +635,7 @@ async def test_scoped_caller_sees_no_content_when_dataset_map_read_fails() -> No
     # Fail-closed: without attribution nothing is provably visible, so a
     # scoped caller gets an empty content set instead of the whole org graph.
     mesh = KnowledgeMesh(
-        FakeDatasetGateway(
-            ISOLATION_NODES, ISOLATION_EDGES, map_error=RuntimeError("db offline")
-        )
+        FakeDatasetGateway(ISOLATION_NODES, ISOLATION_EDGES, map_error=RuntimeError("db offline"))
     )
 
     graph = await mesh.graph(dataset_visible=lambda name: True)
@@ -682,9 +673,7 @@ async def test_presence_hubs_appear_even_when_caller_sees_none_of_the_content() 
     assert hubs["dataset:seat:empty"]["presence"] == {"documents": 0}
     assert hubs["dataset:masumi-network"]["presence"] == {"documents": 1}
     # Every seat hub anchors to the Central hub so it never floats.
-    presence_edges = [
-        edge for edge in graph["edges"] if edge["relationship"] == "presence"
-    ]
+    presence_edges = [edge for edge in graph["edges"] if edge["relationship"] == "presence"]
     assert {
         "source": "dataset:seat:alice",
         "target": "dataset:masumi-network",
@@ -760,9 +749,7 @@ async def test_fallback_payloads_still_carry_presence_hubs() -> None:
 async def test_graph_empty_fallback_counts_presence_from_available_map() -> None:
     # graph_empty is the one fallback where the dataset map CAN be read:
     # presence counts come from the map instead of degrading to 0.
-    mesh = KnowledgeMesh(
-        FakeDatasetGateway([], [], dataset_map={"doc-1": ["seat:alice"]})
-    )
+    mesh = KnowledgeMesh(FakeDatasetGateway([], [], dataset_map={"doc-1": ["seat:alice"]}))
 
     graph = await mesh.graph(presence=PRESENCE)
 
@@ -885,9 +872,7 @@ def test_internal_document_labeled_by_nodeset_membership() -> None:
         ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
         ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
     ]
-    payload = build_graph_payload(
-        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10
-    )
+    payload = build_graph_payload(nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10)
 
     doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
     assert doc["label"] == "user_sessions_from_cache"
@@ -923,9 +908,7 @@ def test_collapse_orphans_folds_internal_documents_into_nodeset() -> None:
         ("doc-1", "set-1", "belongs_to_set", {}),
         ("doc-2", "set-1", "belongs_to_set", {}),
     ]
-    payload = build_graph_payload(
-        nodes, edges, limit=10, collapse_orphan_documents=True
-    )
+    payload = build_graph_payload(nodes, edges, limit=10, collapse_orphan_documents=True)
 
     ids = {node["id"] for node in payload["nodes"]}
     assert ids == {"set-1"}
@@ -940,9 +923,7 @@ def test_orphans_are_not_collapsed_without_opt_in() -> None:
         ("doc-1", {"name": INTERNAL_DOC_NAME, "type": "TextDocument"}),
         ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
     ]
-    payload = build_graph_payload(
-        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10
-    )
+    payload = build_graph_payload(nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10)
 
     ids = {node["id"] for node in payload["nodes"]}
     assert ids == {"doc-1", "set-1"}
@@ -952,7 +933,13 @@ def test_orphans_are_not_collapsed_without_opt_in() -> None:
 
 def test_summary_boilerplate_lead_in_is_stripped_from_labels() -> None:
     nodes = [
-        ("sum-1", {"text": "This chunk is about a repository of question-answer pairs", "type": "TextSummary"}),
+        (
+            "sum-1",
+            {
+                "text": "This chunk is about a repository of question-answer pairs",
+                "type": "TextSummary",
+            },
+        ),
         ("sum-2", {"name": "This document describes the release checklist", "type": "TextSummary"}),
         ("sum-3", {"text": "This input is a list of 40 empty questions", "type": "TextSummary"}),
     ]
@@ -988,7 +975,9 @@ def test_named_document_is_never_collapsed() -> None:
         ("set-1", {"name": "user_sessions_from_cache", "type": "NodeSet"}),
     ]
     payload = build_graph_payload(
-        nodes, [("doc-1", "set-1", "belongs_to_set", {})], limit=10,
+        nodes,
+        [("doc-1", "set-1", "belongs_to_set", {})],
+        limit=10,
         collapse_orphan_documents=True,
     )
 

--- a/tests/test_learning_agent.py
+++ b/tests/test_learning_agent.py
@@ -23,9 +23,7 @@ def github_run_result(**overrides: Any) -> dict[str, Any]:
         "commit_count": 1,
         "open_pull_request_count": 1,
         "merged_pull_request_count": 0,
-        "changed_repositories": [
-            {"name": "agent", "full_name": "masumi-network/agent"}
-        ],
+        "changed_repositories": [{"name": "agent", "full_name": "masumi-network/agent"}],
         "recent_commits": [
             {"repo": "masumi-network/agent", "sha": "abc123def456", "message": "add retry"}
         ],
@@ -225,7 +223,9 @@ async def test_repo_content_sync_failure_propagates() -> None:
 
 
 async def test_vault_search_failure_degrades_to_empty_context() -> None:
-    learning_agent, _, _, _, _ = agent(citadel=FakeCitadel(search_error=RuntimeError("cognee down")))
+    learning_agent, _, _, _, _ = agent(
+        citadel=FakeCitadel(search_error=RuntimeError("cognee down"))
+    )
 
     result = await learning_agent.run()
 

--- a/tests/test_linear_sync.py
+++ b/tests/test_linear_sync.py
@@ -188,7 +188,9 @@ async def test_linear_sync_writes_each_issue_to_central(
     citadel = Citadel(config)
     ingests: list[dict[str, Any]] = []
 
-    async def fake_learn(self: Any, data: str, *, dataset: str | None = None, tags: list[str] | None = None, **_: Any) -> Any:
+    async def fake_learn(
+        self: Any, data: str, *, dataset: str | None = None, tags: list[str] | None = None, **_: Any
+    ) -> Any:
         ingests.append({"dataset": dataset, "tags": tags or [], "data": data})
 
         class Outcome:
@@ -247,7 +249,9 @@ async def test_linear_sync_auto_maps_assignee_by_member_email(
             "assignee": {"id": "linear-user-john", "name": "John", "email": None},  # no email
         }
     ]
-    members = [{"id": "linear-user-john", "name": "John Doe", "email": "john@example.com", "active": True}]
+    members = [
+        {"id": "linear-user-john", "name": "John Doe", "email": "john@example.com", "active": True}
+    ]
 
     async def fake_learn(self: Any, data: str, **_: Any) -> Any:
         class Outcome:
@@ -654,9 +658,7 @@ def _incremental_syncer(
     store: AccessStore | None = None
     if with_seat:
         store = AccessStore(config.access_store_path)
-        store.create_seat(
-            name="John Doe", slug="john", email="john@example.com", issue_token=False
-        )
+        store.create_seat(name="John Doe", slug="john", email="john@example.com", issue_token=False)
     ingests: list[dict[str, Any]] = []
     _capture_learn(monkeypatch, ingests)
     scheduled: list[list[str]] = []
@@ -665,9 +667,7 @@ def _incremental_syncer(
         "schedule_cognify",
         lambda datasets: scheduled.append(list(datasets)) or True,
     )
-    syncer = LinearSyncer(
-        citadel, client=FakeLinearClient(sample_issues), access_store=store
-    )
+    syncer = LinearSyncer(citadel, client=FakeLinearClient(sample_issues), access_store=store)
     return syncer, ingests, scheduled
 
 

--- a/tests/test_llm_enrichment.py
+++ b/tests/test_llm_enrichment.py
@@ -98,9 +98,7 @@ def test_malformed_llm_output_falls_back_deterministically(
 ) -> None:
     enable_enrichment(monkeypatch)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    monkeypatch.setattr(
-        llm_enrichment, "openrouter_chat", lambda *a, **k: "definitely { not json"
-    )
+    monkeypatch.setattr(llm_enrichment, "openrouter_chat", lambda *a, **k: "definitely { not json")
 
     outcome = enrich_source_material(LONG_MATERIAL)
 
@@ -163,9 +161,7 @@ def test_security_flagged_material_is_never_sent_to_the_llm(
         raise AssertionError("flagged content must never reach the LLM")
 
     monkeypatch.setattr(llm_enrichment, "openrouter_chat", explode)
-    flagged = (
-        "Deploy notes\n\nghp_0123456789abcdefghijklmnopqrstuvwxyz123456\n\nMore text"
-    )
+    flagged = "Deploy notes\n\nghp_0123456789abcdefghijklmnopqrstuvwxyz123456\n\nMore text"
 
     outcome = enrich_source_material(flagged)
 
@@ -246,9 +242,7 @@ async def test_learning_process_ingests_enriched_chunks_with_merged_tags(
         "chunks": 2,
         "model": "deepseek/deepseek-v4-flash",
     }
-    enrichment_events = [
-        event for event in snapshot["events"] if event["type"] == "enrichment"
-    ]
+    enrichment_events = [event for event in snapshot["events"] if event["type"] == "enrichment"]
     assert enrichment_events[0]["details"]["used_llm"] is True
     assert enrichment_events[0]["details"]["chunks"] == 2
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -94,21 +94,14 @@ def test_configure_cognee_logging_scopes_threshold_to_named_loggers(
     monkeypatch.delenv("CITADEL_COGNEE_LOG_LEVEL", raising=False)
     configure_cognee_logging()
 
-    assert all(
-        logger.level == logging.WARNING
-        for logger in restore_cognee_loggers.values()
-    )
+    assert all(logger.level == logging.WARNING for logger in restore_cognee_loggers.values())
 
 
-def test_configure_cognee_logging_allows_explicit_diagnostics(
-    restore_cognee_loggers, monkeypatch
-):
+def test_configure_cognee_logging_allows_explicit_diagnostics(restore_cognee_loggers, monkeypatch):
     monkeypatch.delenv("CITADEL_COGNEE_LOG_LEVEL", raising=False)
     configure_cognee_logging("debug")
 
-    assert all(
-        logger.level == logging.DEBUG for logger in restore_cognee_loggers.values()
-    )
+    assert all(logger.level == logging.DEBUG for logger in restore_cognee_loggers.values())
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -143,9 +143,7 @@ def test_tools_list_session_resolved_in_process_not_via_self_call(
     # ...but a clean MISS is the store answering "this token does not exist",
     # and must be distinguishable from the transient case (#171).
     monkeypatch.setattr(server_mod, "access_key_identity", lambda token: None)
-    assert isinstance(
-        mcp_server._session_from_token_inprocess("ctdl_x"), mcp_server._UnknownToken
-    )
+    assert isinstance(mcp_server._session_from_token_inprocess("ctdl_x"), mcp_server._UnknownToken)
 
 
 def test_streamable_http_uses_json_response_not_sse() -> None:
@@ -189,7 +187,9 @@ def test_streamable_http_uses_json_response_not_sse() -> None:
                 if sid:
                     headers = {**headers, "mcp-session-id": sid}
                 await client.post(
-                    "/", headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+                    "/",
+                    headers=headers,
+                    json={"jsonrpc": "2.0", "method": "notifications/initialized"},
                 )
                 resp = await client.post(
                     "/",
@@ -282,9 +282,7 @@ def test_discovery_resource_reads_public_manifest_only() -> None:
         "path": "/.well-known/citadel.json",
         "public": True,
     }
-    assert client.public_gets == [
-        {"path": "/.well-known/citadel.json", "extra_headers": {}}
-    ]
+    assert client.public_gets == [{"path": "/.well-known/citadel.json", "extra_headers": {}}]
     assert client.gets == []
 
 
@@ -395,9 +393,7 @@ def test_authed_resource_uses_caller_token_on_hosted_transport(
 
     fake_ctx = SimpleNamespace(
         request_context=SimpleNamespace(
-            request=SimpleNamespace(
-                headers={"authorization": "Bearer ctdl_resourcetoken"}
-            )
+            request=SimpleNamespace(headers={"authorization": "Bearer ctdl_resourcetoken"})
         )
     )
     monkeypatch.setattr(server, "get_context", lambda: fake_ctx)
@@ -1097,9 +1093,7 @@ def test_hosted_transport_tools_list_filters_through_real_resolution(
     # kb.server registers at import so this exercises the real wiring.
     server_mod.set_tools_list_session_resolver(server_mod._mcp_tools_list_session)
 
-    async def list_tool_names(
-        client: httpx.AsyncClient, authorization: str | None
-    ) -> set[str]:
+    async def list_tool_names(client: httpx.AsyncClient, authorization: str | None) -> set[str]:
         headers = {
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
@@ -1225,9 +1219,7 @@ def test_http_errors_are_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
             403,
             "Forbidden",
             {},
-            BytesIO(
-                b'{"detail":"bearer ctdl_secret_token token: ctdl_other api_key=sk-test"}'
-            ),
+            BytesIO(b'{"detail":"bearer ctdl_secret_token token: ctdl_other api_key=sk-test"}'),
         )
 
     monkeypatch.setattr(mcp_server, "urlopen", fake_urlopen)
@@ -1261,9 +1253,7 @@ def test_contribute_tool_posts_through_the_contribute_endpoint() -> None:
     assert result["tool_name"] == "citadel_contribute"
     assert result["payload"]["title"] == "Decision: adopt deepseek"
     assert result["payload"]["tags"] == ["decision"]
-    assert result["payload"]["source_url"] == (
-        "https://github.com/masumi-network/Citadel-Archive"
-    )
+    assert result["payload"]["source_url"] == ("https://github.com/masumi-network/Citadel-Archive")
 
 
 def test_list_sources_includes_repo_content_sync() -> None:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -16,7 +16,9 @@ async def test_record_ingest_adds_document_node_and_event() -> None:
     mesh = MeshState()
     result = IngestResult(True, "accepted", "notes", ("ops",))
 
-    await mesh.record_ingest(CONFIG, result, data="Runbook: rotate keys", dataset="notes", tags=["ops"])
+    await mesh.record_ingest(
+        CONFIG, result, data="Runbook: rotate keys", dataset="notes", tags=["ops"]
+    )
     snapshot = await mesh.snapshot(CONFIG)
 
     assert snapshot["stats"]["tracked_sources"] == 1
@@ -161,11 +163,7 @@ async def test_snapshot_always_includes_central_dataset_node() -> None:
 
     snapshot = await mesh.snapshot(config)
 
-    dataset_labels = {
-        node["label"]
-        for node in snapshot["nodes"]
-        if node["type"] == "dataset"
-    }
+    dataset_labels = {node["label"] for node in snapshot["nodes"] if node["type"] == "dataset"}
     assert dataset_labels == {"seat:alice", "masumi-network"}
     central_id = next(
         node["id"]

--- a/tests/test_next_auth_flow.py
+++ b/tests/test_next_auth_flow.py
@@ -13,11 +13,7 @@ def _client() -> TestClient:
 
 def test_next_login_routes_readers_to_next_and_privileged_roles_to_legacy_app() -> None:
     source = (
-        Path(server_module.__file__).resolve().parent.parent
-        / "web"
-        / "src"
-        / "pages"
-        / "login.tsx"
+        Path(server_module.__file__).resolve().parent.parent / "web" / "src" / "pages" / "login.tsx"
     ).read_text(encoding="utf-8")
 
     assert 'session.role === "reader" ? "/next/app" : "/app"' in source

--- a/tests/test_next_preview.py
+++ b/tests/test_next_preview.py
@@ -69,9 +69,7 @@ def test_every_preview_route_is_served_under_the_strict_policy() -> None:
     # No preview path is in the one opt-in list that can relax the policy, and
     # none may join it. The list is empty today; while / held the opt-in, this
     # is exactly where it would have been copied across by reflex.
-    assert not any(
-        path.startswith("/next") for path in server_module.CSP_INLINE_STYLE_PATHS
-    )
+    assert not any(path.startswith("/next") for path in server_module.CSP_INLINE_STYLE_PATHS)
 
 
 def test_the_preview_route_set_is_closed() -> None:
@@ -201,12 +199,27 @@ def test_dashboard_views_are_role_gated_at_the_route() -> None:
     the server.
     """
     expected = {
-        "test-reader": {"/next/app": 200, "/next/app/search": 200, "/next/app/sources": 200, "/next/app/review": 403,
-                        "/next/app/admin": 403},
-        "test-writer": {"/next/app": 200, "/next/app/search": 200, "/next/app/sources": 200, "/next/app/review": 200,
-                        "/next/app/admin": 403},
-        "test-admin": {"/next/app": 200, "/next/app/search": 200, "/next/app/sources": 200, "/next/app/review": 200,
-                       "/next/app/admin": 200},
+        "test-reader": {
+            "/next/app": 200,
+            "/next/app/search": 200,
+            "/next/app/sources": 200,
+            "/next/app/review": 403,
+            "/next/app/admin": 403,
+        },
+        "test-writer": {
+            "/next/app": 200,
+            "/next/app/search": 200,
+            "/next/app/sources": 200,
+            "/next/app/review": 200,
+            "/next/app/admin": 403,
+        },
+        "test-admin": {
+            "/next/app": 200,
+            "/next/app/search": 200,
+            "/next/app/sources": 200,
+            "/next/app/review": 200,
+            "/next/app/admin": 200,
+        },
     }
 
     for access_key, paths in expected.items():
@@ -261,9 +274,7 @@ def test_graph_view_is_a_real_next_dashboard_route() -> None:
 
     compiled = "\n".join(
         path.read_text(encoding="utf-8")
-        for path in (server_module.WEBUI_DIR / "_next/static/chunks/pages/app").glob(
-            "graph-*.js"
-        )
+        for path in (server_module.WEBUI_DIR / "_next/static/chunks/pages/app").glob("graph-*.js")
     )
     assert "visible_nodes" in compiled
     assert "Presence-only view. No content nodes are visible for this scope." in compiled

--- a/tests/test_next_search_filters.py
+++ b/tests/test_next_search_filters.py
@@ -52,9 +52,9 @@ def test_search_request_contains_only_supported_filter_fields() -> None:
     builder = _block(SEARCH, "function buildSearchRequest", "const SECTION_ORDER")
     assert "if (dataset) request.dataset = dataset;" in builder
     assert 'if (source !== "all") request.source = source;' in builder
-    assert 'scope:' not in builder
-    assert 'source_type' not in builder
-    assert 'filters:' not in builder
+    assert "scope:" not in builder
+    assert "source_type" not in builder
+    assert "filters:" not in builder
     assert "buildSearchRequest(query, selectedDataset, source)" in SEARCH
 
 
@@ -63,7 +63,7 @@ def test_filter_controls_preserve_query_url_and_static_csp_navigation() -> None:
     assert 'name="q"' in SEARCH
     assert 'new URLSearchParams(window.location.search).get("q")' in SEARCH
     assert 'type="button"' in SEARCH
-    assert 'aria-pressed=' in SEARCH
+    assert "aria-pressed=" in SEARCH
     assert 'label: "Everything"' in SEARCH
     assert 'label: "Central only"' in SEARCH
     assert 'label: "My Node only"' in SEARCH

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -90,7 +90,7 @@ def test_ensure_token_shell_quote_safe(tmp_path: Path) -> None:
     nasty = "ctdl_a'b$(whoami)`id`"  # quotes + shell metachars
     ensure_token_in_rc(rc, nasty)
     out = subprocess.run(
-        ["sh", "-c", f". {rc} >/dev/null 2>&1; printf %s \"$CITADEL_MCP_ACCESS_TOKEN\""],
+        ["sh", "-c", f'. {rc} >/dev/null 2>&1; printf %s "$CITADEL_MCP_ACCESS_TOKEN"'],
         capture_output=True,
         text=True,
     )
@@ -177,11 +177,7 @@ def test_merge_claude_settings_adds_then_idempotent(tmp_path: Path) -> None:
     assert merge_claude_settings(path, python="/usr/bin/python3") == "added"
     data = json.loads(path.read_text())
     assert "PreToolUse" in data["hooks"]  # preserved
-    cmds = [
-        h["command"]
-        for g in data["hooks"]["SessionEnd"]
-        for h in g["hooks"]
-    ]
+    cmds = [h["command"] for g in data["hooks"]["SessionEnd"] for h in g["hooks"]]
     assert any("kb.hooks.sync_session" in c for c in cmds)
     assert TOKEN_ENV in data["httpHookAllowedEnvVars"]
     start_groups = data["hooks"]["SessionStart"]
@@ -229,6 +225,7 @@ def test_agent_policy_section_matches_session_start() -> None:
     assert "skills/masumi" in section
     assert "no authoritative hit" in section
     assert "Citadel confirms" in section
+
 
 def test_cursor_agent_policy_rule_matches_session_start() -> None:
     text = cursor_agent_policy_rule_text()
@@ -430,8 +427,7 @@ def test_read_token_from_rc_quoted_value_with_trailing_comment(tmp_path: Path) -
 def test_read_token_from_rc_last_export_wins_like_the_shell(tmp_path: Path) -> None:
     rc = tmp_path / ".zshrc"
     rc.write_text(
-        f"export {TOKEN_ENV}='ctdl_first_1234567890'\n"
-        f"export {TOKEN_ENV}=ctdl_last_0987654321\n"
+        f"export {TOKEN_ENV}='ctdl_first_1234567890'\nexport {TOKEN_ENV}=ctdl_last_0987654321\n"
     )
     assert read_token_from_rc(rc) == "ctdl_last_0987654321"
 
@@ -442,10 +438,7 @@ def test_ensure_env_in_rc_rewrites_last_duplicate(tmp_path: Path) -> None:
     from kb.onboard import ensure_env_in_rc
 
     rc = tmp_path / ".zshrc"
-    rc.write_text(
-        f"export {TOKEN_ENV}='ctdl_old_a'\n"
-        f"export {TOKEN_ENV}='ctdl_old_b'\n"
-    )
+    rc.write_text(f"export {TOKEN_ENV}='ctdl_old_a'\nexport {TOKEN_ENV}='ctdl_old_b'\n")
     assert ensure_env_in_rc(rc, TOKEN_ENV, "ctdl_new_c", comment="x") == "updated"
     lines = rc.read_text().splitlines()
     assert lines[0] == f"export {TOKEN_ENV}='ctdl_old_a'"  # untouched (shadowed anyway)
@@ -468,12 +461,20 @@ def _interactive_onboard_args(tmp_path: Path) -> argparse.Namespace:
 
 def _auth_ok() -> Check:
     return Check(
-        "auth", ok=True, detail="valid",
-        data={"seat_slug": "sarthi", "role": "writer", "capabilities": {"read": True, "write": True}},
+        "auth",
+        ok=True,
+        detail="valid",
+        data={
+            "seat_slug": "sarthi",
+            "role": "writer",
+            "capabilities": {"read": True, "write": True},
+        },
     )
 
 
-def test_onboard_offers_keep_or_replace_for_configured_token(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_onboard_offers_keep_or_replace_for_configured_token(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
     # Token already wired in the rc (fresh shell: env unset) → onboard must show
     # it masked and let the user swap in a new one instead of silently reusing it.
     monkeypatch.delenv(TOKEN_ENV, raising=False)
@@ -534,7 +535,9 @@ def test_onboard_rc_token_wins_over_stale_env(tmp_path: Path, monkeypatch, capsy
     assert "ctdl_rotated_rc_4321" in body and "ctdl_stale_env_67890" not in body
 
 
-def test_onboard_rejected_token_offers_immediate_replacement(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_onboard_rejected_token_offers_immediate_replacement(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
     # A 401 must surface before the other prompts, with an inline re-paste —
     # not "saved anyway" at the very end of the run.
     monkeypatch.setenv(TOKEN_ENV, "ctdl_stale_234567890")
@@ -545,10 +548,12 @@ def test_onboard_rejected_token_offers_immediate_replacement(tmp_path: Path, mon
     monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
     pastes = iter(["ctdl_fresh_bcdef12345", ""])  # replacement token, skip OpenRouter key
     monkeypatch.setattr("kb.cli.getpass.getpass", lambda prompt="": next(pastes))
-    verdicts = iter([
-        Check("auth", ok=False, detail="HTTP Error 401: Unauthorized"),
-        _auth_ok(),
-    ])
+    verdicts = iter(
+        [
+            Check("auth", ok=False, detail="HTTP Error 401: Unauthorized"),
+            _auth_ok(),
+        ]
+    )
     monkeypatch.setattr("kb.status.check_auth", lambda *a, **k: next(verdicts))
 
     assert asyncio.run(_onboard(args)) == 0

--- a/tests/test_organization_digest.py
+++ b/tests/test_organization_digest.py
@@ -543,8 +543,7 @@ def test_llm_agent_read_logs_model_and_response_body_on_http_400(
     assert "HTTP 400" in caplog.text
     # Resolved and configured ids are both recorded, distinguishably.
     assert (
-        "for model deepseek/deepseek-v4-flash "
-        "(configured openrouter/deepseek/deepseek-v4-flash)"
+        "for model deepseek/deepseek-v4-flash (configured openrouter/deepseek/deepseek-v4-flash)"
     ) in caplog.text
     # The response body reaches the log, so the next occurrence is diagnosable.
     assert "is not a valid model ID" in caplog.text

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -25,7 +25,9 @@ SECRET_TEXT = "deploy creds " + "AKIA" + "ABCDEFGHIJKLMNOP" + " rotate me"
 
 
 class FakeCitadel:
-    def __init__(self, config: CitadelConfig, nodes: list[str], *, central_hits: bool = False) -> None:
+    def __init__(
+        self, config: CitadelConfig, nodes: list[str], *, central_hits: bool = False
+    ) -> None:
         self.config = config
         self._nodes = nodes
         self.central_hits = central_hits
@@ -101,10 +103,7 @@ def _engine(
 
 
 def _org_note(extra: str = "roadmap") -> str:
-    return (
-        f"Org note about the product {extra} — "
-        "https://github.com/masumi-network/Citadel-Archive"
-    )
+    return f"Org note about the product {extra} — https://github.com/masumi-network/Citadel-Archive"
 
 
 def _github_state(tmp_path: Path) -> CitadelConfig:
@@ -116,24 +115,46 @@ def _github_state(tmp_path: Path) -> CitadelConfig:
     return _config(github_sync_state_path=str(state_path))
 
 
-def _stub_llm(monkeypatch: pytest.MonkeyPatch, *, relevant: bool = True, sensitive: bool = False, score: float = 0.9, fail: bool = False) -> None:
+def _stub_llm(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    relevant: bool = True,
+    sensitive: bool = False,
+    score: float = 0.9,
+    fail: bool = False,
+) -> None:
     def fake_chat(*args: Any, **kwargs: Any) -> str | None:
         if fail:
             return None
-        return json.dumps({"relevant": relevant, "sensitive": sensitive, "score": score, "reason": "stubbed"})
+        return json.dumps(
+            {"relevant": relevant, "sensitive": sensitive, "score": score, "reason": "stubbed"}
+        )
 
     monkeypatch.setattr(promotion, "openrouter_chat", fake_chat)
 
 
 def test_coerce_classification_rejects_malformed() -> None:
-    assert _coerce_classification({"relevant": True, "sensitive": False, "score": 0.8, "reason": "ok"}) is not None
-    assert _coerce_classification({"relevant": "yes", "sensitive": False, "score": 0.8, "reason": "ok"}) is None
-    assert _coerce_classification({"relevant": True, "sensitive": False, "score": 2, "reason": "ok"}) is None
+    assert (
+        _coerce_classification({"relevant": True, "sensitive": False, "score": 0.8, "reason": "ok"})
+        is not None
+    )
+    assert (
+        _coerce_classification(
+            {"relevant": "yes", "sensitive": False, "score": 0.8, "reason": "ok"}
+        )
+        is None
+    )
+    assert (
+        _coerce_classification({"relevant": True, "sensitive": False, "score": 2, "reason": "ok"})
+        is None
+    )
     assert _coerce_classification({"relevant": True, "sensitive": False, "score": 0.8}) is None
     assert _coerce_classification("not a dict") is None
 
 
-async def test_dry_run_proposes_but_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_dry_run_proposes_but_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, store = _engine(
         tmp_path,
         [_org_note()],
@@ -152,7 +173,9 @@ async def test_dry_run_proposes_but_writes_nothing(tmp_path: Path, monkeypatch: 
     assert store.recent_audit_events(action="promotion.promote") == []
 
 
-async def test_relevant_clean_item_is_promoted_to_central_with_audit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_relevant_clean_item_is_promoted_to_central_with_audit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, store = _engine(
         tmp_path,
         [_org_note()],
@@ -201,7 +224,9 @@ async def test_auto_promotion_attests_the_request_actor(
     assert attestation["promoted_at"].endswith("+00:00")
 
 
-async def test_sensitive_item_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_sensitive_item_is_not_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, store = _engine(tmp_path, ["my personal salary and home address"])
     _stub_llm(monkeypatch, relevant=True, sensitive=True, score=0.95)
 
@@ -213,7 +238,9 @@ async def test_sensitive_item_is_not_promoted(tmp_path: Path, monkeypatch: pytes
     assert result["proposals"][0]["reason"] == "sensitive"
 
 
-async def test_secret_bearing_item_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_secret_bearing_item_is_not_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, _store = _engine(tmp_path, [SECRET_TEXT])
     # Even if the classifier would say "promote", the secret gate must win.
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.99)
@@ -227,7 +254,9 @@ async def test_secret_bearing_item_is_not_promoted(tmp_path: Path, monkeypatch: 
     assert result["proposals"][0]["secret_blocked"] is True
 
 
-async def test_llm_failure_falls_back_to_skip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_llm_failure_falls_back_to_skip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, _store = _engine(
         tmp_path,
         [_org_note()],
@@ -243,7 +272,9 @@ async def test_llm_failure_falls_back_to_skip(tmp_path: Path, monkeypatch: pytes
     assert result["proposals"][0]["reason"] == "llm_unavailable"
 
 
-async def test_below_threshold_is_not_promoted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_below_threshold_is_not_promoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine, learning, _store = _engine(
         tmp_path,
         [_org_note("marginal")],
@@ -258,8 +289,12 @@ async def test_below_threshold_is_not_promoted(tmp_path: Path, monkeypatch: pyte
     assert result["proposals"][0]["reason"] == "below_threshold"
 
 
-async def test_disabled_returns_status_and_does_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    engine, learning, _store = _engine(tmp_path, ["anything"], config=_config(promotion_enabled=False))
+async def test_disabled_returns_status_and_does_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine, learning, _store = _engine(
+        tmp_path, ["anything"], config=_config(promotion_enabled=False)
+    )
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.9)
 
     result = await engine.run(SEAT, dry_run=False)
@@ -275,12 +310,10 @@ async def test_non_seat_dataset_rejected(tmp_path: Path) -> None:
         await engine.run(CENTRAL, dry_run=True)
 
 
-async def test_personal_capture_tag_never_promotes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    summary = (
-        "# Capture summary: notes\n"
-        "- Capture Root Tags: personal\n"
-        "- Path: `/tmp/notes`\n"
-    )
+async def test_personal_capture_tag_never_promotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary = "# Capture summary: notes\n- Capture Root Tags: personal\n- Path: `/tmp/notes`\n"
     engine, learning, _store = _engine(tmp_path, [summary])
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.99)
 
@@ -292,7 +325,9 @@ async def test_personal_capture_tag_never_promotes(tmp_path: Path, monkeypatch: 
     assert result["proposals"][0]["reason"] == "capture_tag_personal"
 
 
-async def test_new_org_project_queues_pending_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_new_org_project_queues_pending_approval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     summary = (
         "# Capture summary: side project\n"
         "- Remote: `https://github.com/other-org/new-app.git`\n"
@@ -464,7 +499,7 @@ async def test_enumerate_stays_best_effort_when_one_query_fails(tmp_path: Path) 
 
 
 async def test_enumerate_names_an_unprovisioned_seat_distinctly(tmp_path: Path) -> None:
-    """"This seat has no dataset" is a different problem from "search is broken" (#147).
+    """ "This seat has no dataset" is a different problem from "search is broken" (#147).
 
     The driver in scripts/run_railway.py logs exc.__class__.__name__, so the two
     cases were indistinguishable in production even though one is an outage to
@@ -581,9 +616,7 @@ async def test_slow_classifier_does_not_block_the_event_loop(
             # The loop never freed us: degrade to the llm_unavailable skip so
             # the red direction fails on the liveness assert, not a hang.
             return None
-        return json.dumps(
-            {"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"}
-        )
+        return json.dumps({"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"})
 
     monkeypatch.setattr(promotion, "openrouter_chat", stalled_chat)
     engine, _learning, _store = _engine(tmp_path, [_org_note()], _github_state(tmp_path))
@@ -658,9 +691,7 @@ async def test_duplicate_across_seats_skips_the_classifier_call(
 
     def counting_chat(*args: Any, **kwargs: Any) -> str:
         classifier_calls["count"] += 1
-        return json.dumps(
-            {"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"}
-        )
+        return json.dumps({"relevant": True, "sensitive": False, "score": 0.9, "reason": "stubbed"})
 
     monkeypatch.setattr(promotion, "openrouter_chat", counting_chat)
 
@@ -737,9 +768,7 @@ async def test_approve_pending_surfaces_the_write_reason(
         "- Capture Root Tags: org-work\n"
     )
     state_path = tmp_path / "github-state.json"
-    state_path.write_text(
-        '{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8"
-    )
+    state_path.write_text('{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8")
     config = _config(github_sync_state_path=str(state_path))
     learning = FakeLearning(central_reject_reason="duplicate_in_process")
     store = AccessStore(str(tmp_path / "access.json"))
@@ -777,9 +806,7 @@ async def test_approved_promotion_attests_the_approver(
         "- Capture Root Tags: org-work\n"
     )
     state_path = tmp_path / "github-state.json"
-    state_path.write_text(
-        '{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8"
-    )
+    state_path.write_text('{"repos": {"masumi-network/Citadel-Archive": {}}}', encoding="utf-8")
     config = _config(github_sync_state_path=str(state_path))
     engine, learning, store = _engine(tmp_path, [summary], config)
     _stub_llm(monkeypatch, relevant=True, sensitive=False, score=0.95)

--- a/tests/test_promotion_refs.py
+++ b/tests/test_promotion_refs.py
@@ -69,7 +69,9 @@ async def test_assess_org_reference_known_repo(tmp_path: Path) -> None:
 
 async def test_assess_org_reference_new_project(tmp_path: Path) -> None:
     state_path = tmp_path / "github-state.json"
-    state_path.write_text(json.dumps({"repos": {"masumi-network/Citadel-Archive": {}}}), encoding="utf-8")
+    state_path.write_text(
+        json.dumps({"repos": {"masumi-network/Citadel-Archive": {}}}), encoding="utf-8"
+    )
     text = "Remote: https://github.com/other-org/brand-new-app.git"
     result = await assess_org_reference(
         FakeCitadel(central_hits=False),

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -10,7 +10,7 @@ def test_publish_requires_main_ancestry_and_current_ci_gate() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     guard = workflow.split("  release-guard:\n", 1)[1].split("\n  build:\n", 1)[0]
 
-    assert "git merge-base --is-ancestor \"$GITHUB_SHA\" \"origin/main\"" in guard
+    assert 'git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"' in guard
     assert "commits/${GITHUB_SHA}/check-runs" in guard
     assert 'select(.name == "CI gate" and .conclusion == "success")' in guard
     assert "needs: release-guard" in workflow

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -194,7 +194,13 @@ def test_pipeline_runs_all_enabled_stages_in_order(monkeypatch: Any) -> None:
     _patch_stages(monkeypatch, calls)
 
     assert run_railway.run("pipeline") == 0
-    assert calls == ["github_sync", "repo_content_sync", "skills_refresh", "self_improve", "backup_mirror"]
+    assert calls == [
+        "github_sync",
+        "repo_content_sync",
+        "skills_refresh",
+        "self_improve",
+        "backup_mirror",
+    ]
 
 
 def test_pipeline_self_improve_stage_is_off_by_default(monkeypatch: Any) -> None:
@@ -493,7 +499,9 @@ def test_evolve_runs_cognee_stage_bodies_on_one_loop(monkeypatch: Any) -> None:
         return 0
 
     monkeypatch.setattr(run_railway, "_github_sync_stage", lambda: 0)
-    monkeypatch.setattr(run_railway, "_repo_content_sync_stage", lambda: run_railway.run_async(_record()))
+    monkeypatch.setattr(
+        run_railway, "_repo_content_sync_stage", lambda: run_railway.run_async(_record())
+    )
     monkeypatch.setattr(run_railway, "_self_improve_stage", lambda: 0)
     monkeypatch.setattr(run_railway, "_promotion_stage", lambda: 0)
     monkeypatch.setattr(run_railway, "_linear_sync_stage", lambda: run_railway.run_async(_record()))
@@ -514,9 +522,7 @@ def test_evolve_stage_lists_stay_in_sync() -> None:
     Phase 2, which the old subprocess expressed via an env toggle.
     """
     sync_stages = [(name, enabled) for name, enabled, _ in run_railway.evolve_stages()]
-    async_stages = [
-        (name, enabled) for name, enabled, _ in run_railway.evolve_stages_async()
-    ]
+    async_stages = [(name, enabled) for name, enabled, _ in run_railway.evolve_stages_async()]
 
     assert [name for name, _ in sync_stages if name != "cognify"] == [
         name for name, _ in async_stages

--- a/tests/test_repair_journal.py
+++ b/tests/test_repair_journal.py
@@ -270,7 +270,5 @@ async def test_repair_rechecks_journal_after_acquiring_lease(
 
     assert result["ok"] is False
     assert result["reason"] == "repair_interrupted"
-    assert result["pending_operations"] == [
-        {"operation_id": "crashed-after-preflight"}
-    ]
+    assert result["pending_operations"] == [{"operation_id": "crashed-after-preflight"}]
     assert journal.checks == [True]

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -67,9 +67,7 @@ class FakeLearningProcess:
                 dataset_id=uuid5(NAMESPACE_URL, str(kwargs.get("dataset", "x"))),
                 dataset_name=str(kwargs.get("dataset", "x")),
                 payload=None,
-                data_ingestion_info=[
-                    {"data_id": str(uuid5(NAMESPACE_URL, f"data:{data}"))}
-                ],
+                data_ingestion_info=[{"data_id": str(uuid5(NAMESPACE_URL, f"data:{data}"))}],
             ),
             "background_cognify": True,
         }
@@ -77,9 +75,7 @@ class FakeLearningProcess:
         reason = self.reasons.pop(0) if self.reasons else "accepted"
 
         class Outcome:
-            ingest = IngestResult(
-                True, reason, kwargs.get("dataset", "x"), (), cognee_result
-            )
+            ingest = IngestResult(True, reason, kwargs.get("dataset", "x"), (), cognee_result)
             chunk_ingests = ()
             improve = {"ok": True} if kwargs.get("run_improve") else None
 
@@ -176,7 +172,10 @@ class FakeRepoContentClient(RepoContentGitHubClient):
 
 def test_resolve_repo_full_name() -> None:
     assert resolve_repo_full_name("sokosumi", "masumi-network") == "masumi-network/sokosumi"
-    assert resolve_repo_full_name("masumi-network/sokosumi", "masumi-network") == "masumi-network/sokosumi"
+    assert (
+        resolve_repo_full_name("masumi-network/sokosumi", "masumi-network")
+        == "masumi-network/sokosumi"
+    )
 
 
 def test_format_repo_content_document() -> None:
@@ -473,9 +472,7 @@ class FailingRepoContentClient(RepoContentGitHubClient):
         super().__init__(token=None)
 
     def fetch_default_branch(self, full_name: str) -> str:
-        raise GitHubAPIError(
-            "GitHub API returned 403: API rate limit exceeded for 95.90.238.57"
-        )
+        raise GitHubAPIError("GitHub API returned 403: API rate limit exceeded for 95.90.238.57")
 
 
 @pytest.mark.asyncio
@@ -512,7 +509,9 @@ class FakeAutoJoinClient(RepoContentGitHubClient):
             "masumi-network/sokosumi-cli/SKILL.md",
         }
 
-    def _repo(self, name: str, *, archived: bool = False, branch: str | None = "main") -> GitHubRepo:
+    def _repo(
+        self, name: str, *, archived: bool = False, branch: str | None = "main"
+    ) -> GitHubRepo:
         return GitHubRepo(
             name=name,
             full_name=f"masumi-network/{name}",
@@ -531,7 +530,9 @@ class FakeAutoJoinClient(RepoContentGitHubClient):
             license_name=None,
         )
 
-    def fetch_repos(self, org: str, *, max_repos: int, include_private: bool = True) -> list[GitHubRepo]:
+    def fetch_repos(
+        self, org: str, *, max_repos: int, include_private: bool = True
+    ) -> list[GitHubRepo]:
         return [
             self._repo("masumi-agent-messenger"),
             self._repo("no-markers-here"),
@@ -581,7 +582,9 @@ def test_resolved_repos_autojoin_disabled_skips_discovery() -> None:
     fetch_calls: list[int] = []
 
     class TrackingClient(FakeAutoJoinClient):
-        def fetch_repos(self, org: str, *, max_repos: int, include_private: bool = True) -> list[GitHubRepo]:
+        def fetch_repos(
+            self, org: str, *, max_repos: int, include_private: bool = True
+        ) -> list[GitHubRepo]:
             fetch_calls.append(1)
             return super().fetch_repos(org, max_repos=max_repos, include_private=include_private)
 
@@ -689,7 +692,13 @@ def test_a_truncated_tree_falls_back_instead_of_syncing_a_partial_repo() -> None
     paths = discover_repo_paths(client, "o/r", ref="sha", **_DISCOVERY_KW)
 
     assert client.probe_calls > 0, "truncation must fall back to probing"
-    assert paths == ["README.md", "AGENTS.md", "skills/a/SKILL.md", "skills/a/b/deep.md", "docs/guide.md"]
+    assert paths == [
+        "README.md",
+        "AGENTS.md",
+        "skills/a/SKILL.md",
+        "skills/a/b/deep.md",
+        "docs/guide.md",
+    ]
 
 
 def test_an_unreadable_tree_falls_back_and_still_finds_everything() -> None:
@@ -708,9 +717,8 @@ def test_max_files_cap_is_respected_identically_on_both_paths() -> None:
     via_probe.tree_fails = True
     kw = {**_DISCOVERY_KW, "max_files": 3}
 
-    assert (
-        discover_repo_paths(via_tree, "o/r", ref="sha", **kw)
-        == discover_repo_paths(via_probe, "o/r", ref="sha", **kw)
+    assert discover_repo_paths(via_tree, "o/r", ref="sha", **kw) == discover_repo_paths(
+        via_probe, "o/r", ref="sha", **kw
     )
 
 
@@ -754,7 +762,9 @@ def test_a_binding_cap_keeps_the_shallower_file_on_both_paths() -> None:
     probe_paths = discover_repo_paths(via_probe, "o/r", ref="sha", **kw)
 
     assert probe_paths == ["skills/zzz.md"], "the walk takes the prefix's own files first"
-    assert tree_paths == probe_paths, f"selection drifted under the cap: {tree_paths} != {probe_paths}"
+    assert tree_paths == probe_paths, (
+        f"selection drifted under the cap: {tree_paths} != {probe_paths}"
+    )
 
 
 # --- resumability -----------------------------------------------------------
@@ -1048,9 +1058,9 @@ def test_cognee_data_ids_reads_the_real_cognee_return_type() -> None:
         assert _cognee_data_ids(outcome({"added": real, **extra})) == [data_id]
 
     # Forward compatibility: a future cognee returning a plain mapping still works.
-    assert _cognee_data_ids(
-        outcome({"added": {"data_ingestion_info": [{"data_id": "d-9"}]}})
-    ) == ["d-9"]
+    assert _cognee_data_ids(outcome({"added": {"data_ingestion_info": [{"data_id": "d-9"}]}})) == [
+        "d-9"
+    ]
 
     # Genuinely empty stays empty, so the guard still refuses to trust a
     # claim it cannot check.
@@ -1176,9 +1186,7 @@ async def test_run_makes_no_github_call_on_the_event_loop(tmp_path: Path) -> Non
             self._stall()
             return super().fetch_last_commit_sha(full_name, path, ref=ref)
 
-        def fetch_file_text(
-            self, full_name: str, path: str, *, ref: str
-        ) -> RepoContentFile | None:
+        def fetch_file_text(self, full_name: str, path: str, *, ref: str) -> RepoContentFile | None:
             self._stall()
             return super().fetch_file_text(full_name, path, ref=ref)
 
@@ -1555,9 +1563,7 @@ async def test_content_the_ingest_can_never_accept_is_not_resubmitted_every_sync
     second = await syncer.run()
 
     assert len(learning.calls) == 2, "the same bytes were submitted for a second refusal"
-    assert second["files_skipped_by_reason"] == {
-        "refused_unchanged:unchunkable_content": 2
-    }
+    assert second["files_skipped_by_reason"] == {"refused_unchanged:unchunkable_content": 2}
     entry = json.loads(state_path.read_text(encoding="utf-8"))["files"][
         "masumi-network/sokosumi-cli/README.md"
     ]
@@ -1589,9 +1595,7 @@ async def test_a_refusal_that_is_not_about_the_content_is_retried(
     second = await syncer.run()
 
     assert len(learning.calls) == 4, "a process-scoped refusal was made permanent"
-    assert second["files_skipped_by_reason"] == {
-        "ingest_rejected:duplicate_in_process": 2
-    }
+    assert second["files_skipped_by_reason"] == {"ingest_rejected:duplicate_in_process": 2}
 
 
 @pytest.mark.asyncio

--- a/tests/test_repo_stats.py
+++ b/tests/test_repo_stats.py
@@ -43,9 +43,7 @@ def _stats(fetched_at: str, *, commits: int = 340) -> repo_stats.RepoStats:
 
 
 def _write_cache(config: CitadelConfig, stats: repo_stats.RepoStats) -> None:
-    Path(config.repo_stats_state_path).write_text(
-        json.dumps(stats.as_cache()), encoding="utf-8"
-    )
+    Path(config.repo_stats_state_path).write_text(json.dumps(stats.as_cache()), encoding="utf-8")
 
 
 # --------------------------------------------------------------------------
@@ -69,6 +67,7 @@ def test_cache_is_served_when_github_is_unreachable(tmp_path: Path, monkeypatch:
         repo_stats.RepoStatsUnavailable("still computing"),
         RuntimeError("something entirely unexpected"),
     ):
+
         def _boom(*args: Any, **kwargs: Any) -> Any:
             raise failure
 
@@ -229,9 +228,7 @@ def test_api_state_serves_cached_commits_and_flags_staleness(
 ) -> None:
     """Cached numbers are published, and old ones are labelled old."""
     config = _config(tmp_path)
-    monkeypatch.setattr(
-        "kb.server.get_citadel", lambda: type("_C", (), {"config": config})()
-    )
+    monkeypatch.setattr("kb.server.get_citadel", lambda: type("_C", (), {"config": config})())
 
     fresh = datetime.now(UTC) - timedelta(hours=3)
     _write_cache(config, _stats(fresh.isoformat()))
@@ -289,6 +286,7 @@ def test_api_state_survives_a_broken_repo_stats_module(monkeypatch: Any) -> None
     /api/state is polled by every public page load, so it fails soft on this
     the way it already does on a syncer hiccup.
     """
+
     def _boom(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("stats exploded")
 

--- a/tests/test_repository_update.py
+++ b/tests/test_repository_update.py
@@ -140,9 +140,9 @@ def test_digest_is_stable_when_the_window_content_is_unchanged() -> None:
 
     assert first.digest == second.digest
     assert "Checked at:" not in first.digest, "a per-sync timestamp reintroduces duplicates"
-    assert (
-        "Window started at:" not in first.digest
-    ), "a wall-clock-derived window bound reintroduces duplicates"
+    assert "Window started at:" not in first.digest, (
+        "a wall-clock-derived window bound reintroduces duplicates"
+    )
 
 
 def test_force_treats_all_activity_as_new() -> None:
@@ -191,9 +191,7 @@ def test_active_repositories_rank_pull_requests_above_commits_and_events() -> No
     update = compose(
         repos=[repo(), other_repo],
         events=[event("evt-1")],
-        commits_by_repo={
-            "masumi-network/scout": [commit("ddd", repo_name="masumi-network/scout")]
-        },
+        commits_by_repo={"masumi-network/scout": [commit("ddd", repo_name="masumi-network/scout")]},
         pull_requests_by_repo={"masumi-network/agent": [pull_request(42)]},
     )
 

--- a/tests/test_result_metadata_trust.py
+++ b/tests/test_result_metadata_trust.py
@@ -67,9 +67,7 @@ def test_deduped_node_copy_of_a_shared_trace_keeps_reference_only() -> None:
 
     app.state.access_store = AccessStore(Path(tempfile.mkdtemp()) / "access.json")
     admin = authed_client()
-    token = admin.post("/api/access/seats", json={"name": "Carol", "slug": "carol"}).json()[
-        "token"
-    ]
+    token = admin.post("/api/access/seats", json={"name": "Carol", "slug": "carol"}).json()["token"]
     app.state.citadel = DualWritten()
     client = TestClient(app, base_url="https://testserver")
 

--- a/tests/test_search_bench.py
+++ b/tests/test_search_bench.py
@@ -5,6 +5,7 @@ Fixtures mirror the REAL /search hit shape: repo-content hits carry a
 terminated by ``---``, an ``id`` distinct from ``document_id``, a ``_citadel``
 envelope, and NO top-level ``dataset`` key.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -48,7 +49,8 @@ def repo_hit(
     digest = hashlib.sha256(text.encode()).hexdigest()[:12]
     return {
         "id": f"chunk:{digest}",
-        "document_id": document_id or f"doc-{hashlib.sha256((path + blob).encode()).hexdigest()[:8]}",
+        "document_id": document_id
+        or f"doc-{hashlib.sha256((path + blob).encode()).hexdigest()[:8]}",
         "text": text,
         "_citadel": {
             "rank": 1,
@@ -141,9 +143,7 @@ class TestPathAndBlobDiversityBothSurvive:
 
     def test_path_and_blob_views_disagree_on_one_file_under_two_blobs(self):
         span = "the unique answer sentence lives here"
-        hits = [repo_hit(PATH_DOC, BLOB_A, span)] * 6 + [
-            repo_hit(PATH_DOC, BLOB_B, span)
-        ] * 4
+        hits = [repo_hit(PATH_DOC, BLOB_A, span)] * 6 + [repo_hit(PATH_DOC, BLOB_B, span)] * 4
         row = sb.score_question(question(spans=[span]), hits, {})
         # Blob view: two distinct (path, blob) identities in ten slots.
         assert row["duplicate_blob_rate_at_10"] == pytest.approx(0.8)
@@ -152,9 +152,7 @@ class TestPathAndBlobDiversityBothSurvive:
         assert row["distinct_source_ratio"] == pytest.approx(0.1)
         # If these ever agree on this fixture, one view has been collapsed into
         # the other and a real signal has been lost.
-        assert row["distinct_source_ratio"] != pytest.approx(
-            1 - row["duplicate_blob_rate_at_10"]
-        )
+        assert row["distinct_source_ratio"] != pytest.approx(1 - row["duplicate_blob_rate_at_10"])
 
     def test_unresolvable_sources_are_counted_and_split_out(self):
         span = "the unique answer sentence lives here"
@@ -162,10 +160,7 @@ class TestPathAndBlobDiversityBothSurvive:
         hits = (
             [repo_hit(PATH_DOC, BLOB_A, span)] * 3
             + [repo_hit(PATH_OTHER, BLOB_B, span)] * 2
-            + [
-                {"id": f"chunk:none{i}", "document_id": f"doc-{i}", "text": span}
-                for i in range(5)
-            ]
+            + [{"id": f"chunk:none{i}", "document_id": f"doc-{i}", "text": span} for i in range(5)]
         )
         row = sb.score_question(question(spans=[span]), hits, {})
         assert row["hits_with_unresolvable_source"] == 5
@@ -178,9 +173,7 @@ class TestPathAndBlobDiversityBothSurvive:
 class TestDuplicationMetrics:
     def test_two_blob_page_scores_once_with_dup_rate(self):
         span = "the unique answer sentence lives here"
-        hits = [repo_hit(PATH_DOC, BLOB_A, span)] * 6 + [
-            repo_hit(PATH_DOC, BLOB_B, span)
-        ] * 4
+        hits = [repo_hit(PATH_DOC, BLOB_A, span)] * 6 + [repo_hit(PATH_DOC, BLOB_B, span)] * 4
         row = sb.score_question(question(spans=[span]), hits, {})
         assert row["duplicate_blob_rate_at_10"] == pytest.approx(0.8)
         assert row["distinct_files_at_10"] == 1
@@ -189,7 +182,9 @@ class TestDuplicationMetrics:
         assert row["answer_pass_at_5"] is True
         # One question, one pass: recall over [row] + probe must be 1.0, not
         # inflated by the 10 duplicate slots.
-        probe = sb.score_question(question("p01", expect=["masumi-network/x/gone.md"], recall=0), [], {})
+        probe = sb.score_question(
+            question("p01", expect=["masumi-network/x/gone.md"], recall=0), [], {}
+        )
         summary = sb.summarize([row, probe], [])
         assert summary["quality"]["answer_recall_at_5"] == 1.0
         assert summary["quality"]["answer_recall_at_1"] == 1.0
@@ -214,7 +209,7 @@ class TestDuplicationMetrics:
 
 class TestSpanMatching:
     def test_normalization_survives_backticks_emphasis_whitespace(self):
-        body = "Use the **`create_coworker_task`** tool,\n  with `status=\"READY\"` set."
+        body = 'Use the **`create_coworker_task`** tool,\n  with `status="READY"` set.'
         span = 'Use the create_coworker_task tool, with status="READY" set.'
         assert sb.normalize(span) in sb.normalize(body)
 
@@ -478,12 +473,8 @@ class TestFingerprints:
         assert one["files"] == 2
 
     def test_content_fingerprint_moves_when_a_blob_changes(self, tmp_path):
-        before = sb.content_fingerprint(
-            self._state(tmp_path, [(PATH_DOC, BLOB_A)], "a.json")
-        )
-        after = sb.content_fingerprint(
-            self._state(tmp_path, [(PATH_DOC, BLOB_B)], "b.json")
-        )
+        before = sb.content_fingerprint(self._state(tmp_path, [(PATH_DOC, BLOB_A)], "a.json"))
+        after = sb.content_fingerprint(self._state(tmp_path, [(PATH_DOC, BLOB_B)], "b.json"))
         assert before["sha256"] != after["sha256"]
 
     def _fingerprint(self, sha, questions="q" * 64):
@@ -535,8 +526,7 @@ class TestLint:
         "Another paragraph with completely different content for padding.\n"
     )
     OTHER_BODY = (
-        "# Other Doc Title\n\n"
-        "Entirely unrelated prose that shares no sentences with the example.\n"
+        "# Other Doc Title\n\nEntirely unrelated prose that shares no sentences with the example.\n"
     )
 
     def _write_golden(self, tmp_path, questions):
@@ -566,9 +556,7 @@ class TestLint:
             "expect_any": [PATH_DOC],
             "category": "test",
             "expected_recall": 1,
-            "answer_spans": [
-                "persists attempted charges with a null transaction id"
-            ],
+            "answer_spans": ["persists attempted charges with a null transaction id"],
         }
         base.update(overrides)
         return base
@@ -580,9 +568,7 @@ class TestLint:
 
     def test_cmd_lint_accepts_explicit_ground_truth_path(self, tmp_path, capsys):
         path, gt = self._write_golden(tmp_path, [self._q()])
-        assert sb.main(
-            ["lint", "--questions", str(path), "--ground-truth", str(gt)]
-        ) == 0
+        assert sb.main(["lint", "--questions", str(path), "--ground-truth", str(gt)]) == 0
         assert "lint OK: 1 question(s)" in capsys.readouterr().out
 
     def test_cmd_ci_accepts_the_shipped_fixture(self, capsys):
@@ -609,9 +595,7 @@ class TestLint:
         assert any("not found in any cached ground-truth body" in p for p in problems)
 
     def test_span_matching_first_line_fails(self, tmp_path):
-        path, gt = self._write_golden(
-            tmp_path, [self._q(answer_spans=["Example Doc Title"])]
-        )
+        path, gt = self._write_golden(tmp_path, [self._q(answer_spans=["Example Doc Title"])])
         problems, _ = sb.lint_questions(path, gt)
         assert any("first line" in p for p in problems)
 
@@ -815,9 +799,7 @@ class TestRunTimestamp:
 
         span = "the unique answer sentence lives here"
         qs = [question(spans=[span]), question("p01", recall=0)]
-        result = sb.execute_benchmark(
-            qs, lambda q, k: ({"results": []}, 1.0, None), quiet=True
-        )
+        result = sb.execute_benchmark(qs, lambda q, k: ({"results": []}, 1.0, None), quiet=True)
         stamped = datetime.fromisoformat(result["run_at"])
         assert stamped.tzinfo is not None
 
@@ -826,9 +808,7 @@ class TestRunExitStatus:
     def test_cmd_run_fails_when_every_search_attempt_errors(self, tmp_path, monkeypatch, capsys):
         questions_path = tmp_path / "questions.json"
         questions_path.write_text(
-            json.dumps(
-                {"questions": [question(spans=["x" * 20]), question("p01", recall=0)]}
-            ),
+            json.dumps({"questions": [question(spans=["x" * 20]), question("p01", recall=0)]}),
             encoding="utf-8",
         )
         monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
@@ -880,13 +860,23 @@ class TestRunExitStatus:
             ),
         ]
         summary = sb.summarize(rows, [])
-        summary["latency"] = {"errors": 0, "p50_ms": 1.0, "p95_ms": 1.0, "mean_ms": 1.0, "samples": 3}
+        summary["latency"] = {
+            "errors": 0,
+            "p50_ms": 1.0,
+            "p95_ms": 1.0,
+            "mean_ms": 1.0,
+            "samples": 3,
+        }
         summary["repeats"] = 1
         monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
         monkeypatch.setattr(
             sb,
             "execute_benchmark",
-            lambda *args, **kwargs: {"run_at": "2026-08-06T00:00:00+00:00", "summary": summary, "rows": rows},
+            lambda *args, **kwargs: {
+                "run_at": "2026-08-06T00:00:00+00:00",
+                "summary": summary,
+                "rows": rows,
+            },
         )
         monkeypatch.setattr(
             sb,
@@ -980,9 +970,7 @@ class TestCompareCensusNote:
         assert any("census" in line and "2867" in line and "3100" in line for line in verdicts)
 
     def test_missing_census_adds_no_note(self):
-        comparable, verdicts = sb.compare_fingerprints(
-            self._fingerprint(), self._fingerprint()
-        )
+        comparable, verdicts = sb.compare_fingerprints(self._fingerprint(), self._fingerprint())
         assert comparable is True
         assert not any("census" in line for line in verdicts)
 
@@ -1113,9 +1101,7 @@ class TestEnforce:
             ("error", "HTTP 403", "census failed"),
         ],
     )
-    def test_enforce_rejects_incomplete_or_unmeasured_census(
-        self, field, value, needle
-    ):
+    def test_enforce_rejects_incomplete_or_unmeasured_census(self, field, value, needle):
         baseline = make_enforce_run()
         candidate = make_enforce_run()
         candidate["fingerprint"]["census"][field] = value
@@ -1145,9 +1131,7 @@ class TestEnforce:
     def test_enforce_rejects_unstable_trust(self):
         baseline = make_enforce_run()
         candidate = make_enforce_run()
-        candidate["summary"]["metadata_stability"][
-            "chunks_with_unstable_trust_tier"
-        ] = 1
+        candidate["summary"]["metadata_stability"]["chunks_with_unstable_trust_tier"] = 1
 
         _comparable, _verdicts, failures = sb.enforce_acceptance(baseline, candidate)
 
@@ -1165,9 +1149,7 @@ class TestEnforce:
     def test_enforce_rejects_retrieval_regression(self, section, metric):
         baseline = make_enforce_run()
         candidate = make_enforce_run()
-        candidate["summary"][section][metric] = (
-            baseline["summary"][section][metric] - 0.01
-        )
+        candidate["summary"][section][metric] = baseline["summary"][section][metric] - 0.01
 
         _comparable, _verdicts, failures = sb.enforce_acceptance(baseline, candidate)
 
@@ -1230,9 +1212,7 @@ class TestMarkdownReport:
     def test_each_row_is_self_contained_with_date_commit_and_n(self):
         markdown = sb.build_markdown_report(make_run())
         row = next(
-            line
-            for line in markdown.splitlines()
-            if "answer_recall_at_5" in line and "|" in line
+            line for line in markdown.splitlines() if "answer_recall_at_5" in line and "|" in line
         )
         # A row copied out of the table alone must still carry its value, the
         # date, the commit, the sample count, and what it matched on.
@@ -1243,11 +1223,7 @@ class TestMarkdownReport:
         assert sb.METRIC_DEFINITIONS["answer_recall_at_5"] in row
 
     def test_report_refuses_a_metric_without_a_definition(self, monkeypatch):
-        trimmed = {
-            key: value
-            for key, value in sb.METRIC_DEFINITIONS.items()
-            if key != "mrr_body"
-        }
+        trimmed = {key: value for key, value in sb.METRIC_DEFINITIONS.items() if key != "mrr_body"}
         monkeypatch.setattr(sb, "METRIC_DEFINITIONS", trimmed)
         with pytest.raises(sb.BenchError, match="mrr_body"):
             sb.build_markdown_report(make_run())
@@ -1284,9 +1260,7 @@ class TestMarkdownReport:
         run_path = tmp_path / "run.json"
         run_path.write_text(json.dumps(make_run()), encoding="utf-8")
         out_path = tmp_path / "block.md"
-        exit_code = sb.main(
-            ["report", str(run_path), "--markdown", "--out", str(out_path)]
-        )
+        exit_code = sb.main(["report", str(run_path), "--markdown", "--out", str(out_path)])
         assert exit_code == 0
         written = out_path.read_text(encoding="utf-8")
         assert "answer_recall_at_5" in written
@@ -1319,9 +1293,7 @@ class TestPublishedPathsAndProse:
         # compare_fingerprints treats EMPTY_MAP_SHA256 as unavailable; the
         # report must apply the same judgement or the two tools disagree
         # about the same run JSON.
-        markdown = sb.build_markdown_report(
-            make_run(content_sha=sb.EMPTY_MAP_SHA256)
-        )
+        markdown = sb.build_markdown_report(make_run(content_sha=sb.EMPTY_MAP_SHA256))
         assert "NOT comparable on content" in markdown
         assert "empty file map" in markdown
 
@@ -1361,25 +1333,20 @@ class TestPublishedPathsAndProse:
 
 class TestShippedGoldenSet:
     def test_every_question_has_spans_or_explicit_marker(self):
-        data = json.loads(
-            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8"))
         for q in data["questions"]:
             if q.get("expected_recall", 1) == 0:
                 continue
             has_spans = bool(q.get("answer_spans"))
             has_marker = bool(q.get(sb.UNCONVERTED_KEY))
             assert has_spans != has_marker, (
-                f"{q['id']}: must have exactly one of answer_spans / "
-                f"{sb.UNCONVERTED_KEY}"
+                f"{q['id']}: must have exactly one of answer_spans / {sb.UNCONVERTED_KEY}"
             )
 
     def test_probes_exist_and_resolve_against_live_scanner(self):
         """`run` refuses on zero probes, so the shipped set must carry them,
         and every blocked_pattern must still be a rule the scanner enforces."""
-        data = json.loads(
-            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8"))
         probes = [q for q in data["questions"] if q.get("expected_recall", 1) == 0]
         pattern_probes = [q for q in probes if q.get("blocked_pattern")]
         controls = [q for q in probes if not q.get("blocked_pattern")]
@@ -1394,8 +1361,15 @@ class TestShippedGoldenSet:
             assert control.get("expect_any"), control["id"]
 
 
-def scored_hit(path: str, blob: str, body: str, coverage: float | None,
-               *, tier: str = "unattested", sha: str | None = None) -> dict:
+def scored_hit(
+    path: str,
+    blob: str,
+    body: str,
+    coverage: float | None,
+    *,
+    tier: str = "unattested",
+    sha: str | None = None,
+) -> dict:
     """A repo hit carrying the node's own reported term_coverage and trust tier."""
     hit = repo_hit(path, blob, body)
     hit["_citadel"]["relevance"] = (
@@ -1474,9 +1448,7 @@ class TestRankingIsMeasuredSeparatelyFromRetrieval:
         assert sb.normalize(span) not in sb.normalize(
             sb.split_header_body(sb.hit_text(header_carrier))[1]
         )
-        row = sb.score_question(
-            question(spans=[span]), [header_carrier, body_carrier], {}
-        )
+        row = sb.score_question(question(spans=[span]), [header_carrier, body_carrier], {})
         assert row["answer_slot"] == 2
         assert row["answer_term_coverage"] == 1.0
         assert row["outranked_by_coverage"] == 0.05
@@ -1496,17 +1468,13 @@ class TestRankingIsMeasuredSeparatelyFromRetrieval:
         # supplies coverage above the answer's, stops being an inversion.
         answer = scored_hit(PATH_DOC, BLOB_A, f"prose {self.SPAN} prose", 0.40)
         decoy_high = scored_hit(PATH_OTHER, BLOB_B, "filler", 0.60)
-        hidden = sb.score_question(
-            question(spans=[self.SPAN]), [decoy_high, answer], {}
-        )
+        hidden = sb.score_question(question(spans=[self.SPAN]), [decoy_high, answer], {})
         assert hidden["answer_slot"] == 2
         assert hidden["outranked_by_coverage"] is None
         # Same page, same bodies, same order: only the decoy's reported
         # coverage drops to what its BODY alone would earn.
         decoy_low = scored_hit(PATH_OTHER, BLOB_B, "filler", 0.0)
-        revealed = sb.score_question(
-            question(spans=[self.SPAN]), [decoy_low, answer], {}
-        )
+        revealed = sb.score_question(question(spans=[self.SPAN]), [decoy_low, answer], {})
         assert revealed["answer_slot"] == 2
         assert revealed["outranked_by_coverage"] == 0.0
 
@@ -1651,14 +1619,18 @@ class TestEmbeddingWindowPairs:
 
         # A head with no tail: it is not a within-document comparison, so it
         # must not move the rate, the penalty, or the count.
-        dangling_head = [row for row in self._pair_rows(False, False, "w02") if row["window_role"] == "head"]
+        dangling_head = [
+            row for row in self._pair_rows(False, False, "w02") if row["window_role"] == "head"
+        ]
         with_head = sb.summarize(complete + dangling_head, [])
         assert with_head["window"]["pairs_complete"] == 1
         assert with_head["window"]["head_recall_at_5"] == 1.0
         assert with_head["window"]["window_penalty"] == 1.0
 
         # And a tail with no head, the other direction.
-        dangling_tail = [row for row in self._pair_rows(True, True, "w03") if row["window_role"] == "tail"]
+        dangling_tail = [
+            row for row in self._pair_rows(True, True, "w03") if row["window_role"] == "tail"
+        ]
         with_tail = sb.summarize(complete + dangling_tail, [])
         assert with_tail["window"]["pairs_complete"] == 1
         assert with_tail["window"]["tail_recall_at_5"] == 0.0
@@ -1678,7 +1650,11 @@ class TestEmbeddingWindowPairs:
             {},
         )
         # Both pairs name PATH_DOC (see `question`'s default expect_any).
-        rows = [plain, probe] + self._pair_rows(True, False, "w01") + self._pair_rows(True, False, "w02")
+        rows = (
+            [plain, probe]
+            + self._pair_rows(True, False, "w01")
+            + self._pair_rows(True, False, "w02")
+        )
         summary = sb.summarize(rows, [])
         assert summary["window"]["pairs_complete"] == 2
         assert summary["window"]["documents"] == 1
@@ -1725,9 +1701,10 @@ class TestEmbeddingWindowPairs:
         assert before["quality"]["header_credit_rate"] == after["quality"]["header_credit_rate"]
         # Moved: computed from positives / rows. Both are in REPORT_METRICS.
         assert after["quality"]["doc_recall_at_5"] != before["quality"]["doc_recall_at_5"]
-        assert {
-            key for _, key, _ in sb.REPORT_METRICS
-        } & {"doc_recall_at_5", "duplicate_blob_rate_at_10"} == {
+        assert {key for _, key, _ in sb.REPORT_METRICS} & {
+            "doc_recall_at_5",
+            "duplicate_blob_rate_at_10",
+        } == {
             "doc_recall_at_5",
             "duplicate_blob_rate_at_10",
         }
@@ -1751,7 +1728,7 @@ class TestEmbeddingWindowPairs:
 class TestWindowFixtureContract:
     """The rules that make a failing tail evidence rather than a failing question."""
 
-    HEAD_TEXT = "alpha beta gamma delta epsilon " * 40           # ~1200 chars
+    HEAD_TEXT = "alpha beta gamma delta epsilon " * 40  # ~1200 chars
     TAIL_TEXT = "zeta thermodynamic eigenvector quaternion sentence here to quote."
     BODY = "# Doc Title\n\n" + HEAD_TEXT + ("filler padding words. " * 200) + TAIL_TEXT
 
@@ -1784,7 +1761,9 @@ class TestWindowFixtureContract:
             "window_role": "tail",
             "source_offset_chars": self.BODY.find(self.TAIL_TEXT),
             "novel_terms_absent_from_head": [
-                "thermodynamic", "eigenvector", "quaternion",
+                "thermodynamic",
+                "eigenvector",
+                "quaternion",
             ],
         }
         base.update(overrides)
@@ -1825,9 +1804,7 @@ class TestWindowFixtureContract:
         assert any("BELOW" in p for p in problems)
         assert not any("above the" in p for p in problems), problems
 
-    def test_a_declared_offset_cannot_smuggle_a_shallow_quote_into_the_tail(
-        self, tmp_path
-    ):
+    def test_a_declared_offset_cannot_smuggle_a_shallow_quote_into_the_tail(self, tmp_path):
         """`source_offset_chars` is a claim; body.find(quote) is the fact.
 
         Trusting the claim let a quote inside the first 2000 characters ship
@@ -1868,9 +1845,7 @@ class TestWindowFixtureContract:
         contain cannot make the quote novel."""
         path, gt = self._golden(
             tmp_path,
-            self._tail_q(
-                novel_terms_absent_from_head=["absolute", "meridian", "portcullis"]
-            ),
+            self._tail_q(novel_terms_absent_from_head=["absolute", "meridian", "portcullis"]),
         )
         problems, _ = sb.lint_questions(path, gt)
         assert any("are not terms of the quote" in p for p in problems), problems
@@ -1880,9 +1855,7 @@ class TestWindowFixtureContract:
         and stricter than the generic normalize()-based span check. Nothing
         exercised it, so it could be deleted with the suite still green."""
         missing = "this exact sentence is nowhere in the cached body at all"
-        path, gt = self._golden(
-            tmp_path, self._tail_q(question=missing, answer_spans=[missing])
-        )
+        path, gt = self._golden(tmp_path, self._tail_q(question=missing, answer_spans=[missing]))
         problems, _ = sb.lint_questions(path, gt)
         assert any("not present verbatim in the cached body" in p for p in problems)
 
@@ -1907,9 +1880,7 @@ class TestWindowFixtureContract:
         assert row["window_role"] == "tail"
 
     def test_tail_without_enough_novel_terms_fails(self, tmp_path):
-        path, gt = self._golden(
-            tmp_path, self._tail_q(novel_terms_absent_from_head=["quaternion"])
-        )
+        path, gt = self._golden(tmp_path, self._tail_q(novel_terms_absent_from_head=["quaternion"]))
         problems, _ = sb.lint_questions(path, gt)
         assert any("novel_terms_absent_from_head" in p for p in problems)
 
@@ -1919,9 +1890,7 @@ class TestWindowFixtureContract:
         and a pass proves nothing about reach."""
         path, gt = self._golden(
             tmp_path,
-            self._tail_q(
-                novel_terms_absent_from_head=["thermodynamic", "eigenvector", "alpha"]
-            ),
+            self._tail_q(novel_terms_absent_from_head=["thermodynamic", "eigenvector", "alpha"]),
         )
         problems, _ = sb.lint_questions(path, gt)
         assert any("the control is void" in p for p in problems)
@@ -1929,8 +1898,11 @@ class TestWindowFixtureContract:
 
     def test_head_fixture_outside_the_window_fails(self, tmp_path):
         head = self._tail_q(
-            id="w01h", category="window_head", window_role="head",
-            question=self.TAIL_TEXT, answer_spans=[self.TAIL_TEXT],
+            id="w01h",
+            category="window_head",
+            window_role="head",
+            question=self.TAIL_TEXT,
+            answer_spans=[self.TAIL_TEXT],
         )
         head.pop("novel_terms_absent_from_head")
         path, gt = self._golden(tmp_path, head)
@@ -1940,9 +1912,7 @@ class TestWindowFixtureContract:
     def test_shipped_window_pairs_satisfy_the_contract(self):
         """The committed set, not a fixture: every pair has both sides, both
         quotes are unique to one document, and every tail clears the controls."""
-        data = json.loads(
-            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8"))
         window = [q for q in data["questions"] if sb.is_window_question(q)]
         assert len(window) >= 20
         by_pair = {}
@@ -1956,9 +1926,7 @@ class TestWindowFixtureContract:
             # buckets on window_role; a set where they disagree is one where a
             # row is scored without ever being validated. This runs in CI,
             # where ground_truth/ does not exist and `lint` cannot.
-            expected_category = (
-                "window_head" if q["window_role"] == "head" else "window_tail"
-            )
+            expected_category = "window_head" if q["window_role"] == "head" else "window_tail"
             assert q["category"] == expected_category, q["id"]
             if q["window_role"] == "tail":
                 assert q["depth_fraction"] >= sb.TAIL_MIN_DEPTH, q["id"]
@@ -2007,9 +1975,7 @@ class TestFrozenFixtureSet:
         assert any("no `frozen` block" in p for p in problems)
 
     def test_shipped_questions_file_matches_its_own_pin(self):
-        data = json.loads(
-            (Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((Path(sb.HERE) / "golden_questions.json").read_text(encoding="utf-8"))
         assert data["frozen"]["questions_sha256"] == sb.questions_pin(data["questions"])
 
 
@@ -2126,13 +2092,17 @@ class TestReportCoversTheNewMetrics:
             "run_at": "2026-08-04T00:00:00+00:00",
             "summary": {
                 "quality": {
-                    "answer_recall_at_5": 0.9, "raw_page_recall_at_5": 0.8,
-                    "doc_recall_at_5": 0.9, "mrr_body": 0.7,
-                    "header_credit_rate": 0.0, "negative_hit_rate": 0.0,
+                    "answer_recall_at_5": 0.9,
+                    "raw_page_recall_at_5": 0.8,
+                    "doc_recall_at_5": 0.9,
+                    "mrr_body": 0.7,
+                    "header_credit_rate": 0.0,
+                    "negative_hit_rate": 0.0,
                 },
                 "duplication": {"duplicate_blob_rate_at_10": 0.3},
                 "counts": {
-                    "questions_with_spans": 39, "questions_positive": 61,
+                    "questions_with_spans": 39,
+                    "questions_positive": 61,
                     "questions_blocked_probe": 8,
                 },
                 "latency": {"p50_ms": 600.0, "p95_ms": 900.0, "samples": 105},
@@ -2146,16 +2116,23 @@ class TestReportCoversTheNewMetrics:
         run = self._run(
             {
                 "window": {
-                    "head_recall_at_5": 0.667, "tail_recall_at_5": 0.0,
-                    "tail_recall_given_head_at_5": 0.0, "window_penalty": 0.667,
-                    "pairs_complete": 18, "pairs_head_reachable": 11,
+                    "head_recall_at_5": 0.667,
+                    "tail_recall_at_5": 0.0,
+                    "tail_recall_given_head_at_5": 0.0,
+                    "window_penalty": 0.667,
+                    "pairs_complete": 18,
+                    "pairs_head_reachable": 11,
                 },
                 "ranking": {"rank_inversion_rate": 0.63, "answers_ranked": 19},
             }
         )
         markdown = sb.build_markdown_report(run)
-        for key in ("head_recall_at_5", "tail_recall_at_5", "window_penalty",
-                    "rank_inversion_rate"):
+        for key in (
+            "head_recall_at_5",
+            "tail_recall_at_5",
+            "window_penalty",
+            "rank_inversion_rate",
+        ):
             assert key in markdown
             assert sb.METRIC_DEFINITIONS[key][:40] in markdown
         assert "| 18 |" in markdown
@@ -2190,8 +2167,7 @@ class TestTailRecallIsConditionedOnAReachableDocument:
         for pair, (head_pass, tail_pass) in pairs.items():
             for role, passed in (("head", head_pass), ("tail", tail_pass)):
                 q = question(f"{pair}{role[0]}", spans=[self.SPAN])
-                q.update({"category": f"window_{role}", "window_role": role,
-                          "window_pair": pair})
+                q.update({"category": f"window_{role}", "window_role": role, "window_pair": pair})
                 hits = (
                     [scored_hit(PATH_DOC, BLOB_A, self.SPAN, 1.0)]
                     if passed
@@ -2202,26 +2178,22 @@ class TestTailRecallIsConditionedOnAReachableDocument:
 
     def test_unreachable_documents_are_excluded_from_the_conditional(self):
         # w01 reachable, tail missed. w02 unreachable on both sides.
-        summary = sb.summarize(
-            self._rows({"w01": (True, False), "w02": (False, False)}), []
-        )
+        summary = sb.summarize(self._rows({"w01": (True, False), "w02": (False, False)}), [])
         window = summary["window"]
         assert window["pairs_complete"] == 2
         assert window["pairs_neither"] == 1
-        assert window["tail_recall_at_5"] == 0.0          # 0 of 2, pessimistic
-        assert window["pairs_head_reachable"] == 1        # only w01 is evidence
+        assert window["tail_recall_at_5"] == 0.0  # 0 of 2, pessimistic
+        assert window["pairs_head_reachable"] == 1  # only w01 is evidence
         assert window["tail_recall_given_head_at_5"] == 0.0
 
     def test_conditional_counts_only_proven_reachable_documents(self):
         summary = sb.summarize(
-            self._rows(
-                {"w01": (True, True), "w02": (True, False), "w03": (False, False)}
-            ),
+            self._rows({"w01": (True, True), "w02": (True, False), "w03": (False, False)}),
             [],
         )
         window = summary["window"]
         assert window["pairs_head_reachable"] == 2
-        assert window["tail_recall_given_head_at_5"] == 0.5   # 1 of 2
+        assert window["tail_recall_given_head_at_5"] == 0.5  # 1 of 2
         assert window["tail_recall_at_5"] == round(1 / 3, 4)  # 1 of 3, pessimistic
 
     def test_conditional_is_none_when_no_head_ever_retrieved(self):
@@ -2238,9 +2210,10 @@ class TestRunRecordsWhichFrozenSetItAnswered:
         reformatted.write_text(json.dumps({"questions": questions, "version": 5}, indent=4))
         # Reformatting moves the file hash but must NOT move the pin: the run
         # answered the same questions.
-        assert hashlib.sha256(path.read_bytes()).hexdigest() != hashlib.sha256(
-            reformatted.read_bytes()
-        ).hexdigest()
+        assert (
+            hashlib.sha256(path.read_bytes()).hexdigest()
+            != hashlib.sha256(reformatted.read_bytes()).hexdigest()
+        )
         assert sb.questions_pin(sb.load_questions(path)) == sb.questions_pin(
             sb.load_questions(reformatted)
         )
@@ -2267,9 +2240,7 @@ class TestRunRecordsWhichFrozenSetItAnswered:
         assert "questions_pin" in fingerprint
         assert fingerprint["questions_pin"] == sb.questions_pin(sb.load_questions(path))
 
-    def test_build_fingerprint_records_the_ground_truth_cache(
-        self, tmp_path, monkeypatch
-    ):
+    def test_build_fingerprint_records_the_ground_truth_cache(self, tmp_path, monkeypatch):
         """ground_truth/ is gitignored, refetched from an unpinned upstream
         HEAD, and feeds doc_rank's shingle fallback and legacy_rank. Two runs
         at the same pin against the same node can therefore score differently.
@@ -2285,9 +2256,7 @@ class TestRunRecordsWhichFrozenSetItAnswered:
         assert after["ground_truth"]["sha256"] != before["ground_truth"]["sha256"]
 
     def test_an_absent_ground_truth_cache_says_so(self, tmp_path, monkeypatch):
-        fingerprint, _ = self._fingerprint(
-            tmp_path, monkeypatch, gt_dir=tmp_path / "nope"
-        )
+        fingerprint, _ = self._fingerprint(tmp_path, monkeypatch, gt_dir=tmp_path / "nope")
         assert fingerprint["ground_truth"]["sha256"] is None
         assert "NOT" in fingerprint["ground_truth"]["reason"]
 

--- a/tests/test_search_feedback.py
+++ b/tests/test_search_feedback.py
@@ -147,9 +147,7 @@ async def test_mesh_record_search_telemetry_increments_feedback_index() -> None:
         primary_dataset="notes",
         tool_name="citadel_search",
     )
-    feedback_id = await mesh.record_search_telemetry(
-        CONFIG, telemetry=telemetry, dataset="notes"
-    )
+    feedback_id = await mesh.record_search_telemetry(CONFIG, telemetry=telemetry, dataset="notes")
     snapshot = await mesh.snapshot(CONFIG)
 
     assert feedback_id.startswith("feedback:")

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -79,7 +79,9 @@ def test_docs_mode_excludes_ambient() -> None:
     shaped = shape_search_payload(payload, query="USDCx payment token", mode="docs")
     assert shaped["docs_mode"] is True
     assert all(h["doc_type"] != "activity" for h in shaped["results"])
-    assert any("not sole authority" in w.lower() or "skills/masumi" in w for w in shaped["warnings"])
+    assert any(
+        "not sole authority" in w.lower() or "skills/masumi" in w for w in shaped["warnings"]
+    )
 
 
 def test_shape_timeout_sets_code() -> None:
@@ -238,7 +240,9 @@ def test_shape_search_payload_filters_and_schema() -> None:
     assert hit["snippet"]
     assert "url" in hit and "path" in hit and "repo" in hit
 
-    canonical = shape_search_payload(payload, query="x", canonical_only=True, apply_spec_ranking=False)
+    canonical = shape_search_payload(
+        payload, query="x", canonical_only=True, apply_spec_ranking=False
+    )
     # canonical_only is a shape filter, not a trust filter — it must never be
     # satisfied by a tier, because a tier can no longer be earned from content.
     assert all(h["doc_type"] in {"spec", "skill", "canonical-docs"} for h in canonical["results"])
@@ -635,11 +639,7 @@ _SESSION_TRACE_WORST_CASE_INPUTS: list[tuple[str, str, Callable[[int], str]]] = 
 
 
 def _module_patterns(module: object) -> dict[str, re.Pattern[str]]:
-    return {
-        name: value
-        for name, value in vars(module).items()
-        if isinstance(value, re.Pattern)
-    }
+    return {name: value for name, value in vars(module).items() if isinstance(value, re.Pattern)}
 
 
 @pytest.mark.parametrize(
@@ -696,8 +696,8 @@ def test_pattern_cost_stays_proportional_to_input_size(
         if elapsed > _PROPORTIONAL_BUDGET_SECONDS:
             over_budget.append(f"{name}.{method} on {len(text)} chars took {elapsed:.2f}s")
 
-    assert not over_budget, (
-        "matching cost grew faster than the input for: " + "; ".join(over_budget)
+    assert not over_budget, "matching cost grew faster than the input for: " + "; ".join(
+        over_budget
     )
 
 

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -82,9 +82,7 @@ class PageCitadel:
 def shaped_client(citadel: Any) -> TestClient:
     app.state.citadel = citadel
     app.state.mesh = MeshState()
-    app.state.conflict_store = KnowledgeConflictStore(
-        Path(tempfile.mkdtemp()) / "conflicts.json"
-    )
+    app.state.conflict_store = KnowledgeConflictStore(Path(tempfile.mkdtemp()) / "conflicts.json")
     client = TestClient(app, base_url="https://testserver")
     response = client.post("/admin/session", json={"access_key": "test-admin"})
     assert response.status_code == 200
@@ -120,9 +118,7 @@ def test_linear_header_populates_issue_id_and_url() -> None:
 
     assert provenance["issue"] == "SOK-623"
     assert provenance["title"] == "coworker init UX"
-    assert provenance["source_url"] == (
-        "https://linear.app/masumi/issue/SOK-623/coworker-init-ux"
-    )
+    assert provenance["source_url"] == ("https://linear.app/masumi/issue/SOK-623/coworker-init-ux")
     # The URL quoted inside the description was not credited.
     assert "evil.example" not in provenance["source_url"]
 
@@ -156,9 +152,7 @@ def test_forged_header_on_a_later_chunk_is_not_credited() -> None:
 
     assert parse_content_header(text, chunk_index=1) == {}
     assert parse_content_header(text, chunk_index=2.0) == {}
-    assert parse_content_header(text, chunk_index=0)["repo"] == (
-        "masumi-network/sokosumi-docs"
-    )
+    assert parse_content_header(text, chunk_index=0)["repo"] == ("masumi-network/sokosumi-docs")
     assert parse_content_header(text)["repo"] == "masumi-network/sokosumi-docs"
 
     forged = result_provenance({"id": "f1", "text": text, "chunk_index": 2})
@@ -182,9 +176,7 @@ def test_forged_later_chunk_header_cannot_join_repo_filtered_results() -> None:
         }
     )
 
-    assert [h["id"] for h in filter_hits([forged, genuine], repo="sokosumi-cli")] == [
-        "genuine"
-    ]
+    assert [h["id"] for h in filter_hits([forged, genuine], repo="sokosumi-cli")] == ["genuine"]
 
     # Same conclusion on the server-shaped path (raw payload + envelope).
     server_forged = with_result_metadata(
@@ -275,9 +267,7 @@ def test_absent_content_query_is_flagged_not_confident() -> None:
 
 def test_matching_content_is_not_flagged() -> None:
     """The marker must be earnable in both directions, not another inert guard."""
-    citadel = PageCitadel(
-        [{"id": "n1", "text": "the kupo retry policy is exponential backoff"}]
-    )
+    citadel = PageCitadel([{"id": "n1", "text": "the kupo retry policy is exponential backoff"}])
     client = shaped_client(citadel)
 
     response = client.post("/search", json={"query": "kupo retry policy"})
@@ -285,9 +275,7 @@ def test_matching_content_is_not_flagged() -> None:
     body = response.json()
     assert body["relevance"]["no_lexical_match"] is False
     assert body["relevance"]["max_term_coverage"] == 1.0
-    assert not any(
-        "No result contains any query term" in w for w in body.get("warnings", [])
-    )
+    assert not any("No result contains any query term" in w for w in body.get("warnings", []))
 
 
 # --- defect 4: mode=docs was a no-op and filters matched body text ----------
@@ -339,9 +327,7 @@ def test_docs_mode_ranks_within_a_class_by_term_coverage() -> None:
     }
     match = {
         "id": "h",
-        "text": repo_doc_text(
-            "masumi-network/b", "docs/retry.md", "kupo indexer retry policy"
-        ),
+        "text": repo_doc_text("masumi-network/b", "docs/retry.md", "kupo indexer retry policy"),
     }
 
     ranked = apply_query_ranking([miss, match], "kupo retry policy", mode="docs")
@@ -384,8 +370,7 @@ def test_repo_filter_is_identity_not_body_substring() -> None:
     # Identity still matches the org prefix and the exact full name.
     assert len(filter_hits([docs_file, cli_file], repo="masumi-network")) == 2
     assert [
-        h["id"]
-        for h in filter_hits([docs_file, cli_file], repo="masumi-network/sokosumi-docs")
+        h["id"] for h in filter_hits([docs_file, cli_file], repo="masumi-network/sokosumi-docs")
     ] == ["docs"]
 
 
@@ -423,8 +408,7 @@ def test_filtered_search_over_fetches_and_fills_the_page() -> None:
     # And the page is FULL, not the 0 of 5 the old order of operations left.
     assert len(body["results"]) == 5
     assert all(
-        hit["_citadel"]["provenance"]["repo"] == "masumi-network/widget"
-        for hit in body["results"]
+        hit["_citadel"]["provenance"]["repo"] == "masumi-network/widget" for hit in body["results"]
     )
     assert body["filtering"]["candidates_fetched"] == 15
     assert body["filtering"]["candidates_matched"] == 7
@@ -450,8 +434,7 @@ def test_empty_retrieval_with_filters_gets_dataset_help_not_filter_blame() -> No
     assert body["results"] == []
     assert body["filtering"]["candidates_fetched"] == 0
     assert not any(
-        "post-retrieval filters excluded" in warning
-        for warning in body.get("warnings", [])
+        "post-retrieval filters excluded" in warning for warning in body.get("warnings", [])
     )
     assert "note" in body
     assert body["known_datasets"]
@@ -479,8 +462,7 @@ def test_short_page_where_filters_excluded_nothing_is_not_blamed_on_filters() ->
     assert body["filtering"]["candidates_fetched"] == 1
     assert body["filtering"]["candidates_matched"] == 1
     assert not any(
-        "post-retrieval filters excluded" in warning
-        for warning in body.get("warnings", [])
+        "post-retrieval filters excluded" in warning for warning in body.get("warnings", [])
     )
 
 
@@ -504,9 +486,7 @@ def test_short_filtered_page_is_documented_honestly() -> None:
     body = response.json()
     assert len(body["results"]) == 1
     assert body["filtering"]["candidates_matched"] == 1
-    assert any(
-        "post-retrieval filters excluded" in warning for warning in body["warnings"]
-    )
+    assert any("post-retrieval filters excluded" in warning for warning in body["warnings"])
 
 
 # --- head-of-document truncation hides the match ----------------------------

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -221,7 +221,7 @@ def test_file_scheme_is_still_blocked() -> None:
 
 def test_env_lookups_are_not_secret_assignments() -> None:
     for snippet in (
-        'const apiKey = process.env.SOKOSUMI_API_KEY;',
+        "const apiKey = process.env.SOKOSUMI_API_KEY;",
         "const apiKey = getApiKeyFromEnv();",
         'api_key = os.environ.get("RAILWAY_API_KEY")',
         "api_key = request.query_params.get('api_key')",
@@ -307,4 +307,3 @@ def test_high_confidence_patterns_are_untouched_by_the_carve_outs() -> None:
         result = scan(f"token = {value}")
         assert expected in categories(result), value
         assert result["blocked"] is True
-

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -74,8 +74,7 @@ async def test_pass_is_bounded_by_max_items(monkeypatch: pytest.MonkeyPatch) -> 
         self_improve_module,
         "propose_optimizations",
         lambda items: [
-            {"label": item["label"], "summary": "better", "tags": ["better-tag"]}
-            for item in items
+            {"label": item["label"], "summary": "better", "tags": ["better-tag"]} for item in items
         ],
     )
     optimizer = SelfImprovement(citadel, mesh=mesh)
@@ -120,9 +119,7 @@ async def test_no_llm_is_a_deterministic_noop_that_still_improves() -> None:
     assert citadel.ingest_calls == []  # nothing re-ingested without proposals
     assert citadel.improve_calls  # the existing improve step still ran
     snapshot = await mesh.snapshot(citadel.config)
-    optimization_events = [
-        event for event in snapshot["events"] if event["type"] == "optimization"
-    ]
+    optimization_events = [event for event in snapshot["events"] if event["type"] == "optimization"]
     assert optimization_events[0]["details"]["used_llm"] is False
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,7 +66,9 @@ class FakeCitadel:
     async def improve(self, **kwargs: Any) -> dict[str, Any]:
         return {"dataset": kwargs["dataset"], "session_ids": kwargs["session_ids"]}
 
-    async def cognify_dataset(self, *, dataset: Any = None, verify: bool = False, force: bool = False) -> dict[str, Any]:
+    async def cognify_dataset(
+        self, *, dataset: Any = None, verify: bool = False, force: bool = False
+    ) -> dict[str, Any]:
         return {
             "ok": True,
             "dataset": dataset or self.config.default_dataset,
@@ -75,7 +77,12 @@ class FakeCitadel:
             "graph_grew": True,
             "verify": verify,
             "verification": (
-                {"marker": "COGNIFY_TEST_MARKER_x", "search_hit": True, "graph_grew": True, "ok": True}
+                {
+                    "marker": "COGNIFY_TEST_MARKER_x",
+                    "search_hit": True,
+                    "graph_grew": True,
+                    "ok": True,
+                }
                 if verify
                 else None
             ),
@@ -150,6 +157,7 @@ class FakeCitadel:
             },
             "after": None,
         }
+
 
 class FakeLinearSyncer:
     async def status(self) -> dict[str, Any]:
@@ -330,9 +338,7 @@ def authed_client(access_key: str = "test-admin") -> TestClient:
     app.state.linear_syncer = FakeLinearSyncer()
     app.state.learning_agent = FakeLearningAgent()
     # Keep knowledge-conflict state out of the repo-local .citadel directory.
-    app.state.conflict_store = KnowledgeConflictStore(
-        Path(tempfile.mkdtemp()) / "conflicts.json"
-    )
+    app.state.conflict_store = KnowledgeConflictStore(Path(tempfile.mkdtemp()) / "conflicts.json")
     client = TestClient(app, base_url="https://testserver")
     response = client.post("/admin/session", json={"access_key": access_key})
     assert response.status_code == 200
@@ -350,9 +356,7 @@ LEGACY_PUBLIC_SOURCES = {
 def legacy_public_markup(path: str) -> str:
     if path == "/login":
         return server_module.LOGIN_HTML
-    return (server_module.STATIC_DIR / LEGACY_PUBLIC_SOURCES[path]).read_text(
-        encoding="utf-8"
-    )
+    return (server_module.STATIC_DIR / LEGACY_PUBLIC_SOURCES[path]).read_text(encoding="utf-8")
 
 
 def test_healthz() -> None:
@@ -418,9 +422,7 @@ def test_security_headers_are_applied_to_http_responses() -> None:
     assert response.headers["cross-origin-opener-policy"] == "same-origin"
     assert response.headers["cross-origin-resource-policy"] == "same-origin"
     assert "camera=()" in response.headers["permissions-policy"]
-    assert response.headers["strict-transport-security"] == (
-        "max-age=31536000; includeSubDomains"
-    )
+    assert response.headers["strict-transport-security"] == ("max-age=31536000; includeSubDomains")
 
 
 def test_no_path_relaxes_style_src() -> None:
@@ -599,6 +601,7 @@ def test_login_page_uses_the_public_design_system() -> None:
     assert 'class="topnav"' in page
     assert 'id="themebtn"' in page
 
+
 def test_use_cases_page_is_public_and_csp_clean() -> None:
     page = legacy_public_markup("/use-cases")
     # No token, no session — a coordinator or a curious engineer must be able
@@ -688,7 +691,11 @@ def test_public_pages_share_the_band_layout() -> None:
         # tracks the section in view.
         assert '<script src="/static/landing.js" defer></script>' in page, path
         # The live pill rides in the index bar, where / carries it.
-        index = page[page.index('<nav class="index"'):page.index("</nav>", page.index('<nav class="index"'))]
+        index = page[
+            page.index('<nav class="index"') : page.index(
+                "</nav>", page.index('<nav class="index"')
+            )
+        ]
         assert 'id="pill-health"' in index, path
 
 
@@ -709,9 +716,7 @@ def test_every_internal_link_on_the_public_pages_resolves() -> None:
 
     pages = ("/", "/info", "/use-cases", "/contact", "/login")
     bodies = {path: client.get(path).text for path in pages}
-    ids = {
-        path: set(re.findall(r'id="([^"]+)"', body)) for path, body in bodies.items()
-    }
+    ids = {path: set(re.findall(r'id="([^"]+)"', body)) for path, body in bodies.items()}
 
     checked = 0
     for page, body in bodies.items():
@@ -740,8 +745,7 @@ def test_every_internal_link_on_the_public_pages_resolves() -> None:
                 target = path or page
                 assert target in ids, f"{page} -> {href} targets an unaudited page"
                 assert fragment in ids[target], (
-                    f"{page} -> {href} points at #{fragment}, which does not "
-                    f"exist on {target}"
+                    f"{page} -> {href} points at #{fragment}, which does not exist on {target}"
                 )
 
     # A regex that stopped matching would pass every assertion above.
@@ -831,8 +835,7 @@ def test_home_owns_install_and_the_diagram() -> None:
     """
     home = legacy_public_markup("/")
     others = {
-        path: legacy_public_markup(path)
-        for path in ("/info", "/use-cases", "/contact", "/login")
+        path: legacy_public_markup(path) for path in ("/info", "/use-cases", "/contact", "/login")
     }
 
     assert 'class="spine"' in home
@@ -854,7 +857,7 @@ def test_home_hero_has_no_terminal_block() -> None:
     This pins the decision so it cannot drift back in.
     """
     home = legacy_public_markup("/")
-    hero = home[home.index('<header class="hero">'):home.index("</header>")]
+    hero = home[home.index('<header class="hero">') : home.index("</header>")]
 
     assert "<pre" not in hero
     assert 'class="term' not in hero
@@ -898,7 +901,7 @@ def test_home_motion_respects_reduced_motion() -> None:
     css = (server_module.STATIC_DIR / "info.css").read_text(encoding="utf-8")
 
     start = css.index("@media (prefers-reduced-motion: reduce)")
-    block = css[start:css.index("\n}", start)]
+    block = css[start : css.index("\n}", start)]
 
     # Both animations exist...
     assert "@keyframes drift" in css
@@ -929,8 +932,8 @@ def test_home_rotator_window_and_track_are_separate_elements() -> None:
     # rindex, not index: `.roll-track` also appears inside the reduced-motion
     # block earlier in the file, where it is deliberately set to `animation: none`.
     # The real declaration is the later one.
-    window = css[css.index(".roll {"):css.index("\n", css.index(".roll {"))]
-    track = css[css.rindex(".roll-track {"):css.index("\n", css.rindex(".roll-track {"))]
+    window = css[css.index(".roll {") : css.index("\n", css.index(".roll {"))]
+    track = css[css.rindex(".roll-track {") : css.index("\n", css.rindex(".roll-track {"))]
 
     assert "overflow: hidden" in window, ".roll must be the clipping window"
     assert "animation:" not in window, (
@@ -954,8 +957,8 @@ def test_home_rotator_window_and_track_are_separate_elements() -> None:
 
     # Offsets in em, not percentages: percentages resolve against the track's
     # own height, so adding or removing a word silently drifts every step.
-    frames = css[css.index("@keyframes rollup"):]
-    frames = frames[:frames.index("\n}")]
+    frames = css[css.index("@keyframes rollup") :]
+    frames = frames[: frames.index("\n}")]
     assert "%)" not in frames.replace("0%,", "").replace("%,", ""), (
         "rollup offsets must be in em, matching the item height"
     )
@@ -1258,9 +1261,7 @@ def test_knowledge_events_api_returns_resumable_timeline() -> None:
     typed = client.get("/api/knowledge/events?type=search")
     invalid_limit = client.get("/api/knowledge/events?limit=0")
     invalid_after = client.get("/api/knowledge/events?after_id=-1")
-    unauthenticated = TestClient(app, base_url="https://testserver").get(
-        "/api/knowledge/events"
-    )
+    unauthenticated = TestClient(app, base_url="https://testserver").get("/api/knowledge/events")
 
     assert ingest.status_code == 200
     assert search.status_code == 200
@@ -1398,9 +1399,7 @@ def test_mcp_accept_shim_advertises_both_content_types() -> None:
         captured.clear()
         asyncio.run(shim({"type": "http", "headers": headers}, None, None))
         return [
-            v.decode("latin-1")
-            for n, v in captured["scope"]["headers"]
-            if n.lower() == b"accept"
+            v.decode("latin-1") for n, v in captured["scope"]["headers"] if n.lower() == b"accept"
         ]
 
     both = "application/json, text/event-stream"
@@ -1545,7 +1544,7 @@ def test_app_nav_has_five_primary_entries() -> None:
     page = client.get("/app").text
 
     nav = re.search(r'<nav class="side-nav".*?</nav>', page, re.S)
-    assert nav, "the /app shell no longer renders a <nav class=\"side-nav\">"
+    assert nav, 'the /app shell no longer renders a <nav class="side-nav">'
     labels = re.findall(r'<span class="nav-label">([^<]+)</span>', nav.group(0))
 
     assert labels == ["Home", "Search", "Graph", "Review", "Admin"], labels
@@ -1608,7 +1607,9 @@ def test_app_home_leads_with_search_and_three_numbers() -> None:
     client = authed_client()
 
     page = client.get("/app").text
-    home = re.search(r'<section class="page page-active" data-page="home".*?\n          </section>', page, re.S)
+    home = re.search(
+        r'<section class="page page-active" data-page="home".*?\n          </section>', page, re.S
+    )
     assert home, "the shell no longer renders a home page section"
     home_markup = home.group(0)
 
@@ -1669,9 +1670,7 @@ def test_review_is_the_only_place_with_approve_and_reject() -> None:
     assert 'id="reviewQueueList"' in page
     assert 'id="reviewSourceList"' in page
 
-    row = re.search(
-        r"function promotionNeedsRow\(item\) \{(.*?)\n\}", app_js, re.S
-    )
+    row = re.search(r"function promotionNeedsRow\(item\) \{(.*?)\n\}", app_js, re.S)
     assert row, "promotionNeedsRow moved"
     body = row.group(1)
     assert 'canUse("admin")' in body
@@ -1755,15 +1754,9 @@ def test_graph_inspector_resolves_one_hop_document_neighbors() -> None:
     """
     app_js = (STATIC_DIR / "app.js").read_text(encoding="utf-8")
 
-    bearing = re.search(
-        r"function isDocumentBearingNode\(node\) \{(.*?)\n\}", app_js, re.S
-    )
-    candidates = re.search(
-        r"function documentCandidates\(node\) \{(.*?)\n\}", app_js, re.S
-    )
-    loader = re.search(
-        r"async function loadNodeDocument\(node\) \{(.*?)\n\}", app_js, re.S
-    )
+    bearing = re.search(r"function isDocumentBearingNode\(node\) \{(.*?)\n\}", app_js, re.S)
+    candidates = re.search(r"function documentCandidates\(node\) \{(.*?)\n\}", app_js, re.S)
+    loader = re.search(r"async function loadNodeDocument\(node\) \{(.*?)\n\}", app_js, re.S)
     assert bearing and candidates and loader
 
     bearing_body = bearing.group(1)
@@ -3107,7 +3100,9 @@ def test_search_across_datasets_runs_concurrently() -> None:
     class ConcurrentCitadel:
         config = FakeCitadel.config
 
-        async def search(self, query: str, *, dataset: str, session_id: Any, top_k: int) -> list[Any]:
+        async def search(
+            self, query: str, *, dataset: str, session_id: Any, top_k: int
+        ) -> list[Any]:
             order.append(("start", dataset))
             await aio.sleep(0.05)
             order.append(("end", dataset))
@@ -3165,6 +3160,7 @@ def test_single_literal_search_preserves_each_dataset_candidate() -> None:
 
 def test_search_single_literal_query_ranks_cross_dataset_match(monkeypatch: Any) -> None:
     """The API ranks the exact token before unrelated returned hits (#106)."""
+
     async def fake_search(*args: Any, **kwargs: Any) -> tuple[list[tuple[str, Any]], bool]:
         return [
             ("central", {"id": "central", "text": "unrelated central note"}),
@@ -3172,9 +3168,7 @@ def test_search_single_literal_query_ranks_cross_dataset_match(monkeypatch: Any)
         ], False
 
     monkeypatch.setattr(server_module, "_search_within_budget", fake_search)
-    response = authed_client().post(
-        "/search", json={"query": "quokka-beacon-8823", "top_k": 2}
-    )
+    response = authed_client().post("/search", json={"query": "quokka-beacon-8823", "top_k": 2})
 
     assert response.status_code == 200
     body = response.json()
@@ -3193,9 +3187,7 @@ def test_search_returns_429_when_at_capacity(monkeypatch: Any) -> None:
     assert r.headers["X-RateLimit-Remaining"] == "0"
 
 
-def test_mesh_graph_and_search_have_independent_budgets(
-    monkeypatch: Any, tmp_path: Any
-) -> None:
+def test_mesh_graph_and_search_have_independent_budgets(monkeypatch: Any, tmp_path: Any) -> None:
     # CHANGE 2 (#50): the mesh graph read and /search hold SEPARATE concurrency
     # budgets, so a ~15-seat login burst on the default Knowledge Mesh view can't
     # 429 /search — and vice versa. This is a WIRING test (distinct in-flight
@@ -3217,9 +3209,7 @@ def test_mesh_graph_and_search_have_independent_budgets(
     mesh = client.get("/api/mesh/graph")
     assert mesh.status_code == 429
     assert mesh.headers["Retry-After"] == "1"
-    assert mesh.headers["X-RateLimit-Limit"] == str(
-        FakeCitadel.config.mesh_graph_max_concurrency
-    )
+    assert mesh.headers["X-RateLimit-Limit"] == str(FakeCitadel.config.mesh_graph_max_concurrency)
     assert mesh.headers["X-RateLimit-Remaining"] == "0"
     assert client.post("/search", json={"query": "q", "top_k": 3}).status_code == 200
 
@@ -3306,12 +3296,14 @@ def test_document_endpoint_for_result_covers_real_ids_only() -> None:
     assert document_endpoint_for_result("ghsync:abc") == "/api/documents/ghsync:abc"
     assert document_endpoint_for_result("doc_123") == "/api/documents/doc_123"
     assert document_endpoint_for_result(uuid) == f"/api/documents/{uuid}"
-    assert document_endpoint_for_result(
-        "chunk-uuid", document_id="document-uuid"
-    ) == "/api/documents/document-uuid"
-    assert document_endpoint_for_result(
-        "chunk:deadbeef", document_id="document-uuid"
-    ) == "/api/documents/document-uuid"
+    assert (
+        document_endpoint_for_result("chunk-uuid", document_id="document-uuid")
+        == "/api/documents/document-uuid"
+    )
+    assert (
+        document_endpoint_for_result("chunk:deadbeef", document_id="document-uuid")
+        == "/api/documents/document-uuid"
+    )
     assert document_endpoint_for_result("../../api/access") == (
         "/api/documents/..%2F..%2Fapi%2Faccess"
     )
@@ -3372,9 +3364,7 @@ def test_search_drilldown_prefers_parent_document_id_for_chunk_hit(
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = ParentDocumentSearchCitadel()
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
     api = TestClient(app, base_url="https://testserver")
@@ -3431,9 +3421,7 @@ def test_knowledge_conflict_listing_and_resolution_are_role_gated(tmp_path: Any)
     conflict_id = conflicts[0]["id"]
 
     mesh = writer.get("/api/mesh")
-    conflict_events = [
-        event for event in mesh.json()["events"] if event["type"] == "conflict"
-    ]
+    conflict_events = [event for event in mesh.json()["events"] if event["type"] == "conflict"]
     assert conflict_events[0]["details"]["conflict_id"] == conflict_id
 
     reader_store = app.state.conflict_store
@@ -3666,14 +3654,10 @@ def test_mesh_projection_hides_seat_content_from_plain_readers(tmp_path: Any) ->
             dataset="seat:alice",
             tags=[],
         )
-        await mesh.record_search(
-            config, query=secret_query, dataset="seat:alice", result_count=1
-        )
+        await mesh.record_search(config, query=secret_query, dataset="seat:alice", result_count=1)
         await mesh.record_ingest(
             config,
-            IngestResult(
-                accepted=True, reason="stored", dataset="masumi-network", tags=()
-            ),
+            IngestResult(accepted=True, reason="stored", dataset="masumi-network", tags=()),
             data=org_doc,
             dataset="masumi-network",
             tags=[],
@@ -3682,12 +3666,8 @@ def test_mesh_projection_hides_seat_content_from_plain_readers(tmp_path: Any) ->
     asyncio.run(_populate())
 
     api = TestClient(app, base_url="https://testserver")
-    reader_view = api.get(
-        "/api/mesh", headers={"Authorization": f"Bearer {reader_token}"}
-    ).json()
-    alice_view = api.get(
-        "/api/mesh", headers={"Authorization": f"Bearer {alice_token}"}
-    ).json()
+    reader_view = api.get("/api/mesh", headers={"Authorization": f"Bearer {reader_token}"}).json()
+    alice_view = api.get("/api/mesh", headers={"Authorization": f"Bearer {alice_token}"}).json()
     admin_view = admin.get("/api/mesh").json()
 
     reader_blob = json.dumps(reader_view)
@@ -3699,14 +3679,12 @@ def test_mesh_projection_hides_seat_content_from_plain_readers(tmp_path: Any) ->
     assert org_doc in reader_blob
     # Seat presence stays universal: the seat's dataset hub is still there.
     assert any(
-        node.get("metadata", {}).get("dataset") == "seat:alice"
-        and node["type"] == "dataset"
+        node.get("metadata", {}).get("dataset") == "seat:alice" and node["type"] == "dataset"
         for node in reader_view["nodes"]
     )
     # No content-bearing seat node survives for the reader.
     assert not any(
-        node.get("metadata", {}).get("dataset") == "seat:alice"
-        and node["type"] != "dataset"
+        node.get("metadata", {}).get("dataset") == "seat:alice" and node["type"] != "dataset"
         for node in reader_view["nodes"]
     )
     # Owner and admin both retain their own/all content.
@@ -3822,9 +3800,7 @@ def test_mesh_graph_isolates_content_per_caller_but_presence_is_universal(
 def test_mesh_graph_map_failure_fails_closed_for_scoped_callers(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway(map_error=True))
     try:
         bob_view = (
@@ -3907,9 +3883,7 @@ def test_document_drilldown_enforces_read_scope_without_existence_oracle(
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = DrilldownIsolationCitadel()  # authed_client resets citadel
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
     api = TestClient(app, base_url="https://testserver")
@@ -3952,9 +3926,7 @@ def test_document_drilldown_map_failure_fails_closed_for_scoped_callers(
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = DrilldownIsolationCitadel()
     api = TestClient(app, base_url="https://testserver")
     bob = {"Authorization": f"Bearer {bob_token}"}
@@ -3989,16 +3961,12 @@ def test_document_drilldown_denies_when_gateway_lacks_node_dataset_map(
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = DrilldownIsolationCitadel()
     app.state.knowledge_mesh = KnowledgeMesh(_NoMapGateway())
     api = TestClient(app, base_url="https://testserver")
     try:
-        own = api.get(
-            "/api/documents/doc-b", headers={"Authorization": f"Bearer {bob_token}"}
-        )
+        own = api.get("/api/documents/doc-b", headers={"Authorization": f"Bearer {bob_token}"})
         admin_doc = admin.get("/api/documents/doc-a")
     finally:
         app.state.knowledge_mesh = None
@@ -4028,9 +3996,7 @@ class DrilldownSearchCitadel(DrilldownIsolationCitadel):
 
 def _search_hint(body: dict[str, Any]) -> dict[str, bool]:
     return {
-        hit["_citadel"]["result_id"]: hit["_citadel"]["retrieval"][
-            "document_drilldown_available"
-        ]
+        hit["_citadel"]["result_id"]: hit["_citadel"]["retrieval"]["document_drilldown_available"]
         for hit in body["results"]
     }
 
@@ -4044,9 +4010,7 @@ def test_search_drilldown_hint_matches_document_endpoint_per_caller(
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = DrilldownSearchCitadel()  # authed_client resets citadel
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
     api = TestClient(app, base_url="https://testserver")
@@ -4055,10 +4019,7 @@ def test_search_drilldown_hint_matches_document_endpoint_per_caller(
     try:
         bob_body = api.post("/search", json={"query": "x"}, headers=bob).json()
         admin_body = admin.post("/search", json={"query": "x"}).json()
-        bob_status = {
-            doc: api.get(f"/api/documents/{doc}", headers=bob).status_code
-            for doc in ids
-        }
+        bob_status = {doc: api.get(f"/api/documents/{doc}", headers=bob).status_code for doc in ids}
         # Admin's textless entity 404s too (get_document is None), which the
         # bypass hint cannot cheaply foresee; assert consistency on resolvable ids.
         admin_status = {
@@ -4109,9 +4070,7 @@ def test_search_drilldown_hint_fails_closed_on_cold_map(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     app.state.citadel = DrilldownSearchCitadel()
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway(empty_map=True))
     api = TestClient(app, base_url="https://testserver")
@@ -4166,9 +4125,7 @@ def test_search_hint_never_assembles_document_bodies(tmp_path: Any) -> None:
     # get_document again.
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     citadel = DrilldownCountingCitadel()
     app.state.citadel = citadel
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
@@ -4205,13 +4162,11 @@ def test_search_hint_never_assembles_document_bodies(tmp_path: Any) -> None:
     # before it (the pre-fix latency_ms was measured before the drill-down
     # pass, under-reporting exactly what it added).
     events = app.state.access_store.snapshot()["audit_events"]
-    search_events = [
-        event for event in events if event["detail"].get("operation") == "search"
-    ]
+    search_events = [event for event in events if event["detail"].get("operation") == "search"]
     assert search_events
     assert isinstance(search_events[-1]["detail"].get("drilldown_ms"), (int, float))
-    assert search_events[-1]["detail"]["latency_ms"] >= (
-        search_events[-1]["detail"]["drilldown_ms"]
+    assert (
+        search_events[-1]["detail"]["latency_ms"] >= (search_events[-1]["detail"]["drilldown_ms"])
     )
 
 
@@ -4230,18 +4185,14 @@ def test_search_hint_pass_denies_once_its_deadline_expires(tmp_path: Any) -> Non
             search_timeout_seconds=0.2,
         )
 
-        async def resolve_document_owner_ids(
-            self, document_id: str
-        ) -> list[str] | None:
+        async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
             self.owner_id_calls.append(document_id)
             await asyncio.sleep(30)  # cancelled by the pass deadline
             return None
 
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
-    bob_token = admin.post(
-        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
-    ).json()["token"]
+    bob_token = admin.post("/api/access/seats", json={"name": "Bob", "slug": "bob"}).json()["token"]
     citadel = _HungResolverCitadel()
     app.state.citadel = citadel
     app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
@@ -4511,9 +4462,7 @@ def test_optimize_endpoint_is_admin_only_bounded_and_audited(
     assert payload["llm_used"] is False
 
     events = store.snapshot()["audit_events"]
-    optimize_events = [
-        event for event in events if event["action"] == "learning_agent.optimize"
-    ]
+    optimize_events = [event for event in events if event["action"] == "learning_agent.optimize"]
     assert len(optimize_events) == 1
     assert optimize_events[0]["success"] is True
     assert optimize_events[0]["detail"]["dry_run"] is True
@@ -4526,7 +4475,10 @@ class MultiSearchCitadel(FakeCitadel):
         self.cognee = type(
             "_Cognee",
             (),
-            {"scheduled": [], "schedule_cognify": lambda self, datasets: self.scheduled.append(list(datasets))},
+            {
+                "scheduled": [],
+                "schedule_cognify": lambda self, datasets: self.scheduled.append(list(datasets)),
+            },
         )()
 
     async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
@@ -4590,9 +4542,7 @@ def test_create_seat_api_provisions_node_and_writer_token(tmp_path: Any) -> None
     assert invalid.status_code == 422
 
 
-def test_a_422_says_why_in_the_log_without_echoing_the_payload(
-    tmp_path: Any, caplog: Any
-) -> None:
+def test_a_422_says_why_in_the_log_without_echoing_the_payload(tmp_path: Any, caplog: Any) -> None:
     """A rejected write must be diagnosable from the node, not just from the caller.
 
     Production showed ten consecutive PUT .../capture-roots 422s with nothing in
@@ -4880,7 +4830,11 @@ def test_seat_cannot_recall_another_seats_session(tmp_path: Any) -> None:
 
     search = api_client.post(
         "/search",
-        json={"query": "anything", "dataset": "masumi-network", "session_id": "masumi-github-daily"},
+        json={
+            "query": "anything",
+            "dataset": "masumi-network",
+            "session_id": "masumi-github-daily",
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -5165,9 +5119,7 @@ def test_seat_session_reports_own_seat_slug_and_node(tmp_path: Any) -> None:
     ).json()["token"]
     api_client = TestClient(app, base_url="https://testserver")
 
-    session = api_client.get(
-        "/api/session", headers={"Authorization": f"Bearer {token}"}
-    )
+    session = api_client.get("/api/session", headers={"Authorization": f"Bearer {token}"})
 
     assert session.status_code == 200
     payload = session.json()
@@ -5190,9 +5142,7 @@ def test_me_summary_for_seat_reports_node_scope(tmp_path: Any) -> None:
     ).json()["token"]
     api_client = TestClient(app, base_url="https://testserver")
 
-    summary = api_client.get(
-        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
-    )
+    summary = api_client.get("/api/me/summary", headers={"Authorization": f"Bearer {token}"})
 
     assert summary.status_code == 200
     payload = summary.json()
@@ -5234,9 +5184,7 @@ def test_me_summary_uses_audit_when_mesh_empty(tmp_path: Any) -> None:
     )
     api_client = TestClient(app, base_url="https://testserver")
 
-    summary = api_client.get(
-        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
-    )
+    summary = api_client.get("/api/me/summary", headers={"Authorization": f"Bearer {token}"})
 
     assert summary.status_code == 200
     payload = summary.json()
@@ -5286,9 +5234,7 @@ def test_me_summary_keeps_node_activity_when_central_is_busy(tmp_path: Any) -> N
     asyncio.run(_populate())
     api_client = TestClient(app, base_url="https://testserver")
 
-    summary = api_client.get(
-        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
-    )
+    summary = api_client.get("/api/me/summary", headers={"Authorization": f"Bearer {token}"})
 
     assert summary.status_code == 200
     payload = summary.json()
@@ -5312,9 +5258,7 @@ def test_me_summary_non_seat_has_null_seat(tmp_path: Any) -> None:
     ).json()["token"]
     api_client = TestClient(app, base_url="https://testserver")
 
-    summary = api_client.get(
-        "/api/me/summary", headers={"Authorization": f"Bearer {token}"}
-    )
+    summary = api_client.get("/api/me/summary", headers={"Authorization": f"Bearer {token}"})
 
     assert summary.status_code == 200
     payload = summary.json()
@@ -5340,9 +5284,7 @@ def test_non_seat_token_session_nulls_seat_slug(tmp_path: Any) -> None:
     ).json()["token"]
     api_client = TestClient(app, base_url="https://testserver")
 
-    session = api_client.get(
-        "/api/session", headers={"Authorization": f"Bearer {token}"}
-    )
+    session = api_client.get("/api/session", headers={"Authorization": f"Bearer {token}"})
 
     assert session.status_code == 200
     payload = session.json()
@@ -5381,9 +5323,7 @@ def test_list_seats_returns_active_seats_with_token_counts(tmp_path: Any) -> Non
     assert "token_hash" not in seat["tokens"][0]
 
     # Revoking the seat's token drops the active count to zero but keeps the seat.
-    revoked = client.post(
-        f"/api/access/tokens/{created['api_token']['id']}/revoke"
-    )
+    revoked = client.post(f"/api/access/tokens/{created['api_token']['id']}/revoke")
     assert revoked.status_code == 200
     after = client.get("/api/access/seats").json()["seats"]
     assert after[0]["active_token_count"] == 0
@@ -5830,7 +5770,9 @@ def test_mcp_seat_contribute_forbidden(tmp_path: Any) -> None:
 def test_seat_contribute_forbidden(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
-    token = admin.post("/api/access/seats", json={"name": "Mcp Dana", "slug": "mcp-dana"}).json()["token"]
+    token = admin.post("/api/access/seats", json={"name": "Mcp Dana", "slug": "mcp-dana"}).json()[
+        "token"
+    ]
     api_client = TestClient(app, base_url="https://testserver")
 
     response = api_client.post(
@@ -5993,15 +5935,11 @@ def test_github_webhook_merged_pr_returns_202_nonblocking_and_audits(
     assert merge_events[0]["detail"]["triggered"] == "github_sync"
 
 
-def test_github_webhook_invalid_signature_returns_401(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_github_webhook_invalid_signature_returns_401(tmp_path: Path, monkeypatch: Any) -> None:
     secret = secrets.token_hex(16)
     syncer = _setup_webhook(tmp_path, secret)
     triggered: list[Any] = []
-    monkeypatch.setattr(
-        server_module, "_run_webhook_reingest", lambda s: triggered.append(s)
-    )
+    monkeypatch.setattr(server_module, "_run_webhook_reingest", lambda s: triggered.append(s))
 
     body = _merge_payload()
     client = TestClient(app, base_url="https://testserver")
@@ -6061,9 +5999,9 @@ def test_github_webhook_non_merge_close_returns_204(tmp_path: Path) -> None:
     secret = secrets.token_hex(16)
     syncer = _setup_webhook(tmp_path, secret)
 
-    body = json.dumps(
-        {"action": "closed", "pull_request": {"merged": False, "number": 7}}
-    ).encode("utf-8")
+    body = json.dumps({"action": "closed", "pull_request": {"merged": False, "number": 7}}).encode(
+        "utf-8"
+    )
     client = TestClient(app, base_url="https://testserver")
     response = client.post(
         "/api/webhooks/github",
@@ -6144,8 +6082,7 @@ def test_seat_capture_policy_admin_crud(tmp_path: Any) -> None:
 
     audit = admin.get("/api/audit")
     assert any(
-        event["action"] == "access.capture_policy.update"
-        for event in audit.json()["audit_events"]
+        event["action"] == "access.capture_policy.update" for event in audit.json()["audit_events"]
     )
 
 
@@ -6248,7 +6185,9 @@ def test_promotion_approve_reject_require_admin_not_seat_writer(tmp_path: Any) -
     for verb in ("approve", "reject"):
         # Seat-writer is 403'd for both its own real item and a bogus id (authz first).
         own = bob.post(f"/api/promotion/pending/{item.id}/{verb}", headers=bob_headers, json={})
-        bogus = bob.post(f"/api/promotion/pending/does-not-exist/{verb}", headers=bob_headers, json={})
+        bogus = bob.post(
+            f"/api/promotion/pending/does-not-exist/{verb}", headers=bob_headers, json={}
+        )
         assert own.status_code == 403, verb
         assert bogus.status_code == 403, verb
         # Admin passes the authz gate (proven by reaching the 404 id lookup).
@@ -6274,8 +6213,8 @@ class ShareCitadel(FakeCitadel):
         self.ingest_calls: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled = []
-        self.cognee.schedule_cognify = (
-            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        self.cognee.schedule_cognify = lambda datasets: (
+            self.cognee.scheduled.append(list(datasets)) or True
         )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
@@ -6292,8 +6231,8 @@ class CrossSeatTraceCitadel(FakeCitadel):
         self.traces: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = (
-            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        self.cognee.schedule_cognify = lambda datasets: (
+            self.cognee.scheduled.append(list(datasets)) or True
         )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
@@ -6348,9 +6287,7 @@ def test_share_session_dual_writes_and_schedules_cognify(tmp_path: Any) -> None:
 def test_share_session_surfaces_rejected_durable_queue(tmp_path: Any) -> None:
     app.state.access_store = AccessStore(tmp_path / "access.json")
     admin = authed_client()
-    token = admin.post(
-        "/api/access/seats", json={"name": "Alice", "slug": "alice"}
-    ).json()["token"]
+    token = admin.post("/api/access/seats", json={"name": "Alice", "slug": "alice"}).json()["token"]
     citadel = ShareCitadel()
     citadel.cognee.schedule_cognify = lambda datasets: False
     app.state.citadel = citadel
@@ -6369,14 +6306,10 @@ def test_share_session_surfaces_rejected_durable_queue(tmp_path: Any) -> None:
     assert payload["ok"] is True
     assert payload["accepted"] is True
     assert payload["cognify"] == "not_scheduled"
-    assert payload["message"] == (
-        "Shared Session Trace accepted, but indexing was not scheduled."
-    )
+    assert payload["message"] == ("Shared Session Trace accepted, but indexing was not scheduled.")
     events = app.state.access_store.snapshot()["audit_events"]
     successful = [
-        event
-        for event in events
-        if event["action"] == "share_session" and event["success"]
+        event for event in events if event["action"] == "share_session" and event["success"]
     ]
     assert successful[-1]["detail"]["cognify"] == "not_scheduled"
 
@@ -6566,8 +6499,8 @@ class PartialSessionTraceWriteCitadel(FakeCitadel):
         self.ingest_calls: list[dict[str, Any]] = []
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = (
-            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        self.cognee.schedule_cognify = lambda datasets: (
+            self.cognee.scheduled.append(list(datasets)) or True
         )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
@@ -6586,8 +6519,8 @@ class FlakySessionTraceWriteCitadel(FakeCitadel):
         self.session_traces_attempts = 0
         self.cognee = type("_FakeCognee", (), {})()
         self.cognee.scheduled: list[list[str]] = []
-        self.cognee.schedule_cognify = (
-            lambda datasets: self.cognee.scheduled.append(list(datasets)) or True
+        self.cognee.schedule_cognify = lambda datasets: (
+            self.cognee.scheduled.append(list(datasets)) or True
         )
 
     async def ingest(self, data: str, **kwargs: Any) -> IngestResult:
@@ -6669,7 +6602,9 @@ def test_share_session_fails_when_session_traces_write_rejected(tmp_path: Any) -
     ]
     assert app.state.citadel.cognee.scheduled == []
     events = app.state.access_store.snapshot()["audit_events"]
-    failed = [event for event in events if event["action"] == "share_session" and not event["success"]]
+    failed = [
+        event for event in events if event["action"] == "share_session" and not event["success"]
+    ]
     assert failed
     assert failed[-1]["detail"]["error_type"] == "partial_write_failure"
     assert failed[-1]["detail"]["retried"] is True
@@ -7055,9 +6990,7 @@ def test_weak_env_access_key_refuses_to_start(monkeypatch) -> None:
         server_module,
         "get_citadel",
         lambda: SimpleNamespace(
-            config=SimpleNamespace(
-                admin_key="owner-admin-key", writer_keys=(), reader_keys=()
-            )
+            config=SimpleNamespace(admin_key="owner-admin-key", writer_keys=(), reader_keys=())
         ),
     )
 
@@ -7074,9 +7007,7 @@ def test_a_strong_env_access_key_starts_normally(monkeypatch) -> None:
         server_module,
         "get_citadel",
         lambda: SimpleNamespace(
-            config=SimpleNamespace(
-                admin_key="x" * 64, writer_keys=(), reader_keys=()
-            )
+            config=SimpleNamespace(admin_key="x" * 64, writer_keys=(), reader_keys=())
         ),
     )
 
@@ -7317,6 +7248,8 @@ def test_api_mesh_activity_counters_are_scoped_not_top_level(
     assert {"searches", "feedback", "upgrades", "errors"} <= set(since)
     # The window the counters cover ships with them.
     assert since["started_at"]
+
+
 class FakeCorpusCognee:
     """Fake at the kb.cognee_client METHOD boundary.
 
@@ -7527,9 +7460,7 @@ def test_corpus_census_clamps_a_future_dated_cursor_so_later_rows_land() -> None
 
     # A real row arrives after the cursor was handed out, just past the skew
     # window. With the future-dated cursor it would never be seen.
-    fake.rows.append(
-        _corpus_row("doc-later", (now + timedelta(seconds=601)).isoformat())
-    )
+    fake.rows.append(_corpus_row("doc-later", (now + timedelta(seconds=601)).isoformat()))
 
     page_two = client.get(f"/api/corpus?limit=3&cursor={cursor}").json()
     assert "doc-later" in [row["id"] for row in page_two["documents"]]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -219,7 +219,9 @@ async def test_search_falls_back_to_persisted_github_digest(tmp_path: Any) -> No
         cognee=EmptyCognee(),
     )
 
-    result = await kb.search("what were the new updates all week in the org", dataset="masumi-network")
+    result = await kb.search(
+        "what were the new updates all week in the org", dataset="masumi-network"
+    )
 
     assert result[0]["source"] == "github_sync_state"
     assert result[0]["metadata"]["org"] == "masumi-network"
@@ -772,8 +774,7 @@ async def test_reconcile_corpus_repairs_mixed_candidates_once_and_holds_lock(tmp
             self, document_ids: list[str]
         ) -> dict[str, dict[str, Any]]:
             return {
-                document_id: {"content_hash": f"hash-{document_id}"}
-                for document_id in document_ids
+                document_id: {"content_hash": f"hash-{document_id}"} for document_id in document_ids
             }
 
     fake = RepairGateway()
@@ -849,9 +850,7 @@ async def test_reconcile_corpus_refuses_apply_when_source_manifest_fails(tmp_pat
                 "missing_document_id_violation_count": 0,
             }
 
-        async def source_manifest_for_documents(
-            self, _: list[str]
-        ) -> dict[str, dict[str, Any]]:
+        async def source_manifest_for_documents(self, _: list[str]) -> dict[str, dict[str, Any]]:
             raise RuntimeError("source unavailable")
 
         async def delete_document_chunks(self, document_ids: list[str]) -> dict[str, Any]:
@@ -1255,9 +1254,7 @@ async def test_reconcile_corpus_refuses_recovery_when_dataset_membership_changed
     assert result["reason"] == "repair_dataset_membership_changed"
     assert fake.cognify_calls == []
     assert result["pending_operations"][0]["operation_id"] == "membership-drift-op"
-    assert result["pending_operations"][0]["reason"] == (
-        "repair_dataset_membership_changed"
-    )
+    assert result["pending_operations"][0]["reason"] == ("repair_dataset_membership_changed")
 
 
 @pytest.mark.asyncio
@@ -1286,9 +1283,9 @@ async def test_reconcile_corpus_refuses_recovery_without_source_manifest(tmp_pat
 
 @pytest.mark.asyncio
 async def test_reconcile_corpus_recovery_requires_apply() -> None:
-    result = await Citadel(CitadelConfig(default_dataset="notes"), cognee=FakeCognee()).reconcile_corpus(
-        recover=True
-    )
+    result = await Citadel(
+        CitadelConfig(default_dataset="notes"), cognee=FakeCognee()
+    ).reconcile_corpus(recover=True)
 
     assert result["ok"] is False
     assert result["reason"] == "repair_recovery_requires_apply"
@@ -1296,9 +1293,9 @@ async def test_reconcile_corpus_recovery_requires_apply() -> None:
 
 @pytest.mark.asyncio
 async def test_reconcile_corpus_recovery_requires_force() -> None:
-    result = await Citadel(CitadelConfig(default_dataset="notes"), cognee=FakeCognee()).reconcile_corpus(
-        apply=True, recover=True
-    )
+    result = await Citadel(
+        CitadelConfig(default_dataset="notes"), cognee=FakeCognee()
+    ).reconcile_corpus(apply=True, recover=True)
 
     assert result["ok"] is False
     assert result["reason"] == "repair_recovery_requires_force"
@@ -1522,9 +1519,7 @@ async def test_reconcile_corpus_reports_failure_phase_after_deletion(tmp_path) -
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("repair_method", ["combined", "oversized"])
-async def test_reconcile_stops_after_partial_delete_failure(
-    tmp_path, repair_method: str
-) -> None:
+async def test_reconcile_stops_after_partial_delete_failure(tmp_path, repair_method: str) -> None:
     class PartialDeleteGateway(FakeCognee):
         def __init__(self) -> None:
             super().__init__()
@@ -2245,8 +2240,7 @@ def test_github_digest_fossil_never_matches_real_content() -> None:
     # (g) A line the renderer never emitted inside the header block.
     tampered = _DIGEST_FOSSIL_DOC.replace(
         "Source: https://github.com/orgs/masumi-network/repositories",
-        "Source: https://github.com/orgs/masumi-network/repositories\n"
-        "Reviewed by: sarthi",
+        "Source: https://github.com/orgs/masumi-network/repositories\nReviewed by: sarthi",
     )
     assert _legacy_garbage_kind("d8", {"text": tampered}) is None
     # (h) Header fields out of renderer order.
@@ -2271,10 +2265,7 @@ def test_github_digest_fossil_is_matched() -> None:
     from kb.service import _legacy_garbage_kind
 
     assert _legacy_garbage_kind("g1", {"text": _DIGEST_FOSSIL_DOC}) == "github_digest_fossil"
-    assert (
-        _legacy_garbage_kind("g2", {"text": _DIGEST_FOSSIL_OLDEST_DOC})
-        == "github_digest_fossil"
-    )
+    assert _legacy_garbage_kind("g2", {"text": _DIGEST_FOSSIL_OLDEST_DOC}) == "github_digest_fossil"
     # The middle vintage rendered Checked at: without a Window started at: line.
     no_window = _DIGEST_FOSSIL_DOC.replace("Window started at: 2026-07-18T05:44:02Z\n", "")
     assert _legacy_garbage_kind("g3", {"text": no_window}) == "github_digest_fossil"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -151,7 +151,7 @@ def test_get_skill_connect() -> None:
     assert connect["integrity"] == f"sha256-{base64.b64encode(digest).decode('ascii')}"
     assert response.headers["x-citadel-skill-sha256"] == sha256
     assert response.headers["x-citadel-skill-integrity"] == connect["integrity"]
-    assert response.headers["etag"] == f"\"sha256-{sha256}\""
+    assert response.headers["etag"] == f'"sha256-{sha256}"'
     assert response.headers["cache-control"] == "public, max-age=300"
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -76,7 +76,9 @@ def test_check_local_setup(tmp_path: Path, monkeypatch) -> None:
     user_settings = claude_user_settings_path()
     user_settings.parent.mkdir(parents=True, exist_ok=True)
     user_settings.write_text(
-        json.dumps({"hooks": {"SessionEnd": [{"hooks": [{"command": status_mod.SESSION_HOOK_MARKER}]}]}})
+        json.dumps(
+            {"hooks": {"SessionEnd": [{"hooks": [{"command": status_mod.SESSION_HOOK_MARKER}]}]}}
+        )
     )
     cfg = tmp_path / "capture.json"
     cfg.write_text(json.dumps({"roots": [{"path": "/tmp/x", "tags": ["org-work"]}]}))
@@ -124,7 +126,9 @@ def test_assess_mcp_setup_states(tmp_path: Path, monkeypatch) -> None:
     # a token alone will not expose hosted tools.
     monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
     (tmp_path / ".mcp.json").write_text(
-        json.dumps({"mcpServers": {"citadel": {"command": "python", "args": ["-m", "kb.mcp_server"]}}})
+        json.dumps(
+            {"mcpServers": {"citadel": {"command": "python", "args": ["-m", "kb.mcp_server"]}}}
+        )
     )
     unconfigured_no_token = status_mod.assess_mcp_setup(tmp_path)
     assert unconfigured_no_token.data["state"] == status_mod.MCP_STATE_READY_BUT_UNCONFIGURED
@@ -137,11 +141,7 @@ def test_assess_mcp_setup_states(tmp_path: Path, monkeypatch) -> None:
 
     (tmp_path / ".mcp.json").write_text(
         json.dumps(
-            {
-                "mcpServers": {
-                    "citadel": {"type": "http", "url": "https://citadel.example/mcp/"}
-                }
-            }
+            {"mcpServers": {"citadel": {"type": "http", "url": "https://citadel.example/mcp/"}}}
         )
     )
     ready = status_mod.assess_mcp_setup(tmp_path)
@@ -171,9 +171,13 @@ def test_gather_status_skips_search_by_default(tmp_path: Path, monkeypatch) -> N
         if "/healthz" in url:
             return _FakeResp({"ok": True})
         if "/api/session" in url:
-            return _FakeResp({"ok": True, "role": "writer", "seat_slug": "s", "actor": {"name": "S"}})
+            return _FakeResp(
+                {"ok": True, "role": "writer", "seat_slug": "s", "actor": {"name": "S"}}
+            )
         if "/readyz" in url:
-            return _FakeResp({"ok": True, "corpus": {"ok": True, "tracked_sources": 1, "indexed_docs": 1}})
+            return _FakeResp(
+                {"ok": True, "corpus": {"ok": True, "tracked_sources": 1, "indexed_docs": 1}}
+            )
         if "/api/contributions/recent" in url:
             return _FakeResp({"contributions": []})
         raise AssertionError(f"unexpected URL {url}")
@@ -216,7 +220,9 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
                     "actor": {"name": "Sarthi"},
                 },
                 "/search": {"results": [{"id": 1}]},
-                "/api/contributions/recent": {"contributions": [{"title": "feat: x", "created_at": "2026-06-27T10:00:00"}]},
+                "/api/contributions/recent": {
+                    "contributions": [{"title": "feat: x", "created_at": "2026-06-27T10:00:00"}]
+                },
             }
         ),
     )
@@ -247,8 +253,12 @@ def test_readiness_auth_required_and_search_codes(tmp_path: Path) -> None:
         healthy=False,
         identity={},
         checks=[
-            Check("auth", ok=False, detail="no token", data={"code": status_mod.CODE_AUTH_REQUIRED}),
-            Check("search", ok=False, detail="skipped", data={"code": status_mod.CODE_AUTH_REQUIRED}),
+            Check(
+                "auth", ok=False, detail="no token", data={"code": status_mod.CODE_AUTH_REQUIRED}
+            ),
+            Check(
+                "search", ok=False, detail="skipped", data={"code": status_mod.CODE_AUTH_REQUIRED}
+            ),
         ],
         recent=[],
         repo=str(tmp_path),
@@ -335,11 +345,17 @@ def test_check_corpus_red_when_readyz_503(monkeypatch) -> None:
     import urllib.error
 
     body = json.dumps(
-        {"ok": False, "corpus": {"ok": False, "tracked_sources": 200, "indexed_docs": 0}, "canary": None}
+        {
+            "ok": False,
+            "corpus": {"ok": False, "tracked_sources": 200, "indexed_docs": 0},
+            "canary": None,
+        }
     ).encode()
 
     def raise_503(request, timeout=None):
-        raise urllib.error.HTTPError(request.full_url, 503, "Service Unavailable", {}, io.BytesIO(body))
+        raise urllib.error.HTTPError(
+            request.full_url, 503, "Service Unavailable", {}, io.BytesIO(body)
+        )
 
     monkeypatch.setattr(status_mod._OPENER, "open", raise_503)
     check = status_mod.check_corpus("https://node.example", "ctdl_tok")
@@ -352,7 +368,15 @@ def test_check_corpus_ok_when_readyz_healthy(monkeypatch) -> None:
     monkeypatch.setattr(
         status_mod._OPENER,
         "open",
-        _route({"/readyz": {"ok": True, "corpus": {"ok": True, "tracked_sources": 200, "indexed_docs": 280}, "canary": {"ok": True}}}),
+        _route(
+            {
+                "/readyz": {
+                    "ok": True,
+                    "corpus": {"ok": True, "tracked_sources": 200, "indexed_docs": 280},
+                    "canary": {"ok": True},
+                }
+            }
+        ),
     )
     check = status_mod.check_corpus("https://node.example", "ctdl_tok")
     assert check is not None and check.ok is True
@@ -368,7 +392,9 @@ def test_gather_status_node_down(tmp_path: Path) -> None:
     original = s._OPENER.open
     s._OPENER.open = boom  # type: ignore[assignment]
     try:
-        report = gather_status("https://node.example", "ctdl_tok", repo=tmp_path, config_path=tmp_path / "c.json")
+        report = gather_status(
+            "https://node.example", "ctdl_tok", repo=tmp_path, config_path=tmp_path / "c.json"
+        )
     finally:
         s._OPENER.open = original  # type: ignore[assignment]
     assert not report.healthy
@@ -422,7 +448,12 @@ def test_render_text_search_failure_warns_not_fails() -> None:
         identity={},
         checks=[
             Check("node", ok=True, detail="healthy"),
-            Check("search", ok=False, detail="timed out after 3s — node warming up", data={"timed_out": True}),
+            Check(
+                "search",
+                ok=False,
+                detail="timed out after 3s — node warming up",
+                data={"timed_out": True},
+            ),
         ],
         recent=[],
     )
@@ -495,14 +526,24 @@ def test_humanize_net_error_translates_dns_noise() -> None:
     # Raw urllib reasons read like C errno dumps — humans get words.
     exc = OSError("<urlopen error [Errno 8] nodename nor servname provided, or not known>")
     assert status_mod._humanize_net_error(exc) == "cannot resolve host"
-    assert status_mod._humanize_net_error(OSError("[Errno 61] Connection refused")) == "connection refused"
+    assert (
+        status_mod._humanize_net_error(OSError("[Errno 61] Connection refused"))
+        == "connection refused"
+    )
 
 
 def test_status_command_json_and_exit(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         status_mod._OPENER,
         "open",
-        _route({"/healthz": {"ok": True}, "/api/session": {"ok": True, "role": "writer", "seat_slug": "s"}, "/search": {"results": []}, "/api/contributions/recent": {"contributions": []}}),
+        _route(
+            {
+                "/healthz": {"ok": True},
+                "/api/session": {"ok": True, "role": "writer", "seat_slug": "s"},
+                "/search": {"results": []},
+                "/api/contributions/recent": {"contributions": []},
+            }
+        ),
     )
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_tok")
     args = argparse.Namespace(
@@ -555,7 +596,10 @@ def test_fetch_events_builds_scoped_url_and_parses(monkeypatch) -> None:
     def fake_open(request: Any, timeout: float | None = None) -> _FakeResp:
         captured["url"] = request.full_url
         return _FakeResp(
-            {"events": [{"id": 7, "type": "ingest", "message": "Memory indexed"}], "latest_event_id": 7}
+            {
+                "events": [{"id": 7, "type": "ingest", "message": "Memory indexed"}],
+                "latest_event_id": 7,
+            }
         )
 
     monkeypatch.setattr(status_mod._OPENER, "open", fake_open)
@@ -609,10 +653,18 @@ def test_fetch_presence_extracts_only_seat_hubs_no_content(monkeypatch) -> None:
     graph = {
         "nodes": [
             {"id": "doc-1", "label": "Alice private doc", "type": "TextDocument"},
-            {"id": "dataset:seat:alice", "label": "seat:alice", "type": "dataset",
-             "presence": {"documents": 5}},
-            {"id": "dataset:masumi-network", "label": "masumi-network", "type": "dataset",
-             "presence": {"documents": 100}},
+            {
+                "id": "dataset:seat:alice",
+                "label": "seat:alice",
+                "type": "dataset",
+                "presence": {"documents": 5},
+            },
+            {
+                "id": "dataset:masumi-network",
+                "label": "masumi-network",
+                "type": "dataset",
+                "presence": {"documents": 100},
+            },
         ]
     }
     monkeypatch.setattr(status_mod._OPENER, "open", _route({"/api/mesh/graph": graph}))
@@ -651,7 +703,9 @@ def test_seat_hint_suppressed_when_auth_failed() -> None:
         identity={"code": "AUTH_REQUIRED"},
         checks=[
             Check("node", ok=False, detail="unreachable (timed out)"),
-            Check("auth", ok=False, detail="unreachable (timed out)", data={"code": "AUTH_REQUIRED"}),
+            Check(
+                "auth", ok=False, detail="unreachable (timed out)", data={"code": "AUTH_REQUIRED"}
+            ),
         ],
         recent=[],
     )
@@ -674,10 +728,12 @@ def test_seat_hint_suppressed_when_auth_failed() -> None:
 def test_render_presence_board_sorts_by_count() -> None:
     from kb.cli import _render_presence
 
-    board = {"seats": [
-        {"seat": "seat:sarthi", "documents": 23},
-        {"seat": "masumi-network", "documents": 1022},
-    ]}
+    board = {
+        "seats": [
+            {"seat": "seat:sarthi", "documents": 23},
+            {"seat": "masumi-network", "documents": 1022},
+        ]
+    }
     out = _render_presence(board, color=False)
     assert "Team presence" in out
     assert "seat:sarthi" in out
@@ -690,8 +746,14 @@ def test_render_presence_board_sorts_by_count() -> None:
 
 def _activity_args(**kw) -> argparse.Namespace:
     base = dict(
-        limit=20, local=False, config=None, node_url="https://node.example",
-        json=True, watch=False, type=None, global_broadcast=False,
+        limit=20,
+        local=False,
+        config=None,
+        node_url="https://node.example",
+        json=True,
+        watch=False,
+        type=None,
+        global_broadcast=False,
     )
     base.update(kw)
     return argparse.Namespace(**base)

--- a/tests/test_style_invariants.py
+++ b/tests/test_style_invariants.py
@@ -82,7 +82,12 @@ def test_every_stylesheet_makes_the_hidden_attribute_win() -> None:
     # we do not write.
     linked = set()
     for page in exported_pages():
-        linked.update(re.findall(r'<link rel="stylesheet" href="/next(/[^"]+\.css)"', page.read_text(encoding="utf-8")))
+        linked.update(
+            re.findall(
+                r'<link rel="stylesheet" href="/next(/[^"]+\.css)"',
+                page.read_text(encoding="utf-8"),
+            )
+        )
     assert linked, "no exported document links a stylesheet"
     for href in sorted(linked):
         css = WEBUI / href.lstrip("/")

--- a/tests/test_sync_push.py
+++ b/tests/test_sync_push.py
@@ -59,9 +59,7 @@ def test_missing_token_no_post(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(sync_push, "_sync_one", fake_sync)
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert recorder == []
@@ -103,9 +101,7 @@ def test_post_omits_dataset_field(monkeypatch: Any, tmp_path: Path) -> None:
 
     stdin = io.StringIO(
         "refs/heads/feature abcdef0123456789abcdef0123456789abcdef0 "
-        "refs/heads/feature "
-        + "0" * 40
-        + "\n"
+        "refs/heads/feature " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     body = captured["body"]
@@ -135,9 +131,7 @@ def test_run_swallows_post_errors(monkeypatch: Any, tmp_path: Path) -> None:
 
     monkeypatch.setattr(sync_push, "_sync_one", boom)
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert called  # proves the swallowed-exception path actually executed
@@ -165,9 +159,7 @@ def test_run_absent_config_fails_closed(monkeypatch: Any, tmp_path: Path, capsys
     monkeypatch.setattr(sync_push, "_sync_one", lambda *a, **k: posted.append(k))
 
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert posted == []
@@ -214,9 +206,7 @@ def test_run_corrupt_config_fails_closed(monkeypatch: Any, tmp_path: Path) -> No
     monkeypatch.setattr(sync_push, "_sync_one", lambda *a, **k: posted.append(k))
 
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert posted == []  # corrupt allowlist captures nothing
@@ -233,9 +223,7 @@ def test_run_skips_repo_outside_allowlist(monkeypatch: Any, tmp_path: Path, caps
     monkeypatch.setattr(sync_push, "_sync_one", lambda *a, **k: posted.append(k))
 
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert posted == []
@@ -253,9 +241,7 @@ def test_run_captures_approved_repo_with_root_tags(monkeypatch: Any, tmp_path: P
     monkeypatch.setattr(sync_push, "_sync_one", lambda *a, **k: calls.append(k))
 
     stdin = io.StringIO(
-        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main "
-        + "0" * 40
-        + "\n"
+        "refs/heads/main abcdef0123456789abcdef0123456789abcdef0 refs/heads/main " + "0" * 40 + "\n"
     )
     assert sync_push.run(stdin, remote_name="origin") == 0
     assert len(calls) == 1
@@ -296,9 +282,7 @@ def _fake_urlopen_with_body(monkeypatch: Any, body: bytes) -> None:
         def read(self) -> bytes:
             return body
 
-    monkeypatch.setattr(
-        sync_push.urllib.request, "urlopen", lambda request, timeout=None: _Resp()
-    )
+    monkeypatch.setattr(sync_push.urllib.request, "urlopen", lambda request, timeout=None: _Resp())
 
 
 def _receipt_text() -> str:
@@ -353,9 +337,7 @@ def test_receipt_on_unreadable_body_does_not_claim_capture(
     assert "captured commit" not in receipt
 
 
-def test_receipt_on_timeout_says_write_may_have_completed(
-    monkeypatch: Any, tmp_path: Path
-) -> None:
+def test_receipt_on_timeout_says_write_may_have_completed(monkeypatch: Any, tmp_path: Path) -> None:
     _approve_repo_for_real_sync(monkeypatch, tmp_path)
 
     def boom(request: Any, timeout: int | None = None) -> None:

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -25,9 +25,7 @@ def _assistant_edit(file_path: str) -> dict[str, Any]:
     return {
         "type": "assistant",
         "message": {
-            "content": [
-                {"type": "tool_use", "name": "Edit", "input": {"file_path": file_path}}
-            ]
+            "content": [{"type": "tool_use", "name": "Edit", "input": {"file_path": file_path}}]
         },
     }
 
@@ -58,9 +56,7 @@ class _RecordingPost:
         self.calls: list[dict[str, Any]] = []
 
     def __call__(self, base_url: str, token: str, data: str, tags: list[str]) -> None:
-        self.calls.append(
-            {"base_url": base_url, "token": token, "data": data, "tags": tags}
-        )
+        self.calls.append({"base_url": base_url, "token": token, "data": data, "tags": tags})
 
 
 # --- distillation -----------------------------------------------------------
@@ -134,9 +130,7 @@ def test_iter_transcript_missing_file_returns_empty() -> None:
     assert sync_session._iter_transcript("/nonexistent/path/to/transcript.jsonl") == []
 
 
-def test_iter_transcript_refuses_paths_outside_allowlist(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_iter_transcript_refuses_paths_outside_allowlist(tmp_path: Path, monkeypatch: Any) -> None:
     monkeypatch.delenv("CITADEL_TRANSCRIPT_ALLOW_ROOT", raising=False)
     path = _write_transcript(tmp_path, _sample_entries())
     assert sync_session._iter_transcript(str(path)) == []
@@ -145,9 +139,7 @@ def test_iter_transcript_refuses_paths_outside_allowlist(
 # --- run(): missing token -> no POST + clean exit ---------------------------
 
 
-def test_missing_token_no_post_clean_exit(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_missing_token_no_post_clean_exit(tmp_path: Path, monkeypatch: Any) -> None:
     monkeypatch.delenv("CITADEL_MCP_ACCESS_TOKEN", raising=False)
     recorder = _RecordingPost()
     monkeypatch.setattr(sync_session, "post_ingest", recorder)
@@ -227,19 +219,14 @@ def test_post_omits_dataset_field(monkeypatch: Any, tmp_path: Path) -> None:
 
 def test_post_refuses_non_https() -> None:
     with pytest.raises(ValueError):
-        sync_session.post_ingest(
-            "http://example.invalid", "ctdl_x", "note", ["dev-session"]
-        )
+        sync_session.post_ingest("http://example.invalid", "ctdl_x", "note", ["dev-session"])
 
 
 def test_redirects_are_not_followed() -> None:
     # A 3xx (esp. an https->http downgrade) must not re-send the Authorization
     # header. The handler refuses to follow any redirect.
     handler = sync_session._NoRedirectHandler()
-    assert (
-        handler.redirect_request(None, None, 302, "Found", {}, "http://evil.invalid")
-        is None
-    )
+    assert handler.redirect_request(None, None, 302, "Found", {}, "http://evil.invalid") is None
 
 
 def test_run_swallows_post_errors(monkeypatch: Any, tmp_path: Path) -> None:
@@ -350,9 +337,7 @@ def test_receipt_on_unreadable_body_does_not_claim_capture(
     assert "session captured" not in receipt
 
 
-def test_receipt_on_timeout_says_write_may_have_completed(
-    monkeypatch: Any, tmp_path: Path
-) -> None:
+def test_receipt_on_timeout_says_write_may_have_completed(monkeypatch: Any, tmp_path: Path) -> None:
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test_token")
     monkeypatch.setattr(sync_session, "build_tags", lambda cwd: ["dev-session"])
 

--- a/tests/test_sync_start.py
+++ b/tests/test_sync_start.py
@@ -32,6 +32,7 @@ def test_agent_policy_token_authority_lines() -> None:
     assert "no authoritative hit" in text
     assert "official docs / skill first" in text
 
+
 def test_empty_recent_still_injects_agent_policy(monkeypatch, capsys) -> None:
     monkeypatch.setenv(sync_start.TOKEN_ENV, "ctdl_x")
     monkeypatch.setattr(sync_start, "fetch_recent", lambda *a, **k: [])

--- a/tests/test_tool_detect.py
+++ b/tests/test_tool_detect.py
@@ -26,7 +26,10 @@ def test_cursor_merge_preserves_and_idempotent(tmp_path, monkeypatch) -> None:
     data = json.loads(cur.read_text())
     assert "other" in data["mcpServers"]  # sibling server preserved
     assert data["mcpServers"]["citadel"]["url"] == "https://node.example/mcp/"
-    assert "${env:CITADEL_MCP_ACCESS_TOKEN}" in data["mcpServers"]["citadel"]["headers"]["Authorization"]
+    assert (
+        "${env:CITADEL_MCP_ACCESS_TOKEN}"
+        in data["mcpServers"]["citadel"]["headers"]["Authorization"]
+    )
 
     assert td.apply("cursor", node_url=NODE).action == "unchanged"
 
@@ -62,7 +65,9 @@ def test_codex_append_fallback_idempotent(tmp_path, monkeypatch) -> None:
 def test_gemini_write_uses_httpurl_and_dollar_var(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     assert td.apply("gemini", node_url=NODE).action == "wrote"
-    entry = json.loads((tmp_path / ".gemini" / "settings.json").read_text())["mcpServers"]["citadel"]
+    entry = json.loads((tmp_path / ".gemini" / "settings.json").read_text())["mcpServers"][
+        "citadel"
+    ]
     assert entry["httpUrl"] == "https://node.example/mcp/"  # httpUrl, not url (SSE)
     # Gemini expands $VAR, NOT the ${env:} form.
     assert entry["headers"]["Authorization"] == "Bearer $CITADEL_MCP_ACCESS_TOKEN"
@@ -71,9 +76,9 @@ def test_gemini_write_uses_httpurl_and_dollar_var(tmp_path, monkeypatch) -> None
 def test_windsurf_write_uses_serverurl_and_env_ref(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     assert td.apply("windsurf", node_url=NODE).action == "wrote"
-    entry = json.loads(
-        (tmp_path / ".codeium" / "windsurf" / "mcp_config.json").read_text()
-    )["mcpServers"]["citadel"]
+    entry = json.loads((tmp_path / ".codeium" / "windsurf" / "mcp_config.json").read_text())[
+        "mcpServers"
+    ]["citadel"]
     assert entry["serverUrl"] == "https://node.example/mcp/"
     assert entry["headers"]["Authorization"] == "Bearer ${env:CITADEL_MCP_ACCESS_TOKEN}"
 

--- a/tests/test_webhook_gateway.py
+++ b/tests/test_webhook_gateway.py
@@ -28,6 +28,7 @@ def _no_real_dns(monkeypatch):
         wg.socket, "getaddrinfo", lambda host, *a, **k: [(2, 1, 6, "", ("93.184.216.34", 0))]
     )
 
+
 GOOD = "https://hooks.example.com/services/T000/B000/xxxx"
 
 
@@ -219,8 +220,10 @@ def test_the_validated_ip_is_the_one_connected_to(monkeypatch) -> None:
     handlers: list[Any] = []
     monkeypatch.setattr(
         "kb.webhook_gateway.urllib.request.build_opener",
-        lambda *hs: handlers.extend(hs)
-        or type("O", (), {"open": staticmethod(lambda r, timeout: _Response(200))})(),
+        lambda *hs: (
+            handlers.extend(hs)
+            or type("O", (), {"open": staticmethod(lambda r, timeout: _Response(200))})()
+        ),
     )
     gateway.post_digest("body")
 
@@ -252,6 +255,7 @@ def test_a_trailing_dot_cannot_dodge_the_suffix_blocklist() -> None:
 
 def test_an_unresolvable_host_is_refused_not_allowed(monkeypatch) -> None:
     """Failing open on a resolution error would make DNS downtime a bypass."""
+
     def boom(*a: Any, **k: Any) -> Any:
         raise OSError("no such host")
 
@@ -300,6 +304,7 @@ def test_one_broken_provider_does_not_unregister_the_others(monkeypatch) -> None
     """GoogleChatDelivery.__init__ raises on a space name missing `spaces/`, so
     without isolation a single mistyped env var would also drop a perfectly good
     webhook and take LearningAgent.__init__ with it."""
+
     def explode(config: Any) -> Any:
         raise ValueError("CITADEL_GOOGLE_CHAT_SPACE_NAME must look like spaces/...")
 


### PR DESCRIPTION
## Summary
- `ruff format` was configured but never enforced, and the tree had drifted: `uv run ruff format --check .` reported 109 files that would be reformatted (54 already formatted).
- Two commits, exactly per the issue's suggested approach:
  1. `style: adopt ruff format across the tree` — runs `uv run ruff format .` and nothing else. No logic changes, pure noise.
  2. `chore: add ruff format commit to .git-blame-ignore-revs` — excludes the mechanical reformat commit from `git blame` so blame keeps surfacing the commit that actually changed a line's logic.
- Enforcing this in CI (`test.yml`) is deliberately left for a separate follow-up PR, keeping the mechanical change separate from the policy change, as the issue requested.

Fixes #127

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 163 files already formatted (0 remaining)
- [x] `uv run pytest tests/ -q` — 1727 passed, 1 skipped (unchanged from baseline)