### PR TITLE
fix(lifecycle): missing-document check no longer races the drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ### Fixed
 
+- **The post-cognify stored-chunk check no longer fails on documents the
+  lifecycle drain is still projecting (#286).** Phase-2 incremental cognify
+  sweeps in-flight documents into its receipt while the drain still owns
+  their chunk writes, so the census counted the not-yet-written chunks as
+  missing and failed the whole pass with zero violations (live 18:02Z canary;
+  same design family as #273, one layer deeper). Missing document ids are now
+  partitioned by projection-job state through a narrow lifecycle-store read
+  (a drain-projected document's cognee `Data.id` is its
+  `source_revision_id`): pending/running ids are logged by id and skipped;
+  a missing id with no active job stays fatal, and budget violations stay
+  fatal regardless, so the check keeps its fail-closed property for real
+  gaps. Deployments without a lifecycle store keep the old fully fail-closed
+  behavior.
+
 - **`/api/documents/{id}` 404'd every DocumentChunk and TextSummary id.**
   Under access control each dataset lives in its own graph database
   (ADR-0020), and the targeted drill-down read used the ambient engine

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -502,6 +502,15 @@ class CogneePublicClient:
         retry_queue: CognifyRetryQueue | None = None,
     ) -> None:
         self._startup_migrations_done = False
+        # Wired by the service layer when a lifecycle store exists: maps a list
+        # of cognee document ids (== lifecycle source_revision_ids for drain-
+        # projected docs) to the subset whose projection is still in flight, so
+        # the post-cognify stored check does not fail on chunks the drain has
+        # not written yet (#286). None (no lifecycle) keeps the check fully
+        # fail-closed.
+        self.lifecycle_active_projection_lookup: (
+            Callable[[list[str]], set[str]] | None
+        ) = None
         configured_queue_path = queue_path or os.getenv("CITADEL_COGNIFY_QUEUE_PATH")
         self.cognify_queue = retry_queue or CognifyRetryQueue(
             configured_queue_path or DEFAULT_COGNIFY_QUEUE_PATH
@@ -4577,33 +4586,77 @@ class CogneePublicClient:
                     "VECTOR_DB_PROVIDER does not support exact enumeration"
                 )
             elif not stored_check["ok"]:
-                # Name the violators. The check already collects chunk_id and
-                # document_id per violation, but this site used to drop them and
-                # raise a bare count, so the 2026-08-13 canary failed for hours
-                # on one unidentifiable chunk out of ~1951 with no surface
-                # anywhere naming the offending document.
-                named = "; ".join(
-                    f"document {violation.get('document_id') or 'unknown'} "
-                    f"chunk {violation.get('chunk_id') or 'unknown'} "
-                    f"({violation.get('measured_tokens') or violation.get('configured_size')}"
-                    f" tokens > budget {stored_check.get('budget')})"
-                    for violation in (stored_check.get("violations") or [])[:3]
-                ) or "no violation rows"
-                missing = stored_check.get("missing_document_ids") or []
-                if missing:
-                    named += f"; missing document ids {missing[:3]}"
-                logger.error(
-                    "stored chunk budget check failed after cognify: "
-                    "%d violation(s) across %d chunk(s): %s",
-                    stored_check["violation_count"],
-                    stored_check["chunks_scanned"],
-                    named,
-                )
-                raise RuntimeError(
-                    "stored chunk budget check failed: "
-                    f"{stored_check['violation_count']} violation(s) across "
-                    f"{stored_check['chunks_scanned']} persisted chunk(s): {named}"
-                )
+                missing = list(stored_check.get("missing_document_ids") or [])
+                # Phase-2 incremental cognify sweeps docs the lifecycle drain
+                # is still projecting into its receipt, so the census counts
+                # their not-yet-written chunks as missing (#286, the 18:02Z
+                # canary; same design family as #273, one layer deeper — the
+                # check raced the drain). Partition the missing ids by job
+                # state: a missing id WITH a pending/running projection is
+                # in-flight, not a gap — the drain's own post-projection check
+                # gates those chunks when they land. A missing id with NO
+                # active job stays fatal (fail-closed), and violations are
+                # fatal regardless.
+                in_flight: set[str] = set()
+                lookup = self.lifecycle_active_projection_lookup
+                if missing and lookup is not None:
+                    try:
+                        in_flight = await asyncio.to_thread(lookup, list(missing))
+                    except Exception:  # noqa: BLE001 - advisory read; absence fails closed
+                        logger.warning(
+                            "lifecycle in-flight lookup failed; treating all "
+                            "missing document ids as fatal",
+                            exc_info=True,
+                        )
+                        in_flight = set()
+                fatal_missing = [
+                    document_id
+                    for document_id in missing
+                    if document_id not in in_flight
+                ]
+                if (
+                    stored_check["violation_count"] == 0
+                    and missing
+                    and not fatal_missing
+                ):
+                    logger.warning(
+                        "stored chunk budget check: %d document id(s) missing "
+                        "only because their lifecycle projection is still in "
+                        "flight, not failing: %s",
+                        len(missing),
+                        missing[:10],
+                    )
+                else:
+                    # Name the violators. The check already collects chunk_id
+                    # and document_id per violation, but this site used to drop
+                    # them and raise a bare count, so the 2026-08-13 canary
+                    # failed for hours on one unidentifiable chunk out of ~1951
+                    # with no surface anywhere naming the offending document.
+                    named = "; ".join(
+                        f"document {violation.get('document_id') or 'unknown'} "
+                        f"chunk {violation.get('chunk_id') or 'unknown'} "
+                        f"({violation.get('measured_tokens') or violation.get('configured_size')}"
+                        f" tokens > budget {stored_check.get('budget')})"
+                        for violation in (stored_check.get("violations") or [])[:3]
+                    ) or "no violation rows"
+                    if fatal_missing:
+                        named += f"; missing document ids {fatal_missing[:3]}"
+                    if in_flight:
+                        named += (
+                            f"; {len(in_flight)} more still in lifecycle projection"
+                        )
+                    logger.error(
+                        "stored chunk budget check failed after cognify: "
+                        "%d violation(s) across %d chunk(s): %s",
+                        stored_check["violation_count"],
+                        stored_check["chunks_scanned"],
+                        named,
+                    )
+                    raise RuntimeError(
+                        "stored chunk budget check failed: "
+                        f"{stored_check['violation_count']} violation(s) across "
+                        f"{stored_check['chunks_scanned']} persisted chunk(s): {named}"
+                    )
         return result
 
     async def add_feedback(

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -502,14 +502,14 @@ class CogneePublicClient:
         retry_queue: CognifyRetryQueue | None = None,
     ) -> None:
         self._startup_migrations_done = False
-        # Wired by the service layer when a lifecycle store exists: maps a list
-        # of cognee document ids (== lifecycle source_revision_ids for drain-
-        # projected docs) to the subset whose projection is still in flight, so
-        # the post-cognify stored check does not fail on chunks the drain has
-        # not written yet (#286). None (no lifecycle) keeps the check fully
-        # fail-closed.
-        self.lifecycle_active_projection_lookup: (
-            Callable[[list[str]], set[str]] | None
+        # Wired by the service layer when a lifecycle store exists: partitions
+        # cognee document ids (== lifecycle source_revision_ids for drain-
+        # projected docs) into active and completed-searchable projections. The
+        # post-cognify stored check can then distinguish chunks not written yet
+        # from a stale census after completion (#286). None (no lifecycle) keeps
+        # the check fully fail-closed.
+        self.lifecycle_projection_state_lookup: (
+            Callable[[list[str]], tuple[set[str], set[str]]] | None
         ) = None
         configured_queue_path = queue_path or os.getenv("CITADEL_COGNIFY_QUEUE_PATH")
         self.cognify_queue = retry_queue or CognifyRetryQueue(
@@ -4598,34 +4598,102 @@ class CogneePublicClient:
                 # active job stays fatal (fail-closed), and violations are
                 # fatal regardless.
                 in_flight: set[str] = set()
-                lookup = self.lifecycle_active_projection_lookup
+                completed_searchable: set[str] = set()
+                lookup = self.lifecycle_projection_state_lookup
                 if missing and lookup is not None:
                     try:
-                        in_flight = await asyncio.to_thread(lookup, list(missing))
+                        in_flight, completed_searchable = await asyncio.to_thread(
+                            lookup, list(missing)
+                        )
                     except Exception:  # noqa: BLE001 - advisory read; absence fails closed
                         logger.warning(
-                            "lifecycle in-flight lookup failed; treating all "
+                            "lifecycle projection-state lookup failed; treating all "
                             "missing document ids as fatal",
                             exc_info=True,
                         )
                         in_flight = set()
+                        completed_searchable = set()
                 fatal_missing = [
                     document_id
                     for document_id in missing
                     if document_id not in in_flight
+                    and document_id not in completed_searchable
                 ]
+                recheck_ids = [
+                    document_id
+                    for document_id in missing
+                    if document_id in completed_searchable
+                    and document_id not in in_flight
+                ]
+                stale_missing_cleared: list[str] = []
                 if (
                     stored_check["violation_count"] == 0
-                    and missing
+                    and recheck_ids
+                ):
+                    # The projection can finish after the census reports a
+                    # missing id but before the lifecycle lookup runs. A
+                    # completed-searchable job is correctly absent from
+                    # ``in_flight``, but its earlier census result is stale.
+                    # Recheck only ids with positive completion evidence.
+                    # Failed, stale, absent, and unscoped ids remain fatal.
+                    requested_recheck_ids = set(recheck_ids)
+                    recheck_ids_by_dataset: dict[str, list[str]] = {}
+                    for dataset, document_ids in processed_ids_by_dataset.items():
+                        scoped_ids = [
+                            document_id
+                            for document_id in document_ids
+                            if document_id in requested_recheck_ids
+                        ]
+                        if scoped_ids:
+                            recheck_ids_by_dataset[dataset] = scoped_ids
+                    mapped_recheck_ids = {
+                        document_id
+                        for document_ids in recheck_ids_by_dataset.values()
+                        for document_id in document_ids
+                    }
+                    for document_id in recheck_ids:
+                        if document_id not in mapped_recheck_ids:
+                            fatal_missing.append(document_id)
+                    scoped_recheck_ids = [
+                        document_id
+                        for document_id in recheck_ids
+                        if document_id in mapped_recheck_ids
+                    ]
+                    if scoped_recheck_ids:
+                        refreshed_check = await self.stored_chunk_budget_check(
+                            document_ids=scoped_recheck_ids,
+                            datasets=list(recheck_ids_by_dataset),
+                            document_ids_by_dataset=recheck_ids_by_dataset,
+                        )
+                        if refreshed_check is None:
+                            fatal_missing.extend(scoped_recheck_ids)
+                        elif refreshed_check["ok"]:
+                            stale_missing_cleared = scoped_recheck_ids
+                        else:
+                            stored_check = refreshed_check
+                            for document_id in list(
+                                refreshed_check.get("missing_document_ids") or []
+                            ):
+                                if document_id not in fatal_missing:
+                                    fatal_missing.append(document_id)
+                if (
+                    stored_check["violation_count"] == 0
                     and not fatal_missing
                 ):
-                    logger.warning(
-                        "stored chunk budget check: %d document id(s) missing "
-                        "only because their lifecycle projection is still in "
-                        "flight, not failing: %s",
-                        len(missing),
-                        missing[:10],
-                    )
+                    if in_flight:
+                        logger.warning(
+                            "stored chunk budget check: %d document id(s) missing "
+                            "only because their lifecycle projection is still in "
+                            "flight, not failing: %s",
+                            len(in_flight),
+                            sorted(in_flight)[:10],
+                        )
+                    if stale_missing_cleared:
+                        logger.warning(
+                            "stored chunk budget check: stale missing document ids "
+                            "cleared after lifecycle projection completion: %s",
+                            stale_missing_cleared[:10],
+                        )
                 else:
                     # Name the violators. The check already collects chunk_id
                     # and document_id per violation, but this site used to drop

--- a/kb/lifecycle.py
+++ b/kb/lifecycle.py
@@ -1486,32 +1486,44 @@ class LifecycleStore:
             ).fetchall()
         return tuple(str(row[0]) for row in rows)
 
-    def active_projection_source_revision_ids(
-        self, source_revision_ids: list[str]
-    ) -> set[str]:
-        """Which of these revision ids still have a projection in flight.
-
-        A drain-projected document's cognee ``Data.id`` IS its lifecycle
-        ``source_revision_id`` (the projection worker passes it as
-        ``data_id``), so the stored-chunk census can ask directly whether a
-        document whose chunks it could not find is simply not projected yet
-        (#286). In flight means job state 'pending' or 'running' — a retrying
-        job is a 'pending' row with attempt > 0. 'failed', 'stale', and
-        'completed' rows are NOT in flight: chunks absent for those are a real
-        gap and must stay fatal.
-        """
+    def projection_source_revision_states(
+        self,
+        source_revision_ids: list[str],
+        *,
+        generation_id: str,
+        projection_version: str,
+        config_digest: str,
+    ) -> tuple[set[str], set[str]]:
+        """Partition revisions into active and completed-searchable projections."""
         candidates = sorted({str(value) for value in source_revision_ids if value})
         if not candidates:
-            return set()
+            return set(), set()
         placeholders = ",".join("?" for _ in candidates)
         with self._connect() as connection:
             rows = connection.execute(
-                "SELECT DISTINCT source_revision_id FROM projection_jobs "
-                "WHERE state IN ('pending', 'running') "
-                f"AND source_revision_id IN ({placeholders})",
-                candidates,
+                "SELECT job.source_revision_id, job.state, "
+                "MAX(CASE WHEN receipt.backend = 'vector' "
+                "AND receipt.state = 'searchable' THEN 1 ELSE 0 END) "
+                "AS vector_searchable "
+                "FROM projection_jobs AS job "
+                "LEFT JOIN projection_receipts AS receipt "
+                "ON receipt.projection_job_id = job.projection_job_id "
+                "WHERE job.generation_id = ? "
+                "AND job.projection_version = ? "
+                "AND job.config_digest = ? "
+                f"AND job.source_revision_id IN ({placeholders}) "
+                "GROUP BY job.source_revision_id, job.state",
+                (generation_id, projection_version, config_digest, *candidates),
             ).fetchall()
-        return {str(row[0]) for row in rows}
+        active: set[str] = set()
+        completed_searchable: set[str] = set()
+        for row in rows:
+            source_revision_id = str(row["source_revision_id"])
+            if row["state"] in {"pending", "running"}:
+                active.add(source_revision_id)
+            elif row["state"] == "completed" and bool(row["vector_searchable"]):
+                completed_searchable.add(source_revision_id)
+        return active, completed_searchable
 
     def claim_next_job(
         self,

--- a/kb/lifecycle.py
+++ b/kb/lifecycle.py
@@ -1486,6 +1486,33 @@ class LifecycleStore:
             ).fetchall()
         return tuple(str(row[0]) for row in rows)
 
+    def active_projection_source_revision_ids(
+        self, source_revision_ids: list[str]
+    ) -> set[str]:
+        """Which of these revision ids still have a projection in flight.
+
+        A drain-projected document's cognee ``Data.id`` IS its lifecycle
+        ``source_revision_id`` (the projection worker passes it as
+        ``data_id``), so the stored-chunk census can ask directly whether a
+        document whose chunks it could not find is simply not projected yet
+        (#286). In flight means job state 'pending' or 'running' — a retrying
+        job is a 'pending' row with attempt > 0. 'failed', 'stale', and
+        'completed' rows are NOT in flight: chunks absent for those are a real
+        gap and must stay fatal.
+        """
+        candidates = sorted({str(value) for value in source_revision_ids if value})
+        if not candidates:
+            return set()
+        placeholders = ",".join("?" for _ in candidates)
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT DISTINCT source_revision_id FROM projection_jobs "
+                "WHERE state IN ('pending', 'running') "
+                f"AND source_revision_id IN ({placeholders})",
+                candidates,
+            ).fetchall()
+        return {str(row[0]) for row in rows}
+
     def claim_next_job(
         self,
         *,

--- a/kb/service.py
+++ b/kb/service.py
@@ -97,13 +97,23 @@ class Citadel:
             self.lifecycle_store = LifecycleStore(self.config.lifecycle_store_path)
             lifecycle_projection = self._lifecycle_projection_request()
             self.lifecycle_store.assert_generation_binding(lifecycle_projection)
-            # Let the post-cognify stored check distinguish "chunks not written
-            # YET" (projection pending/running) from a real gap (#286) — the
-            # drain-projected document's cognee Data.id is its
-            # source_revision_id, so the store can answer by id.
+            # Let the post-cognify stored check distinguish active projections,
+            # completed-searchable projections, and real gaps (#286). Scope the
+            # state snapshot to the same generation and projection contract.
+            def lifecycle_projection_state_lookup(
+                source_revision_ids: list[str],
+            ) -> tuple[set[str], set[str]]:
+                assert self.lifecycle_store is not None
+                return self.lifecycle_store.projection_source_revision_states(
+                    source_revision_ids,
+                    generation_id=lifecycle_projection.generation_id,
+                    projection_version=lifecycle_projection.projection_version,
+                    config_digest=lifecycle_projection.config_digest,
+                )
+
             try:
-                self.cognee.lifecycle_active_projection_lookup = (
-                    self.lifecycle_store.active_projection_source_revision_ids
+                self.cognee.lifecycle_projection_state_lookup = (
+                    lifecycle_projection_state_lookup
                 )
             except AttributeError:
                 # A gateway that rejects attribute injection (bare/slotted test

--- a/kb/service.py
+++ b/kb/service.py
@@ -97,6 +97,18 @@ class Citadel:
             self.lifecycle_store = LifecycleStore(self.config.lifecycle_store_path)
             lifecycle_projection = self._lifecycle_projection_request()
             self.lifecycle_store.assert_generation_binding(lifecycle_projection)
+            # Let the post-cognify stored check distinguish "chunks not written
+            # YET" (projection pending/running) from a real gap (#286) — the
+            # drain-projected document's cognee Data.id is its
+            # source_revision_id, so the store can answer by id.
+            try:
+                self.cognee.lifecycle_active_projection_lookup = (
+                    self.lifecycle_store.active_projection_source_revision_ids
+                )
+            except AttributeError:
+                # A gateway that rejects attribute injection (bare/slotted test
+                # doubles) simply keeps the fully fail-closed check.
+                pass
             self.lifecycle_worker = LifecycleProjectionWorker(
                 self.lifecycle_store,
                 self.cognee,

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -4806,16 +4806,27 @@ async def test_get_document_summary_chunk_scope_serves_summary_text(
 # ---- stored check vs the lifecycle drain (#286) -------------------------------
 
 
-def _cognify_fakes(monkeypatch: Any, *, missing: list[str], violations: int) -> Any:
+def _cognify_fakes(
+    monkeypatch: Any,
+    *,
+    missing: list[str],
+    violations: int,
+    processed_by_dataset: dict[str, list[str]] | None = None,
+) -> Any:
     """Client whose cognify receipt swept one doc and whose census reports it."""
     monkeypatch.setenv("LLM_API_KEY", "test-key")
-    run = SimpleNamespace(data_ingestion_info=[{"data_id": doc} for doc in missing])
+    processed = processed_by_dataset or {"dataset-id": missing}
 
     async def run_migrations() -> None:
         return None
 
     async def cognify(**_: Any) -> dict[str, Any]:
-        return {"dataset-id": run}
+        return {
+            dataset: SimpleNamespace(
+                data_ingestion_info=[{"data_id": doc} for doc in document_ids]
+            )
+            for dataset, document_ids in processed.items()
+        }
 
     monkeypatch.setitem(
         sys.modules,
@@ -4861,11 +4872,11 @@ async def test_cognify_missing_docs_with_active_projection_do_not_fail(
     client = _cognify_fakes(monkeypatch, missing=[live_id], violations=0)
     looked_up: list[list[str]] = []
 
-    def lookup(document_ids: list[str]) -> set[str]:
+    def lookup(document_ids: list[str]) -> tuple[set[str], set[str]]:
         looked_up.append(list(document_ids))
-        return {live_id}
+        return {live_id}, set()
 
-    client.lifecycle_active_projection_lookup = lookup
+    client.lifecycle_projection_state_lookup = lookup
 
     with caplog.at_level("WARNING"):
         await client.cognify(datasets=["notes"])  # must not raise
@@ -4886,12 +4897,58 @@ async def test_cognify_missing_docs_without_active_job_still_fail(
     """Fail-closed for real gaps: a missing id with NO pending/running job is
     exactly as fatal as before the partition existed."""
     client = _cognify_fakes(monkeypatch, missing=["doc-gone"], violations=0)
-    client.lifecycle_active_projection_lookup = lambda document_ids: set()
+    client.lifecycle_projection_state_lookup = lambda document_ids: (set(), set())
 
     with pytest.raises(RuntimeError) as excinfo:
         await client.cognify(datasets=["notes"])
 
     assert "doc-gone" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_cognify_rechecks_missing_doc_after_projection_completes(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """A completed job can make the first census stale before its state lookup."""
+    live_id = "4552e276-e329-5dbf-9d45-d029160d82f4"
+    client = _cognify_fakes(
+        monkeypatch,
+        missing=[live_id],
+        violations=0,
+        processed_by_dataset={"notes": [live_id], "other": ["other-id"]},
+    )
+    first_check = client.stored_chunk_budget_check
+    checks: list[dict[str, Any]] = []
+
+    async def completing_check(**kwargs: Any) -> dict[str, Any]:
+        checks.append(kwargs)
+        result = await first_check(**kwargs)
+        if len(checks) == 2:
+            return {
+                **result,
+                "ok": True,
+                "chunks_scanned": 1,
+                "missing_document_ids": [],
+            }
+        return result
+
+    monkeypatch.setattr(client, "stored_chunk_budget_check", completing_check)
+    client.lifecycle_projection_state_lookup = lambda document_ids: (
+        set(),
+        {live_id},
+    )
+
+    with caplog.at_level("WARNING"):
+        await client.cognify(datasets=["notes", "other"])
+
+    assert len(checks) == 2
+    assert checks[1]["document_ids"] == [live_id]
+    assert checks[1]["datasets"] == ["notes"]
+    assert checks[1]["document_ids_by_dataset"] == {"notes": [live_id]}
+    assert any(
+        "cleared after lifecycle projection completion" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -4901,7 +4958,10 @@ async def test_cognify_violations_fail_even_when_missing_ids_are_in_flight(
     """A budget violation is fatal regardless of drain state; the message
     still notes the in-flight ids so the operator sees both facts."""
     client = _cognify_fakes(monkeypatch, missing=["doc-pending"], violations=1)
-    client.lifecycle_active_projection_lookup = lambda document_ids: {"doc-pending"}
+    client.lifecycle_projection_state_lookup = lambda document_ids: (
+        {"doc-pending"},
+        set(),
+    )
 
     with pytest.raises(RuntimeError) as excinfo:
         await client.cognify(datasets=["notes"])

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -4801,3 +4801,111 @@ async def test_get_document_summary_chunk_scope_serves_summary_text(
     assert document is not None
     assert document["body"] == "a summary"
     assert "doc-1" in document["dataset_node_ids"]
+
+
+# ---- stored check vs the lifecycle drain (#286) -------------------------------
+
+
+def _cognify_fakes(monkeypatch: Any, *, missing: list[str], violations: int) -> Any:
+    """Client whose cognify receipt swept one doc and whose census reports it."""
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    run = SimpleNamespace(data_ingestion_info=[{"data_id": doc} for doc in missing])
+
+    async def run_migrations() -> None:
+        return None
+
+    async def cognify(**_: Any) -> dict[str, Any]:
+        return {"dataset-id": run}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee",
+        SimpleNamespace(run_migrations=run_migrations, cognify=cognify),
+    )
+    client = CogneePublicClient()
+
+    async def stored_chunk_budget_check(**_: Any) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "violation_count": violations,
+            "chunks_scanned": 2094,
+            "budget": 256,
+            "violations": (
+                [
+                    {
+                        "reason": "chunk_over_budget",
+                        "chunk_id": "chunk-1",
+                        "document_id": "doc-oversized",
+                        "measured_tokens": 999,
+                    }
+                ]
+                if violations
+                else []
+            ),
+            "missing_document_ids": list(missing),
+        }
+
+    monkeypatch.setattr(client, "stored_chunk_budget_check", stored_chunk_budget_check)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_cognify_missing_docs_with_active_projection_do_not_fail(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """The live 18:02Z failure (#286): zero violations, one missing id whose
+    lifecycle projection was still pending. Phase-2 incremental cognify sweeps
+    in-flight docs into its receipt while the drain still owns their chunk
+    writes — in-flight is not a gap, so the check must warn, not raise."""
+    live_id = "4552e276-e329-5dbf-9d45-d029160d82f4"
+    client = _cognify_fakes(monkeypatch, missing=[live_id], violations=0)
+    looked_up: list[list[str]] = []
+
+    def lookup(document_ids: list[str]) -> set[str]:
+        looked_up.append(list(document_ids))
+        return {live_id}
+
+    client.lifecycle_active_projection_lookup = lookup
+
+    with caplog.at_level("WARNING"):
+        await client.cognify(datasets=["notes"])  # must not raise
+
+    assert looked_up == [[live_id]]
+    warning = next(
+        record.getMessage()
+        for record in caplog.records
+        if "in flight" in record.getMessage()
+    )
+    assert live_id in warning  # the ids are named, not just counted
+
+
+@pytest.mark.asyncio
+async def test_cognify_missing_docs_without_active_job_still_fail(
+    monkeypatch: Any,
+) -> None:
+    """Fail-closed for real gaps: a missing id with NO pending/running job is
+    exactly as fatal as before the partition existed."""
+    client = _cognify_fakes(monkeypatch, missing=["doc-gone"], violations=0)
+    client.lifecycle_active_projection_lookup = lambda document_ids: set()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await client.cognify(datasets=["notes"])
+
+    assert "doc-gone" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_cognify_violations_fail_even_when_missing_ids_are_in_flight(
+    monkeypatch: Any,
+) -> None:
+    """A budget violation is fatal regardless of drain state; the message
+    still notes the in-flight ids so the operator sees both facts."""
+    client = _cognify_fakes(monkeypatch, missing=["doc-pending"], violations=1)
+    client.lifecycle_active_projection_lookup = lambda document_ids: {"doc-pending"}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await client.cognify(datasets=["notes"])
+
+    message = str(excinfo.value)
+    assert "doc-oversized" in message
+    assert "still in lifecycle projection" in message

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1092,13 +1092,23 @@ def test_requeue_failed_projections_ignores_healthy_jobs(tmp_path: Path) -> None
     assert store.requeue_failed_projections(now=T0) == 0
 
 
-def test_active_projection_source_revision_ids_tracks_in_flight_jobs(
+def test_projection_source_revision_states_tracks_active_and_completed_jobs(
     tmp_path: Path,
 ) -> None:
     # The stored-chunk census resolves missing cognee document ids against
-    # this read (#286): a pending/running projection means "not written YET",
-    # a completed one means a real gap.
+    # this read (#286): a pending/running projection means "not written YET";
+    # a completed-searchable one gets one exact census recheck before failure.
     store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="cognee-1.4.1-qdrant-v1",
+        config_digest="sha256:config-1",
+        providers={
+            "relational": "sqlite",
+            "vector": "qdrant",
+            "graph": "ladybug",
+        },
+    )
     accepted = store.accept_source(
         b"in-flight lookup",
         capture=CaptureContext(
@@ -1110,31 +1120,42 @@ def test_active_projection_source_revision_ids_tracks_in_flight_jobs(
             capture_run_id="run-in-flight",
             captured_at=T0,
         ),
-        projection=ProjectionRequest(
-            generation_id="generation-1",
-            projection_version="cognee-1.4.1-qdrant-v1",
-            config_digest="sha256:config-1",
-            providers={
-                "relational": "sqlite",
-                "vector": "qdrant",
-                "graph": "ladybug",
-            },
-        ),
+        projection=projection,
         now=T0,
     )
     revision_id = accepted.source_revision_id
 
     # Pending job: in flight. Unknown ids and empty input never match.
-    assert store.active_projection_source_revision_ids([revision_id]) == {revision_id}
-    assert store.active_projection_source_revision_ids(["no-such-id"]) == set()
-    assert store.active_projection_source_revision_ids([]) == set()
+    lookup_kwargs = {
+        "generation_id": projection.generation_id,
+        "projection_version": projection.projection_version,
+        "config_digest": projection.config_digest,
+    }
+    assert store.projection_source_revision_states(
+        [revision_id], **lookup_kwargs
+    ) == ({revision_id}, set())
+    assert store.projection_source_revision_states(
+        ["no-such-id"], **lookup_kwargs
+    ) == (set(), set())
+    assert store.projection_source_revision_states([], **lookup_kwargs) == (
+        set(),
+        set(),
+    )
+    assert store.projection_source_revision_states(
+        [revision_id],
+        generation_id="other-generation",
+        projection_version=projection.projection_version,
+        config_digest=projection.config_digest,
+    ) == (set(), set())
 
-    # Drive the job to completed through the real choreography: no longer
-    # in flight — absent chunks for it are a real gap again (fail-closed).
+    # Drive the job to completed-searchable through the real choreography.
+    # The caller may recheck a stale census once; a still-missing id is fatal.
     lease = store.claim_next_job(worker_id="worker-1", now=T0, lease_seconds=30)
     assert lease is not None
     for backend in ("relational", "vector", "graph"):
         store.begin_backend(lease, backend, now=T0)
         store.complete_backend(lease, backend, affected_count=1, now=T0)
         store.mark_backend_searchable(lease, backend, now=T0)
-    assert store.active_projection_source_revision_ids([revision_id]) == set()
+    assert store.projection_source_revision_states(
+        [revision_id], **lookup_kwargs
+    ) == (set(), {revision_id})

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1090,3 +1090,51 @@ def test_requeue_failed_projections_ignores_healthy_jobs(tmp_path: Path) -> None
     )
     store.accept_source(b"leave me queued", capture=capture, projection=projection, now=T0)
     assert store.requeue_failed_projections(now=T0) == 0
+
+
+def test_active_projection_source_revision_ids_tracks_in_flight_jobs(
+    tmp_path: Path,
+) -> None:
+    # The stored-chunk census resolves missing cognee document ids against
+    # this read (#286): a pending/running projection means "not written YET",
+    # a completed one means a real gap.
+    store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
+    accepted = store.accept_source(
+        b"in-flight lookup",
+        capture=CaptureContext(
+            dataset="seat:alice",
+            source_key="manual:in-flight",
+            source_locator=None,
+            media_type="text/plain",
+            capture_actor_id="alice",
+            capture_run_id="run-in-flight",
+            captured_at=T0,
+        ),
+        projection=ProjectionRequest(
+            generation_id="generation-1",
+            projection_version="cognee-1.4.1-qdrant-v1",
+            config_digest="sha256:config-1",
+            providers={
+                "relational": "sqlite",
+                "vector": "qdrant",
+                "graph": "ladybug",
+            },
+        ),
+        now=T0,
+    )
+    revision_id = accepted.source_revision_id
+
+    # Pending job: in flight. Unknown ids and empty input never match.
+    assert store.active_projection_source_revision_ids([revision_id]) == {revision_id}
+    assert store.active_projection_source_revision_ids(["no-such-id"]) == set()
+    assert store.active_projection_source_revision_ids([]) == set()
+
+    # Drive the job to completed through the real choreography: no longer
+    # in flight — absent chunks for it are a real gap again (fail-closed).
+    lease = store.claim_next_job(worker_id="worker-1", now=T0, lease_seconds=30)
+    assert lease is not None
+    for backend in ("relational", "vector", "graph"):
+        store.begin_backend(lease, backend, now=T0)
+        store.complete_backend(lease, backend, affected_count=1, now=T0)
+        store.mark_backend_searchable(lease, backend, now=T0)
+    assert store.active_projection_source_revision_ids([revision_id]) == set()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2995,3 +2995,25 @@ async def test_every_rejection_line_in_ingest_escapes_the_dataset_name(
     for message in messages:
         assert "\n" not in message, "a caller-supplied value opened a new log line"
         assert "\\n" in message, "the value must survive the escaping, not be deleted"
+
+
+def test_lifecycle_wires_the_in_flight_lookup_into_cognee(tmp_path) -> None:
+    # The post-cognify stored check partitions missing document ids by
+    # projection state through this hook (#286). Unwired (lifecycle off) it
+    # stays None and the check remains fully fail-closed.
+    fake = FakeCognee()
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=fake,
+    )
+    assert kb.lifecycle_store is not None
+    assert (
+        fake.lifecycle_active_projection_lookup
+        == kb.lifecycle_store.active_projection_source_revision_ids
+    )
+
+    unwired = Citadel(CitadelConfig(lifecycle_enabled=False), cognee=FakeCognee())
+    assert getattr(unwired.cognee, "lifecycle_active_projection_lookup", None) is None

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2997,10 +2997,13 @@ async def test_every_rejection_line_in_ingest_escapes_the_dataset_name(
         assert "\\n" in message, "the value must survive the escaping, not be deleted"
 
 
-def test_lifecycle_wires_the_in_flight_lookup_into_cognee(tmp_path) -> None:
+def test_lifecycle_wires_projection_state_lookup_into_cognee(
+    tmp_path, monkeypatch
+) -> None:
     # The post-cognify stored check partitions missing document ids by
-    # projection state through this hook (#286). Unwired (lifecycle off) it
-    # stays None and the check remains fully fail-closed.
+    # projection state through this hook (#286). The closure must preserve the
+    # configured generation and projection contract. Unwired (lifecycle off)
+    # it stays None and the check remains fully fail-closed.
     fake = FakeCognee()
     kb = Citadel(
         CitadelConfig(
@@ -3010,10 +3013,29 @@ def test_lifecycle_wires_the_in_flight_lookup_into_cognee(tmp_path) -> None:
         cognee=fake,
     )
     assert kb.lifecycle_store is not None
-    assert (
-        fake.lifecycle_active_projection_lookup
-        == kb.lifecycle_store.active_projection_source_revision_ids
+    captured: dict[str, Any] = {}
+
+    def state_lookup(
+        source_revision_ids: list[str], **scope: str
+    ) -> tuple[set[str], set[str]]:
+        captured.update(scope)
+        return set(source_revision_ids), set()
+
+    monkeypatch.setattr(
+        kb.lifecycle_store,
+        "projection_source_revision_states",
+        state_lookup,
     )
+    projection = kb._lifecycle_projection_request()
+    assert fake.lifecycle_projection_state_lookup(["revision-1"]) == (
+        {"revision-1"},
+        set(),
+    )
+    assert captured == {
+        "generation_id": projection.generation_id,
+        "projection_version": projection.projection_version,
+        "config_digest": projection.config_digest,
+    }
 
     unwired = Citadel(CitadelConfig(lifecycle_enabled=False), cognee=FakeCognee())
-    assert getattr(unwired.cognee, "lifecycle_active_projection_lookup", None) is None
+    assert getattr(unwired.cognee, "lifecycle_projection_state_lookup", None) is None


### PR DESCRIPTION
Refs #286.

The 18:02Z evolve pass stamped the canary red with zero budget violations: the stored check's missing-document condition fired for a freshly-synced document whose lifecycle projection was still draining (census at that moment: 5 pending, 1 running). Phase 2's incremental cognify sweeps in-flight documents into the check scope, and the check counted their legitimately-absent chunks as missing — the check racing the drain, the same design family as #273 one layer deeper.

One commit. The partition lives in cognify's post-check interpreter, deliberately not in the census, so the census stays a pure store measurement for the canary and repair paths. A new `LifecycleStore.active_projection_source_revision_ids` answers which missing ids have a pending or running job (retrying jobs are pending rows, covered); the identity that makes the lookup valid — a drain-projected document's cognee `Data.id` is its `source_revision_id` — was already pinned by an existing test on the remember call. Missing-with-active-job and zero violations now logs a warning naming the ids and does not raise; missing-with-no-job raises exactly as before; violations raise regardless, with the in-flight count appended. The lookup is advisory and fails closed: unwired, mistyped, or erroring, all missing ids stay fatal, and the wiring test asserts strict equality with the real store method so a silent no-op cannot ship.

Review: SHIP after one round — the identity guard verified as two independently-produced live values, an over-forgiveness mutation caught by the store test's unknown-id assertion, the lookup verified to run after the writer lock releases (the census's own pre-existing pattern), and the revert-proof reproducing the 18:02Z failure verbatim on pre-fix sources. Gate: 2179 passed, 1 skipped, the one pre-existing stock-wheel failure. Ruff clean.
