### PR TITLE
fix(railway): boot the published image via kb.lite_runtime

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,13 +2,17 @@
 builder = "RAILPACK"
 
 [deploy]
-# Same entry command for every service. CITADEL_RUN_MODE selects the role:
-#   web (default)  - FastAPI Organization Vault service
-#   pipeline       - full scheduled run: GitHub org sync, skills catalog
-#                    refresh, self-improvement pass, backup mirror export
-#   github-sync / learning-agent / backup-mirror - single jobs
-startCommand = "python -m scripts.run_railway"
+# The published image (Dockerfile) is the SQLite-Lite + Qdrant runtime and does
+# not vendor scripts/, so `python -m scripts.run_railway` is unavailable in it.
+# kb.lite_runtime is the image's own entrypoint: it validates the Lite profile,
+# prepares the SQLite/Ladybug/cache layout under the mounted /data volume, then
+# serves the FastAPI Organization Vault. The job/dispatcher modes that used
+# scripts.run_railway (github-sync, backup-mirror, pipeline) run from a
+# source/RAILPACK build and are configured per-service, not here.
+startCommand = "python -m kb.lite_runtime"
 healthcheckPath = "/healthz"
-healthcheckTimeout = 30
+# Cold boot downloads the fastembed embedding model and initialises cognee +
+# Ladybug before /healthz answers, which can exceed 30s on a fresh volume.
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -7,11 +7,20 @@ import tomllib
 from scripts import run_railway
 
 
-def test_railway_toml_uses_testable_dispatcher() -> None:
+def test_railway_toml_boots_the_published_image_entrypoint() -> None:
+    # The deployed web build (RAILPACK) installs the `kb` package but not the
+    # top-level scripts/ directory, so `python -m scripts.run_railway` raises
+    # ModuleNotFoundError on boot. railway.toml must start the image via
+    # kb.lite_runtime, which is importable there. The scripts.run_railway
+    # dispatcher and its job modes still exist for source/RAILPACK job services
+    # and are exercised by the tests below.
+    import importlib.util
+
     with open("railway.toml", "rb") as file:
         config = tomllib.load(file)
 
-    assert config["deploy"]["startCommand"] == "python -m scripts.run_railway"
+    assert config["deploy"]["startCommand"] == "python -m kb.lite_runtime"
+    assert importlib.util.find_spec("kb.lite_runtime") is not None
 
 
 def test_web_mode_execs_uvicorn(monkeypatch: Any) -> None:


### PR DESCRIPTION
Second and final Railway deploy fix. After #263 the v0.5 build succeeds, but the container crashes on boot:

```
ModuleNotFoundError: No module named 'scripts'
```

The published Docker image is the SQLite-Lite + Qdrant runtime; it ships the `kb` package (entrypoint `kb.lite_runtime`) and does NOT vendor `scripts/`, so `railway.toml`'s `python -m scripts.run_railway` is not importable in it.

This points the web start command at `kb.lite_runtime` (the image's own entrypoint, which validates the Lite profile, prepares the SQLite/Ladybug/cache layout under the mounted `/data` volume, then serves the vault) and raises `healthcheckTimeout` to 300s for the cold-start fastembed model download.

The Qdrant service is already up and Citadel-Archive's env is wired for the Lite profile (DB_PROVIDER=sqlite, GRAPH_DATABASE_PROVIDER=ladybug, VECTOR_DB_PROVIDER=qdrant + URL/key/generation). Merging this triggers the deploy that should boot healthy. Production stays on v0.4.1 until it does (blue-green).

Note: Citadel-GitHub-Sync uses the scripts.run_railway job modes and needs a separate per-service start command; it is out of scope here and already failing independently.