### PR TITLE
fix(mesh): merge every dataset store into the org-wide graph read

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -1175,12 +1175,20 @@ class CogneePublicClient:
         ``(source_id, target_id, relationship_name, properties)`` tuples, per
         ``cognee.infrastructure.databases.graph.graph_db_interface``.
 
-        The read scans the ENTIRE graph — every provisioned dataset store, see
-        ``_read_graph_data`` — (~0.3s+ on the prod node) and is front-loaded on
-        every dashboard open, so the result is cached for
-        ``GRAPH_DATA_CACHE_TTL_SECONDS`` behind a single-flight lock: a burst of
-        concurrent /api/mesh/graph opens collapses to one store sweep instead of
-        one per caller (#28/#50). Per-caller shaping still runs per request.
+        The refill is one full ``get_graph_data()`` per provisioned dataset
+        store (see ``_read_graph_data``), sequential, each store entered
+        through cognee's semaphore-backed DatasetQueue
+        (``DATASET_QUEUE_MAX_CONCURRENT``, defaulting to
+        ``DATABASE_MAX_LRU_CACHE_SIZE`` = 6), the whole sweep under
+        ``_graph_data_lock``. Cost scales with the store count, and
+        provisioned datasets beyond the engine LRU cap churn the cached
+        engines — raise ``DATABASE_MAX_LRU_CACHE_SIZE`` in the deploy
+        environment when stores exceed 6 (ADR-0020). The sweep is
+        front-loaded on every dashboard open, so the result is cached for
+        ``GRAPH_DATA_CACHE_TTL_SECONDS`` behind that single-flight lock: a
+        burst of concurrent /api/mesh/graph opens collapses to one store
+        sweep instead of one per caller (#28/#50). Per-caller shaping still
+        runs per request.
         """
         cached = self._graph_data_cache
         if cached is not None and monotonic() - cached[0] < GRAPH_DATA_CACHE_TTL_SECONDS:
@@ -1223,6 +1231,13 @@ class CogneePublicClient:
         stores only, so a read never creates databases — and a node with no
         provisioned store keeps the single ambient-context read (access
         control off, single-store deployments, local fakes).
+
+        A store that fails to open or read is skipped — logged by dataset id
+        and exception class only, never row contents — and the healthy stores
+        still merge, so one Kuzu lock timeout does not blank the mesh for
+        every caller. When EVERY provisioned store fails the read raises:
+        /api/mesh/graph keeps its honest fallback and corpus health degrades,
+        instead of a dead graph layer presenting as an empty vault (ADR-0020).
         """
         self._prepare_cognee_environment()
         import cognee
@@ -1235,10 +1250,25 @@ class CogneePublicClient:
         edges: list[Any] = []
         seen_nodes: set[str] = set()
         seen_edges: set[tuple[str, str, str]] = set()
+        failures = 0
+        last_failure: Exception | None = None
         for dataset_id, owner_id in provisioned:
-            scoped_nodes, scoped_edges = await self._read_graph_data_for_dataset(
-                dataset_id, owner_id
-            )
+            try:
+                scoped_nodes, scoped_edges = await self._read_graph_data_for_dataset(
+                    dataset_id, owner_id
+                )
+            except Exception as exc:  # noqa: BLE001 - one bad store must not blank the mesh
+                # Dataset id + exception class only: dataset_database rows
+                # carry store credentials in other columns, and exception
+                # text can quote connection strings.
+                failures += 1
+                last_failure = exc
+                logger.warning(
+                    "org-wide graph read skipped dataset %s: %s",
+                    dataset_id,
+                    exc.__class__.__name__,
+                )
+                continue
             for raw in scoped_nodes:
                 try:
                     node_id = str(raw[0])
@@ -1259,6 +1289,8 @@ class CogneePublicClient:
                     continue
                 seen_edges.add(edge_key)
                 edges.append(raw)
+        if last_failure is not None and failures == len(provisioned):
+            raise last_failure
         return nodes, edges
 
     async def _provisioned_dataset_databases(self) -> list[tuple[UUID, UUID]]:

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -1175,10 +1175,11 @@ class CogneePublicClient:
         ``(source_id, target_id, relationship_name, properties)`` tuples, per
         ``cognee.infrastructure.databases.graph.graph_db_interface``.
 
-        The read scans the ENTIRE graph (~0.3s+ on the prod node) and is now
-        front-loaded on every dashboard open, so the result is cached for
+        The read scans the ENTIRE graph — every provisioned dataset store, see
+        ``_read_graph_data`` — (~0.3s+ on the prod node) and is front-loaded on
+        every dashboard open, so the result is cached for
         ``GRAPH_DATA_CACHE_TTL_SECONDS`` behind a single-flight lock: a burst of
-        concurrent /api/mesh/graph opens collapses to one Kuzu read instead of
+        concurrent /api/mesh/graph opens collapses to one store sweep instead of
         one per caller (#28/#50). Per-caller shaping still runs per request.
         """
         cached = self._graph_data_cache
@@ -1200,10 +1201,123 @@ class CogneePublicClient:
         self._graph_data_cache = None
 
     async def _read_graph_data(self) -> tuple[list[Any], list[Any]]:
+        """Merge every provisioned dataset store into one org-wide graph read.
+
+        Under ENABLE_BACKEND_ACCESS_CONTROL each dataset lives in its own graph
+        database, and ``get_graph_engine()`` resolves whichever per-dataset
+        config the cognee ``graph_db_config`` ContextVar carries — cognee
+        deliberately leaves the LAST entered dataset context in place after an
+        ``async with set_database_global_context_variables(...)`` block exits.
+        Trusting that ambient context made this read return whichever single
+        store the current task last touched: refilled after a cognify it was
+        the content dataset's store (43,732 total nodes live on 2026-08-13),
+        refilled right after the corpus-health census — whose per-dataset loop
+        ends on the alphabetically last probed dataset — it was that store (21
+        total nodes, same day), and /api/mesh/graph plus the corpus-health
+        ``indexed_docs``/``indexed_edges`` flapped between the two. ADR-0020
+        names the org-wide read: one ``get_graph_data()`` per dataset, merged
+        with node-id deduplication. Edges dedupe on (source, target,
+        relationship), the triple cognee's adapters MERGE on within a store,
+        so a document mirrored into two datasets returns once. Datasets come
+        from the relational ``dataset_database`` rows — already-provisioned
+        stores only, so a read never creates databases — and a node with no
+        provisioned store keeps the single ambient-context read (access
+        control off, single-store deployments, local fakes).
+        """
         self._prepare_cognee_environment()
         import cognee
 
         await self._ensure_cognee_ready(cognee)
+        provisioned = await self._provisioned_dataset_databases()
+        if not provisioned:
+            return await self._read_graph_data_current_context()
+        nodes: list[Any] = []
+        edges: list[Any] = []
+        seen_nodes: set[str] = set()
+        seen_edges: set[tuple[str, str, str]] = set()
+        for dataset_id, owner_id in provisioned:
+            scoped_nodes, scoped_edges = await self._read_graph_data_for_dataset(
+                dataset_id, owner_id
+            )
+            for raw in scoped_nodes:
+                try:
+                    node_id = str(raw[0])
+                except (TypeError, IndexError, KeyError):
+                    nodes.append(raw)
+                    continue
+                if node_id in seen_nodes:
+                    continue
+                seen_nodes.add(node_id)
+                nodes.append(raw)
+            for raw in scoped_edges:
+                try:
+                    edge_key = (str(raw[0]), str(raw[1]), str(raw[2]))
+                except (TypeError, IndexError, KeyError):
+                    edges.append(raw)
+                    continue
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
+                edges.append(raw)
+        return nodes, edges
+
+    async def _provisioned_dataset_databases(self) -> list[tuple[UUID, UUID]]:
+        """(dataset_id, owner_id) for every dataset with a provisioned database.
+
+        Read straight from the relational ``dataset_database`` rows so the
+        org-wide loop only ever opens stores that already exist:
+        ``set_database_global_context_variables`` provisions a database for a
+        dataset that lacks one, and a read path must not create databases.
+        Sorted by dataset id for a deterministic merge order.
+        """
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.users.models import DatasetDatabase
+        from sqlalchemy import select
+
+        engine = get_relational_engine()
+        async with engine.get_async_session() as session:
+            rows = await session.execute(
+                select(DatasetDatabase.dataset_id, DatasetDatabase.owner_id)
+            )
+            pairs = rows.all()
+        return sorted(
+            ((dataset_id, owner_id) for dataset_id, owner_id in pairs),
+            key=lambda pair: str(pair[0]),
+        )
+
+    async def _read_graph_data_for_dataset(
+        self, dataset_id: UUID, owner_id: UUID
+    ) -> tuple[list[Any], list[Any]]:
+        """One dataset store's raw graph, with the ambient context restored.
+
+        cognee keeps the per-dataset graph/vector/file-storage configs set
+        after the ``async with`` block exits, on purpose, so callers can keep
+        reading the dataset databases they just wrote. This read must not
+        repoint the surrounding task at whichever dataset merged last:
+        ``cognify_dataset`` deletes its verify marker through the engine the
+        ambient context resolves, and that marker lives in the just-cognified
+        dataset's store. The prior values go back once the store is read.
+        """
+        from cognee.context_global_variables import (
+            graph_db_config,
+            set_database_global_context_variables,
+            vector_db_config,
+        )
+        from cognee.infrastructure.files.storage.config import file_storage_config
+
+        prior = [
+            (variable, variable.get(None))
+            for variable in (graph_db_config, vector_db_config, file_storage_config)
+        ]
+        try:
+            async with set_database_global_context_variables(dataset_id, owner_id):
+                return await self._read_graph_data_current_context()
+        finally:
+            for variable, value in prior:
+                variable.set(value)
+
+    async def _read_graph_data_current_context(self) -> tuple[list[Any], list[Any]]:
+        """Raw nodes and edges from the engine the active context resolves."""
         from cognee.infrastructure.databases.graph import get_graph_engine
 
         engine = await get_graph_engine()

--- a/kb/server.py
+++ b/kb/server.py
@@ -4754,13 +4754,19 @@ async def _corpus_health_impl() -> dict[str, Any]:
             return _cache_corpus_health_result(cache_key, result)
         return result
     except Exception as exc:  # noqa: BLE001 - convert dependency failures to readiness state
-        logger.warning("corpus health check degraded: %s", exc)
+        # Class name only, in the log and in the payload: /readyz embeds this
+        # dict verbatim for any reader-scoped caller, and exception text can
+        # quote connection strings (dataset_database rows carry plaintext
+        # store credentials in their URL columns).
+        logger.warning(
+            "corpus health check degraded: %s", exc.__class__.__name__
+        )
         result = {
             "ok": False,
             "tracked_sources": None,
             "indexed_docs": None,
             "indexed_edges": None,
-            "degraded": str(exc),
+            "degraded": exc.__class__.__name__,
         }
         if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
             return _cache_corpus_health_result(cache_key, result)

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -7,7 +7,7 @@ import sys
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, Mapping
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -298,6 +298,152 @@ async def test_cognify_invalidates_cached_graph_snapshot(monkeypatch: Any) -> No
     await client.graph_data()
 
     assert reads == 2
+
+
+@pytest.mark.asyncio
+async def test_graph_data_merges_every_provisioned_dataset_store(
+    monkeypatch: Any,
+) -> None:
+    """Org-wide totals come from the per-dataset loop, never one ambient store.
+
+    Under backend access control each dataset lives in its own graph database
+    and cognee leaves the LAST entered dataset context set after use. Pre-fix,
+    ``_read_graph_data`` resolved that ambient engine, so /api/mesh/graph
+    ``total_nodes``/``total_edges`` and the corpus-health ``indexed_docs``/
+    ``indexed_edges`` published whichever store a prior operation leaked into
+    the refilling task: 43,732 total nodes after a cognify refill vs 21 after a
+    corpus-health census refill, live on 2026-08-13, on the endpoint the app
+    graph page renders (kb/static/app.js /api/mesh/graph). ADR-0020: the
+    org-wide read loops the provisioned dataset stores and merges, deduping
+    nodes by id and edges by (source, target, relationship).
+    """
+    client = CogneePublicClient()
+    owner = uuid4()
+    dataset_a, dataset_b = sorted((uuid4(), uuid4()), key=str)
+    stores: dict[UUID, tuple[list[Any], list[Any]]] = {
+        dataset_a: (
+            [("doc-a", {"name": "a"}), ("shared", {"name": "s"})],
+            [("doc-a", "shared", "is_part_of", {})],
+        ),
+        dataset_b: (
+            [("doc-b", {"name": "b"}), ("shared", {"name": "s"})],
+            [
+                ("doc-b", "shared", "is_part_of", {}),
+                ("doc-a", "shared", "is_part_of", {}),
+            ],
+        ),
+    }
+    read_order: list[UUID] = []
+
+    async def ensure_ready(_: Any) -> None:
+        return None
+
+    async def provisioned() -> list[tuple[UUID, UUID]]:
+        return [(dataset_a, owner), (dataset_b, owner)]
+
+    async def read_for_dataset(
+        dataset_id: UUID, owner_id: UUID
+    ) -> tuple[list[Any], list[Any]]:
+        assert owner_id == owner
+        read_order.append(dataset_id)
+        scoped_nodes, scoped_edges = stores[dataset_id]
+        return list(scoped_nodes), list(scoped_edges)
+
+    monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
+    monkeypatch.setattr(client, "_ensure_cognee_ready", ensure_ready)
+    monkeypatch.setattr(client, "_provisioned_dataset_databases", provisioned)
+    monkeypatch.setattr(client, "_read_graph_data_for_dataset", read_for_dataset)
+    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace())
+
+    nodes, edges = await client.graph_data()
+
+    assert read_order == [dataset_a, dataset_b]
+    # The mirrored "shared" node dedupes by id; the cross-store duplicate edge
+    # dedupes by (source, target, relationship).
+    assert sorted(str(node_id) for node_id, _ in nodes) == ["doc-a", "doc-b", "shared"]
+    assert sorted((str(s), str(t)) for s, t, *_ in edges) == [
+        ("doc-a", "shared"),
+        ("doc-b", "shared"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_graph_data_without_provisioned_stores_reads_current_context(
+    monkeypatch: Any,
+) -> None:
+    """No dataset_database rows (access control off, local fakes): the single
+    ambient-context read stands, byte-for-byte."""
+    client = CogneePublicClient()
+
+    async def ensure_ready(_: Any) -> None:
+        return None
+
+    async def provisioned() -> list[tuple[UUID, UUID]]:
+        return []
+
+    async def current_context() -> tuple[list[Any], list[Any]]:
+        return ([("only", {})], [])
+
+    monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
+    monkeypatch.setattr(client, "_ensure_cognee_ready", ensure_ready)
+    monkeypatch.setattr(client, "_provisioned_dataset_databases", provisioned)
+    monkeypatch.setattr(client, "_read_graph_data_current_context", current_context)
+    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace())
+
+    nodes, edges = await client.graph_data()
+
+    assert nodes == [("only", {})]
+    assert edges == []
+
+
+@pytest.mark.asyncio
+async def test_per_dataset_graph_read_restores_ambient_context(
+    monkeypatch: Any,
+) -> None:
+    """The org-wide loop must not leave the task pointed at the last store.
+
+    cognee intentionally persists a dataset context after ``async with`` exit;
+    ``cognify_dataset`` relies on that to delete its verify marker from the
+    just-cognified store. The per-dataset read therefore puts the prior
+    graph/vector/file-storage configs back after reading.
+    """
+    from cognee import context_global_variables as context_module
+
+    client = CogneePublicClient()
+    sentinel = {"graph": "prior"}
+    prior_vector = context_module.vector_db_config.get(None)
+    token = context_module.graph_db_config.set(sentinel)
+    try:
+
+        class FakeContext:
+            def __init__(self, dataset_id: UUID, owner_id: UUID) -> None:
+                pass
+
+            async def __aenter__(self) -> "FakeContext":
+                # Mimic cognee: the entered configs persist past __aexit__.
+                context_module.graph_db_config.set({"graph": "leaked"})
+                context_module.vector_db_config.set({"vector": "leaked"})
+                return self
+
+            async def __aexit__(self, *exc: Any) -> None:
+                return None
+
+        async def current_context() -> tuple[list[Any], list[Any]]:
+            return ([], [])
+
+        monkeypatch.setattr(
+            context_module, "set_database_global_context_variables", FakeContext
+        )
+        monkeypatch.setattr(
+            client, "_read_graph_data_current_context", current_context
+        )
+
+        await client._read_graph_data_for_dataset(uuid4(), uuid4())
+
+        assert context_module.graph_db_config.get(None) is sentinel
+        assert context_module.vector_db_config.get(None) is prior_vector
+    finally:
+        context_module.graph_db_config.reset(token)
 
 
 class _FakeGraphEngine:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -397,6 +397,67 @@ async def test_graph_data_without_provisioned_stores_reads_current_context(
 
 
 @pytest.mark.asyncio
+async def test_graph_data_skips_failing_store_and_keeps_healthy_totals(
+    monkeypatch: Any,
+) -> None:
+    """One broken store must not blank the org-wide mesh graph.
+
+    A Kuzu lock timeout (or a store read racing a dataset delete) on ONE
+    dataset previously propagated out of the merge loop, so knowledge_mesh
+    served ``fallback: true`` — an empty canvas for every caller on every
+    cache refill. The loop skips the failing store (logging dataset id and
+    exception class only; ``dataset_database`` rows carry store credentials
+    in other columns) and merges the healthy ones. Only when EVERY
+    provisioned store fails does the read raise, keeping the honest fallback
+    instead of presenting a dead graph layer as an empty vault (ADR-0020).
+    """
+    client = CogneePublicClient()
+    owner = uuid4()
+    dataset_a, dataset_b, dataset_c = sorted((uuid4(), uuid4(), uuid4()), key=str)
+
+    async def ensure_ready(_: Any) -> None:
+        return None
+
+    async def provisioned() -> list[tuple[UUID, UUID]]:
+        return [(dataset_a, owner), (dataset_b, owner), (dataset_c, owner)]
+
+    async def read_for_dataset(
+        dataset_id: UUID, owner_id: UUID
+    ) -> tuple[list[Any], list[Any]]:
+        if dataset_id == dataset_b:
+            raise RuntimeError("store lock timeout")
+        marker = "a" if dataset_id == dataset_a else "c"
+        return (
+            [(f"doc-{marker}", {})],
+            [(f"doc-{marker}", "hub", "is_part_of", {})],
+        )
+
+    monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
+    monkeypatch.setattr(client, "_ensure_cognee_ready", ensure_ready)
+    monkeypatch.setattr(client, "_provisioned_dataset_databases", provisioned)
+    monkeypatch.setattr(client, "_read_graph_data_for_dataset", read_for_dataset)
+    monkeypatch.setitem(sys.modules, "cognee", SimpleNamespace())
+
+    nodes, edges = await client.graph_data()
+
+    assert sorted(str(node_id) for node_id, _ in nodes) == ["doc-a", "doc-c"]
+    assert sorted((str(s), str(t)) for s, t, *_ in edges) == [
+        ("doc-a", "hub"),
+        ("doc-c", "hub"),
+    ]
+
+    async def every_store_fails(
+        dataset_id: UUID, owner_id: UUID
+    ) -> tuple[list[Any], list[Any]]:
+        raise RuntimeError("all stores down")
+
+    monkeypatch.setattr(client, "_read_graph_data_for_dataset", every_store_fails)
+    client._graph_data_cache = None
+    with pytest.raises(RuntimeError, match="all stores down"):
+        await client.graph_data()
+
+
+@pytest.mark.asyncio
 async def test_per_dataset_graph_read_restores_ambient_context(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3069,8 +3069,43 @@ def test_readyz_reports_503_when_corpus_measurement_fails() -> None:
         "tracked_sources": None,
         "indexed_docs": None,
         "indexed_edges": None,
-        "degraded": "graph unavailable",
+        "degraded": "RuntimeError",
     }
+
+
+def test_readyz_degraded_field_never_carries_exception_text(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/readyz is reader-scoped and embeds the corpus dict verbatim, and a
+    failing store's exception text can quote connection strings — the
+    ``dataset_database`` rows carry plaintext store credentials in their URL
+    columns. The degraded corpus payload and the warning log therefore carry
+    the exception CLASS NAME only, never ``str(exc)``.
+    """
+    sentinel = "postgresql://user:SECRET@host"
+
+    class LeakyGraphCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            raise RuntimeError(f"could not connect to {sentinel}")
+
+    class HealthySyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 50, "tracked_files": 0, "issue_count": 0}
+
+    client = authed_client("test-reader")
+    app.state.citadel = LeakyGraphCitadel()
+    app.state.github_syncer = HealthySyncer()
+    app.state.repo_content_syncer = HealthySyncer()
+    app.state.linear_syncer = HealthySyncer()
+
+    with caplog.at_level(logging.WARNING):
+        ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["corpus"]["degraded"] == "RuntimeError"
+    assert sentinel not in ready.text
+    assert sentinel not in caplog.text
+    assert "RuntimeError" in caplog.text
 
 
 def test_readyz_does_not_use_graph_nodes_as_projection_health(
@@ -3233,7 +3268,7 @@ def test_readyz_rejects_inconsistent_complete_corpus_probe(
         "tracked_sources": None,
         "indexed_docs": None,
         "indexed_edges": None,
-        "degraded": "complete bounded corpus probe does not cover the relational document total",
+        "degraded": "RuntimeError",
     }
 
 


### PR DESCRIPTION
Refs #272.

Implements the org-wide graph read that ADR-0020 prescribed and no code ever provided, hardens it against per-store failures, and stops a reader-visible surface from echoing exception text.

## The defect

`/api/mesh/graph` reported three different graph totals in one day from the same call: 43,732 nodes after a cognify, 21 after a corpus-health refresh, 15,449 after the next cognify. There is no org-wide read anywhere: `_read_graph_data` resolves cognee's ambient dataset context, and cognee 1.4.1 deliberately leaves the last dataset context set after a scoped operation. Whichever task refills the 30-second cache picks the per-dataset store everyone sees. The app UI's graph page calls exactly this endpoint (`kb/static/app.js:2509`), so the vault rendered as ~21 nodes while holding the full corpus. The same roulette degrades the readiness canary's verify path, which reads graph counts before and after its marker round-trip.

## The commits

1. `3f84b7d` implements the ADR-0020 read: enumerate provisioned `dataset_database` rows (existing stores only, a read never creates one), read each store in an explicit dataset context, merge with node dedup by `id` and edge dedup by `(source, target, relationship)`, matching the ladybug adapter's own MERGE identity, and restore the prior ambient graph, vector, and file-storage configs afterward. The restore is load-bearing: without it the loop would leave the ambient context on the last dataset and reopen the marker-leak class the delete path already fixed once. Zero provisioned rows falls back to the old single read, so non-ACL deployments are unchanged.
2. `4997ccd` isolates per-store failures: one failing store is skipped with a warning carrying the dataset id and exception class only, and the healthy stores still merge. When every store fails the read raises rather than presenting an empty vault, per ADR-0020's consequence that a dataset failure must not look like emptiness.
3. `9cbcd73` closes the claim end to end: `_corpus_health_impl` logged and published `str(exc)` in the `degraded` field, and reader-scoped `/readyz` embeds that dict verbatim, in a system where exception messages can quote connection strings. Both surfaces now carry the exception class name only, with a sentinel-credential test asserting the secret string reaches neither the payload nor the log.

## Review provenance

Three adversarial rounds by an independent reviewer against a real checkout: contextvar semantics verified against the installed wheel (task-local, so the merge loop cannot corrupt concurrent tasks, and `except Exception` provably lets `CancelledError` propagate), dedup keys verified against the adapter's Cypher MERGE clauses, the context restore traced end to end into the marker-delete path, and every protective claim mutation-tested: disabled dedup, removed restore, raise-on-any-failure, silent-empty-on-all-fail, payload-only and log-only reversions of the text fix. Each mutation was caught by a test.

## Verification

Full non-live suite: 2140 passed, 1 skipped, and exactly the one pre-existing failure (`test_installed_cognee_141_metadata_accepts_secure_cryptography`, the stock-versus-patched cognee wheel metadata gap, reproduced identically at the base commit). Ruff clean. Every commit is revert-proven: reverting only its source file makes its test fail on the defect itself, including the leak test failing on the literal credential string.

## Deploy note

The refill now costs one read per provisioned dataset store, serialized through cognee's DatasetQueue semaphore. With provisioned stores beyond `DATABASE_MAX_LRU_CACHE_SIZE` (default 6), raise that variable in the deploy environment. Three stores exist today.
