### PR TITLE
fix(release): embedding offline hardening, truthful status, and the failed-projection requeue path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,7 +315,7 @@ jobs:
               # Fatal classes cannot share the warning allowlist. Otherwise a
               # warning substring on the same line can hide a fatal condition.
               if grep -Eni \
-                'error|traceback|exception|died|critical|panic|fatal|oom|corruption|failure|failed' \
+                'error|traceback|exception|died|critical|panic|fatal|oom|corrupt|failure|failed' \
                 "$log_file"; then
                 echo "::error::Unexpected fatal container log in $log_file"
                 return 1
@@ -522,7 +522,7 @@ jobs:
               # Fatal classes cannot share the warning allowlist. Otherwise a
               # warning substring on the same line can hide a fatal condition.
               if grep -Eni \
-                'error|traceback|exception|died|critical|panic|fatal|oom|corruption|failure|failed' \
+                'error|traceback|exception|died|critical|panic|fatal|oom|corrupt|failure|failed' \
                 "$log_file"; then
                 echo "::error::Unexpected fatal runtime log in $log_file"
                 return 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,16 +260,16 @@ jobs:
   container-tests:
     name: Docker test target
     runs-on: ubuntu-latest
-    # Roughly a minute to build and a few more to run the suites, so this is
-    # several times the working duration. It exists to cap a hang, not to pace
-    # the job: without it a stuck step burns the 360-minute default.
+    # A few minutes to build (including ~64 MiB of baked ONNX weights) and a
+    # few more to run the suites, so this is several times the working
+    # duration. It exists to cap a hang, not to pace the job: without it a
+    # stuck step burns the 360-minute default.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - name: Build Docker test target
         run: docker build --target test --tag citadel-archive:ci-test .
-
 
       - name: Prove baked embedding engine works offline
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,6 +270,13 @@ jobs:
       - name: Build Docker test target
         run: docker build --target test --tag citadel-archive:ci-test .
 
+
+      - name: Prove baked embedding engine works offline
+        run: |
+          docker run --rm --network none \
+            --env CITADEL_EMBEDDING_BAKE_SMOKE=1 \
+            citadel-archive:ci-test \
+            python -m pytest -q tests/test_embedding_bake_smoke.py
       - name: Run non-live and Qdrant contract suites with captured logs
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     HOME=/home/citadel \
     CITADEL_LITE_DATA_ROOT=/data \
     CITADEL_BUILD_ID_PATH=/opt/citadel/build-id \
-    HF_HOME=/opt/hf-cache
+    HF_HOME=/opt/hf-cache \
+    FASTEMBED_CACHE_PATH=/opt/fastembed-cache
 
 RUN groupadd --gid 10001 citadel \
     && useradd --uid 10001 --gid 10001 --home-dir /home/citadel --create-home citadel \
@@ -45,12 +46,19 @@ RUN install -d /opt/citadel \
 # tokenizer under a read-only rootfs with no runtime network fetch.
 RUN python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('BAAI/bge-small-en-v1.5')" \
     && chmod -R a+rX /opt/hf-cache
-# Do NOT set HF_HUB_OFFLINE here: the baked cache covers only the transformers
-# tokenizer, while fastembed downloads its ONNX embedding weights at runtime
-# into its own cache. Offline mode blocked that download in production on
-# 2026-08-12 ("Could not find model in cache_dir" every ~2.5s) and froze the
-# vector and graph projection backends. Offline hardening needs the fastembed
-# weights baked too; see issue #266.
+# Bake the fastembed ONNX embedding weights (HF repo
+# qdrant/bge-small-en-v1.5-onnx-q, ~64 MiB) so runtime embedding needs no
+# network. TextEmbedding() both downloads and writes fastembed's
+# files_metadata.json, which the offline load path verifies.
+RUN python -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5')" \
+    && chmod -R a+rX /opt/fastembed-cache
+# Build-time proof the image embeds offline before it ships. This is the gate
+# that would have caught the 2026-08-12 outage: HF_HUB_OFFLINE=1 with only the
+# tokenizer baked fails here, at build, not in production.
+RUN HF_HUB_OFFLINE=1 python -c "from fastembed import TextEmbedding; v = list(TextEmbedding(model_name='BAAI/bge-small-en-v1.5').embed(['smoke']))[0]; assert len(v) == 384"
+# Offline may only be pinned together with BOTH bakes above; the tokenizer
+# cache alone froze vector and graph projection in production on 2026-08-12.
+ENV HF_HUB_OFFLINE=1
 
 EXPOSE 8000
 # No VOLUME instruction: Railway rejects `docker VOLUME` (it uses Railway

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,10 +79,15 @@ RUN python -c "import ladybug; ladybug.Connection(ladybug.Database('/tmp/lbbake'
     && chmod -R a+rX /home/citadel/.lbdb
 # Build-time proof the graph extension is present and loadable, mirroring the
 # embedding gate above. LOAD EXTENSION never installs, so this fails the build
-# when the bake is missing instead of failing cognify in production.
+# when the bake is missing instead of failing cognify in production. The proof
+# runs as the shipped user, not root: the bake chowns and chmods the tree, and
+# a root-only proof would still pass if a future change left it unreadable to
+# uid 10001, which is the only identity that ever opens the graph at runtime.
+USER 10001:10001
 RUN python -c "import glob; assert glob.glob('/home/citadel/.lbdb/extension/*/*/json/libjson.lbug_extension'), 'ladybug json extension is not baked'" \
     && python -c "import ladybug; ladybug.Connection(ladybug.Database('/tmp/lbproof')).execute('LOAD EXTENSION JSON;')" \
     && rm -rf /tmp/lbproof
+USER root
 
 EXPOSE 8000
 # No VOLUME instruction: Railway rejects `docker VOLUME` (it uses Railway

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,26 @@ RUN HF_HUB_OFFLINE=1 python -c "from fastembed import TextEmbedding; v = list(Te
 # Offline may only be pinned together with BOTH bakes above; the tokenizer
 # cache alone froze vector and graph projection in production on 2026-08-12.
 ENV HF_HUB_OFFLINE=1
+# Bake the Ladybug json extension into $HOME/.lbdb. Ladybug resolves its
+# extension directory from $HOME when a Database opens, and it ignores
+# LADYBUG_HOME_DIRECTORY: that name is a Citadel convention which reaches
+# Ladybug only as a connection-level `CALL home_directory`, far too late for
+# ladybug.Database(). cognee_db_workers' OP_OPEN_DATABASE carries no
+# home_directory field either, so the open path can never be redirected off
+# $HOME. Caching the extension under /data/ladybug-home therefore leaves
+# Database() reading an empty $HOME/.lbdb, which is how graph projection froze
+# on 2026-08-12 ("Failed to load library ... libjson.lbug_extension: cannot
+# open shared object file"). Baking it here also removes the runtime download.
+RUN python -c "import ladybug; ladybug.Connection(ladybug.Database('/tmp/lbbake')).execute('INSTALL JSON;')" \
+    && rm -rf /tmp/lbbake \
+    && chown -R 10001:10001 /home/citadel/.lbdb \
+    && chmod -R a+rX /home/citadel/.lbdb
+# Build-time proof the graph extension is present and loadable, mirroring the
+# embedding gate above. LOAD EXTENSION never installs, so this fails the build
+# when the bake is missing instead of failing cognify in production.
+RUN python -c "import glob; assert glob.glob('/home/citadel/.lbdb/extension/*/*/json/libjson.lbug_extension'), 'ladybug json extension is not baked'" \
+    && python -c "import ladybug; ladybug.Connection(ladybug.Database('/tmp/lbproof')).execute('LOAD EXTENSION JSON;')" \
+    && rm -rf /tmp/lbproof
 
 EXPOSE 8000
 # No VOLUME instruction: Railway rejects `docker VOLUME` (it uses Railway

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,14 @@ ENV HF_HUB_OFFLINE=1
 # Ladybug only as a connection-level `CALL home_directory`, far too late for
 # ladybug.Database(). cognee_db_workers' OP_OPEN_DATABASE carries no
 # home_directory field either, so the open path can never be redirected off
-# $HOME. Caching the extension under /data/ladybug-home therefore leaves
-# Database() reading an empty $HOME/.lbdb, which is how graph projection froze
-# on 2026-08-12 ("Failed to load library ... libjson.lbug_extension: cannot
-# open shared object file"). Baking it here also removes the runtime download.
+# $HOME. That open-time load is WAL-replay driven: a cleanly closed database
+# reopens fine with an empty home, but after an unclean shutdown the replay
+# needs the extension before any connection exists. Caching it only under
+# /data/ladybug-home therefore leaves Database() reading an empty $HOME/.lbdb,
+# which is how graph projection froze on 2026-08-12 ("Failed to load library
+# ... libjson.lbug_extension: cannot open shared object file"). This bake fixes
+# the open path only. The adapter still installs into /data/ladybug-home on a
+# fresh volume, which is unchanged behaviour.
 RUN python -c "import ladybug; ladybug.Connection(ladybug.Database('/tmp/lbbake')).execute('INSTALL JSON;')" \
     && rm -rf /tmp/lbbake \
     && chown -R 10001:10001 /home/citadel/.lbdb \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,9 @@ services:
       TELEMETRY_DISABLED: "true"
       AUTO_FEEDBACK: "false"
       XDG_CACHE_HOME: /data/model-cache
-      HF_HOME: /data/model-cache/huggingface
+      # No HF_HOME override: the image bakes the tokenizer at /opt/hf-cache and
+      # pins HF_HUB_OFFLINE=1; pointing HF_HOME at the volume made the bake
+      # unreachable and silently degraded chunk sizing to TikToken (2026-08-12).
     volumes:
       - citadel-data:/data
     tmpfs:

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -1322,9 +1322,18 @@ async def _capture(args: argparse.Namespace) -> int:
                     print(f"FAIL {root.path}: {exc}", file=sys.stderr)
             continue
         # HTTP 200 is not proof of storage: the server states its decision in
-        # `accepted`. Only an explicit false is a rejection (legacy bodies
-        # without the field keep the old 200-means-stored contract).
-        accepted = response.get("accepted") is not False
+        # `accepted`, and only an explicit true is a success. A 2xx body
+        # without the field is reported unconfirmed, matching the capture
+        # hooks (CITADEL-OBSERVED-OUTCOMES-01); the server always emits the
+        # boolean, so this fires only on a misbehaving or foreign node.
+        accepted = response.get("accepted") is True
+        if not accepted and response.get("accepted") is not False:
+            reason = "unconfirmed: server did not state accepted: true"
+            results.append({"root": root.path, "ok": False, "reason": reason})
+            failures += 1
+            if not as_json:
+                print(f"UNCONFIRMED {root.path}: {reason}", file=sys.stderr)
+            continue
         reason = response.get("reason")
         cognee_result = response.get("cognee_result")
         status = (

--- a/kb/deploy_assets/docker-compose.yml
+++ b/kb/deploy_assets/docker-compose.yml
@@ -54,7 +54,9 @@ services:
       TELEMETRY_DISABLED: "true"
       AUTO_FEEDBACK: "false"
       XDG_CACHE_HOME: /data/model-cache
-      HF_HOME: /data/model-cache/huggingface
+      # No HF_HOME override: the image bakes the tokenizer at /opt/hf-cache and
+      # pins HF_HUB_OFFLINE=1; pointing HF_HOME at the volume made the bake
+      # unreachable and silently degraded chunk sizing to TikToken (2026-08-12).
     volumes:
       - citadel-data:/data
     tmpfs:

--- a/kb/hooks/sync_push.py
+++ b/kb/hooks/sync_push.py
@@ -362,10 +362,14 @@ def receipt_summary(response: dict[str, Any] | None, *, short_sha: str, branch: 
     """Receipt line for a completed POST, mirroring the server's decision."""
     if response is None:
         return f"commit {short_sha} sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    if response.get("accepted") is True:
         return f"captured commit {short_sha} on {branch} → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    if response.get("accepted") is False:
+        reason = response.get("reason") or "rejected"
+        return f"commit {short_sha} not stored: server rejected the write ({reason})"
+    # A 2xx without accepted: true is not a success; claiming "captured" here
+    # hid real failures (CITADEL-OBSERVED-OUTCOMES-01, capture truthfulness).
+    return f"commit {short_sha} unconfirmed: server did not state accepted: true"
 
 
 def _send_failure_summary(exc: BaseException, *, short_sha: str) -> str:

--- a/kb/hooks/sync_session.py
+++ b/kb/hooks/sync_session.py
@@ -253,10 +253,14 @@ def receipt_summary(response: dict[str, Any] | None) -> str:
     """Receipt line for a completed POST, mirroring the server's decision."""
     if response is None:
         return "session sent: server replied 2xx but the response body was unreadable"
-    if response.get("accepted") is not False:
+    if response.get("accepted") is True:
         return "session captured → your Node"
-    reason = response.get("reason") or "rejected"
-    return f"session not stored: server rejected the write ({reason})"
+    if response.get("accepted") is False:
+        reason = response.get("reason") or "rejected"
+        return f"session not stored: server rejected the write ({reason})"
+    # A 2xx without accepted: true is not a success; claiming "captured" here
+    # hid real failures (CITADEL-OBSERVED-OUTCOMES-01, capture truthfulness).
+    return "session unconfirmed: server did not state accepted: true"
 
 
 def _send_failure_summary(exc: BaseException) -> str:

--- a/kb/lifecycle.py
+++ b/kb/lifecycle.py
@@ -965,6 +965,57 @@ class LifecycleStore:
                 raise
         return tuple(self.get_operation(job_id) for job_id in job_ids)
 
+    def requeue_failed_projections(self, *, now: datetime | None = None) -> int:
+        """Reset every failed projection job (and its receipts) to pending.
+
+        The heal-on-recapture path in accept_source only fires when the same
+        bytes are re-submitted, and the sync layer skips unchanged content
+        before submitting, so a failed job for content that never changes
+        again stays failed forever (2026-08-12: 235 jobs failed while the
+        embedding engine was down, with no path back). This is the manual
+        path: the same reset accept_source applies, over all failed jobs.
+        The worker then drains them via claim_next_job.
+        """
+        changed_text = _utc_text(now or datetime.now(UTC))
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                failed_jobs = [
+                    str(row["projection_job_id"])
+                    for row in connection.execute(
+                        "SELECT projection_job_id FROM projection_jobs WHERE state = 'failed'"
+                    ).fetchall()
+                ]
+                for job_id in failed_jobs:
+                    connection.execute(
+                        """
+                        UPDATE projection_jobs
+                        SET state = 'pending', attempt = 0, lease_id = NULL,
+                            lease_owner = NULL, leased_until = NULL,
+                            available_at = ?, updated_at = ?, last_error_code = NULL,
+                            last_error_message = NULL
+                        WHERE projection_job_id = ?
+                        """,
+                        (changed_text, changed_text, job_id),
+                    )
+                    connection.execute(
+                        """
+                        UPDATE projection_receipts
+                        SET state = 'pending', attempt = 0,
+                            provider_operation_id = NULL, affected_ids_json = '[]',
+                            affected_count = NULL, model = NULL, dimensions = NULL,
+                            metadata_json = '{}', updated_at = ?, completed_at = NULL,
+                            searchable_at = NULL, error_code = NULL, error_message = NULL
+                        WHERE projection_job_id = ?
+                        """,
+                        (changed_text, job_id),
+                    )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        return len(failed_jobs)
+
     def read_retained_content(self, source_revision_id: str) -> bytes:
         with self._connect() as connection:
             row = connection.execute(

--- a/kb/lite_runtime.py
+++ b/kb/lite_runtime.py
@@ -45,8 +45,23 @@ def _build_id() -> str:
     return value
 
 
+# Must match the model the Dockerfile bakes into /opt/fastembed-cache and
+# /opt/hf-cache; under HF_HUB_OFFLINE=1 nothing else can load.
+BAKED_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
+
+
 def configure_lite_environment(data_root: Path | None = None) -> Path:
     root = (data_root or Path(os.getenv("CITADEL_LITE_DATA_ROOT", "/data"))).resolve()
+    if os.getenv("HF_HUB_OFFLINE") == "1":
+        model = os.getenv("EMBEDDING_MODEL", BAKED_EMBEDDING_MODEL)
+        if model != BAKED_EMBEDDING_MODEL:
+            # Without this, the drift surfaces later as fastembed's buried
+            # "Could not load model ... from any source" loop (2026-08-12).
+            raise LiteConfigurationError(
+                f"EMBEDDING_MODEL={model!r} cannot load under HF_HUB_OFFLINE=1: "
+                f"only {BAKED_EMBEDDING_MODEL!r} is baked into this image. "
+                "Rebake the image with the new model or unset HF_HUB_OFFLINE."
+            )
     defaults = {
         "SYSTEM_ROOT_DIRECTORY": str(root / "cognee-system"),
         "DATA_ROOT_DIRECTORY": str(root / "data-storage"),

--- a/kb/lite_runtime.py
+++ b/kb/lite_runtime.py
@@ -51,6 +51,9 @@ def configure_lite_environment(data_root: Path | None = None) -> Path:
         "SYSTEM_ROOT_DIRECTORY": str(root / "cognee-system"),
         "DATA_ROOT_DIRECTORY": str(root / "data-storage"),
         "CACHE_ROOT_DIRECTORY": str(root / "cache"),
+        # fastembed otherwise defaults to world-shared /tmp/fastembed_cache;
+        # inside the image the Dockerfile ENV (baked, read-only) wins over this.
+        "FASTEMBED_CACHE_PATH": str(root / "cache" / "fastembed"),
         "COGNEE_LOGS_DIR": str(root / "logs"),
         "CITADEL_STATE_DIRECTORY": str(root / "citadel-state"),
         "LADYBUG_HOME_DIRECTORY": str(root / "ladybug-home"),

--- a/kb/lite_runtime.py
+++ b/kb/lite_runtime.py
@@ -52,7 +52,9 @@ BAKED_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 
 def configure_lite_environment(data_root: Path | None = None) -> Path:
     root = (data_root or Path(os.getenv("CITADEL_LITE_DATA_ROOT", "/data"))).resolve()
-    if os.getenv("HF_HUB_OFFLINE") == "1":
+    # fastembed treats any of {1, true, yes, on} as offline; matching only "1"
+    # let HF_HUB_OFFLINE=true bypass this guard while still blocking downloads.
+    if (os.getenv("HF_HUB_OFFLINE") or "").strip().lower() in {"1", "true", "yes", "on"}:
         model = os.getenv("EMBEDDING_MODEL", BAKED_EMBEDDING_MODEL)
         if model != BAKED_EMBEDDING_MODEL:
             # Without this, the drift surfaces later as fastembed's buried

--- a/kb/server.py
+++ b/kb/server.py
@@ -6618,10 +6618,20 @@ async def lifecycle_requeue_failed(request: Request) -> dict[str, Any]:
     failed jobs for stable content are otherwise permanent (2026-08-12).
     """
     require_access(request, "admin", "access:manage")
+    citadel = get_citadel()
     try:
-        requeued = get_citadel().lifecycle_requeue_failed()
+        requeued = citadel.lifecycle_requeue_failed()
     except LifecycleNotFoundError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    # Resetting rows is not enough on its own. next_wakeup_delay only counts
+    # 'pending' and 'running' jobs, so while every job sat in 'failed' the
+    # drain task had already returned (kb/service.py:424-425) and nothing was
+    # left polling. Without this kick the requeued work waits for the next
+    # caller of resume_lifecycle_queue, which is the hourly evolve pass, so a
+    # 200 here would report success while the corpus stayed frozen.
+    resume = getattr(citadel, "resume_lifecycle_queue", None)
+    if callable(resume):
+        resume()
     return {"ok": True, "requeued": requeued}
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -6609,6 +6609,22 @@ async def ingest(body: IngestBody, request: Request) -> Any:
     return payload
 
 
+@app.post("/api/lifecycle/requeue-failed")
+async def lifecycle_requeue_failed(request: Request) -> dict[str, Any]:
+    """Reset every failed projection job to pending so the worker re-drains it.
+
+    The manual half of the heal design: accept_source heals a failed job only
+    when the same bytes are re-submitted, and sync skips unchanged content, so
+    failed jobs for stable content are otherwise permanent (2026-08-12).
+    """
+    require_access(request, "admin", "access:manage")
+    try:
+        requeued = get_citadel().lifecycle_requeue_failed()
+    except LifecycleNotFoundError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return {"ok": True, "requeued": requeued}
+
+
 @app.get("/api/operations/{projection_job_id}")
 async def projection_operation(projection_job_id: str, request: Request) -> Any:
     identity = require_access(request, "reader", "kb:read")

--- a/kb/service.py
+++ b/kb/service.py
@@ -547,6 +547,12 @@ class Citadel:
             ],
         }
 
+    def lifecycle_requeue_failed(self) -> int:
+        """Reset all failed projection jobs to pending; returns the count."""
+        if self.lifecycle_store is None:
+            raise LifecycleNotFoundError("lifecycle v1 is disabled")
+        return self.lifecycle_store.requeue_failed_projections()
+
     def lifecycle_census(self) -> dict[str, Any]:
         """Return exact SQLite lifecycle counts and state buckets."""
         if self.lifecycle_store is None:

--- a/kb/status.py
+++ b/kb/status.py
@@ -437,24 +437,43 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
         detail = f"corpus probe unavailable: {corpus['degraded']}"
     else:
         detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
-    # Name the component that actually failed; the probe text alone read as a
-    # contradiction ("x Data plane ... complete: 34/34 fully indexed") while
-    # the canary was the failing gate.
+    # Name the component that actually failed, PREPENDED: the row renderer
+    # truncates long details, and an appended clause vanished at 80 columns
+    # while the probe text alone read as a contradiction ("x Data plane ...
+    # complete: 34/34 fully indexed") with the canary as the failing gate.
+    failures: list[str] = []
     if not canary_ok:
         canary_error = (canary or {}).get("error")
         canary_hit = (canary or {}).get("search_hit")
-        detail += f"; search canary failed (search_hit={canary_hit}"
-        detail += f", error={canary_error})" if canary_error else ")"
+        clause = f"search canary failed (search_hit={canary_hit}"
+        clause += f", error={canary_error})" if canary_error else ")"
+        failures.append(clause)
     if not lifecycle_ok:
-        detail += "; lifecycle invariants failing"
-    by_backend = (lifecycle.get("current_generation") or {}).get(
-        "current_searchable_by_backend"
-    ) or {}
-    # An aggregate searchable count masked two frozen backends on 2026-08-12;
-    # show the split whenever the backends disagree.
-    if by_backend and len(set(by_backend.values())) > 1:
+        # /readyz carries the specifics; a generic sentence wasted them.
+        errors = lifecycle.get("invariant_errors") or []
+        if errors:
+            failures.append("lifecycle invariants failing: " + ", ".join(errors[:3]))
+        elif lifecycle.get("error_type"):
+            failures.append(f"lifecycle census error: {lifecycle['error_type']}")
+        else:
+            failures.append("lifecycle invariants failing")
+    generation = lifecycle.get("current_generation") or {}
+    # Zero-fill from the receipts universe: a backend with NOTHING searchable
+    # is absent from current_searchable_by_backend, and that absent backend is
+    # the worst form of the 2026-08-12 freeze, not a healthy one.
+    backends = generation.get("current_receipts_by_backend") or {}
+    searchable = generation.get("current_searchable_by_backend") or {}
+    by_backend = {name: int(searchable.get(name, 0)) for name in backends} or dict(searchable)
+    if by_backend and (not lifecycle_ok or len(set(by_backend.values())) > 1):
         split = ", ".join(f"{name} {count}" for name, count in sorted(by_backend.items()))
-        detail += f"; searchable by backend: {split}"
+        failures.append(f"searchable by backend: {split}")
+    if ok and data.get("ok") is False:
+        # The server's own gate is authoritative; if it refuses readiness for
+        # a reason this client does not model yet, say so instead of drifting.
+        failures.append("node reports not ready (server-side gate not modeled here)")
+        ok = False
+    if failures:
+        detail = "; ".join(failures) + f"; {detail}"
     return Check(
         "corpus",
         ok=ok,

--- a/kb/status.py
+++ b/kb/status.py
@@ -406,9 +406,15 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
     latency = int((time.monotonic() - started) * 1000)
     corpus = data.get("corpus") or {}
     canary = data.get("canary")
+    lifecycle = data.get("lifecycle") or {}
     indexed = corpus.get("indexed_docs")
     tracked = corpus.get("tracked_sources")
-    ok = bool(corpus.get("ok", True)) and (canary is None or bool(canary.get("ok", True)))
+    corpus_ok = bool(corpus.get("ok", True))
+    canary_ok = canary is None or bool(canary.get("ok", True))
+    # /readyz gates on lifecycle.ok too; ignoring it rendered a green Data
+    # plane over a 503 node (2026-08-12).
+    lifecycle_ok = bool(lifecycle.get("ok", True))
+    ok = corpus_ok and canary_ok and lifecycle_ok
     probe_documents = corpus.get("probe_documents")
     relational_documents = corpus.get("relational_documents")
     fully_indexed = corpus.get("probe_fully_indexed_documents")
@@ -431,12 +437,35 @@ def check_corpus(base_url: str, token: str | None, *, timeout: float = _TIMEOUT)
         detail = f"corpus probe unavailable: {corpus['degraded']}"
     else:
         detail = "ok" if indexed is None else f"{indexed} indexed / {tracked} tracked"
+    # Name the component that actually failed; the probe text alone read as a
+    # contradiction ("x Data plane ... complete: 34/34 fully indexed") while
+    # the canary was the failing gate.
+    if not canary_ok:
+        canary_error = (canary or {}).get("error")
+        canary_hit = (canary or {}).get("search_hit")
+        detail += f"; search canary failed (search_hit={canary_hit}"
+        detail += f", error={canary_error})" if canary_error else ")"
+    if not lifecycle_ok:
+        detail += "; lifecycle invariants failing"
+    by_backend = (lifecycle.get("current_generation") or {}).get(
+        "current_searchable_by_backend"
+    ) or {}
+    # An aggregate searchable count masked two frozen backends on 2026-08-12;
+    # show the split whenever the backends disagree.
+    if by_backend and len(set(by_backend.values())) > 1:
+        split = ", ".join(f"{name} {count}" for name, count in sorted(by_backend.items()))
+        detail += f"; searchable by backend: {split}"
     return Check(
         "corpus",
         ok=ok,
         detail=detail,
         latency_ms=latency,
-        data={"canary": canary, "corpus": dict(corpus)},
+        data={
+            "canary": canary,
+            "corpus": dict(corpus),
+            "lifecycle_ok": lifecycle_ok,
+            "searchable_by_backend": dict(by_backend),
+        },
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ server = [
     # Real tokenizer for BGE chunk sizing; the resolver silently falls back to
     # approximate TikToken counts when transformers is missing.
     "transformers==5.15.0",
+    "huggingface-hub==1.27.0",
+    "tokenizers==0.22.2",
     "cryptography==50.0.0",
     "fastapi>=0.116.2,<1.0.0",
     "google-auth>=2.40.0,<3.0.0",

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,8 @@
 [build]
-builder = "RAILPACK"
+# Railway builds the repo Dockerfile (VERIFIED from the 2026-08-12 build logs,
+# which show the multi-stage [runtime] layers); RAILPACK here contradicted that
+# record. The image bakes the embedding tokenizer and ONNX weights.
+builder = "DOCKERFILE"
 
 [deploy]
 # The published image vendors scripts/ for scheduler and dispatcher imports.
@@ -9,8 +12,9 @@ builder = "RAILPACK"
 # modes such as github-sync, backup-mirror, and pipeline in their own config.
 startCommand = "python -m kb.lite_runtime"
 healthcheckPath = "/healthz"
-# Cold boot downloads the fastembed embedding model and initialises cognee +
-# Ladybug before /healthz answers, which can exceed 30s on a fresh volume.
+# Cold boot initialises cognee + Ladybug before /healthz answers, which can
+# exceed 30s on a fresh volume. The embedding model is baked into the image
+# since 2026-08-12, so no model download happens at boot any more.
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,10 @@ starlette>=1.3.1,<2.0.0
 # Real tokenizer for BGE chunk sizing; without it cognee's resolver falls back
 # to approximate TikToken counts and mis-sizes every chunk.
 transformers==5.15.0
+# Freeze the verified companion set: hub 1.x and tokenizers<=0.23.0 are what
+# transformers 5.15.0 resolves and what fastembed 0.8.0 was verified against.
+huggingface-hub==1.27.0
+tokenizers==0.22.2
 tiktoken==0.13.0
 uvicorn[standard]>=0.34.0,<1.0.0
 

--- a/scripts/classify_docker_logs.py
+++ b/scripts/classify_docker_logs.py
@@ -13,7 +13,15 @@ import sys
 
 _SEVERE = re.compile(
     r"\b(?:warn(?:ing)?|error|panic|fatal|oom|corrupt(?:ion)?|fail(?:ed|ure)?|"
-    r"degrad(?:ed|ation)|exception|traceback)\b",
+    r"degrad(?:ed|ation)|exception|traceback|died|critical)\b",
+    re.I,
+)
+# Fatal classes mirror the shell gates in .github/workflows/test.yml and can
+# never be excused by an expected-pattern match: a warning substring on the
+# same line must not hide a fatal condition (BLK-2026-08-12-01).
+_FATAL = re.compile(
+    r"\b(?:error|panic|fatal|oom|corrupt(?:ion)?|fail(?:ed|ure)?|"
+    r"exception|traceback|died|critical)\b",
     re.I,
 )
 _NON_2XX = re.compile(r"\b(?:1\d\d|3\d\d|4\d\d|5\d\d)\b")
@@ -34,13 +42,24 @@ def classify_logs(
     app_lines: list[str],
     qdrant_lines: list[str],
     expected_patterns: dict[str, list[str]] | None = None,
+    expected_fatal_patterns: dict[str, list[str]] | None = None,
 ) -> dict[str, object]:
-    """Return all severe/non-2xx lines. Only caller-declared regexes are allowed."""
+    """Return all severe/non-2xx lines. Only caller-declared regexes are allowed.
+
+    ``expected_patterns`` excuses warning-class lines only. A line carrying a
+    fatal-class token is excused solely by ``expected_fatal_patterns``, so a
+    warning allowlist can never hide a fatal condition on the same line
+    (BLK-2026-08-12-01).
+    """
     if not phase.strip():
         raise ValueError("phase must be non-empty")
     compiled = {
         source: [re.compile(pattern) for pattern in patterns]
         for source, patterns in (expected_patterns or {}).items()
+    }
+    compiled_fatal = {
+        source: [re.compile(pattern) for pattern in patterns]
+        for source, patterns in (expected_fatal_patterns or {}).items()
     }
     findings: list[Finding] = []
     for source, lines in (("app", app_lines), ("qdrant", qdrant_lines)):
@@ -52,7 +71,11 @@ def classify_logs(
             if _NON_2XX.search(text):
                 reasons.append("non_2xx")
             if reasons:
-                expected = any(pattern.search(text) for pattern in compiled.get(source, []))
+                if _FATAL.search(text):
+                    allowed = compiled_fatal.get(source, [])
+                else:
+                    allowed = compiled.get(source, [])
+                expected = any(pattern.search(text) for pattern in allowed)
                 findings.append(Finding(source, line_number, text, "+".join(reasons), expected))
     expected = [asdict(finding) for finding in findings if finding.expected]
     unexpected = [asdict(finding) for finding in findings if not finding.expected]
@@ -85,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--app-log", type=Path, required=True)
     parser.add_argument("--qdrant-log", type=Path, required=True)
     parser.add_argument("--expect", action="append", default=[])
+    parser.add_argument("--expect-fatal", action="append", default=[])
     parser.add_argument("--output", type=Path)
     args = parser.parse_args(argv)
     try:
@@ -93,6 +117,7 @@ def main(argv: list[str] | None = None) -> int:
             app_lines=_read_lines(args.app_log),
             qdrant_lines=_read_lines(args.qdrant_log),
             expected_patterns=_parse_expectation(args.expect),
+            expected_fatal_patterns=_parse_expectation(args.expect_fatal),
         )
     except (OSError, ValueError, re.error) as exc:
         print(f"log classification failed: {exc}", file=sys.stderr)

--- a/scripts/classify_docker_logs.py
+++ b/scripts/classify_docker_logs.py
@@ -12,16 +12,16 @@ import sys
 
 
 _SEVERE = re.compile(
-    r"\b(?:warn(?:ing)?|error|panic|fatal|oom|corrupt(?:ion)?|fail(?:ed|ure)?|"
-    r"degrad(?:ed|ation)|exception|traceback|died|critical)\b",
+    r"\b(?:warn(?:ing)?s?|errors?|panics?|fatal|oom|corrupt(?:ed|ion|s)?|"
+    r"fail(?:ed|ures?)?|degrad(?:ed|ation)|exceptions?|tracebacks?|died|critical)\b",
     re.I,
 )
 # Fatal classes mirror the shell gates in .github/workflows/test.yml and can
 # never be excused by an expected-pattern match: a warning substring on the
 # same line must not hide a fatal condition (BLK-2026-08-12-01).
 _FATAL = re.compile(
-    r"\b(?:error|panic|fatal|oom|corrupt(?:ion)?|fail(?:ed|ure)?|"
-    r"exception|traceback|died|critical)\b",
+    r"\b(?:errors?|panics?|fatal|oom|corrupt(?:ed|ion|s)?|fail(?:ed|ures?)?|"
+    r"exceptions?|tracebacks?|died|critical)\b",
     re.I,
 )
 _NON_2XX = re.compile(r"\b(?:1\d\d|3\d\d|4\d\d|5\d\d)\b")
@@ -54,11 +54,11 @@ def classify_logs(
     if not phase.strip():
         raise ValueError("phase must be non-empty")
     compiled = {
-        source: [re.compile(pattern) for pattern in patterns]
+        source: [re.compile(pattern, re.I) for pattern in patterns]
         for source, patterns in (expected_patterns or {}).items()
     }
     compiled_fatal = {
-        source: [re.compile(pattern) for pattern in patterns]
+        source: [re.compile(pattern, re.I) for pattern in patterns]
         for source, patterns in (expected_fatal_patterns or {}).items()
     }
     findings: list[Finding] = []
@@ -92,12 +92,12 @@ def _read_lines(path: Path) -> list[str]:
     return path.read_text(encoding="utf-8", errors="replace").splitlines()
 
 
-def _parse_expectation(values: list[str]) -> dict[str, list[str]]:
+def _parse_expectation(values: list[str], *, flag: str = "--expect") -> dict[str, list[str]]:
     grouped: dict[str, list[str]] = {}
     for value in values:
         source, separator, pattern = value.partition(":")
         if separator != ":" or source not in {"app", "qdrant"} or not pattern:
-            raise ValueError("--expect must be app:REGEX or qdrant:REGEX")
+            raise ValueError(f"{flag} must be app:REGEX or qdrant:REGEX")
         grouped.setdefault(source, []).append(pattern)
     return grouped
 
@@ -117,7 +117,7 @@ def main(argv: list[str] | None = None) -> int:
             app_lines=_read_lines(args.app_log),
             qdrant_lines=_read_lines(args.qdrant_log),
             expected_patterns=_parse_expectation(args.expect),
-            expected_fatal_patterns=_parse_expectation(args.expect_fatal),
+            expected_fatal_patterns=_parse_expectation(args.expect_fatal, flag="--expect-fatal"),
         )
     except (OSError, ValueError, re.error) as exc:
         print(f"log classification failed: {exc}", file=sys.stderr)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -365,16 +365,21 @@ def test_capture_json_preserves_returned_lifecycle_fields_per_root(
     assert "projection_state" not in out["results"][1]
 
 
-def test_capture_response_without_accepted_field_still_ok(
+def test_capture_response_without_accepted_field_is_unconfirmed(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
-    # Legacy shape: a 200 body with no explicit rejection reads as accepted.
+    # A 2xx body without accepted: true must not read as stored; the capture
+    # hooks and the CLI now hold the same contract
+    # (CITADEL-OBSERVED-OUTCOMES-01). The server always emits the boolean, so
+    # this fires only on a misbehaving or foreign node.
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_test")
     monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: {"status": "ok"})
     rc = asyncio.run(_capture(_configured_args(tmp_path, as_json=True)))
     out = json.loads(capsys.readouterr().out)
-    assert rc == 0
-    assert out["results"][0]["ok"] is True
+    assert rc != 0
+    entry = out["results"][0]
+    assert entry["ok"] is False
+    assert "unconfirmed" in entry["reason"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -83,6 +83,10 @@ def test_runtime_bakes_the_ladybug_json_extension_under_home() -> None:
     assert "libjson.lbug_extension" in executable
     assert "LOAD EXTENSION JSON;" in executable
     assert executable.index("INSTALL JSON;") < executable.index("LOAD EXTENSION JSON;")
+    # The proof must run as the shipped user. Both adversarial reviewers noted
+    # that a root-only proof still passes when the tree is unreadable to uid
+    # 10001, which is the only identity that opens the graph at runtime.
+    assert executable.index("USER 10001:10001") < executable.index("LOAD EXTENSION JSON;")
 
 
 def test_ci_proves_the_baked_embedding_engine_offline() -> None:

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -35,16 +35,33 @@ def test_runtime_dependency_pins_match_the_production_assertion() -> None:
     assert expected_pins <= set(server_dependencies)
     assert expected_pins <= requirements
     # A global offline pin without the fastembed weight bake froze vector and
-    # graph projection in production on 2026-08-12. Offline mode is allowed
-    # only alongside BOTH bakes and the build-time offline embed proof.
-    if "ENV HF_HUB_OFFLINE=1" in dockerfile:
-        offline_prefix = dockerfile.split("ENV HF_HUB_OFFLINE=1", 1)[0]
-        assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in offline_prefix
-        assert "from fastembed import TextEmbedding" in offline_prefix
-        assert "HF_HUB_OFFLINE=1 python -c" in offline_prefix
+    # graph projection in production on 2026-08-12. The bakes and the
+    # build-time offline embed proof are unconditional policy (a conditional
+    # guard passes vacuously when the ENV and the bake are removed together),
+    # and the offline pin must come after all of them.
+    assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in dockerfile
+    assert "from fastembed import TextEmbedding" in dockerfile
+    assert "HF_HUB_OFFLINE=1 python -c" in dockerfile
+    assert "ENV HF_HUB_OFFLINE=1" in dockerfile
+    offline_prefix = dockerfile.split("ENV HF_HUB_OFFLINE=1", 1)[0]
+    assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in offline_prefix
+    assert "from fastembed import TextEmbedding" in offline_prefix
+    assert "HF_HUB_OFFLINE=1 python -c" in offline_prefix
 
     assert "(version('cognee'), version('ladybug'), version('qdrant-client'))" in dockerfile
     assert "('1.4.1', '0.18.2', '1.19.0')" in dockerfile
+
+
+def test_ci_proves_the_baked_embedding_engine_offline() -> None:
+    # Deleting the smoke step must fail a test, or the offline-bake policy is
+    # unenforced (fresh-eyes R6, 2026-08-12).
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    container_tests = workflow.split("  container-tests:\n", 1)[1].split(
+        "\n  container-runtime:\n", 1
+    )[0]
+    assert "--network none" in container_tests
+    assert "CITADEL_EMBEDDING_BAKE_SMOKE=1" in container_tests
+    assert "tests/test_embedding_bake_smoke.py" in container_tests
 
 
 def test_ci_uses_a_dedicated_docker_test_target_for_qdrant_contracts() -> None:
@@ -213,7 +230,7 @@ def test_container_log_classifiers_use_portable_guarded_grep() -> None:
     tests_code = _executable_lines(container_tests)
     runtime_code = _executable_lines(container_runtime)
     hard_failure_pattern = (
-        "error|traceback|exception|died|critical|panic|fatal|oom|corruption|failure|failed"
+        "error|traceback|exception|died|critical|panic|fatal|oom|corrupt|failure|failed"
     )
     for code in (tests_code, runtime_code):
         assert "command -v grep >/dev/null" in code
@@ -284,6 +301,8 @@ def test_container_log_classifiers_reject_fatal_tokens_before_exemptions(
         "WARNING TLS disabled; FATAL corruption\n",
         "WARNING TLS disabled; ERROR request rejected\n",
         "warning Cognee 1.0 changes: ERROR request rejected\n",
+        # 'corruption' alone missed the past-tense form until 2026-08-12.
+        "corrupted segment detected\n",
     )
 
     for job, function_name, label in classifiers:
@@ -424,7 +443,7 @@ def test_runtime_log_classifier_exempts_only_the_measured_benign_citadel_lines()
     assert code.count("onnxruntime cpuid_info warning: Unknown CPU vendor") == 1
     # Everything outside that list stays fail-closed.
     assert (
-        "error|traceback|exception|died|critical|panic|fatal|oom|corruption|failure|failed"
+        "error|traceback|exception|died|critical|panic|fatal|oom|corrupt|failure|failed"
         in container_runtime
     )
     assert "warn(ing)?|recovery.*(shortfall|failed)" in container_runtime

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -28,14 +28,20 @@ def test_runtime_dependency_pins_match_the_production_assertion() -> None:
         "ladybug==0.18.2",
         "qdrant-client==1.19.0",
         "transformers==5.15.0",
+        "huggingface-hub==1.27.0",
+        "tokenizers==0.22.2",
     }
 
     assert expected_pins <= set(server_dependencies)
     assert expected_pins <= requirements
-    # A global offline pin breaks fastembed's runtime ONNX weight download and
-    # froze vector/graph projection in production on 2026-08-12. Offline mode
-    # may only return together with baked fastembed weights.
-    assert "ENV HF_HUB_OFFLINE" not in dockerfile
+    # A global offline pin without the fastembed weight bake froze vector and
+    # graph projection in production on 2026-08-12. Offline mode is allowed
+    # only alongside BOTH bakes and the build-time offline embed proof.
+    if "ENV HF_HUB_OFFLINE=1" in dockerfile:
+        offline_prefix = dockerfile.split("ENV HF_HUB_OFFLINE=1", 1)[0]
+        assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in offline_prefix
+        assert "from fastembed import TextEmbedding" in offline_prefix
+        assert "HF_HUB_OFFLINE=1 python -c" in offline_prefix
 
     assert "(version('cognee'), version('ladybug'), version('qdrant-client'))" in dockerfile
     assert "('1.4.1', '0.18.2', '1.19.0')" in dockerfile

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -39,11 +39,18 @@ def test_runtime_dependency_pins_match_the_production_assertion() -> None:
     # build-time offline embed proof are unconditional policy (a conditional
     # guard passes vacuously when the ENV and the bake are removed together),
     # and the offline pin must come after all of them.
-    assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in dockerfile
-    assert "from fastembed import TextEmbedding" in dockerfile
-    assert "HF_HUB_OFFLINE=1 python -c" in dockerfile
-    assert "ENV HF_HUB_OFFLINE=1" in dockerfile
-    offline_prefix = dockerfile.split("ENV HF_HUB_OFFLINE=1", 1)[0]
+    # Executable lines of the runtime stage only: a commented-out bake, or a
+    # bake moved into the builder stage where it never reaches the image, must
+    # not satisfy this guard.
+    runtime_stage = dockerfile.split("FROM python", 2)[2].split("FROM runtime AS test", 1)[0]
+    executable = "\n".join(
+        line for line in runtime_stage.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in executable
+    assert "from fastembed import TextEmbedding" in executable
+    assert "HF_HUB_OFFLINE=1 python -c" in executable
+    assert "ENV HF_HUB_OFFLINE=1" in executable
+    offline_prefix = executable.split("ENV HF_HUB_OFFLINE=1", 1)[0]
     assert "FASTEMBED_CACHE_PATH=/opt/fastembed-cache" in offline_prefix
     assert "from fastembed import TextEmbedding" in offline_prefix
     assert "HF_HUB_OFFLINE=1 python -c" in offline_prefix
@@ -62,6 +69,19 @@ def test_ci_proves_the_baked_embedding_engine_offline() -> None:
     assert "--network none" in container_tests
     assert "CITADEL_EMBEDDING_BAKE_SMOKE=1" in container_tests
     assert "tests/test_embedding_bake_smoke.py" in container_tests
+    smoke_step = container_tests.split("Prove baked embedding engine works offline", 1)[1]
+    assert "citadel-archive:ci-test" in smoke_step.split("- name:", 1)[0]
+
+
+def test_compose_does_not_override_the_baked_hf_home() -> None:
+    # HF_HOME pointed at the volume made the baked tokenizer unreachable under
+    # the offline pin and silently degraded chunk sizing (2026-08-12).
+    for name in ("docker-compose.yml", "kb/deploy_assets/docker-compose.yml"):
+        compose = (Path(__file__).resolve().parents[1] / name).read_text(encoding="utf-8")
+        executable = "\n".join(
+            line for line in compose.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "HF_HOME" not in executable, name
 
 
 def test_ci_uses_a_dedicated_docker_test_target_for_qdrant_contracts() -> None:

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -59,6 +59,32 @@ def test_runtime_dependency_pins_match_the_production_assertion() -> None:
     assert "('1.4.1', '0.18.2', '1.19.0')" in dockerfile
 
 
+def test_runtime_bakes_the_ladybug_json_extension_under_home() -> None:
+    # Ladybug resolves its extension directory from $HOME when a Database
+    # opens, and it ignores LADYBUG_HOME_DIRECTORY: that name only reaches
+    # Ladybug as a connection-level `CALL home_directory`, which cannot run
+    # before the database is open. cognee_db_workers' OP_OPEN_DATABASE carries
+    # no home_directory field either. Caching the extension under
+    # /data/ladybug-home therefore left ladybug.Database() reading an empty
+    # $HOME/.lbdb, and graph projection froze at 54 of 289 searchable on
+    # 2026-08-12 with "Failed to load library ... libjson.lbug_extension".
+    # Executable lines of the runtime stage only, so a commented-out bake or
+    # one moved into the builder stage cannot satisfy this guard.
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    runtime_stage = dockerfile.split("FROM python", 2)[2].split("FROM runtime AS test", 1)[0]
+    executable = "\n".join(
+        line for line in runtime_stage.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "INSTALL JSON;" in executable
+    assert "/home/citadel/.lbdb" in executable
+    # LOAD EXTENSION never installs, so the proof fails the build when the bake
+    # is gone. Asserting the .so path keeps the proof from passing vacuously on
+    # an empty extension directory.
+    assert "libjson.lbug_extension" in executable
+    assert "LOAD EXTENSION JSON;" in executable
+    assert executable.index("INSTALL JSON;") < executable.index("LOAD EXTENSION JSON;")
+
+
 def test_ci_proves_the_baked_embedding_engine_offline() -> None:
     # Deleting the smoke step must fail a test, or the offline-bake policy is
     # unenforced (fresh-eyes R6, 2026-08-12).

--- a/tests/test_embedding_bake_smoke.py
+++ b/tests/test_embedding_bake_smoke.py
@@ -1,0 +1,39 @@
+"""In-image proof that the baked embedding engine works offline.
+
+Gated behind CITADEL_EMBEDDING_BAKE_SMOKE=1 and run by CI inside the built
+image with --network none, so both regressions shipped on 2026-08-12 fail
+in CI instead of production: the silent TikToken chunk-sizing fallback and
+the offline pin that blocked fastembed's ONNX weight download.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CITADEL_EMBEDDING_BAKE_SMOKE") != "1",
+    reason="only meaningful inside the baked Docker image",
+)
+
+
+def test_baked_engine_embeds_offline_with_model_tokenizer() -> None:
+    from cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine import (
+        FastembedEmbeddingEngine,
+    )
+    from cognee.infrastructure.llm.tokenizer.HuggingFace.adapter import HuggingFaceTokenizer
+
+    model = os.environ.get("EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
+    dimensions = int(os.environ.get("EMBEDDING_DIMENSIONS", "384"))
+
+    # Raises "Could not load model ... from any source" when the ONNX weights
+    # are not loadable from the image: the offline-pin regression.
+    engine = FastembedEmbeddingEngine(model=model, dimensions=dimensions)
+
+    # The resolver never raises; a missing baked tokenizer silently degrades
+    # to TikToken: the chunk-sizing regression. The isinstance is the only
+    # observable signal.
+    assert isinstance(engine.tokenizer, HuggingFaceTokenizer), type(engine.tokenizer).__name__
+    assert engine.tokenizer.count_tokens("citadel embedding smoke") > 0
+
+    [vector] = list(engine.embedding_model.embed(["citadel embedding smoke"]))
+    assert len(vector) == dimensions

--- a/tests/test_embedding_bake_smoke.py
+++ b/tests/test_embedding_bake_smoke.py
@@ -32,8 +32,8 @@ def test_baked_engine_embeds_offline_with_model_tokenizer() -> None:
     # The resolver never raises; a missing baked tokenizer silently degrades
     # to TikToken: the chunk-sizing regression. The isinstance is the only
     # observable signal.
+    # The isinstance is the only real signal: TikToken also counts tokens.
     assert isinstance(engine.tokenizer, HuggingFaceTokenizer), type(engine.tokenizer).__name__
-    assert engine.tokenizer.count_tokens("citadel embedding smoke") > 0
 
     [vector] = list(engine.embedding_model.embed(["citadel embedding smoke"]))
     assert len(vector) == dimensions

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -217,7 +217,9 @@ def test_capture_json_real_post_shape(tmp_path: Path, monkeypatch, capsys) -> No
           "--root", f"{tmp_path}=personal", "--config", str(cfg)])
     capsys.readouterr()
     monkeypatch.setenv("CITADEL_MCP_ACCESS_TOKEN", "ctdl_headless_token")
-    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: {"status": "ok"})
+    # The real server always states its decision; a body without accepted: true
+    # now reads as unconfirmed, so the "real POST shape" fixture must carry it.
+    monkeypatch.setattr("kb.cli.post_capture", lambda *a, **k: {"accepted": True, "status": "ok"})
 
     rc = _run(["capture", "--json", "--config", str(cfg)])
     assert rc == 0

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1030,3 +1030,63 @@ def test_generation_rebuild_rolls_back_every_precommit_fault(
     )
     assert target_census.current_projection_jobs == 0
     assert target_census.current_projection_receipts == 0
+
+
+def test_requeue_failed_projections_resets_jobs_and_receipts(tmp_path: Path) -> None:
+    # 2026-08-12: 235 jobs failed while the embedding engine was down. The
+    # heal-on-recapture path never fires for unchanged content, so this manual
+    # requeue is the only way back for stable sources.
+    store = LifecycleStore(str(tmp_path / "lifecycle.db"))
+    capture = CaptureContext(
+        dataset="central",
+        source_key="manual:requeue-case",
+        source_locator=None,
+        media_type="text/plain",
+        capture_actor_id="test",
+        capture_run_id="run-1",
+        captured_at=T0,
+    )
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+    accepted = store.accept_source(b"requeue me", capture=capture, projection=projection, now=T0)
+    lease = store.claim_next_job(worker_id="worker-1", now=T0, lease_seconds=30)
+    assert lease is not None
+    store.fail_job(lease, error_code="model_load", error_message="engine down", now=T0)
+    operation = store.get_operation(accepted.projection_job_id)
+    assert operation.job.state == "failed"
+
+    assert store.requeue_failed_projections(now=T0) == 1
+
+    operation = store.get_operation(accepted.projection_job_id)
+    assert operation.job.state == "pending"
+    assert operation.job.attempt == 0
+    assert {receipt.state for receipt in operation.receipts} == {"pending"}
+    # The worker can claim it again: the reset is not cosmetic.
+    release = store.claim_next_job(worker_id="worker-2", now=T0, lease_seconds=30)
+    assert release is not None
+    assert release.projection_job_id == accepted.projection_job_id
+
+
+def test_requeue_failed_projections_ignores_healthy_jobs(tmp_path: Path) -> None:
+    store = LifecycleStore(str(tmp_path / "lifecycle.db"))
+    capture = CaptureContext(
+        dataset="central",
+        source_key="manual:healthy-case",
+        source_locator=None,
+        media_type="text/plain",
+        capture_actor_id="test",
+        capture_run_id="run-1",
+        captured_at=T0,
+    )
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+    store.accept_source(b"leave me queued", capture=capture, projection=projection, now=T0)
+    assert store.requeue_failed_projections(now=T0) == 0

--- a/tests/test_lite_runtime.py
+++ b/tests/test_lite_runtime.py
@@ -272,3 +272,17 @@ def test_container_runtime_home_belongs_to_the_dropped_user() -> None:
     )
 
     assert "HOME=/home/citadel" in dockerfile
+
+
+def test_offline_rejects_a_model_that_is_not_baked(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("EMBEDDING_MODEL", "BAAI/bge-large-en-v1.5")
+    with pytest.raises(lite_runtime.LiteConfigurationError, match="baked into this image"):
+        lite_runtime.configure_lite_environment(tmp_path)
+
+
+def test_offline_accepts_the_baked_model(tmp_path, monkeypatch) -> None:
+    _configured_environment(monkeypatch, tmp_path)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("EMBEDDING_MODEL", lite_runtime.BAKED_EMBEDDING_MODEL)
+    assert lite_runtime.configure_lite_environment() == tmp_path.resolve()

--- a/tests/test_lite_runtime.py
+++ b/tests/test_lite_runtime.py
@@ -45,6 +45,9 @@ def restore_lite_written_environment() -> Iterator[None]:
 
 
 def _configured_environment(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    # The image pins HF_HUB_OFFLINE=1; these tests use a fake EMBEDDING_MODEL
+    # and would trip the offline drift guard when run in-image.
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
     monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", str(root))
     monkeypatch.setenv("CITADEL_GENERATION_ID", "test-generation")
     monkeypatch.setenv("VECTOR_DB_URL", "http://qdrant:6333")

--- a/tests/test_log_classifier.py
+++ b/tests/test_log_classifier.py
@@ -29,9 +29,51 @@ def test_classifier_allows_only_declared_phase_pattern() -> None:
         phase="injected-outage",
         app_lines=["ERROR expected outage HTTP 503"],
         qdrant_lines=["WARN unrelated cache miss"],
-        expected_patterns={"app": [r"expected outage HTTP 503"]},
+        expected_fatal_patterns={"app": [r"expected outage HTTP 503"]},
     )
 
     assert result["expected"][0]["expected"] is True
     assert result["ok"] is False
     assert result["unexpected"][0]["source"] == "qdrant"
+
+
+def test_fatal_token_cannot_be_excused_by_a_warning_allowlist() -> None:
+    result = classify_logs(
+        phase="mixed",
+        app_lines=["WARNING TLS disabled; ERROR database unavailable"],
+        qdrant_lines=[],
+        expected_patterns={"app": [r"TLS disabled"]},
+    )
+    assert result["ok"] is False
+    assert len(result["unexpected"]) == 1
+
+
+def test_died_and_critical_are_detected() -> None:
+    result = classify_logs(
+        phase="fatal",
+        app_lines=["Background task evolve-scheduler died: boom"],
+        qdrant_lines=["CRITICAL storage checksum"],
+    )
+    assert result["ok"] is False
+    assert len(result["unexpected"]) == 2
+
+
+def test_pure_warning_stays_excusable() -> None:
+    result = classify_logs(
+        phase="warn",
+        app_lines=["WARNING TLS disabled for loopback"],
+        qdrant_lines=[],
+        expected_patterns={"app": [r"TLS disabled"]},
+    )
+    assert result["ok"] is True
+
+
+def test_plain_pattern_does_not_excuse_a_fatal_line() -> None:
+    result = classify_logs(
+        phase="injected-outage",
+        app_lines=["ERROR expected outage HTTP 503"],
+        qdrant_lines=[],
+        expected_patterns={"app": [r"expected outage HTTP 503"]},
+    )
+    assert result["ok"] is False
+    assert result["unexpected"][0]["source"] == "app"

--- a/tests/test_log_classifier.py
+++ b/tests/test_log_classifier.py
@@ -77,3 +77,14 @@ def test_plain_pattern_does_not_excuse_a_fatal_line() -> None:
     )
     assert result["ok"] is False
     assert result["unexpected"][0]["source"] == "app"
+
+
+def test_plural_fatal_tokens_are_detected() -> None:
+    # \berror\b missed "5 errors"; the shell gate caught it by substring.
+    result = classify_logs(
+        phase="plural",
+        app_lines=["5 errors during projection", "3 failures in receipts"],
+        qdrant_lines=["two exceptions raised", "corrupted segment"],
+    )
+    assert result["ok"] is False
+    assert len(result["unexpected"]) == 4

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1325,6 +1325,22 @@ def test_cognify_run_requires_admin() -> None:
     assert response.status_code == 403
 
 
+def test_lifecycle_requeue_failed_requires_admin() -> None:
+    client = authed_client("test-writer")
+    assert client.post("/api/lifecycle/requeue-failed").status_code == 403
+
+
+def test_lifecycle_requeue_failed_returns_the_reset_count(monkeypatch) -> None:
+    client = authed_client()
+    import kb.server as server_mod
+
+    citadel = server_mod.get_citadel()
+    monkeypatch.setattr(type(citadel), "lifecycle_requeue_failed", lambda self: 7, raising=False)
+    response = client.post("/api/lifecycle/requeue-failed")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "requeued": 7}
+
+
 def test_admin_can_audit_combined_reconciliation_and_writer_cannot() -> None:
     admin = authed_client()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1341,6 +1341,30 @@ def test_lifecycle_requeue_failed_returns_the_reset_count(monkeypatch) -> None:
     assert response.json() == {"ok": True, "requeued": 7}
 
 
+def test_lifecycle_requeue_failed_restarts_the_drain(monkeypatch) -> None:
+    # Resetting rows to pending is inert on its own. next_wakeup_delay counts
+    # only 'pending' and 'running' jobs, so while every job sat in 'failed' the
+    # drain task had already returned and nothing was polling. Without this
+    # kick the route answers 200 while the corpus stays frozen until the hourly
+    # evolve pass happens to call resume_lifecycle_queue (2026-08-12).
+    client = authed_client()
+    import kb.server as server_mod
+
+    citadel = server_mod.get_citadel()
+    resumed: list[bool] = []
+    monkeypatch.setattr(type(citadel), "lifecycle_requeue_failed", lambda self: 3, raising=False)
+    monkeypatch.setattr(
+        type(citadel),
+        "resume_lifecycle_queue",
+        lambda self: resumed.append(True),
+        raising=False,
+    )
+    response = client.post("/api/lifecycle/requeue-failed")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "requeued": 3}
+    assert resumed == [True], "requeue must restart the projection drain"
+
+
 def test_admin_can_audit_combined_reconciliation_and_writer_cannot() -> None:
     admin = authed_client()
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -454,7 +454,8 @@ def test_check_corpus_names_the_failed_canary_over_a_complete_probe(monkeypatch)
     check = status_mod.check_corpus("https://node.example", "ctdl_tok")
     assert check is not None
     assert check.ok is False
-    assert "search canary failed (search_hit=False)" in check.detail
+    # Prepended so the row renderer's truncation cannot hide it.
+    assert check.detail.startswith("search canary failed (search_hit=False)")
 
 
 def test_check_corpus_folds_lifecycle_ok_and_shows_backend_split(monkeypatch) -> None:
@@ -475,9 +476,52 @@ def test_check_corpus_folds_lifecycle_ok_and_shows_backend_split(monkeypatch) ->
     check = status_mod.check_corpus("https://node.example", "ctdl_tok")
     assert check is not None
     assert check.ok is False
-    assert "lifecycle invariants failing" in check.detail
+    assert check.detail.startswith("lifecycle invariants failing")
     assert "searchable by backend: graph 54, relational 115, vector 54" in check.detail
     assert check.data["searchable_by_backend"] == {"graph": 54, "relational": 115, "vector": 54}
+
+
+def test_check_corpus_zero_fills_backends_absent_from_searchable(monkeypatch) -> None:
+    # A backend with NOTHING searchable is absent from
+    # current_searchable_by_backend; rendering it as 0 (from the receipts
+    # universe) is the whole point, since an absent backend is the worst form
+    # of the 2026-08-12 freeze.
+    body = {
+        "ok": False,
+        "corpus": {"ok": True, "tracked_sources": 333, "indexed_docs": 7656},
+        "canary": {"ok": True},
+        "lifecycle": {
+            "ok": False,
+            "invariant_errors": ["failed_projection"],
+            "current_generation": {
+                "current_receipts_by_backend": {"graph": 289, "relational": 289, "vector": 289},
+                "current_searchable_by_backend": {"relational": 115},
+            },
+        },
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/readyz": body}))
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+    assert check is not None
+    assert check.ok is False
+    assert "lifecycle invariants failing: failed_projection" in check.detail
+    assert "searchable by backend: graph 0, relational 115, vector 0" in check.detail
+    assert check.data["searchable_by_backend"] == {"graph": 0, "relational": 115, "vector": 0}
+
+
+def test_check_corpus_defers_to_an_unmodeled_server_gate(monkeypatch) -> None:
+    # The server's own ok is authoritative: a future gate this client does not
+    # model must not render green (the 2026-08-12 drift class).
+    body = {
+        "ok": False,
+        "corpus": {"ok": True, "tracked_sources": 1, "indexed_docs": 1},
+        "canary": {"ok": True},
+        "lifecycle": {"ok": True},
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/readyz": body}))
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+    assert check is not None
+    assert check.ok is False
+    assert check.detail.startswith("node reports not ready")
 
 
 def test_render_verdict_does_not_infer_empty_search_from_corpus_failure() -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -431,6 +431,55 @@ def test_check_corpus_reports_bounded_probe_and_preserves_payload(monkeypatch) -
     assert check.data["corpus"]["relational_documents"] == 2867
 
 
+def test_check_corpus_names_the_failed_canary_over_a_complete_probe(monkeypatch) -> None:
+    # 2026-08-12: the row printed a red X while the detail read "corpus probe
+    # complete: 34/34 ... fully indexed"; the failing gate was the canary and
+    # the text never said so.
+    body = {
+        "ok": False,
+        "corpus": {
+            "ok": True,
+            "tracked_sources": 333,
+            "indexed_docs": 7656,
+            "relational_documents": 37,
+            "probe_documents": 34,
+            "probe_complete": True,
+            "probe_ok": True,
+            "probe_fully_indexed_documents": 34,
+        },
+        "canary": {"ok": False, "search_hit": False, "graph_grew": True},
+        "lifecycle": {"ok": True},
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/readyz": body}))
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+    assert check is not None
+    assert check.ok is False
+    assert "search canary failed (search_hit=False)" in check.detail
+
+
+def test_check_corpus_folds_lifecycle_ok_and_shows_backend_split(monkeypatch) -> None:
+    # 2026-08-12: aggregate searchable kept rising on relational-only progress
+    # while graph and vector were frozen; the CLI stayed green over a 503 node.
+    body = {
+        "ok": False,
+        "corpus": {"ok": True, "tracked_sources": 333, "indexed_docs": 7656},
+        "canary": {"ok": True},
+        "lifecycle": {
+            "ok": False,
+            "current_generation": {
+                "current_searchable_by_backend": {"graph": 54, "relational": 115, "vector": 54}
+            },
+        },
+    }
+    monkeypatch.setattr(status_mod._OPENER, "open", _route({"/readyz": body}))
+    check = status_mod.check_corpus("https://node.example", "ctdl_tok")
+    assert check is not None
+    assert check.ok is False
+    assert "lifecycle invariants failing" in check.detail
+    assert "searchable by backend: graph 54, relational 115, vector 54" in check.detail
+    assert check.data["searchable_by_backend"] == {"graph": 54, "relational": 115, "vector": 54}
+
+
 def test_render_verdict_does_not_infer_empty_search_from_corpus_failure() -> None:
     report = StatusReport(
         node_url="https://node.example",

--- a/tests/test_sync_push.py
+++ b/tests/test_sync_push.py
@@ -412,3 +412,9 @@ def test_unreachable_node_still_exits_zero(monkeypatch: Any, tmp_path: Path) -> 
     receipt = _receipt_text()
     assert "not captured" in receipt
     assert "captured commit" not in receipt
+
+
+def test_receipt_summary_missing_accepted_is_unconfirmed_not_captured() -> None:
+    # A 2xx body without accepted: true must not read as "captured".
+    summary = sync_push.receipt_summary({"reason": "queued"}, short_sha="abc1234", branch="main")
+    assert summary == "commit abc1234 unconfirmed: server did not state accepted: true"

--- a/tests/test_sync_session.py
+++ b/tests/test_sync_session.py
@@ -395,3 +395,9 @@ def test_empty_session_is_not_sent(monkeypatch: Any, tmp_path: Path) -> None:
     receipt = _receipt_text()
     assert "skipped" in receipt
     assert "captured" not in receipt
+
+
+def test_receipt_summary_missing_accepted_is_unconfirmed_not_captured() -> None:
+    # A 2xx body without accepted: true must not read as "captured".
+    summary = sync_session.receipt_summary({"reason": "queued"})
+    assert summary == "session unconfirmed: server did not state accepted: true"

--- a/uv.lock
+++ b/uv.lock
@@ -674,6 +674,7 @@ server = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "google-auth" },
+    { name = "huggingface-hub" },
     { name = "ladybug" },
     { name = "mcp" },
     { name = "pydantic" },
@@ -682,6 +683,7 @@ server = [
     { name = "requests" },
     { name = "starlette" },
     { name = "tiktoken" },
+    { name = "tokenizers" },
     { name = "transformers" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -703,6 +705,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'server'", specifier = "==50.0.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.116.2,<1.0.0" },
     { name = "google-auth", marker = "extra == 'server'", specifier = ">=2.40.0,<3.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'server'", specifier = "==1.27.0" },
     { name = "ladybug", marker = "extra == 'server'", specifier = "==0.18.2" },
     { name = "mcp", marker = "extra == 'server'", specifier = ">=1.28.1,<2.0.0" },
     { name = "pydantic", marker = "extra == 'server'", specifier = ">=2.10.5,<3.0.0" },
@@ -711,6 +714,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'server'", specifier = ">=2.32.0,<3.0.0" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=1.3.1,<2.0.0" },
     { name = "tiktoken", marker = "extra == 'server'", specifier = "==0.13.0" },
+    { name = "tokenizers", marker = "extra == 'server'", specifier = "==0.22.2" },
     { name = "transformers", marker = "extra == 'server'", specifier = "==5.15.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.34.0,<1.0.0" },
 ]


### PR DESCRIPTION
Refs #266. The comprehensive follow-up to today's embedding incidents (#267, #268), built from a four-agent research sweep and two independent adversarial reviews (one against a real image build). Every item carries a regression test that fails without its fix.

## Offline embedding, done right this time

- Bake the fastembed ONNX weights (~64 MiB, qdrant/bge-small-en-v1.5-onnx-q) into /opt/fastembed-cache next to the already-baked tokenizer, then restore HF_HUB_OFFLINE=1. The offline load path was verified to take zero cache writes (read-only rootfs safe).
- The Dockerfile proves the image embeds offline AT BUILD TIME. A bake mistake now fails the build, not production.
- CI runs the new env-gated smoke inside the built image with --network none. It fails on both regression classes we shipped today: the silent TikToken chunk-sizing fallback and a blocked model download.
- Both Compose files stop overriding HF_HOME onto the volume (that override silently restored the TikToken regression on the shipped deploy path; a structural test now forbids it).
- kb/lite_runtime.py pins the fastembed cache below the data root and fails fast when EMBEDDING_MODEL is not the baked model under offline (matching fastembed's full 1/true/yes/on value set).
- Pins frozen to the verified set: transformers==5.15.0, huggingface-hub==1.27.0, tokenizers==0.22.2 (0.23.1 violates transformers' cap). Parity enforced across pyproject, requirements.txt, and the Dockerfile assertion.
- railway.toml records the builder Railway actually uses (Dockerfile, verified from build logs) and drops the stale cold-boot-download comment.

## The missing remediation: failed projections could never heal

During the outage, 235 projection jobs converted to failed. The lifecycle heal path only fires when the same bytes are re-submitted, and sync skips unchanged content, so failed jobs for stable sources stay failed forever. New: POST /api/lifecycle/requeue-failed (admin) applies the same reset the heal path uses to every failed job; the worker drains them via claim_next_job. This is the path we will use to recover production's current corpus.

## The second blocker: graph projection could not recover either

Requeuing alone would have recovered vector and left graph exactly where it was. A separate runtime-asset failure, of the same class as the embedding one, kept every graph write failing:

```
RuntimeError: IO exception: Failed to load library:
/home/citadel/.lbdb/extension/0.18.1/linux_amd64/json/libjson.lbug_extension
which is needed by extension: json.
```

Ladybug resolves its extension directory from `$HOME` when a Database opens, and it ignores `LADYBUG_HOME_DIRECTORY`. That name is ours, not Ladybug's: `scripts/build_secure_cognee.py` turns it into a connection-level `CALL home_directory`, which cannot run before the database is open. `cognee_db_workers`' `OP_OPEN_DATABASE` carries no home_directory field either, so the open path can never be redirected off `$HOME`. Verified directly: with `LADYBUG_HOME_DIRECTORY=/opt/lb2` exported, `INSTALL JSON` still wrote to `$HOME/.lbdb` and `/opt/lb2` stayed empty.

Origin: `f25f94c` ("build(docker): harden production runtime", 2026-08-10) took the LADYBUG patch count in `scripts/build_secure_cognee.py` from 0 to 24, redirecting installs to `/data/ladybug-home`. Before it, each container's runtime `INSTALL JSON` populated the default `$HOME/.lbdb` that the open path reads, which is why 54 documents ever became graph-searchable and then it stopped.

Fix: bake the extension into the image at build time, mirroring the fastembed bake, plus a build-time gate. `LOAD EXTENSION` never installs, so removing the bake fails the build rather than production. Verified both directions: with the bake, the image loads the extension under `--network none` as uid 10001 and creates a JSON-typed node table; without it, the build fails with `AssertionError: ladybug json extension is not baked`.

Why this matters for sequencing: a deploy resets the container's writable layer, so the bake has to be in the image before the requeue runs, or the 235 jobs simply fail again.

Second defect found on the same path: the route reset the rows and returned 200, but nothing restarted the worker. `next_wakeup_delay` counts only `pending` and `running` jobs (`kb/lifecycle.py:2057`), so while all 235 jobs sat in `failed` there was nothing due, `_drain_lifecycle` had already returned (`kb/service.py:424-425`), and no task was polling. The requeued work would have waited for the next caller of `resume_lifecycle_queue`, which in production is the hourly evolve pass, so the route would have reported success while the corpus stayed frozen. The route now kicks the drain after the reset.

## Truthful status surfaces (what today's outage exposed)

- citadel status names the failing gate (search canary, lifecycle invariant names from the readyz payload) PREPENDED so row truncation cannot hide it; folds lifecycle.ok into the data-plane verdict; prints the per-backend searchable split zero-filled from the receipts universe (an absent backend is the worst case, not a healthy one); and defers to the server's own readyz ok for gates this client does not model.
- citadel capture and both capture hooks now hold one contract: a 2xx without accepted: true reads unconfirmed, never captured.
- scripts/classify_docker_logs.py: fatal-class lines can only be excused by an explicit --expect-fatal tier, never by the warning allowlist; plural fatal tokens ('5 errors') are caught; the shell gates additionally catch 'corrupted' (substring).

## Review provenance

Fresh-eyes round 1 (semantics lens): 8 REAL findings, all fixed with the reviewer's reproductions turned into tests. Round 2 (docker lens, against a real build of the branch): 2 blockers + 2 real findings, all fixed. Both reviews also verified the per-test claim that each new test fails with its protection removed.

## Verification

Full non-live suite: 2132 passed, 6 skipped. Ruff clean. The in-image lane result at this head is CI's to prove; the reviewer's build of the previous head plus the isolated causation (guard env cleared => 2127 passed) predicts green.

## Convergence, checked against the invariant

`kb/server.py:4362-4396` is the only place `invariant_errors` is built, and it runs six checks. Against the live 14:59Z census five already pass: jobs 291 is not below revisions 291, receipts 873 equals 291x3, current jobs 289 equals current sources 289, current receipts 867 equals 289x3, and `current_receipts_by_backend` is 289 on graph, relational and vector. Only `if failed_jobs or failed_receipts` fires, from 235 failed jobs and 470 failed receipts. So draining those empties `invariant_errors` and flips `lifecycle.ok` to true. Receipt arithmetic: 470 failed + 397 searchable + 6 stale = 873, so draining the 470 yields 867 searchable, which is 289 per backend, moving graph and vector from 54 to 289.

`stale` appears nowhere in that computation, so the 2 stale jobs and 6 stale receipts that `requeue_failed_projections` does not touch (it selects `WHERE state = 'failed'` only) do not gate `lifecycle.ok`. Convergence does not stall short.
