### PR TITLE
fix(docker): drop HF_HUB_OFFLINE so fastembed can fetch its ONNX weights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,12 @@ RUN install -d /opt/citadel \
 # tokenizer under a read-only rootfs with no runtime network fetch.
 RUN python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('BAAI/bge-small-en-v1.5')" \
     && chmod -R a+rX /opt/hf-cache
-# Verified: with the cache populated, transformers loads the tokenizer under
-# HF_HUB_OFFLINE=1, so the runtime never reaches the network for it.
-ENV HF_HUB_OFFLINE=1
+# Do NOT set HF_HUB_OFFLINE here: the baked cache covers only the transformers
+# tokenizer, while fastembed downloads its ONNX embedding weights at runtime
+# into its own cache. Offline mode blocked that download in production on
+# 2026-08-12 ("Could not find model in cache_dir" every ~2.5s) and froze the
+# vector and graph projection backends. Offline hardening needs the fastembed
+# weights baked too; see issue #266.
 
 EXPOSE 8000
 # No VOLUME instruction: Railway rejects `docker VOLUME` (it uses Railway

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -32,6 +32,11 @@ def test_runtime_dependency_pins_match_the_production_assertion() -> None:
 
     assert expected_pins <= set(server_dependencies)
     assert expected_pins <= requirements
+    # A global offline pin breaks fastembed's runtime ONNX weight download and
+    # froze vector/graph projection in production on 2026-08-12. Offline mode
+    # may only return together with baked fastembed weights.
+    assert "ENV HF_HUB_OFFLINE" not in dockerfile
+
     assert "(version('cognee'), version('ladybug'), version('qdrant-client'))" in dockerfile
     assert "('1.4.1', '0.18.2', '1.19.0')" in dockerfile
 


### PR DESCRIPTION
Refs #266. Production regression hotfix for #267.

## What broke

#267 set `ENV HF_HUB_OFFLINE=1` after baking the transformers tokenizer cache. The bake covers only the tokenizer; fastembed fetches its ONNX embedding weights at runtime into its own cache, and offline mode blocked that fetch. VERIFIED live on deployment 0718c2d1 from 13:15:41Z:

```
ERROR | fastembed.common.model_management:download_model:466 - Could not find model in cache_dir
ValueError: Could not load model BAAI/bge-small-en-v1.5 from any source.
```

repeating every ~2.5s, with `current_searchable_by_backend` frozen at `graph 54 / vector 54` while relational advanced (the rising total `searchable` counter masks this). CI missed it because no lane exercises a real embedding.

## Fix

Remove the offline pin (one line). This restores the runtime download behavior that worked on the previous build and keeps the transformers tokenizer fix from #267 intact. A docker-workflow test now rejects any `ENV HF_HUB_OFFLINE` line so it cannot silently return; proper offline hardening needs the fastembed weights baked as well and stays tracked in #266.

## Post-merge verification gate

Not the absence of the tokenizer warning (confounded). The gate is `current_searchable_by_backend.vector` and `.graph` increasing across two samples a few minutes apart, plus zero `Could not load model` lines on the new deployment.