### PR TITLE
fix(lifecycle): close the Phase 1 drain stall class and name budget-gate violators

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4231,16 +4231,32 @@ class CogneePublicClient:
                     "VECTOR_DB_PROVIDER does not support exact enumeration"
                 )
             elif not stored_check["ok"]:
+                # Name the violators. The check already collects chunk_id and
+                # document_id per violation, but this site used to drop them and
+                # raise a bare count, so the 2026-08-13 canary failed for hours
+                # on one unidentifiable chunk out of ~1951 with no surface
+                # anywhere naming the offending document.
+                named = "; ".join(
+                    f"document {violation.get('document_id') or 'unknown'} "
+                    f"chunk {violation.get('chunk_id') or 'unknown'} "
+                    f"({violation.get('measured_tokens') or violation.get('configured_size')}"
+                    f" tokens > budget {stored_check.get('budget')})"
+                    for violation in (stored_check.get("violations") or [])[:3]
+                ) or "no violation rows"
+                missing = stored_check.get("missing_document_ids") or []
+                if missing:
+                    named += f"; missing document ids {missing[:3]}"
                 logger.error(
                     "stored chunk budget check failed after cognify: "
-                    "%d violation(s) across %d chunk(s)",
+                    "%d violation(s) across %d chunk(s): %s",
                     stored_check["violation_count"],
                     stored_check["chunks_scanned"],
+                    named,
                 )
                 raise RuntimeError(
                     "stored chunk budget check failed: "
                     f"{stored_check['violation_count']} violation(s) across "
-                    f"{stored_check['chunks_scanned']} persisted chunk(s)"
+                    f"{stored_check['chunks_scanned']} persisted chunk(s): {named}"
                 )
         return result
 

--- a/kb/repo_content_sync.py
+++ b/kb/repo_content_sync.py
@@ -21,6 +21,7 @@ from typing import Any
 from urllib.parse import quote
 
 from kb import chunk_window
+from kb.cognee_client import _suppress_inline_cognify
 from kb.github_sync import GitHubAPIError, GitHubOrgClient, utc_now
 from kb.learning import LearningProcess
 from kb.security_scan import SecurityScanEntry, scan_text_entries
@@ -897,7 +898,13 @@ class RepoContentSyncer:
                             _checkpoint(tracked)
                         elif operations and states <= {"pending", "running", "completed"}:
                             resume = getattr(self.citadel, "resume_lifecycle_queue", None)
-                            if callable(resume):
+                            # Not during evolve Phase 1. This walks nearly the
+                            # whole tracked corpus every pass, and an
+                            # unconditional resume here started a drain that
+                            # parked on the writer lock Phase 1 holds (the
+                            # 2026-08-13 stall). The scheduler resumes the
+                            # queue itself once the pass ends.
+                            if callable(resume) and not _suppress_inline_cognify():
                                 resume()
                             _record_skip(repo_result, "projection_pending")
                             continue

--- a/kb/server.py
+++ b/kb/server.py
@@ -407,6 +407,19 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             # make a node with one broken stage restart its clock forever, which
             # is the bug this fixes (#153).
             record_completed(state_path)
+            # Drain whatever the pass deferred. Projection starts are
+            # suppressed while Phase 1 holds the writer lock, and Phase 2
+            # cognifies directly without touching the lifecycle queue, so
+            # without this kick a job accepted mid-pass waits for the next
+            # external ingest or the next pass. The lock is free and the
+            # suppression scope has ended by this point, and the call is a
+            # no-op when a drain is already running.
+            resume = getattr(get_citadel(), "resume_lifecycle_queue", None)
+            if callable(resume):
+                try:
+                    resume()
+                except Exception:
+                    logger.exception("Evolve scheduler: post-pass projection resume failed")
 
 
 def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":

--- a/kb/service.py
+++ b/kb/service.py
@@ -13,7 +13,11 @@ from uuid import uuid4
 from typing import Any
 
 from kb import chunk_window
-from kb.cognee_client import CogneeGateway, CogneePublicClient
+from kb.cognee_client import (
+    CogneeGateway,
+    CogneePublicClient,
+    _suppress_inline_cognify,
+)
 from kb.config import CitadelConfig
 from kb.filters import PreIngestFilter
 from kb.logging_utils import safe_log_value
@@ -377,12 +381,16 @@ class Citadel:
 
     @staticmethod
     def _inline_projection_suppressed() -> bool:
-        return os.getenv("CITADEL_SUPPRESS_INLINE_COGNIFY", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        # Delegate rather than re-read the environment. Evolve Phase 1 moved
+        # into the web process (#88) and now marks itself with the
+        # _SUPPRESS_INLINE_COGNIFY context variable, not the environment
+        # variable, precisely because the env var is process-wide and would
+        # silence a teammate's ingest too. This checker only read os.getenv, so
+        # it returned False for the whole of Phase 1 and started the drain while
+        # Phase 1 held the graph writer lock. On 2026-08-13 that parked a
+        # projection job on writer_lock.acquire() for 66 minutes, and the lease
+        # heartbeat renewed it throughout, so nothing reclaimed it.
+        return _suppress_inline_cognify()
 
     def _start_lifecycle_projection(self) -> bool:
         if self.lifecycle_worker is None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -2680,6 +2680,57 @@ async def test_cognify_fails_when_stored_chunk_check_is_red(monkeypatch: Any) ->
 
 
 @pytest.mark.asyncio
+async def test_cognify_budget_failure_names_the_violating_chunk(monkeypatch: Any) -> None:
+    """The raise must carry the violator's identity, not a bare count.
+
+    The check collects chunk_id and document_id per violation, but the raise
+    site used to drop them, so the 2026-08-13 readiness canary failed for hours
+    on "1 violation(s) across 1951 persisted chunk(s)" with no surface anywhere
+    naming the offending document.
+    """
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    run = SimpleNamespace(data_ingestion_info=[{"data_id": "doc-a"}])
+
+    async def run_migrations() -> None:
+        return None
+
+    async def cognify(**_: Any) -> dict[str, Any]:
+        return {"dataset-id": run}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_migrations=run_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient()
+
+    async def stored_chunk_budget_check(**_: Any) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "violation_count": 1,
+            "chunks_scanned": 1951,
+            "budget": 256,
+            "violations": [
+                {
+                    "reason": "chunk_over_budget",
+                    "chunk_id": "chunk-9f1e",
+                    "document_id": "doc-minified-js",
+                    "measured_tokens": 1710,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(client, "stored_chunk_budget_check", stored_chunk_budget_check)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await client.cognify(datasets=["notes"])
+    message = str(excinfo.value)
+    assert "document doc-minified-js" in message
+    assert "chunk chunk-9f1e" in message
+    assert "1710 tokens > budget 256" in message
+
+
+@pytest.mark.asyncio
 async def test_stored_chunk_budget_check_scans_exact_pgvector_payloads(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -78,6 +78,14 @@ async def test_stop_evolve_scheduler_handles_none() -> None:
 class _FakeCitadel:
     def __init__(self, cognify_calls: list[bool]) -> None:
         self._cognify_calls = cognify_calls
+        self.resume_calls: list[bool] = []
+
+    def resume_lifecycle_queue(self) -> bool:
+        # The scheduler kicks the projection drain after every pass, because
+        # starts are suppressed while Phase 1 holds the writer lock and Phase 2
+        # never drains the lifecycle queue itself.
+        self.resume_calls.append(True)
+        return True
 
     async def cognify_dataset(self, *, force: bool = False, verify: bool = False) -> dict[str, Any]:
         self._cognify_calls.append(force)
@@ -134,7 +142,8 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
         raise AssertionError("the evolve scheduler must not spawn a subprocess")
 
     monkeypatch.setattr(server.asyncio, "create_subprocess_exec", forbidden_exec)
-    monkeypatch.setattr(server, "get_citadel", lambda: _FakeCitadel(cognify_calls))
+    fake_citadel = _FakeCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
 
     task = asyncio.create_task(server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json")))
     try:
@@ -155,6 +164,11 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
     assert len(cognify_calls) >= 2
     # The verify canary verdict is recorded for /readyz (#27).
     assert server._LAST_CANARY is not None and server._LAST_CANARY["ok"] is True
+    # Every pass ends by kicking the projection drain: starts are suppressed
+    # while Phase 1 holds the writer lock, and Phase 2 cognifies directly
+    # without draining the lifecycle queue, so a job accepted mid-pass would
+    # otherwise wait for the next external ingest or the next pass.
+    assert len(fake_citadel.resume_calls) >= 1
 
 
 class _RaisingCitadel:

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -227,6 +227,26 @@ async def test_add_only_mode_does_not_leak_outside_the_pass(tmp_path: Path) -> N
     assert await asyncio.create_task(observer()) is False
 
 
+async def test_inline_projection_suppression_honours_the_context_variable() -> None:
+    """The service-side checker must read the same flag Phase 1 actually sets.
+
+    Phase 1 moved into the web process (#88) and marks itself with the
+    _SUPPRESS_INLINE_COGNIFY context variable, deliberately NOT the environment
+    variable, which is process-wide. `Citadel._inline_projection_suppressed`
+    read only os.getenv, so it answered False for the whole of Phase 1 and let
+    accept_source start the projection drain while Phase 1 held the graph
+    writer lock. On 2026-08-13 that parked a job on writer_lock.acquire() for
+    66 minutes while the lease heartbeat renewed it, so nothing reclaimed it.
+    """
+    from kb.cognee_client import suppress_inline_cognify
+    from kb.service import Citadel
+
+    assert Citadel._inline_projection_suppressed() is False
+    with suppress_inline_cognify():
+        assert Citadel._inline_projection_suppressed() is True
+    assert Citadel._inline_projection_suppressed() is False
+
+
 async def test_evolve_scheduler_loop_cognifies_even_if_phase1_raises(
     monkeypatch: Any, tmp_path: Path
 ) -> None:

--- a/tests/test_repo_content_sync.py
+++ b/tests/test_repo_content_sync.py
@@ -1039,13 +1039,24 @@ async def test_lifecycle_projection_checkpoint_polls_without_duplicate_ingest(
 
     first = await syncer.run()
     second = await syncer.run()
+    # Under evolve Phase 1 the resume must NOT fire: this branch walks nearly
+    # the whole tracked corpus every pass, and an unconditional resume started
+    # a drain that parked on the writer lock Phase 1 holds (2026-08-13). The
+    # scheduler resumes the queue itself once the pass ends.
+    from kb.cognee_client import suppress_inline_cognify
+
+    with suppress_inline_cognify():
+        suppressed_pass = await syncer.run()
     citadel.operation_state = "searchable"
     third = await syncer.run()
 
     assert first["files_ingested"] == 1
     assert second["files_skipped_by_reason"] == {"projection_pending": 1}
+    assert suppressed_pass["files_skipped_by_reason"] == {"projection_pending": 1}
     assert third["files_skipped_by_reason"] == {"unchanged": 1}
     assert len(learning.calls) == 1
+    # Exactly one resume: the unsuppressed second run. The suppressed run
+    # recorded the same skip without kicking the drain.
     assert citadel.resume_calls == 1
 
 


### PR DESCRIPTION
Refs #266. Closes the projection-stall class found on 2026-08-13 and makes the chunk-budget gate name its violator. Three commits, each revert-proven, adversarially reviewed (verdict: ship, after its one real finding was fixed in the third commit).

## The stall, in one paragraph

Evolve Phase 1 acquires the graph writer lock and holds it across every stage; github_sync held it for 66 minutes on 2026-08-13. The suppression guard that should keep projection starts out of Phase 1 read only `CITADEL_SUPPRESS_INLINE_COGNIFY` from the environment, while Phase 1 marks itself with a context variable (deliberately, since an env var is process-wide and would silence teammate ingests too). The guard therefore never fired: the drain started mid-pass, parked on `writer_lock.acquire()` (which has no timeout), the lease heartbeat renewed the parked job forever so lease-expiry reclaim could never fire, and the strictly serial drain froze for 22 minutes with zero errors logged and `lifecycle.ok` reporting true throughout.

## The commits

1. `c4188bc` — `Citadel._inline_projection_suppressed` delegates to the checker that reads the context variable first. Context variables propagate by task tree, so this also covers stage-private `Citadel.from_env()` instances' own ingest kickoffs.
2. `e83e1bc` — the stored-chunk-budget raise names up to three violators (document_id, chunk_id, measured tokens against the budget) plus missing document ids, instead of an anonymous count. The check already collected these and dropped them; no surface anywhere in the system named the offending document, which is why the canary failure stayed unactionable across five days of occurrences (chunks_scanned 1911 through 1970, violation_count always exactly 1). No stored text or secret can enter the message: violation items carry ids and a sha256[:12] digest only, both provider paths checked.
3. `8a73ab5` — review finding: `repo_content_sync`'s `projection_pending` branch resumed the drain unconditionally, walks nearly the whole tracked corpus each pass, and runs inside Phase 1, so it reproduced the stall shape hourly. Gated on the same context variable. Counterpart: the scheduler now resumes the lifecycle queue in the pass `finally` (suppression ended, lock free, fires on failed passes too), so a job accepted mid-pass drains at pass end deterministically instead of waiting for the next external ingest.

## What this does not fix, on purpose

- The writer lock is per-instance, so the single-writer guarantee still does not hold across stage-private instances. A naive shared lock deadlocks (Phase 1 holds it across stages; stages can reach `delete_document_chunks` in the same task tree; `asyncio.Lock` is not reentrant). Recorded as a design constraint for a separate change.
- The budget gate still raises after the write committed, still self-opens on retry (`if processed_ids:` skips an already-marked batch), and still fails all co-processed receipts on one violation. Naming the violator is the prerequisite for any of those repairs.
- The gate currently fails every evolve pass with `1 violation(s)` and a scan scope that tracks the whole corpus, which matches a forced (non-incremental) canary cognify. Whether `CITADEL_EVOLVE_COGNIFY_FORCE` is set in the service environment is an open operator question; this PR makes the next failure name its document either way.

## Verification

Full non-live suite: 2135 passed, 1 skipped, 1 failed — the failure is the known stock-vs-patched cognee wheel metadata gap, reproduced identically at the base commit with the same venv. Ruff clean. Each commit's protection is revert-proven: reverting only its source file makes its test fail with a non-zero collected count. Adversarial review (refute mode) cleared the naming commit with no real findings and surfaced the unsuppressed entrance that the third commit closes.
