### PR TITLE
feat(api): chunk-scoped text on /api/documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Added
 
+- **`/api/documents/{id}` takes `?scope=chunk`.** A DocumentChunk id used to
+  return the whole assembled parent (a 23k-char daily digest for one clicked
+  passage); with `scope=chunk` the response body is the chunk's OWN text, in
+  the same envelope, with `chunk_id` / `document_id` / `chunk_index` in
+  `metadata`. ADR-0009 visibility is unchanged (the parent still drives the
+  gate). A TextSummary id under `scope=chunk` serves the summary's own text.
+  Absent param and non-chunk ids behave exactly as before; an unknown scope
+  value is a clean 422. The graph inspector consumes this to show what is
+  inside the clicked node.
+
 - **`/api/mesh/graph` takes a `dataset` query parameter and orders the
   caller's seat content into the default view.** The endpoint sampled the
   first nodes of raw enumeration (16,154 live against a 1,000-node cap), so a

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -420,7 +420,9 @@ class CogneeGateway(Protocol):
     def maintenance(self) -> AsyncIterator[None]:
         raise NotImplementedError
 
-    async def get_document(self, document_id: str) -> dict[str, Any] | None:
+    async def get_document(
+        self, document_id: str, *, chunk_scope: bool = False
+    ) -> dict[str, Any] | None:
         raise NotImplementedError
 
     async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
@@ -3839,7 +3841,9 @@ class CogneePublicClient:
             )
             return await self.graph_data()
 
-    async def get_document(self, document_id: str) -> dict[str, Any] | None:
+    async def get_document(
+        self, document_id: str, *, chunk_scope: bool = False
+    ) -> dict[str, Any] | None:
         """Resolve a search-hit node id back to its stored text (#28).
 
         cognee search hits carry a graph node/chunk id with no backing document
@@ -3857,12 +3861,22 @@ class CogneePublicClient:
         retrieve must stay reachable through drill-down. ``None`` only when no
         text exists in either store (textless entities keep resolving to
         None/404).
+
+        ``chunk_scope=True`` (the /api/documents ``?scope=chunk`` contract)
+        keeps a chunk id's OWN text instead of assembling the parent: the
+        graph inspector wants the clicked passage, not the whole document.
+        Ownership is unchanged — the ``is_part_of`` parent still rides in
+        ``dataset_node_ids``, so the ADR-0009 gate decides exactly as it does
+        for the default read. Non-chunk ids (documents, summaries, textless
+        entities) behave as without the flag.
         """
         doc_id = str(document_id)
-        document = await self._document_from_graph(doc_id, follow_parent=True)
+        document = await self._document_from_graph(
+            doc_id, follow_parent=True, chunk_scope=chunk_scope
+        )
         if document is not None:
             return document
-        return await self._document_from_chunk_store(doc_id)
+        return await self._document_from_chunk_store(doc_id, chunk_scope=chunk_scope)
 
     async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:
         """Owner node ids for the ADR-0009 drill-down visibility rule — WITHOUT
@@ -4088,7 +4102,7 @@ class CogneePublicClient:
         return [chunk_id, parent_id]
 
     async def _document_from_graph(
-        self, doc_id: str, *, follow_parent: bool
+        self, doc_id: str, *, follow_parent: bool, chunk_scope: bool = False
     ) -> dict[str, Any] | None:
         """Resolve ``doc_id`` against the graph store (targeted read).
 
@@ -4096,6 +4110,9 @@ class CogneePublicClient:
         text-bearing chunk's ``is_part_of`` parent document and returns the
         parent's FULL assembled body; the recursive parent call passes
         ``follow_parent=False`` so resolution is bounded at one hop.
+        ``chunk_scope=True`` keeps the chunk's own text instead: no parent
+        assembly read, the parent id recorded in ``metadata`` and (via
+        ``part_neighbor_ids``) in ``dataset_node_ids`` as before.
         """
         try:
             nodes, edges = await self._document_graph(doc_id)
@@ -4112,40 +4129,55 @@ class CogneePublicClient:
         text, text_key = self._extract_text(props)
         if text is not None:
             summary_owner_ids: list[str] = []
+            chunk_metadata: dict[str, Any] = {}
             if follow_parent:
-                # A text-bearing node with a TEXTLESS ``is_part_of`` neighbor is
-                # a DocumentChunk next to its parent document (chunks carry the
-                # text; TextDocument nodes carry none). Search hands out CHUNK
-                # ids, so resolving the id to just this chunk's text re-serves
-                # the same fragment the search snippet already showed. Resolve
-                # the PARENT instead so drill-down returns the whole document;
-                # the chunk's own text stays the fallback when the parent
-                # cannot be assembled (never worse than before).
                 parent_id = self._textless_neighbor_id(props_by_id, part_neighbor_ids)
-                if parent_id is not None:
-                    parent = await self._document_from_graph(
-                        parent_id, follow_parent=False
+                if parent_id is not None and chunk_scope:
+                    # ?scope=chunk: the caller wants the clicked passage, not
+                    # the assembled parent — keep the chunk's own text and skip
+                    # the parent assembly read. The parent still rides in
+                    # part_neighbor_ids, so the ADR-0009 gate is unchanged.
+                    chunk_metadata = {"chunk_id": doc_id, "document_id": parent_id}
+                else:
+                    # A text-bearing node with a TEXTLESS ``is_part_of``
+                    # neighbor is a DocumentChunk next to its parent document
+                    # (chunks carry the text; TextDocument nodes carry none).
+                    # Search hands out CHUNK ids, so resolving the id to just
+                    # this chunk's text re-serves the same fragment the search
+                    # snippet already showed. Resolve the PARENT instead so
+                    # drill-down returns the whole document; the chunk's own
+                    # text stays the fallback when the parent cannot be
+                    # assembled (never worse than before).
+                    if parent_id is not None:
+                        parent = await self._document_from_graph(
+                            parent_id, follow_parent=False
+                        )
+                        if parent is not None and parent.get("body"):
+                            owner_ids = list(
+                                parent.get("dataset_node_ids") or [parent_id]
+                            )
+                            if doc_id not in owner_ids:
+                                owner_ids.append(doc_id)
+                            parent["dataset_node_ids"] = owner_ids
+                            return parent
+                    # No is_part_of parent: a TextSummary carries its own text
+                    # but hangs off the content it summarizes via ``made_from``.
+                    # Its id has no relational Data row, so owner ids of just
+                    # [doc_id] fail-close the ADR-0009 drill-down gate on
+                    # content the caller may read — chase the summarized
+                    # chunk's parent document id.
+                    summary_owner_ids = await self._summary_owner_ids(
+                        doc_id, edges, props_by_id
                     )
-                    if parent is not None and parent.get("body"):
-                        owner_ids = list(parent.get("dataset_node_ids") or [parent_id])
-                        if doc_id not in owner_ids:
-                            owner_ids.append(doc_id)
-                        parent["dataset_node_ids"] = owner_ids
-                        return parent
-                # No is_part_of parent: a TextSummary carries its own text but
-                # hangs off the content it summarizes via ``made_from``. Its id
-                # has no relational Data row, so owner ids of just [doc_id]
-                # fail-close the ADR-0009 drill-down gate on content the caller
-                # may read — chase the summarized chunk's parent document id.
-                summary_owner_ids = await self._summary_owner_ids(
-                    doc_id, edges, props_by_id
-                )
             return {
                 "id": doc_id,
                 "source_type": "cognee",
                 "title": props.get("title") or None,
                 "body": text,
-                "metadata": {k: v for k, v in props.items() if k != text_key},
+                "metadata": {
+                    **{k: v for k, v in props.items() if k != text_key},
+                    **chunk_metadata,
+                },
                 "dataset_node_ids": [doc_id, *part_neighbor_ids, *summary_owner_ids],
             }
         # Textless document node: its text lives on DocumentChunk neighbors
@@ -4322,7 +4354,9 @@ class CogneePublicClient:
         retrieve = getattr(engine, "retrieve", None)
         return retrieve if callable(retrieve) else None
 
-    async def _document_from_chunk_store(self, doc_id: str) -> dict[str, Any] | None:
+    async def _document_from_chunk_store(
+        self, doc_id: str, *, chunk_scope: bool = False
+    ) -> dict[str, Any] | None:
         """Assemble a document from the durable chunk store when the graph can't.
 
         Accepts either a chunk id (resolved to its parent via the payload's
@@ -4332,6 +4366,8 @@ class CogneePublicClient:
         shape as the graph assembly; ``dataset_node_ids`` carries the parent
         document id, which is the relational ``Data.id`` the read-scope map
         keys on (ADR-0009), so the drill-down isolation gate is unchanged.
+        ``chunk_scope=True`` with a chunk id serves the seed row's own text
+        (no sibling probe); a non-chunk id ignores the flag.
         """
         try:
             # STRING ids, never uuid.UUID objects — cognee's own retrieve()
@@ -4372,6 +4408,34 @@ class CogneePublicClient:
                     document_id = str(UUID(document_id))
                 except (TypeError, ValueError):
                     document_id = None
+            if chunk_scope and seed_payload is not None:
+                seed_text, _ = self._extract_text(seed_payload)
+                if seed_text is not None:
+                    # ?scope=chunk on a graph-missing chunk: the seed row IS
+                    # the clicked chunk — serve its own text, skip the sibling
+                    # probe. Owner ids keep the parent Data.id first, exactly
+                    # like the assembled shape, so the gate is unchanged.
+                    owner_ids = [document_id] if document_id is not None else []
+                    if requested not in owner_ids:
+                        owner_ids.append(requested)
+                    seed_metadata: dict[str, Any] = {
+                        "assembled_from": "chunk_store",
+                        "chunk_id": requested,
+                    }
+                    if document_id is not None:
+                        seed_metadata["document_id"] = document_id
+                    if seed_payload.get("document_name"):
+                        seed_metadata["document_name"] = seed_payload["document_name"]
+                    if isinstance(seed_payload.get("chunk_index"), (int, float)):
+                        seed_metadata["chunk_index"] = seed_payload["chunk_index"]
+                    return {
+                        "id": requested,
+                        "source_type": "cognee",
+                        "title": seed_payload.get("document_name") or None,
+                        "body": seed_text,
+                        "metadata": seed_metadata,
+                        "dataset_node_ids": owner_ids,
+                    }
             if document_id is not None:
                 sibling_ids = [
                     str(uuid5(NAMESPACE_OID, f"{document_id}-{index}"))

--- a/kb/server.py
+++ b/kb/server.py
@@ -5879,8 +5879,17 @@ async def cognee_document_visible(identity: AccessIdentity, node_ids: list[str])
 
 
 @app.get("/api/documents/{document_id}")
-async def source_document(document_id: str, request: Request) -> Any:
+async def source_document(
+    document_id: str, request: Request, scope: str | None = None
+) -> Any:
     identity = require_access(request, "reader", "kb:read")
+    # ?scope=chunk (graph inspector contract): a DocumentChunk id returns the
+    # chunk's OWN text instead of the assembled parent, same envelope, same
+    # ADR-0009 gate. Non-chunk ids and absent scope keep today's behavior.
+    if scope not in {None, "chunk"}:
+        raise HTTPException(
+            status_code=422, detail="Unsupported document scope (use 'chunk')."
+        )
     if document_id.startswith(f"{GITHUB_DOC_ID_PREFIX}:"):
         github_document = github_section_document(document_id, get_citadel().config)
         if github_document is None:
@@ -5895,8 +5904,14 @@ async def source_document(document_id: str, request: Request) -> Any:
         assert_obsidian_vault_owned(identity, obsidian.document_vault_id(document_id) or "")
     except KeyError:
         # Not a github/obsidian doc — fall back to resolving a native cognee
-        # search-hit id against the graph store (#28).
-        cognee_document = await get_citadel().get_document(document_id)
+        # search-hit id against the graph store (#28). chunk_scope is passed
+        # only when requested so fakes with the plain signature keep working.
+        if scope == "chunk":
+            cognee_document = await get_citadel().get_document(
+                document_id, chunk_scope=True
+            )
+        else:
+            cognee_document = await get_citadel().get_document(document_id)
         if cognee_document is None:
             raise HTTPException(status_code=404, detail="Document not found.") from None
         # dataset_node_ids is internal plumbing (ADR-0009 scope check), never

--- a/kb/service.py
+++ b/kb/service.py
@@ -1497,8 +1497,17 @@ class Citadel:
             "after": None,
         }
 
-    async def get_document(self, document_id: str) -> dict[str, Any] | None:
-        """Resolve a cognee search-hit id to its document/chunk (#28)."""
+    async def get_document(
+        self, document_id: str, *, chunk_scope: bool = False
+    ) -> dict[str, Any] | None:
+        """Resolve a cognee search-hit id to its document/chunk (#28).
+
+        ``chunk_scope=True`` (?scope=chunk) serves a chunk id's own text
+        instead of the assembled parent. Passed through only when set so
+        clients implementing the plain signature keep working.
+        """
+        if chunk_scope:
+            return await self.cognee.get_document(document_id, chunk_scope=True)
         return await self.cognee.get_document(document_id)
 
     async def resolve_document_owner_ids(self, document_id: str) -> list[str] | None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -4764,3 +4764,40 @@ async def test_get_document_summary_carries_mappable_owner_ids(
     assert document["body"] == "a summary"
     assert "chunk-1" in document["dataset_node_ids"]
     assert "doc-1" in document["dataset_node_ids"]
+
+
+@pytest.mark.asyncio
+async def test_get_document_summary_chunk_scope_serves_summary_text(
+    monkeypatch: Any,
+) -> None:
+    """?scope=chunk on a TextSummary id: its own text is the trivially
+    available result of the same read (summaries never assemble a parent), so
+    body and owner ids match the default scope instead of erroring."""
+    client = CogneePublicClient()
+    graphs: dict[str, tuple[list[Any], list[Any]]] = {
+        "summary-1": (
+            [
+                ("summary-1", {"type": "TextSummary", "text": "a summary"}),
+                ("chunk-1", {"type": "DocumentChunk", "text": "chunk text"}),
+            ],
+            [("summary-1", "chunk-1", "made_from", {})],
+        ),
+        "chunk-1": (
+            [
+                ("chunk-1", {"type": "DocumentChunk", "text": "chunk text"}),
+                ("doc-1", {"type": "TextDocument", "name": "parent doc"}),
+            ],
+            [("chunk-1", "doc-1", "is_part_of", {})],
+        ),
+    }
+
+    async def fake_graph(document_id: str) -> tuple[list[Any], list[Any]]:
+        return graphs.get(str(document_id), ([], []))
+
+    monkeypatch.setattr(client, "_document_graph", fake_graph)
+
+    document = await client.get_document("summary-1", chunk_scope=True)
+
+    assert document is not None
+    assert document["body"] == "a summary"
+    assert "doc-1" in document["dataset_node_ids"]

--- a/tests/test_get_document_drilldown.py
+++ b/tests/test_get_document_drilldown.py
@@ -598,3 +598,67 @@ async def test_owner_ids_unresolvable_ids_return_none(real_graph: Any) -> None:
     # The synthetic id never touched the vector engine; the UUID ids paid at
     # most the two seed lookups each.
     assert all(len(ids) == 1 for _, ids in store.calls)
+
+
+# --------------------------------------------------------------------------
+# ?scope=chunk: the clicked chunk's own text, not the assembled parent.
+# --------------------------------------------------------------------------
+
+
+async def test_chunk_scope_returns_the_chunks_own_text(real_graph: Any) -> None:
+    """The graph inspector wants what is INSIDE the clicked node.
+
+    Without the flag a chunk id returns the whole assembled parent (verified
+    live: 23k-char daily digest for one passage). chunk_scope keeps the
+    chunk's own text, same envelope, and the parent still rides in
+    dataset_node_ids so the ADR-0009 gate decides exactly as before.
+    """
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    scoped = await client.get_document(CHUNK_IDS[1], chunk_scope=True)
+    default = await client.get_document(CHUNK_IDS[1])
+
+    assert scoped is not None
+    assert scoped["body"] == "part one"  # the clicked passage only
+    assert default is not None
+    assert default["body"] == FULL_BODY  # absent flag: unchanged
+    assert scoped["metadata"]["chunk_id"] == CHUNK_IDS[1]
+    assert scoped["metadata"]["document_id"] == DOC_ID
+    assert scoped["metadata"]["chunk_index"] == 1
+    # ADR-0009 unchanged: the parent Data.id stays in the owner ids.
+    assert DOC_ID in scoped["dataset_node_ids"]
+    assert CHUNK_IDS[1] in scoped["dataset_node_ids"]
+
+
+async def test_chunk_scope_on_a_document_id_keeps_the_assembly(
+    real_graph: Any,
+) -> None:
+    """Non-chunk ids ignore the flag: a textless document still assembles."""
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _empty_store())
+
+    document = await client.get_document(DOC_ID, chunk_scope=True)
+
+    assert document is not None
+    assert document["body"] == FULL_BODY
+    assert document["chunk_count"] == 3
+
+
+async def test_chunk_scope_orphan_chunk_serves_the_seed_row(real_graph: Any) -> None:
+    """Chunk-store fallback honors the scope too: the seed row IS the chunk."""
+    client = _client_over(real_graph)
+    _install_chunk_store(client, _orphan_store())
+
+    scoped = await client.get_document(ORPHAN_CHUNK_IDS[1], chunk_scope=True)
+    default = await client.get_document(ORPHAN_CHUNK_IDS[1])
+
+    assert scoped is not None
+    assert scoped["body"] == "orphan one"
+    assert default is not None
+    assert default["body"] == "orphan zero\n\norphan one\n\norphan two\n\norphan three"
+    assert scoped["metadata"]["chunk_id"] == ORPHAN_CHUNK_IDS[1]
+    assert scoped["metadata"]["document_id"] == ORPHAN_DOC_ID
+    assert scoped["metadata"]["chunk_index"] == 1
+    # Parent Data.id first, requested chunk id kept — gate inputs unchanged.
+    assert scoped["dataset_node_ids"] == [ORPHAN_DOC_ID, ORPHAN_CHUNK_IDS[1]]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8567,3 +8567,65 @@ def test_mesh_graph_orders_callers_seat_content_into_the_default_view(
     content = [node["id"] for node in seated["nodes"] if node["type"] != "dataset"]
     assert content[0] == "doc-alice"
     assert len(content) == 2
+
+
+def test_source_document_scope_chunk_wiring_and_gate(tmp_path: Any) -> None:
+    # Contract (graph inspector): GET /api/documents/{id}?scope=chunk serves
+    # the chunk's own text in the same envelope. The endpoint's job: pass
+    # chunk_scope through, keep the ADR-0009 gate identical, 422 unknown
+    # scopes, and leave the absent-param path byte-for-byte alone.
+    calls: dict[str, list[bool]] = {}
+
+    class ChunkScopeCitadel(DrilldownIsolationCitadel):
+        cognee_documents = {
+            **DrilldownIsolationCitadel.cognee_documents,
+            "chunk-a": {
+                "id": "chunk-a",
+                "source_type": "cognee",
+                "title": None,
+                "body": "alice chunk text",
+                "metadata": {"chunk_id": "chunk-a", "document_id": "doc-a"},
+                "dataset_node_ids": ["chunk-a", "doc-a"],
+            },
+        }
+
+        async def get_document(
+            self, document_id: str, *, chunk_scope: bool = False
+        ) -> dict[str, Any] | None:
+            calls.setdefault(document_id, []).append(chunk_scope)
+            return self.cognee_documents.get(document_id)
+
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    app.state.obsidian_sync = ObsidianSyncStore(tmp_path / "obsidian.json")
+    admin = authed_client()
+    bob_token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = ChunkScopeCitadel()  # authed_client resets citadel
+    app.state.knowledge_mesh = KnowledgeMesh(IsolationDatasetGateway())
+    api = TestClient(app, base_url="https://testserver")
+    bob = {"Authorization": f"Bearer {bob_token}"}
+    try:
+        scoped = api.get("/api/documents/chunk-b?scope=chunk", headers=bob)
+        default = api.get("/api/documents/chunk-b", headers=bob)
+        foreign = api.get("/api/documents/chunk-a?scope=chunk", headers=bob)
+        missing = api.get("/api/documents/does-not-exist?scope=chunk", headers=bob)
+        invalid = api.get("/api/documents/chunk-b?scope=banana", headers=bob)
+    finally:
+        app.state.knowledge_mesh = None
+
+    # scope=chunk reaches the service as chunk_scope=True; absent stays False.
+    assert calls["chunk-b"] == [True, False]
+    assert scoped.status_code == 200
+    assert scoped.json()["document"]["body"] == "bob chunk text"
+    assert "dataset_node_ids" not in scoped.json()["document"]
+    assert default.status_code == 200
+
+    # The ADR-0009 gate decides identically under scope=chunk: a foreign
+    # seat's chunk is byte-identical to a nonexistent id (no oracle).
+    assert foreign.status_code == 404
+    assert missing.status_code == 404
+    assert foreign.content == missing.content
+
+    # Unknown scope values are a clean 422.
+    assert invalid.status_code == 422


### PR DESCRIPTION
Refs #283.

`GET /api/documents/{id}` always returned the assembled parent body, even for a chunk id — so the graph inspector could name a sourcing chunk but only ever show the whole (often 20k-character) parent document. This adds `?scope=chunk`: a chunk id returns the chunk's own text in the same envelope (metadata gains `chunk_id`, `document_id`, `chunk_index`), a summary id returns the summary's own text, an absent param or non-chunk id is byte-for-byte today's behavior, and an unknown scope value is a 422 per the repo's query-validation precedent.

No new store plumbing: the graph path reuses the existing text-bearing read and skips the parent assembly; the chunk-store fallback reuses its seed-row retrieve and skips the sibling probe — the scoped read is strictly cheaper than the default on both paths. ADR-0009 is unchanged: the parent still rides `dataset_node_ids`, the gate runs identically after either path, and a foreign chunk with the scope is byte-identical to a nonexistent id.

Review: SHIP after one adversarial round — the skipped sibling probe verified side-effect-free, all `get_document` callers enumerated (two), the orphan seed-row path verified to feed the same external gate, and the fall-through-to-parent mutation caught by the named test. Gate: 2179 passed, 1 skipped, the one pre-existing stock-wheel failure. Ruff clean. Revert-proof: exactly five tests fail on pre-fix sources.

Post-merge check: `GET` a mesh chunk id with `?scope=chunk` against production and confirm the body is the passage, not the digest. Frontend consumption (the inspector showing the mentioning passage) follows separately.
