### PR TITLE
fix(cli): read file arguments and default ingest to async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **`citadel ingest` and MCP `citadel_ingest` now default to async.** The old
+  default ran inline cognify: one blocking request held open for around two
+  minutes until the proxy edge killed it with a 502, so the caller was told
+  failure while the Node accepted the write twice (edge retry). Ingest now
+  returns as soon as the Node stores the note (`queued_not_confirmed`), the
+  lifecycle drain makes it searchable within minutes, and the receipt says so
+  (with the `citadel operation <job-id>` handle when the Node returns one).
+  Inline cognify stays as an explicit opt-in (`--cognify` on the CLI,
+  `cognify=true` on MCP) whose help warns it can exceed proxy timeouts.
+  `--no-cognify` still parses and now names the default.
+
+### Fixed
+
+- **`citadel ingest <path>` ingested the literal path string.** The help
+  promised "Text (or a path)", but the file was never read: production got a
+  133-byte path-string note whose projection then died on FileNotFoundError.
+  An argument naming an existing regular file now ingests the file's UTF-8
+  content, with clear client-side errors for binary, unreadable, and empty
+  files. Anything that is not an existing file stays literal text. Payloads
+  are also checked against the Node's ingest byte cap before the POST, so an
+  oversized note fails with a clear local error instead of an HTTP 413.
+
 ## [0.4.1] (2026-08-06)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,14 @@ All notable changes to `citadel-archive` are documented here. Format follows
   133-byte path-string note whose projection then died on FileNotFoundError.
   An argument naming an existing regular file now ingests the file's UTF-8
   content, with clear client-side errors for binary, unreadable, and empty
-  files. Anything that is not an existing file stays literal text. Payloads
-  are also checked against the Node's ingest byte cap before the POST, so an
-  oversized note fails with a clear local error instead of an HTTP 413.
+  files. A directory argument is rejected outright (same defect class: its
+  path string would ship as the note); anything else that names nothing on
+  disk stays literal text. Payloads are also checked against the Node's
+  ingest byte cap before the POST (an oversized file is refused on `stat()`
+  alone, without being read into memory), so an oversized note fails with a
+  clear local error instead of an HTTP 413. The `--json` receipt carries
+  `ingest_source: "file"|"text"` (plus `ingest_path` for files) so scripted
+  callers can tell which way the argument was resolved.
 
 ## [0.4.1] (2026-08-06)
 

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -402,9 +402,92 @@ def _result_exit(value: Any) -> int:
     return 0
 
 
+# Client-side mirror of the Node's ingest byte cap. The authority is
+# kb.mcp_server._max_ingest_bytes (not importable here — the mcp extra);
+# same env + default so the two surfaces agree. Keep the two in sync.
+_DEFAULT_MAX_INGEST_BYTES = 200_000
+
+
+def _max_ingest_bytes() -> int:
+    raw_value = os.getenv("CITADEL_MCP_MAX_INGEST_BYTES")
+    if not raw_value:
+        return _DEFAULT_MAX_INGEST_BYTES
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return _DEFAULT_MAX_INGEST_BYTES
+    return max(1, value)
+
+
+def _resolve_ingest_data(args: argparse.Namespace) -> int | None:
+    """Turn a file-path argument into the file's CONTENT; leave other text alone.
+
+    `citadel ingest NOTES.md` used to ship the literal string "NOTES.md" as the
+    note body — the file was never read, and the projection later died on the
+    path-string note. Only a single existing regular file is read (UTF-8); an
+    argument that is not an existing file stays literal text, since a sentence
+    may legitimately contain a slash. Mutates ``args.data`` and returns None to
+    proceed, or an exit code after a clean client-side error (unreadable or
+    non-text file, payload over the Node's ingest byte cap).
+    """
+    as_json = getattr(args, "json", False)
+    raw = args.data
+    try:
+        is_file = Path(raw).is_file()
+    except (OSError, ValueError):  # literal text can exceed name limits or hold NULs
+        is_file = False
+    if is_file:
+        try:
+            content = Path(raw).read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return _emit_error(
+                "ingest",
+                f"{raw} is not UTF-8 text — only text files can be ingested",
+                as_json=as_json,
+                code="FILE_NOT_TEXT",
+            )
+        except OSError as exc:
+            return _emit_error(
+                "ingest",
+                f"cannot read {raw}: {exc}",
+                as_json=as_json,
+                code="FILE_UNREADABLE",
+            )
+        if not content.strip():
+            return _emit_error(
+                "ingest",
+                f"{raw} is empty — nothing to ingest",
+                as_json=as_json,
+                code="FILE_EMPTY",
+            )
+        args.data = content
+        if not as_json and not getattr(args, "local", False):
+            print(
+                paint(
+                    f"  reading {raw} ({len(content.encode('utf-8'))} bytes)",
+                    "dim",
+                    enable=supports_color(),
+                )
+            )
+    byte_count = len(args.data.encode("utf-8"))
+    max_bytes = _max_ingest_bytes()
+    if byte_count > max_bytes:
+        return _emit_error(
+            "ingest",
+            f"payload is {byte_count} bytes; the Node's ingest limit is {max_bytes} "
+            "bytes (CITADEL_MCP_MAX_INGEST_BYTES) — trim or split it",
+            as_json=as_json,
+            code="PAYLOAD_TOO_LARGE",
+        )
+    return None
+
+
 async def _ingest(args: argparse.Namespace) -> int:
     """Add a note to your Node over HTTP (like MCP citadel_ingest). `--local`
     runs the in-process server stack (needs the [server] extra)."""
+    early_exit = _resolve_ingest_data(args)
+    if early_exit is not None:
+        return early_exit
     if getattr(args, "local", False):
         return await _ingest_local(args)
     _reject_local_only_flags(args, "ingest")
@@ -414,9 +497,11 @@ async def _ingest(args: argparse.Namespace) -> int:
         return _emit_no_token("ingest", as_json=getattr(args, "json", False))
     from kb.status import _COGNIFY_TIMEOUT, _INGEST_TIMEOUT, ingest_node
 
-    # Cognify inline (server-side) by default so the note is immediately
-    # searchable; the one request blocks until cognify finishes (--no-cognify skips).
-    cognify = not getattr(args, "no_cognify", False)
+    # Async by default: the Node accepts the note and the lifecycle drain makes
+    # it searchable within minutes. Inline cognify (--cognify) blocks the one
+    # request until the graph is built — long enough (~2 min on cold nodes) that
+    # proxy edges kill it with a 502 while the server still accepts the write.
+    cognify = bool(getattr(args, "cognify", False))
     as_json = getattr(args, "json", False)
     timeout_arg = getattr(args, "timeout", None)
     if timeout_arg is not None:
@@ -490,6 +575,28 @@ async def _ingest(args: argparse.Namespace) -> int:
         elif cognify:
             # Requested cognify but the Node didn't report it (older Node, pre inline-cognify).
             print(paint("  (graph update will happen on the next Node sync)", "dim", enable=color))
+        else:
+            # Async default. "queued_not_confirmed" is the Node's honest receipt:
+            # the note is stored durably and not yet searchable.
+            job_id = result.get("projection_job_id")
+            track = f" — track: citadel operation {job_id}" if job_id else ""
+            if str(result.get("reason") or "") == "queued_not_confirmed":
+                print(
+                    paint(
+                        f"  queued (not yet searchable) — the Node projects it "
+                        f"within minutes{track}",
+                        "dim",
+                        enable=color,
+                    )
+                )
+            else:
+                print(
+                    paint(
+                        "  queued — data appears in search after the next Node sync",
+                        "dim",
+                        enable=color,
+                    )
+                )
     elif duplicate:
         print(
             f"  {paint(SKIP, 'yellow', enable=color)} already in your vault (duplicate) — nothing new to add"
@@ -3323,18 +3430,28 @@ def build_parser() -> argparse.ArgumentParser:
     ingest = subcommands.add_parser(
         "ingest", help="Add a durable note to your Node (HTTP; --local for the server stack)"
     )
-    ingest.add_argument("data", help="Text (or a path) to ingest")
-    ingest.add_argument("--tag", action="append", default=[], help="Tag to attach (repeatable)")
     ingest.add_argument(
+        "data", help="Text to ingest, or a path to an existing file (its content is ingested)"
+    )
+    ingest.add_argument("--tag", action="append", default=[], help="Tag to attach (repeatable)")
+    cognify_group = ingest.add_mutually_exclusive_group()
+    cognify_group.add_argument(
+        "--cognify",
+        action="store_true",
+        help="Build the graph inline before returning (immediately searchable, but the "
+        "single blocking request can exceed proxy timeouts — a 502 does not mean the "
+        "write failed). Default: async, searchable within minutes",
+    )
+    cognify_group.add_argument(
         "--no-cognify",
         action="store_true",
-        help="Skip the post-ingest cognify (faster; data appears in search later)",
+        help="Skip inline cognify (the default; kept for compatibility)",
     )
     ingest.add_argument(
         "--timeout",
         type=float,
         metavar="SECONDS",
-        help="Max seconds to wait for the Node (default: 180 while cognifying, 60 with --no-cognify)",
+        help="Max seconds to wait for the Node (default: 60, or 180 with --cognify)",
     )
     ingest.add_argument("--json", action="store_true", help="Machine-readable output")
     ingest.add_argument("--node-url", help="Override Node URL")

--- a/kb/cli.py
+++ b/kb/cli.py
@@ -424,21 +424,53 @@ def _resolve_ingest_data(args: argparse.Namespace) -> int | None:
 
     `citadel ingest NOTES.md` used to ship the literal string "NOTES.md" as the
     note body — the file was never read, and the projection later died on the
-    path-string note. Only a single existing regular file is read (UTF-8); an
-    argument that is not an existing file stays literal text, since a sentence
-    may legitimately contain a slash. Mutates ``args.data`` and returns None to
-    proceed, or an exit code after a clean client-side error (unreadable or
-    non-text file, payload over the Node's ingest byte cap).
+    path-string note. Only a single existing regular file is read (UTF-8); a
+    directory is rejected outright (same defect class: its path string would
+    ship as the note), and an argument that names nothing on disk stays literal
+    text, since a sentence may legitimately contain a slash. Mutates
+    ``args.data``, records ``args.ingest_source`` / ``args.ingest_path`` for
+    the JSON receipt, and returns None to proceed, or an exit code after a
+    clean client-side error (directory, unreadable, non-text or empty file,
+    payload over the Node's ingest byte cap).
     """
     as_json = getattr(args, "json", False)
     raw = args.data
+    args.ingest_source = "text"
+    args.ingest_path = None
     try:
-        is_file = Path(raw).is_file()
+        target = Path(raw)
+        is_dir = target.is_dir()
+        is_file = target.is_file()
     except (OSError, ValueError):  # literal text can exceed name limits or hold NULs
+        is_dir = False
         is_file = False
+    if is_dir:
+        return _emit_error(
+            "ingest",
+            f"{raw} is a directory — ingest a single file (directories and globs "
+            "are not supported)",
+            as_json=as_json,
+            code="FILE_IS_DIRECTORY",
+        )
+    max_bytes = _max_ingest_bytes()
     if is_file:
+        # Refuse on stat() alone so an oversized file is never pulled into
+        # memory just to be rejected; the post-read check below stays the
+        # authoritative gate for the encoded size.
         try:
-            content = Path(raw).read_text(encoding="utf-8")
+            file_size = target.stat().st_size
+        except OSError:
+            file_size = 0  # stat raced with deletion; read_text surfaces the error
+        if file_size > max_bytes:
+            return _emit_error(
+                "ingest",
+                f"{raw} is {file_size} bytes; the Node's ingest limit is "
+                f"{max_bytes} bytes (CITADEL_MCP_MAX_INGEST_BYTES) — trim or split it",
+                as_json=as_json,
+                code="PAYLOAD_TOO_LARGE",
+            )
+        try:
+            content = target.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             return _emit_error(
                 "ingest",
@@ -461,6 +493,8 @@ def _resolve_ingest_data(args: argparse.Namespace) -> int | None:
                 code="FILE_EMPTY",
             )
         args.data = content
+        args.ingest_source = "file"
+        args.ingest_path = raw
         if not as_json and not getattr(args, "local", False):
             print(
                 paint(
@@ -470,7 +504,6 @@ def _resolve_ingest_data(args: argparse.Namespace) -> int | None:
                 )
             )
     byte_count = len(args.data.encode("utf-8"))
-    max_bytes = _max_ingest_bytes()
     if byte_count > max_bytes:
         return _emit_error(
             "ingest",
@@ -560,6 +593,13 @@ async def _ingest(args: argparse.Namespace) -> int:
     scope = "your private seat" if str(dataset).startswith("seat:") else "shared org vault"
 
     if as_json:
+        # Client-side provenance for scripted callers: whether the argument was
+        # read as a file (and which one) or shipped as literal text — the same
+        # signal the human gets from the dim "reading …" line. setdefault so a
+        # future server-emitted key of the same name would win.
+        result.setdefault("ingest_source", args.ingest_source)
+        if args.ingest_path:
+            result.setdefault("ingest_path", args.ingest_path)
         _print_json(result)
         return 0 if (accepted or duplicate) else 1
 

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -461,6 +461,8 @@ def _validate_base_url(base_url: str) -> str:
 
 
 def _max_ingest_bytes() -> int:
+    # Keep in sync with the zero-dep CLI mirror (kb.cli._max_ingest_bytes),
+    # which cannot import this module (the mcp extra).
     raw_value = os.getenv("CITADEL_MCP_MAX_INGEST_BYTES")
     if not raw_value:
         return DEFAULT_MAX_INGEST_BYTES

--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -1296,7 +1296,7 @@ def create_mcp_server(
         dataset: str | None = None,
         tags: list[str] | None = None,
         session_id: str | None = None,
-        cognify: bool = True,
+        cognify: bool = False,
     ) -> dict[str, Any]:
         """Stage durable context in the caller's personal seat node. Requires writer access.
 
@@ -1307,9 +1307,11 @@ def create_mcp_server(
         Never ingest secrets, tokens, passwords, keys, seed phrases, PII, or raw logs.
         Summarize and curate first; keep payloads small (cap ~200 KB).
 
-        By default the note is cognified inline so it is searchable immediately (parity
-        with the `citadel ingest` CLI). Pass `cognify=false` to stage without the
-        blocking cognify when you will batch-cognify later.
+        By default the note is accepted immediately and becomes searchable within
+        minutes (the receipt says `queued_not_confirmed` until then; parity with the
+        `citadel ingest` CLI). Pass `cognify=true` to block until the graph is built —
+        that single request can exceed MCP client/proxy timeouts, and a timeout does
+        NOT mean the write failed.
 
         Shared Central is read-only from MCP. Org-wide memory updates via scheduled
         GitHub/Linear sync and selective promotion — not direct MCP ingest.

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -28,7 +28,7 @@ from kb.status import Check, StatusReport
 
 def _ingest_args(**kw):
     base = dict(data="a note", tag=[], json=True, node_url="https://node.example",
-                local=False, dataset=None, session=None, no_cognify=True)
+                local=False, dataset=None, session=None, cognify=False)
     base.update(kw)
     return argparse.Namespace(**base)
 
@@ -699,7 +699,46 @@ def test_ingest_no_token_exits_one(monkeypatch, capsys) -> None:
     assert "no token" in capsys.readouterr().err
 
 
-def test_ingest_cognifies_by_default(monkeypatch, capsys) -> None:
+def test_ingest_default_is_async(monkeypatch, capsys) -> None:
+    # The old default (inline cognify) blocked one request until the proxy edge
+    # 502'd it while the Node accepted the write twice (edge retry). The parser
+    # default must therefore be async: cognify only on explicit opt-in.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, **k):
+        seen["cognify"] = cognify
+        return {"accepted": True, "dataset": "seat:alice", "reason": "queued_not_confirmed"}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
+    args = build_parser().parse_args(
+        ["ingest", "a durable note", "--json", "--node-url", "https://node.example"]
+    )
+    rc = asyncio.run(_ingest(args))
+    assert rc == 0
+    assert seen["cognify"] is False
+
+
+def test_ingest_no_cognify_flag_still_parses(monkeypatch, capsys) -> None:
+    # --no-cognify used to be the only way to skip inline cognify; it now names
+    # the default and must keep working for existing scripts.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, **k):
+        seen["cognify"] = cognify
+        return {"accepted": True, "dataset": "seat:alice"}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
+    args = build_parser().parse_args(
+        ["ingest", "a durable note", "--no-cognify", "--json", "--node-url", "https://node.example"]
+    )
+    rc = asyncio.run(_ingest(args))
+    assert rc == 0
+    assert seen["cognify"] is False
+
+
+def test_ingest_cognify_flag_opts_in(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
     seen: dict = {}
 
@@ -708,10 +747,125 @@ def test_ingest_cognifies_by_default(monkeypatch, capsys) -> None:
         return {"accepted": True, "dataset": "seat:alice", "cognified": True}
 
     monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
-    rc = asyncio.run(_ingest(_ingest_args(no_cognify=False)))
+    args = build_parser().parse_args(
+        ["ingest", "a durable note", "--cognify", "--json", "--node-url", "https://node.example"]
+    )
+    rc = asyncio.run(_ingest(args))
     assert rc == 0
     assert seen["cognify"] is True
     assert json.loads(capsys.readouterr().out)["cognified"] is True
+
+
+def test_ingest_async_receipt_says_when_searchable(monkeypatch, capsys) -> None:
+    # The async default must not leave the user guessing: surface the Node's
+    # queued_not_confirmed receipt as "searchable within minutes" plus the
+    # projection-job handle to track it.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: {
+            "accepted": True,
+            "dataset": "seat:alice",
+            "reason": "queued_not_confirmed",
+            "projection_job_id": "job-7",
+        },
+    )
+    rc = asyncio.run(_ingest(_ingest_args(json=False)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "within minutes" in out
+    assert "citadel operation job-7" in out
+
+
+# ---- citadel ingest <path> reads the file -------------------------------------
+
+
+def test_ingest_path_argument_reads_file_content(tmp_path: Path, monkeypatch, capsys) -> None:
+    # `citadel ingest NOTES.md` used to ship the literal string "NOTES.md" as
+    # the note body — the file was never read, and production projected a
+    # path-string note that later died on FileNotFoundError.
+    note = tmp_path / "NOTES.md"
+    note.write_text("the actual note body", encoding="utf-8")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, **k):
+        seen["data"] = data
+        return {"accepted": True, "dataset": "seat:alice"}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
+    rc = asyncio.run(_ingest(_ingest_args(data=str(note))))
+    assert rc == 0
+    assert seen["data"] == "the actual note body"
+
+
+def test_ingest_missing_path_stays_literal_text(monkeypatch, capsys) -> None:
+    # A sentence may legitimately contain a slash; only an EXISTING file is read.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    seen: dict = {}
+
+    def fake_ingest(base_url, token, data, tags, cognify=False, **k):
+        seen["data"] = data
+        return {"accepted": True, "dataset": "seat:alice"}
+
+    monkeypatch.setattr("kb.status.ingest_node", fake_ingest)
+    literal = "see docs/no-such-file.md for the full write-up"
+    rc = asyncio.run(_ingest(_ingest_args(data=literal)))
+    assert rc == 0
+    assert seen["data"] == literal
+
+
+def test_ingest_binary_file_is_a_clean_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    blob = tmp_path / "image.png"
+    blob.write_bytes(b"\x89PNG\x00\xff\xfe")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {"accepted": True},
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data=str(blob))))
+    assert rc == 1
+    assert called["n"] == 0  # never shipped
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "FILE_NOT_TEXT"
+
+
+def test_ingest_oversized_payload_errors_client_side(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    # The Node rejects oversized bodies with HTTP 413; the CLI must catch the
+    # overrun locally (same limit + env as kb.mcp_server._max_ingest_bytes)
+    # instead of shipping a payload the server refuses.
+    monkeypatch.setenv("CITADEL_MCP_MAX_INGEST_BYTES", "8")
+    big = tmp_path / "big.txt"
+    big.write_text("0123456789abcdef", encoding="utf-8")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {"accepted": True},
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data=str(big))))
+    assert rc == 1
+    assert called["n"] == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "PAYLOAD_TOO_LARGE"
+
+
+def test_ingest_empty_file_is_a_clean_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    empty = tmp_path / "empty.md"
+    empty.write_text("   \n", encoding="utf-8")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {"accepted": True},
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data=str(empty))))
+    assert rc == 1
+    assert called["n"] == 0
+    assert json.loads(capsys.readouterr().out)["code"] == "FILE_EMPTY"
 
 
 # ---- citadel token set --------------------------------------------------------

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -853,6 +853,68 @@ def test_ingest_oversized_payload_errors_client_side(
     assert out["code"] == "PAYLOAD_TOO_LARGE"
 
 
+def test_ingest_directory_argument_is_rejected(tmp_path: Path, monkeypatch, capsys) -> None:
+    # A directory used to fall through to literal text and ship the path string
+    # as the note body — the exact defect class the file fix closed.
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "kb.status.ingest_node",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {"accepted": True},
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data=str(tmp_path))))
+    assert rc == 1
+    assert called["n"] == 0  # never shipped
+    assert json.loads(capsys.readouterr().out)["code"] == "FILE_IS_DIRECTORY"
+
+
+def test_ingest_oversized_file_rejected_before_reading(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    # The size pre-check must fire on stat() alone: a huge file must not be
+    # pulled into memory just to be refused.
+    monkeypatch.setenv("CITADEL_MCP_MAX_INGEST_BYTES", "8")
+    big = tmp_path / "big.txt"
+    big.write_text("0123456789abcdef", encoding="utf-8")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+
+    def forbidden_read(self, *a, **k):
+        raise AssertionError("read_text must not be called for an oversized file")
+
+    monkeypatch.setattr(Path, "read_text", forbidden_read)
+    rc = asyncio.run(_ingest(_ingest_args(data=str(big))))
+    assert rc == 1
+    assert json.loads(capsys.readouterr().out)["code"] == "PAYLOAD_TOO_LARGE"
+
+
+def test_ingest_json_receipt_reports_file_source(tmp_path: Path, monkeypatch, capsys) -> None:
+    # In --json mode the dim "reading …" line is suppressed for output purity,
+    # so the receipt itself must carry the file-vs-literal signal.
+    note = tmp_path / "NOTES.md"
+    note.write_text("the actual note body", encoding="utf-8")
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    monkeypatch.setattr(
+        "kb.status.ingest_node", lambda *a, **k: {"accepted": True, "dataset": "seat:alice"}
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data=str(note))))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ingest_source"] == "file"
+    assert out["ingest_path"] == str(note)
+
+
+def test_ingest_json_receipt_reports_text_source(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
+    monkeypatch.setattr(
+        "kb.status.ingest_node", lambda *a, **k: {"accepted": True, "dataset": "seat:alice"}
+    )
+    rc = asyncio.run(_ingest(_ingest_args(data="a plain literal note")))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ingest_source"] == "text"
+    assert "ingest_path" not in out
+
+
 def test_ingest_empty_file_is_a_clean_error(tmp_path: Path, monkeypatch, capsys) -> None:
     empty = tmp_path / "empty.md"
     empty.write_text("   \n", encoding="utf-8")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -649,9 +649,11 @@ def test_write_tools_reject_empty_or_oversized_payloads(monkeypatch: pytest.Monk
     assert feedback_post["payload"]["correct"] is True
 
 
-def test_ingest_tool_requests_inline_cognify_by_default() -> None:
-    # #53: the MCP ingest tool must send cognify=true (parity with the CLI) so an
-    # agent-ingested note is searchable immediately, not stuck on background cognify.
+def test_ingest_tool_defaults_to_async() -> None:
+    # The inline-cognify default (#53) blocked one request until the proxy edge
+    # 502'd it while the Node accepted the write twice (edge retry). Default is
+    # async now (parity with the CLI): the note lands immediately and the
+    # lifecycle drain makes it searchable within minutes.
     client = FakeHttpClient()
     server = create_mcp_server(client)
 
@@ -660,21 +662,21 @@ def test_ingest_tool_requests_inline_cognify_by_default() -> None:
     assert len(client.posts) == 1
     post = client.posts[0]
     assert post["path"] == "/ingest"
-    assert post["payload"]["cognify"] is True
-    # Inline cognify can exceed the default 30s budget, so the tool extends the timeout.
-    assert post["timeout"] == mcp_server._INGEST_COGNIFY_TIMEOUT
-
-
-def test_ingest_tool_honors_cognify_opt_out() -> None:
-    client = FakeHttpClient()
-    server = create_mcp_server(client)
-
-    run_tool(server, "citadel_ingest", "a durable note", None, cognify=False)
-
-    post = client.posts[0]
     assert post["payload"]["cognify"] is False
     # No extended budget when not blocking on cognify.
     assert post["timeout"] is None
+
+
+def test_ingest_tool_cognify_opt_in_extends_budget() -> None:
+    client = FakeHttpClient()
+    server = create_mcp_server(client)
+
+    run_tool(server, "citadel_ingest", "a durable note", None, cognify=True)
+
+    post = client.posts[0]
+    assert post["payload"]["cognify"] is True
+    # Inline cognify can exceed the default 30s budget, so the tool extends the timeout.
+    assert post["timeout"] == mcp_server._INGEST_COGNIFY_TIMEOUT
 
 
 def test_share_session_tool_preserves_server_lifecycle_operations() -> None:
@@ -773,7 +775,8 @@ def test_ingest_timeout_budget_is_configurable(monkeypatch: pytest.MonkeyPatch) 
     client = FakeHttpClient()
     server = create_mcp_server(client)
 
-    run_tool(server, "citadel_ingest", "a durable note", None)
+    # The extended budget only applies to the blocking cognify opt-in.
+    run_tool(server, "citadel_ingest", "a durable note", None, cognify=True)
 
     assert client.posts[0]["timeout"] == 45.0
 


### PR DESCRIPTION
Refs #275.

Both default ingest paths had sharp edges, reproduced live during the 2026-08-13 seat end-to-end test: `citadel ingest <path>` shipped the literal path string (the projection worker then failed on it, tripping the lifecycle invariant), and the inline-cognify default blocked until the platform edge returned 502 while the server accepted the write twice.

## The commits

1. `3213d80` — file arguments are read client-side: an existing regular file is read as UTF-8 and its content ingested (binary, unreadable, and whitespace-only files get named errors; a non-existent path stays literal text, so a sentence containing a slash still ingests as written). The byte cap mirrors the server's `CITADEL_MCP_MAX_INGEST_BYTES` (default 200,000) client-side so oversized inputs fail before the request. The default flips to async on both the CLI (`--cognify` opt-in, help warns it can exceed proxy timeouts and that a 502 does not mean the write failed; `--no-cognify` kept as the named default) and the hosted MCP tool (`cognify: false`, advertised in the tool schema, verified via a real `list_tools()` call). The async receipt tells the user the note becomes searchable within minutes and how to track it (`citadel operation <job_id>`). Every test pinning the old default was updated deliberately and is named in the commit body.
2. `7d3b9d9` — review round: directory arguments (including symlinks to directories) are rejected with a named error instead of silently falling through to literal text, which reproduced the original defect for that input class; the size check runs on `stat()` before the file is read, proven by a test whose monkeypatch forbids `read_text` outright; `--json` receipts carry `ingest_source` (`file`/`text`) and `ingest_path` so scripted callers see the switch the human sees (client-owned keys, added with `setdefault` so a future server key of the same name wins; verified no such key exists today); the keep-in-sync comment is bidirectional.

## Review provenance

Two adversarial rounds against a real checkout with its own uv-synced venv. The reviewer reproduced the original defect live before the fix (`citadel ingest <tmpdir>` returning rc=0 with the literal path as the body), mutation-tested the byte cap, the file-detection, and the directory rejection, verified the default flip is scoped to the two user surfaces (zero internal cognify-payload constructors affected; the server's `IngestBody.cognify` default was already false), and confirmed the MCP advertised schema rather than trusting the Python signature.

## Verification

Full non-live suite in the branch venv: 2152 passed, 1 skipped, plus exactly the one expected stock-wheel metadata failure. Ruff clean. Revert-proofs are behavioral: restoring pre-fix sources fails 8 tests on the first commit and 4 on the delta, each on the defect itself, including the forbidden-read monkeypatch failing precisely because the old code read the file before checking its size.
