### PR TITLE
fix(webui): entity clicks resolve to sourcing documents, ranked and labeled

### DIFF
--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -2224,26 +2224,93 @@ function nearestDocumentThroughEdges(node) {
   return null;
 }
 
+// Chunks name the entities they mention through `contains` edges
+// (DocumentChunk -> Entity in cognee's extraction; enumerated live 2026-08-13:
+// 868 of the payload's 900 contains edges are chunk->entity). Those chunks —
+// not whichever document happens to sit nearest — are what SOURCES an entity.
+const SOURCING_RELATIONSHIP = "contains";
+
+// The in-view parent document of a chunk, through its is_part_of edge.
+function parentDocumentInView(chunkId) {
+  const real = state.realGraph;
+  if (!real) return null;
+  for (const edge of real.edges) {
+    if (String(edge.relationship || edge.label || "") !== "is_part_of") continue;
+    const otherId =
+      edge.source === chunkId ? edge.target : edge.target === chunkId ? edge.source : null;
+    if (!otherId) continue;
+    const other = real.nodes.get(otherId);
+    if (other && nodeKind(other) === "document") return other;
+  }
+  return null;
+}
+
+// Documents that SOURCE the clicked node: the parents of every chunk that
+// `contains` it, ranked by how many of their chunks mention it — the document
+// most about the node outranks a daily-update digest that name-drops it once
+// (which is exactly the wrong document the unranked one-hop chain used to
+// surface for person entities). A parent outside the truncated payload keeps
+// the chunk itself as the candidate; /api/documents resolves chunk ids to
+// their parent server-side.
+function sourcingDocumentCandidates(node) {
+  const real = state.realGraph;
+  if (!real || !node?.id) return [];
+  const byTarget = new Map();
+  const seenChunks = new Set();
+  for (const edge of real.edges) {
+    if (String(edge.relationship || edge.label || "") !== SOURCING_RELATIONSHIP) continue;
+    const otherId =
+      edge.source === node.id ? edge.target : edge.target === node.id ? edge.source : null;
+    if (!otherId || seenChunks.has(otherId)) continue;
+    seenChunks.add(otherId);
+    const chunk = real.nodes.get(otherId);
+    if (!chunk || nodeKind(chunk) !== "chunk") continue;
+    const target = parentDocumentInView(otherId) || chunk;
+    const entry = byTarget.get(target.id);
+    if (entry) {
+      entry.count += 1;
+    } else {
+      byTarget.set(target.id, { node: target, count: 1 });
+    }
+  }
+  // Stable sort: ties keep payload order.
+  return Array.from(byTarget.values())
+    .sort((a, b) => b.count - a.count)
+    .map((entry) => ({
+      node: entry.node,
+      relationship: SOURCING_RELATIONSHIP,
+      note: "Sources this node",
+    }));
+}
+
 function documentCandidates(node) {
   const candidates = [];
   const seen = new Set();
-  const add = (candidate, relationship = null) => {
+  const add = (candidate, relationship = null, note = null) => {
     const id = candidate?.id;
     if (!id || seen.has(id) || !isDocumentBearingNode(candidate)) return;
     seen.add(id);
-    candidates.push({ node: candidate, relationship });
+    candidates.push({ node: candidate, relationship, note });
   };
 
-  // Nearest reachable document first: it is the candidate /api/documents can
-  // resolve. The old chain (self, then one-hop document-bearing neighbors)
-  // stays as the fallback for payloads whose structural edges were capped away.
-  const nearest = nearestDocumentThroughEdges(node);
-  if (nearest) {
-    add(nearest.node, nearest.hops === 0 ? null : "nearest document");
+  // 1) Real provenance first: documents whose chunks mention the node,
+  //    strongest source on top.
+  for (const item of sourcingDocumentCandidates(node)) {
+    add(item.node, item.relationship, item.note);
   }
+  // 2) The node itself and its one-hop document-bearing neighbors: a clicked
+  //    chunk, summary, or document resolves through its own id (the backend
+  //    resolves chunk ids to their parent), with the real edge label shown.
   add(node);
   for (const item of knowledgeNeighbors(node.id)) {
     add(item.node, item.relationship);
+  }
+  // 3) Last resort, and said out loud: the nearest document by structural
+  //    edges is reachable content, but nothing ties it to the node as a
+  //    source.
+  const nearest = nearestDocumentThroughEdges(node);
+  if (nearest && nearest.hops > 0) {
+    add(nearest.node, null, "Nearest document in view — not a direct source");
   }
   return candidates;
 }
@@ -2280,8 +2347,14 @@ async function loadNodeDocument(node) {
         doc.title && doc.title !== candidate.node.label
           ? `<strong>${escapeHtml(doc.title)}</strong>`
           : "";
-      const source =
-        candidate.node.id !== node.id
+      // Provenance line: a sourcing/nearest candidate says WHY this document
+      // is shown; other candidates keep the raw edge label; the node's own
+      // document needs no line.
+      const source = candidate.note
+        ? `<p class="node-document-source">${escapeHtml(candidate.note)} · ${escapeHtml(
+            candidate.node.label || candidate.node.id
+          )}</p>`
+        : candidate.node.id !== node.id
           ? `<p class="node-document-source">From ${escapeHtml(
               candidate.relationship || "related"
             )} · ${escapeHtml(candidate.node.label || candidate.node.id)}</p>`

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -811,6 +811,19 @@ def test_graph_inspector_prefers_sourcing_chunks_over_nearest_document() -> None
     assert "parentDocumentInView" in sourcing.group(1), (
         "sourcing chunks must resolve to their parent documents when in view"
     )
+    # Structural pins on the two load-bearing lines (logic verified by review,
+    # 2026-08-13): gutting either must fail here, not only deleting the function.
+    assert 'nodeKind(chunk) !== "chunk"' in sourcing.group(1), (
+        "the other-endpoint kind filter is gone; Entity->Entity contains edges "
+        "(32 in the live payload) would count as sourcing chunks"
+    )
+    assert ".sort((a, b) => b.count - a.count)" in sourcing.group(1), (
+        "the sourcing-count ranking is gone; the digest that name-drops a node "
+        "once would tie with the document actually about it"
+    )
+    assert '"Sources this node"' in sourcing.group(1), (
+        "sourcing candidates lost their provenance label"
+    )
     candidates = re.search(
         r"function documentCandidates\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
     )

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -778,3 +778,50 @@ def test_graph_depth_control_is_gone() -> None:
     assert "graph-depth-control" not in index_html and "graph-depth-control" not in styles_css, (
         "dead depth-control markup or styles are back"
     )
+
+
+def test_graph_inspector_prefers_sourcing_chunks_over_nearest_document() -> None:
+    """Live user report on 13c1586: clicking a person entity (then a related
+    entity) showed an arbitrary daily-update digest. Entities carry no
+    is_part_of/made_from edges, so the nearest-document walk returns null for
+    EVERY entity, and the one-hop fallback picked the first document-bearing
+    neighbor in payload edge order — degree-biased toward digests that
+    name-drop dozens of entities (live 2026-08-13: entities 'patricktobler'
+    and its committed-neighbor both resolved to '# masumi-network GitHub
+    daily update'). Chunks name the entities they mention through `contains`
+    edges (868 of the payload's 900 contains edges are chunk->entity), so the
+    inspector now tries sourcing chunks first — resolved to their parent
+    documents and ranked by how many chunks mention the node — and the
+    nearest-walk fallback says out loud that it is not provenance."""
+    import re
+    from pathlib import Path
+
+    import kb.server as server_module
+
+    repo = Path(server_module.__file__).resolve().parent.parent
+    app_js = (repo / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+
+    assert 'SOURCING_RELATIONSHIP = "contains"' in app_js, (
+        "the sourcing edge type (chunk->entity contains) is not pinned"
+    )
+    sourcing = re.search(
+        r"function sourcingDocumentCandidates\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert sourcing, "sourcingDocumentCandidates() not found in kb/static/app.js"
+    assert "parentDocumentInView" in sourcing.group(1), (
+        "sourcing chunks must resolve to their parent documents when in view"
+    )
+    candidates = re.search(
+        r"function documentCandidates\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert candidates, "documentCandidates() not found in kb/static/app.js"
+    body = candidates.group(1)
+    assert "sourcingDocumentCandidates(node)" in body, (
+        "the inspector does not consult sourcing chunks at all"
+    )
+    assert body.index("sourcingDocumentCandidates(node)") < body.index(
+        "nearestDocumentThroughEdges(node)"
+    ), "sourcing candidates must be tried before the nearest-document walk"
+    assert "Nearest document in view — not a direct source" in app_js, (
+        "the nearest-walk fallback must label itself as not being provenance"
+    )


### PR DESCRIPTION
Refs #283.

Clicking a person entity showed a GitHub daily-update document unrelated to the node. Diagnosed on the live payload: entities carry no `is_part_of`/`made_from` edges, so the nearest-document walk never applied to them, and the old fallback picked the first document-bearing neighbor in payload order — degree-biased to digests, unlabeled.

`a7cae09` — source-first selection: chunks that `contains`-link the clicked node (868 of 900 such edges run chunk-to-entity live; the other-endpoint kind filter blocks the 32 entity-to-entity ones) resolve to their in-view parent documents, ranked by sourcing-chunk count, labeled "Sources this node". The nearest-document walk survives only as a labeled last resort ("Nearest document in view — not a direct source"). Non-entity nodes are unaffected: their sourcing set is empty by the kind filter and they fall through to the unchanged chain. Live proof of the ranking: the 'citadel' entity moves from the digest to a document with four sourcing chunks; 85 entities in the current slice have two or more in-view source documents.

`12517ef` — review round: the primary label and both load-bearing lines (the kind filter and the count comparator) are pinned by structural tests with named failure messages, honesty-commented as structural pins with logic verified by review. Mutation-proof: neutralizing the comparator, dropping the kind filter, and nulling the label each fail a distinct assertion.

Review: SHIP after one round; the reviewer traced direction handling, tie determinism, and non-entity fall-through directly, and demonstrated the original test paradigm's blindness that `12517ef` closes. Gate at `a7cae09`: 2175 passed, 1 skipped, the one pre-existing stock-wheel failure; delta is test-only. Ruff clean, node --check clean.

Known limit, stated: entities whose only in-view source is the digest still show the digest, now truthfully labeled. Showing the actual mentioning passage needs a chunk-scoped read on `/api/documents` (in progress separately).
