### PR TITLE
fix(railway): drop unsupported Dockerfile VOLUME instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ RUN install -d /opt/citadel \
     && rm -rf /wheels
 
 EXPOSE 8000
-VOLUME ["/data"]
+# No VOLUME instruction: Railway rejects `docker VOLUME` (it uses Railway
+# Volumes mounted at /data instead), and for Compose/OCI the data volume is
+# declared by the compose file or mounted explicitly, so the anonymous volume
+# a bare VOLUME would create is unwanted. Persistence at /data is provided by
+# the platform mount, not the image.
 HEALTHCHECK --interval=15s --timeout=15s --start-period=120s --retries=5 \
   CMD ["python", "-c", "import os; from urllib.request import Request, urlopen; request = Request('http://127.0.0.1:8000/readyz', headers={'Authorization': 'Bearer ' + os.environ['CITADEL_ADMIN_KEY']}); assert urlopen(request, timeout=12).status == 200"]
 USER 10001:10001


### PR DESCRIPTION
The v0.5 merge (#256) triggered a Railway deploy that FAILED at build with `dockerfile invalid: docker VOLUME at Line 45 is not supported, use Railway Volumes`. Railway rejects the `VOLUME ["/data"]` instruction.

This removes it. Persistence at /data is provided by the platform mount (Railway Volume) or the Compose volume declaration; the bare VOLUME only created an unwanted anonymous volume for OCI users. Unblocks the v0.5 Railway build. Compose and OCI persistence are unaffected.

Merging this re-triggers the Citadel-Archive + Citadel-GitHub-Sync builds, which are wired for Qdrant (new Qdrant service is up, vector env staged).