### PR TITLE
fix(canary): wait for the marker's own lifecycle projection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,10 @@ CITADEL_EVOLVE_INTERVAL_SECONDS=21600
 # on the web container, so point it at localhost. Unset = legacy in-process path.
 CITADEL_COGNIFY_TARGET_URL=http://localhost:8080
 CITADEL_COGNIFY_TIMEOUT_SECONDS=1800
+# Ceiling for the readiness canary's wait on its marker's lifecycle projection
+# (verify=True). The drain runs minutes behind the accept under load. Must be a
+# finite positive number; anything else falls back to the 600s default.
+CITADEL_CANARY_TIMEOUT_SECONDS=600
 # Durable dataset-level retry state. Put this on the persistent Railway volume.
 CITADEL_COGNIFY_QUEUE_PATH=/data/.citadel/cognify_queue.json
 # Where the pipeline stores last-seen skill content hashes for change detection.

--- a/kb/server.py
+++ b/kb/server.py
@@ -366,6 +366,7 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             "yes",
             "on",
         }
+        cancelled = False
         try:
             # verify=True runs the end-to-end ingest+cognify+search canary and
             # records its verdict for /readyz (#27).
@@ -385,6 +386,12 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
                 _LAST_CANARY["ok"],
             )
         except asyncio.CancelledError:
+            # Teardown landing mid-Phase-2 (the canary can now wait minutes on
+            # its marker's projection, so this window is wide): the pass did
+            # NOT run to completion, so stamping it would make the next boot
+            # wait a full interval instead of re-running the interrupted pass,
+            # and kicking a drain task on a loop being torn down helps nobody.
+            cancelled = True
             raise
         except Exception as exc:
             logger.exception("Evolve scheduler: cognify failed")
@@ -400,26 +407,31 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
                 "error": exc.__class__.__name__,
             }
         finally:
-            # Stamp the pass even when a stage failed. This records that the
-            # cycle RAN, which is what the next boot needs to resume the
-            # interval; whether the stages succeeded is already on the "Evolve
-            # finished" line and in /readyz. Recording only clean passes would
-            # make a node with one broken stage restart its clock forever, which
-            # is the bug this fixes (#153).
-            record_completed(state_path)
-            # Drain whatever the pass deferred. Projection starts are
-            # suppressed while Phase 1 holds the writer lock, and Phase 2
-            # cognifies directly without touching the lifecycle queue, so
-            # without this kick a job accepted mid-pass waits for the next
-            # external ingest or the next pass. The lock is free and the
-            # suppression scope has ended by this point, and the call is a
-            # no-op when a drain is already running.
-            resume = getattr(get_citadel(), "resume_lifecycle_queue", None)
-            if callable(resume):
-                try:
-                    resume()
-                except Exception:
-                    logger.exception("Evolve scheduler: post-pass projection resume failed")
+            if not cancelled:
+                # Stamp the pass even when a stage failed. This records that the
+                # cycle RAN, which is what the next boot needs to resume the
+                # interval; whether the stages succeeded is already on the
+                # "Evolve finished" line and in /readyz. Recording only clean
+                # passes would make a node with one broken stage restart its
+                # clock forever, which is the bug this fixes (#153). A CANCELLED
+                # pass is the one exception: it did not run, so it must not
+                # stamp (see the CancelledError branch above).
+                record_completed(state_path)
+                # Drain whatever the pass deferred. Projection starts are
+                # suppressed while Phase 1 holds the writer lock, and Phase 2
+                # cognifies directly without touching the lifecycle queue, so
+                # without this kick a job accepted mid-pass waits for the next
+                # external ingest or the next pass. The lock is free and the
+                # suppression scope has ended by this point, and the call is a
+                # no-op when a drain is already running.
+                resume = getattr(get_citadel(), "resume_lifecycle_queue", None)
+                if callable(resume):
+                    try:
+                        resume()
+                    except Exception:
+                        logger.exception(
+                            "Evolve scheduler: post-pass projection resume failed"
+                        )
 
 
 def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":

--- a/kb/service.py
+++ b/kb/service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from hashlib import sha256
 import json
 import logging
+import math
 import os
 import re
 from uuid import uuid4
@@ -73,7 +74,11 @@ def _canary_timeout_seconds() -> float:
         value = float(raw)
     except ValueError:
         return DEFAULT_CANARY_TIMEOUT_SECONDS
-    return value if value > 0 else DEFAULT_CANARY_TIMEOUT_SECONDS
+    # isfinite: float() parses "inf", which passes a > 0 check and would make
+    # the canary wait poll forever — a silent permanent scheduler hang.
+    if not math.isfinite(value) or value <= 0:
+        return DEFAULT_CANARY_TIMEOUT_SECONDS
+    return value
 
 
 class Citadel:

--- a/kb/service.py
+++ b/kb/service.py
@@ -52,9 +52,28 @@ MAX_SEARCH_TOP_K = 100
 
 # The cognify verify canary re-searches for its marker, because cognify can be
 # settling when the first search runs. Module-level so a test can shrink them
-# instead of sleeping through the real backoff.
+# instead of sleeping through the real backoff. Non-lifecycle deployments only:
+# under lifecycle v1 the canary waits on the marker's projection operation
+# instead (see ``_canary_timeout_seconds``).
 CANARY_SEARCH_ATTEMPTS = 3
 CANARY_SEARCH_BACKOFF_SECONDS = 2.0
+
+# Ceiling for the lifecycle canary's wait on its marker's projection operation.
+# The drain runs minutes behind the accept under normal load, and a held writer
+# lock can park a job far longer, so the default is generous. Env-tunable for
+# operators; tests park the drain instead of shrinking this.
+DEFAULT_CANARY_TIMEOUT_SECONDS = 600.0
+
+
+def _canary_timeout_seconds() -> float:
+    raw = os.getenv("CITADEL_CANARY_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_CANARY_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_CANARY_TIMEOUT_SECONDS
+    return value if value > 0 else DEFAULT_CANARY_TIMEOUT_SECONDS
 
 
 class Citadel:
@@ -1518,30 +1537,76 @@ class Citadel:
         verification: dict[str, Any] | None = None
         if verify:
             marker = f"COGNIFY_TEST_MARKER_{uuid4().hex}"
-            await self.ingest(marker, dataset=target_dataset)
+            marker_ingest = await self.ingest(marker, dataset=target_dataset)
             await self.cognee.cognify(datasets=[target_dataset], force=force)
-            # Cognify can still be settling, so re-search a bounded number of
-            # times before calling it a miss (#114). Without this, requiring a
-            # real search hit would flag a slow-but-healthy node as broken.
             search_hit = False
             attempts = 0
-            for attempt in range(CANARY_SEARCH_ATTEMPTS):
-                attempts = attempt + 1
-                matches = await self.search(marker, dataset=target_dataset, top_k=10)
-                if _marker_in_results(marker, matches):
-                    search_hit = True
-                    break
-                if attempts < CANARY_SEARCH_ATTEMPTS:
-                    await asyncio.sleep(CANARY_SEARCH_BACKOFF_SECONDS)
+            failure_reason: str | None = None
+            if (
+                self.lifecycle_store is not None
+                and marker_ingest.projection_job_id is not None
+            ):
+                # Lifecycle v1: the marker ingest queues an async projection
+                # JOB and returns before cognee sees the content, and search
+                # excludes revisions without a searchable receipt before it
+                # consults any backend — so a seconds-scale re-search loop can
+                # never bridge a minutes-scale drain and the canary was a
+                # deterministic miss (#114's loop predates lifecycle v1). Wait
+                # on the operation record instead (the wait kicks the drain
+                # itself), then run ONE confirming search so a green canary
+                # still proves end-to-end recall, not receipt bookkeeping.
+                try:
+                    await self.wait_for_lifecycle_operation(
+                        marker_ingest.projection_job_id,
+                        timeout_seconds=_canary_timeout_seconds(),
+                    )
+                except TimeoutError:
+                    failure_reason = "projection_timeout"
+                except RuntimeError:
+                    failure_reason = "projection_failed"
+                else:
+                    attempts = 1
+                    matches = await self.search(
+                        marker, dataset=target_dataset, top_k=10
+                    )
+                    search_hit = _marker_in_results(marker, matches)
+                    if not search_hit:
+                        failure_reason = "search_miss_after_searchable"
+            else:
+                # Cognify can still be settling, so re-search a bounded number
+                # of times before calling it a miss (#114). Without this,
+                # requiring a real search hit would flag a slow-but-healthy
+                # node as broken.
+                for attempt in range(CANARY_SEARCH_ATTEMPTS):
+                    attempts = attempt + 1
+                    matches = await self.search(
+                        marker, dataset=target_dataset, top_k=10
+                    )
+                    if _marker_in_results(marker, matches):
+                        search_hit = True
+                        break
+                    if attempts < CANARY_SEARCH_ATTEMPTS:
+                        await asyncio.sleep(CANARY_SEARCH_BACKOFF_SECONDS)
             verification = {
                 "marker": marker,
                 "search_hit": search_hit,
                 "search_attempts": attempts,
             }
+            if marker_ingest.projection_job_id is not None:
+                verification["projection_job_id"] = marker_ingest.projection_job_id
+            if failure_reason is not None:
+                verification["reason"] = failure_reason
             # Backprop (#15): the canary marker used to persist forever, surfacing in
             # search/linear_search results. Delete its node now so verify leaves no
             # trace. Best-effort — never fail the cognify on a cleanup hiccup.
             await self._delete_marker_node(marker)
+            if (
+                self.lifecycle_store is not None
+                and marker_ingest.projection_job_id is not None
+            ):
+                await self._tombstone_marker_source(
+                    marker_ingest.projection_job_id, marker=marker
+                )
 
         after = await self._graph_counts()
         graph_grew = (
@@ -3031,6 +3096,35 @@ class Citadel:
                 await self.cognee.delete_graph_nodes(ids)
         except Exception:  # noqa: BLE001 - cleanup must never fail the cognify
             logger.warning("could not delete cognify verify marker %s", marker, exc_info=True)
+
+    async def _tombstone_marker_source(
+        self, projection_job_id: str, *, marker: str
+    ) -> None:
+        """Best-effort durable cleanup of a verify marker's source revision.
+
+        ``_delete_marker_node`` removes the already-projected graph node, but
+        under lifecycle v1 the marker is also a durable source revision whose
+        current head would otherwise stay searchable forever — one accreted
+        marker document per verify pass. Tombstoning supersedes the head, so
+        the search filters exclude the marker durably whether or not its
+        projection ever drained. The tombstone projection writes current-head
+        exclusion receipts and deletes no provider content
+        (``kb/lifecycle_worker.py`` ``_project_tombstone``), so the vector
+        chunk becomes an excluded orphan rather than disappearing; the graph
+        node is the ``_delete_marker_node`` call above. Never fails the
+        cognify on a cleanup hiccup.
+        """
+        try:
+            operation = self.lifecycle_operation(projection_job_id)
+            await self.tombstone_source(
+                dataset=str(operation["dataset"]),
+                source_key=str(operation["source_revision"]["source_key"]),
+                reason="cognify_verify_marker_cleanup",
+            )
+        except Exception:  # noqa: BLE001 - cleanup must never fail the cognify
+            logger.warning(
+                "could not tombstone cognify verify marker %s", marker, exc_info=True
+            )
 
     async def cleanup_legacy_nodes(self, *, dry_run: bool = True) -> dict[str, Any]:
         """Find (and, when dry_run is False, delete) legacy garbage nodes (#15).

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -798,6 +798,78 @@ async def test_lifecycle_cognify_canary_times_out_red_and_tombstones(
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_cognify_canary_flags_miss_after_searchable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """A searchable operation whose confirming search still misses is red.
+
+    This is the outcome the confirming search exists to catch: every receipt
+    says searchable, yet retrieval does not return the marker — a real
+    end-to-end recall failure that receipt bookkeeping alone would report
+    green. Its distinct reason string separates it from a drain that never
+    finished."""
+
+    class SearchableButUnfindableCognee(FakeCognee):
+        def __init__(self) -> None:
+            super().__init__()
+            self.recall_calls = 0
+
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.recall_calls += 1
+            return []
+
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("DB_PROVIDER", "sqlite")
+    monkeypatch.setenv("VECTOR_DB_PROVIDER", "qdrant")
+    monkeypatch.setenv("GRAPH_DATABASE_PROVIDER", "ladybug")
+    fake = SearchableButUnfindableCognee()
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="masumi-network",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=fake,
+    )
+
+    result = await kb.cognify_dataset(verify=True)
+    await kb.wait_for_lifecycle_idle()
+
+    verification = result["verification"]
+    assert verification["search_hit"] is False
+    assert verification["ok"] is False
+    assert result["ok"] is False
+    assert verification["reason"] == "search_miss_after_searchable"
+    # The wait succeeded, so exactly one confirming search ran and missed.
+    assert verification["search_attempts"] == 1
+    assert fake.recall_calls == 1
+    operation = kb.lifecycle_operation(verification["projection_job_id"])
+    source_key = operation["source_revision"]["source_key"]
+    assert (
+        kb.lifecycle_source_keys(dataset="masumi-network", source_key=source_key)
+        == ()
+    )
+
+
+def test_canary_timeout_rejects_non_finite_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """float() parses "inf", which passes a > 0 check — and an infinite
+    timeout makes the canary wait poll forever, a silent permanent scheduler
+    hang. Non-finite and non-positive values fall back to the default."""
+    for raw in ("inf", "+inf", "-inf", "nan", "0", "-5", "bogus", ""):
+        monkeypatch.setenv("CITADEL_CANARY_TIMEOUT_SECONDS", raw)
+        assert (
+            service._canary_timeout_seconds()
+            == service.DEFAULT_CANARY_TIMEOUT_SECONDS
+        ), raw
+    monkeypatch.setenv("CITADEL_CANARY_TIMEOUT_SECONDS", "45.5")
+    assert service._canary_timeout_seconds() == 45.5
+
+
+@pytest.mark.asyncio
 async def test_search_clamps_top_k_to_safe_bounds() -> None:
     fake = FakeCognee()
     kb = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -678,6 +678,126 @@ async def test_cognify_canary_accepts_a_late_search_hit(
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_cognify_canary_waits_for_projection_then_confirms(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Lifecycle v1: the canary waits on the marker's projection operation.
+
+    The marker ingest queues an async projection job and returns before cognee
+    sees the content, and search excludes revisions without a searchable
+    receipt before consulting any backend, so the pre-fix 3x2s re-search loop
+    was a deterministic miss against a minutes-scale drain (live 2026-08-13: a
+    marker ingested 13:38Z became searchable at 13:43:17Z while its canary had
+    long reported red). The canary now waits on the operation record, runs ONE
+    confirming search, and tombstones the marker's source revision so markers
+    stop accreting as searchable documents, one per pass.
+    """
+
+    class LifecycleCanaryCognee(FakeCognee):
+        def __init__(self) -> None:
+            super().__init__()
+            self.recall_calls = 0
+
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.recall_calls += 1
+            return [
+                {"content": query, "document_id": document_id}
+                for document_id in kwargs.get("document_ids") or []
+            ]
+
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("DB_PROVIDER", "sqlite")
+    monkeypatch.setenv("VECTOR_DB_PROVIDER", "qdrant")
+    monkeypatch.setenv("GRAPH_DATABASE_PROVIDER", "ladybug")
+    fake = LifecycleCanaryCognee()
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="masumi-network",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=fake,
+    )
+
+    result = await kb.cognify_dataset(verify=True)
+    await kb.wait_for_lifecycle_idle()
+
+    verification = result["verification"]
+    assert verification["search_hit"] is True
+    assert verification["ok"] is True
+    assert result["ok"] is True
+    # One confirming search after the operation went searchable — not a blind
+    # retry loop racing the drain.
+    assert verification["search_attempts"] == 1
+    assert fake.recall_calls == 1
+    assert "reason" not in verification
+    operation = kb.lifecycle_operation(verification["projection_job_id"])
+    source_key = operation["source_revision"]["source_key"]
+    # Durable cleanup: the marker's head is tombstoned, so the search filters
+    # exclude it instead of accreting one searchable marker per pass.
+    assert (
+        kb.lifecycle_source_keys(dataset="masumi-network", source_key=source_key)
+        == ()
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_cognify_canary_times_out_red_and_tombstones(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """An undrained projection turns the canary red with a machine-readable
+    reason — and the marker is tombstoned anyway, so a stuck drain cannot
+    accrete markers either."""
+
+    class CountingRecallCognee(FakeCognee):
+        def __init__(self) -> None:
+            super().__init__()
+            self.recall_calls = 0
+
+        async def recall(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.recall_calls += 1
+            return []
+
+    monkeypatch.setattr(service, "CANARY_SEARCH_BACKOFF_SECONDS", 0)
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("DB_PROVIDER", "sqlite")
+    monkeypatch.setenv("VECTOR_DB_PROVIDER", "qdrant")
+    monkeypatch.setenv("GRAPH_DATABASE_PROVIDER", "ladybug")
+    monkeypatch.setenv("CITADEL_CANARY_TIMEOUT_SECONDS", "0.2")
+    fake = CountingRecallCognee()
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="masumi-network",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=fake,
+    )
+    # Park the drain: jobs stay pending, exactly like a held writer lock.
+    monkeypatch.setattr(kb, "_start_lifecycle_projection", lambda: False)
+
+    result = await kb.cognify_dataset(verify=True)
+
+    verification = result["verification"]
+    assert verification["search_hit"] is False
+    assert verification["ok"] is False
+    assert result["ok"] is False
+    assert verification["reason"] == "projection_timeout"
+    # No blind re-search loop ran against the excluded revision.
+    assert verification["search_attempts"] == 0
+    assert fake.recall_calls == 0
+    operation = kb.lifecycle_operation(verification["projection_job_id"])
+    source_key = operation["source_revision"]["source_key"]
+    assert (
+        kb.lifecycle_source_keys(dataset="masumi-network", source_key=source_key)
+        == ()
+    )
+
+
+@pytest.mark.asyncio
 async def test_search_clamps_top_k_to_safe_bounds() -> None:
     fake = FakeCognee()
     kb = Citadel(CitadelConfig(default_dataset="notes"), cognee=fake)


### PR DESCRIPTION
Refs #273.

The readiness canary predates lifecycle v1 and could never pass: its marker becomes an asynchronous projection job, the verify search is receipt-gated and excludes undrained revisions before consulting any backend, and three retries over six seconds race a projection that completes on its own schedule. Live proof of health mismeasured: the 13:38Z pass's marker is searchable at rank 1, its chunk created five minutes after that verify window closed. Meanwhile every missed marker persisted (the cleanup ran before the marker existed), accreting one document per pass.

## The commits

1. `1c054d4` — when a lifecycle store is present and the ingest returns a projection job id, verify awaits `wait_for_lifecycle_operation` (timeout from `CITADEL_CANARY_TIMEOUT_SECONDS`, default 600s) and then runs ONE confirming search, preserving the end-to-end recall proof. Machine-readable failure reasons: `projection_timeout`, `projection_failed`, and `search_miss_after_searchable` (a wait that succeeds while search still misses is a genuine retrieval failure and reads red). The marker's source revision is tombstoned hit or miss — durable search exclusion through the lifecycle receipt path; the graph node is still deleted, and the vector chunk remains a search-excluded orphan, which the helper's docstring states plainly. The legacy no-lifecycle path keeps the existing retry loop verbatim. Phase 2 holds no lock during the wait: Phase 1's finally released the writer lock and the suppression scope closed with it.
2. `683e9ba` — review round: `CITADEL_CANARY_TIMEOUT_SECONDS` rejects non-finite values (an `inf` would have parked the scheduler forever), the miss-after-searchable path gets its committed test, the scheduler's finally skips the pass-completed stamp and the drain kick when the pass was cancelled mid-flight (a cancelled pass did not run; stamping it would make the next boot wait a full interval), and the env var is documented in `.env.example`.

## Review provenance

Three adversarial rounds by an independent reviewer: receipt-gate premise verified in code, writer lock verified free during the wait, `CancelledError` propagation verified against the venv's MRO and then re-verified with a real `task.cancel()` injection into a synthetic reproduction of the scheduler's try/except/finally shape, mutation testing on the wait, the tombstone, the timeout guard, and swallowed-timeout variants — every mutation caught by a committed test.

## Verification

Full non-live suite: 2144 passed, 1 skipped, plus exactly the one pre-existing stock-wheel metadata failure. Ruff clean. Revert-proofs are behavioral: reverting only the source makes the new tests fail on the defect itself (`assert False is True` on the miss, `KeyError: 'reason'` pre-fix, `inf != 600.0` without the guard).

## Operational note

Markers accreted by the pre-fix canary are already in the corpus and need the admin cleanup sweep regardless of this PR; tombstoning here stops new accretion only.
