### PR TITLE
feat(graph): add node search

### DIFF
--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -197,6 +197,11 @@ const conflictFilterButtons = Array.from(document.querySelectorAll("[data-confli
 const graphModeButtons = Array.from(document.querySelectorAll("[data-graph-mode]"));
 const graphAggregateButton = document.getElementById("graphAggregateButton");
 const graphDatasetFilter = document.getElementById("graphDatasetFilter");
+const graphNodeSearch = document.getElementById("graphNodeSearch");
+const graphNodeSearchInput = document.getElementById("graphNodeSearchInput");
+const graphNodeSearchResults = document.getElementById("graphNodeSearchResults");
+const graphViewMenu = document.getElementById("graphViewMenu");
+const graphViewLabel = document.getElementById("graphViewLabel");
 const realGraphEmpty = document.getElementById("realGraphEmpty");
 const graphLegend = document.getElementById("graphLegend");
 const toastStack = document.getElementById("toastStack");
@@ -275,6 +280,8 @@ const graph = {
   highlightLinks: new Set(),
   hoverId: null,
 };
+let graphNodeMatches = [];
+let graphNodeMatchIndex = -1;
 
 // Shared Central dataset (config.github_sync_dataset / access.CENTRAL_DATASET).
 const CENTRAL_DATASET = "masumi-network";
@@ -1977,6 +1984,7 @@ function renderGraph() {
   });
 
   graph.instance.graphData({ nodes: data.nodes, links: data.links });
+  renderGraphNodeSearchResults();
   graph.instance.centerAt(0, 0);
   // Arm a settle-fit for this data set (handled by onEngineStop); keep a single
   // coarse early fit on first paint as a fallback if the engine never stops.
@@ -2325,6 +2333,164 @@ function focusGraphNode(nodeId) {
   }
 }
 
+function renderedGraphNodes() {
+  if (!graph.instance || typeof graph.instance.graphData !== "function") return [];
+  const nodes = graph.instance.graphData()?.nodes;
+  return Array.isArray(nodes) ? nodes : [];
+}
+
+function matchingGraphNodes(query) {
+  const normalized = String(query || "").trim().toLowerCase();
+  if (!normalized) return [];
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  return renderedGraphNodes()
+    .map((node) => {
+      const label = String(node.label || node.id || "");
+      const id = String(node.id || "");
+      const type = String(node.type || "");
+      const dataset = String(node.metadata?.dataset || "");
+      const searchable = `${label} ${id} ${type} ${dataset}`.toLowerCase();
+      if (!tokens.every((token) => searchable.includes(token))) return null;
+      const lowerLabel = label.toLowerCase();
+      const rank =
+        lowerLabel === normalized
+          ? 0
+          : lowerLabel.startsWith(normalized)
+            ? 1
+            : lowerLabel.includes(normalized)
+              ? 2
+              : 3;
+      return { node, label, rank };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.rank - right.rank || left.label.localeCompare(right.label))
+    .slice(0, 8)
+    .map((match) => match.node);
+}
+
+function closeGraphNodeSearchResults() {
+  if (!graphNodeSearchInput || !graphNodeSearchResults) return;
+  graphNodeSearchResults.hidden = true;
+  graphNodeSearchInput.setAttribute("aria-expanded", "false");
+  graphNodeSearchInput.removeAttribute("aria-activedescendant");
+  graphNodeMatchIndex = -1;
+}
+
+function setGraphNodeMatchIndex(index) {
+  if (!graphNodeSearchInput || !graphNodeSearchResults || !graphNodeMatches.length) return;
+  graphNodeMatchIndex = (index + graphNodeMatches.length) % graphNodeMatches.length;
+  const options = Array.from(graphNodeSearchResults.querySelectorAll("[role='option']"));
+  options.forEach((option, optionIndex) => {
+    const active = optionIndex === graphNodeMatchIndex;
+    option.classList.toggle("active", active);
+    option.setAttribute("aria-selected", active ? "true" : "false");
+  });
+  const activeOption = options[graphNodeMatchIndex];
+  if (!activeOption) return;
+  graphNodeSearchInput.setAttribute("aria-activedescendant", activeOption.id);
+  activeOption.scrollIntoView({ block: "nearest" });
+}
+
+function chooseGraphNodeMatch(node) {
+  if (!node || !graphNodeSearchInput) return;
+  graphNodeSearchInput.value = String(node.label || node.id || "");
+  closeGraphNodeSearchResults();
+  handleNodeHover(null);
+  handleNodeClick(node);
+}
+
+function renderGraphNodeSearchResults() {
+  if (!graphNodeSearchInput || !graphNodeSearchResults) return;
+  const query = graphNodeSearchInput.value.trim();
+  graphNodeSearchResults.innerHTML = "";
+  if (!query) {
+    graphNodeMatches = [];
+    closeGraphNodeSearchResults();
+    return;
+  }
+
+  graphNodeMatches = matchingGraphNodes(query);
+  graphNodeMatchIndex = graphNodeMatches.length ? 0 : -1;
+  if (!graphNodeMatches.length) {
+    const empty = document.createElement("div");
+    empty.className = "graph-node-search-empty";
+    empty.setAttribute("role", "option");
+    empty.setAttribute("aria-disabled", "true");
+    empty.textContent = "No nodes match this view.";
+    graphNodeSearchResults.append(empty);
+  } else {
+    graphNodeMatches.forEach((node, index) => {
+      const option = document.createElement("button");
+      option.id = `graph-node-search-result-${index}`;
+      option.type = "button";
+      option.className = `graph-node-search-result${index === 0 ? " active" : ""}`;
+      option.setAttribute("role", "option");
+      option.setAttribute("aria-selected", index === 0 ? "true" : "false");
+      option.title = String(node.id || "");
+      const label = document.createElement("strong");
+      label.textContent = String(node.label || node.id || "Unnamed node");
+      const meta = document.createElement("span");
+      const kind = nodeKind(node);
+      const dataset = String(node.metadata?.dataset || "");
+      meta.textContent = dataset ? `${kind} / ${dataset}` : kind;
+      option.append(label, meta);
+      option.addEventListener("click", () => chooseGraphNodeMatch(node));
+      graphNodeSearchResults.append(option);
+    });
+  }
+  graphNodeSearchResults.hidden = false;
+  graphNodeSearchInput.setAttribute("aria-expanded", "true");
+  if (graphNodeMatches.length) {
+    graphNodeSearchInput.setAttribute("aria-activedescendant", "graph-node-search-result-0");
+  }
+}
+
+function clearGraphNodeSearch() {
+  if (!graphNodeSearchInput) return;
+  graphNodeSearchInput.value = "";
+  graphNodeMatches = [];
+  closeGraphNodeSearchResults();
+}
+
+function closeGraphViewMenu() {
+  if (graphViewMenu) graphViewMenu.open = false;
+}
+
+function initializeGraphNodeSearch() {
+  if (!graphNodeSearch || !graphNodeSearchInput || !graphNodeSearchResults) return;
+  graphNodeSearchInput.addEventListener("input", renderGraphNodeSearchResults);
+  graphNodeSearchInput.addEventListener("focus", () => {
+    if (graphNodeSearchInput.value.trim()) renderGraphNodeSearchResults();
+  });
+  graphNodeSearchInput.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown" && graphNodeMatches.length) {
+      event.preventDefault();
+      setGraphNodeMatchIndex(graphNodeMatchIndex + 1);
+    } else if (event.key === "ArrowUp" && graphNodeMatches.length) {
+      event.preventDefault();
+      setGraphNodeMatchIndex(graphNodeMatchIndex - 1);
+    } else if (event.key === "Enter" && graphNodeMatchIndex >= 0) {
+      event.preventDefault();
+      chooseGraphNodeMatch(graphNodeMatches[graphNodeMatchIndex]);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeGraphNodeSearchResults();
+    }
+  });
+  graphNodeSearch.addEventListener("focusout", (event) => {
+    if (!graphNodeSearch.contains(event.relatedTarget)) closeGraphNodeSearchResults();
+  });
+  document.addEventListener("pointerdown", (event) => {
+    if (!graphNodeSearch.contains(event.target)) closeGraphNodeSearchResults();
+    if (graphViewMenu?.open && !graphViewMenu.contains(event.target)) closeGraphViewMenu();
+  });
+  graphViewMenu?.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    closeGraphViewMenu();
+    graphViewMenu.querySelector("summary")?.focus();
+  });
+}
+
 // Fetch and render stored document text for a knowledge-graph node into the
 // inspector panel. Entity nodes fall through to one-hop document-bearing
 // neighbors, while a 404 remains a quiet empty state.
@@ -2575,6 +2741,7 @@ function toggleGraphKind(kind) {
 
 function setGraphAggregate(enabled) {
   state.graphAggregate = Boolean(enabled);
+  clearGraphNodeSearch();
   if (graphAggregateButton) {
     graphAggregateButton.classList.toggle("active", state.graphAggregate);
     graphAggregateButton.setAttribute(
@@ -2769,6 +2936,10 @@ async function loadKnowledgeGraph(force = false) {
 function setGraphMode(mode) {
   if (state.graphMode === mode) return;
   state.graphMode = mode;
+  clearGraphNodeSearch();
+  if (graphViewLabel) {
+    graphViewLabel.textContent = mode === "knowledge" ? "Knowledge Mesh" : "Vault Activity";
+  }
   graph.viewInitialized = false;
   graphModeButtons.forEach((button) => {
     const active = button.dataset.graphMode === mode;
@@ -4273,12 +4444,14 @@ document.getElementById("logoutButton").addEventListener("click", async () => {
 document.getElementById("meshRetryButton").addEventListener("click", () => loadMesh());
 document.getElementById("fitButton").addEventListener("click", () => {
   resetGraphView();
+  closeGraphViewMenu();
 });
 document.getElementById("pauseButton").addEventListener("click", (event) => {
   state.paused = !state.paused;
-  event.currentTarget.textContent = state.paused ? "Resume" : "Pause";
+  event.currentTarget.textContent = state.paused ? "Resume motion" : "Pause motion";
   canvas.classList.toggle("is-paused", state.paused);
   setGraphPaused(state.paused);
+  closeGraphViewMenu();
 });
 
 auditFilterButtons.forEach((button) => {
@@ -4296,21 +4469,27 @@ conflictFilterButtons.forEach((button) => {
 });
 
 graphModeButtons.forEach((button) => {
-  button.addEventListener("click", () => setGraphMode(button.dataset.graphMode || "live"));
+  button.addEventListener("click", () => {
+    setGraphMode(button.dataset.graphMode || "live");
+    closeGraphViewMenu();
+  });
 });
 
 if (graphAggregateButton) {
   graphAggregateButton.addEventListener("click", () => {
     setGraphAggregate(!state.graphAggregate);
+    closeGraphViewMenu();
   });
 }
 
 if (graphDatasetFilter) {
   graphDatasetFilter.addEventListener("change", (event) => {
     state.graphDataset = String(event.currentTarget.value || "");
+    clearGraphNodeSearch();
     // The filter changes what the SERVER returns, so refetch rather than
     // re-shape the cached org-wide payload.
     loadKnowledgeGraph(true);
+    closeGraphViewMenu();
   });
 }
 
@@ -5103,6 +5282,7 @@ function initializeReviewControls() {
 initializeGraph();
 resizeCanvas();
 initializeThemeToggle();
+initializeGraphNodeSearch();
 initializeSearchFilters();
 initializeHomeSearch();
 initializeReviewControls();

--- a/kb/static/index.html
+++ b/kb/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Citadel Archive</title>
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="/static/styles.css?v=light-1" />
+    <link rel="stylesheet" href="/static/styles.css?v=graph-search-1" />
   </head>
   <body>
     <div class="app-frame">
@@ -430,52 +430,103 @@
                  width here rather than inside .knowledge-grid, which is two-column. -->
               <section id="mesh" class="graph-panel window" aria-labelledby="graphTitle">
                 <div class="window-titlebar graph-toolbar">
-                  <div>
+                  <div class="graph-toolbar-copy">
                     <p class="eyebrow">Linked memory</p>
                     <h2 id="graphTitle">Vault graph</h2>
                     <p id="graphMeta">Waiting for snapshot</p>
                   </div>
-                  <div class="toolbar-actions">
-                    <div class="segmented-control graph-mode" role="group" aria-label="Graph data source">
-                      <button
-                        class="segment-button"
-                        type="button"
-                        data-graph-mode="live"
-                        aria-pressed="false"
-                        title="Vault Activity: what the vault is doing right now — syncs, searches, ingests"
-                      >
-                        Vault Activity
-                      </button>
-                      <button
-                        class="segment-button active"
-                        type="button"
-                        data-graph-mode="knowledge"
-                        aria-pressed="true"
-                        title="Knowledge Mesh: what the vault knows — documents, entities, and the seats they come from"
-                      >
-                        Knowledge Mesh
-                      </button>
-                    </div>
-                    <select
-                      id="graphDatasetFilter"
-                      class="secondary-button compact-button"
-                      aria-label="Filter Knowledge Mesh by dataset"
-                      title="Show only one dataset's nodes (server-filtered); All datasets restores the org view"
-                    >
-                      <option value="">All datasets</option>
-                    </select>
-                    <button
-                      id="graphAggregateButton"
-                      class="secondary-button compact-button active"
-                      type="button"
-                      aria-pressed="true"
-                      title="Concept map: documents and chunks fold into hub counts. Click for the raw graph."
-                    >
-                      Aggregate
-                    </button>
-                    <button id="fitButton" class="secondary-button compact-button" type="button">Fit</button>
-                    <button id="pauseButton" class="secondary-button compact-button" type="button">Pause</button>
+                  <div id="graphNodeSearch" class="graph-node-search" role="search">
+                    <svg class="graph-node-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+                      <circle cx="11" cy="11" r="6.5" />
+                      <path d="m16 16 4 4" />
+                    </svg>
+                    <input
+                      id="graphNodeSearchInput"
+                      type="search"
+                      autocomplete="off"
+                      spellcheck="false"
+                      placeholder="Find a node in this view"
+                      aria-label="Find a node in this graph"
+                      aria-controls="graphNodeSearchResults"
+                      aria-expanded="false"
+                      aria-autocomplete="list"
+                      role="combobox"
+                    />
+                    <div
+                      id="graphNodeSearchResults"
+                      class="graph-node-search-results"
+                      role="listbox"
+                      aria-label="Matching graph nodes"
+                      hidden
+                    ></div>
                   </div>
+                  <details id="graphViewMenu" class="graph-view-menu">
+                    <summary class="secondary-button compact-button">
+                      <svg class="graph-view-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true">
+                        <path d="M4 7h10" />
+                        <path d="M18 7h2" />
+                        <path d="M4 17h2" />
+                        <path d="M10 17h10" />
+                        <circle cx="16" cy="7" r="2" />
+                        <circle cx="8" cy="17" r="2" />
+                      </svg>
+                      <span id="graphViewLabel">Knowledge Mesh</span>
+                      <svg class="graph-view-menu-chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                        <path d="m4 6 4 4 4-4" />
+                      </svg>
+                    </summary>
+                    <div class="graph-view-panel">
+                      <div class="graph-view-group">
+                        <span class="graph-view-group-label">Source</span>
+                        <div class="segmented-control graph-mode" role="group" aria-label="Graph data source">
+                          <button
+                            class="segment-button"
+                            type="button"
+                            data-graph-mode="live"
+                            aria-pressed="false"
+                            title="Vault Activity: current syncs, searches, and ingests"
+                          >
+                            Vault Activity
+                          </button>
+                          <button
+                            class="segment-button active"
+                            type="button"
+                            data-graph-mode="knowledge"
+                            aria-pressed="true"
+                            title="Knowledge Mesh: documents, entities, and their source seats"
+                          >
+                            Knowledge Mesh
+                          </button>
+                        </div>
+                      </div>
+                      <label class="graph-view-group graph-view-field" for="graphDatasetFilter">
+                        <span class="graph-view-group-label">Dataset</span>
+                        <select
+                          id="graphDatasetFilter"
+                          aria-label="Filter Knowledge Mesh by dataset"
+                          title="Show one dataset or restore the organization view"
+                        >
+                          <option value="">All datasets</option>
+                        </select>
+                      </label>
+                      <div class="graph-view-group">
+                        <span class="graph-view-group-label">Canvas</span>
+                        <div class="graph-view-actions">
+                          <button
+                            id="graphAggregateButton"
+                            class="secondary-button compact-button active"
+                            type="button"
+                            aria-pressed="true"
+                            title="Concept map: documents and chunks fold into hub counts. Click for the raw graph."
+                          >
+                            Concept map
+                          </button>
+                          <button id="fitButton" class="secondary-button compact-button" type="button">Fit canvas</button>
+                          <button id="pauseButton" class="secondary-button compact-button" type="button">Pause motion</button>
+                        </div>
+                      </div>
+                    </div>
+                  </details>
                 </div>
                 <div id="meshAlert" class="inline-alert" hidden>
                   <div>
@@ -1539,6 +1590,6 @@ args = [
     <div id="toastStack" class="toast-stack" role="status" aria-live="polite"></div>
 
     <script src="/static/vendor/force-graph.min.js"></script>
-    <script src="/static/app.js?v=graph-nav-1"></script>
+    <script src="/static/app.js?v=graph-search-1"></script>
   </body>
 </html>

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -1058,12 +1058,22 @@ pre {
   display: grid;
   grid-template-rows: auto auto minmax(320px, 1fr) auto;
   min-height: 590px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .graph-toolbar {
   grid-row: 1;
+  position: relative;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: minmax(150px, 0.65fr) minmax(280px, 1.45fr) auto;
+  align-items: center;
+  gap: 18px;
   padding: 16px 20px 14px;
+}
+
+.graph-toolbar-copy {
+  min-width: 0;
 }
 
 #meshAlert {
@@ -1096,11 +1106,234 @@ pre {
   padding: 0 10px;
 }
 
-.graph-toolbar .toolbar-actions {
+.graph-node-search {
+  position: relative;
+  min-width: 0;
+}
+
+.graph-node-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 13px;
+  z-index: 1;
+  width: 18px;
+  height: 18px;
+  transform: translateY(-50%);
+  color: var(--quiet);
+  pointer-events: none;
+}
+
+.graph-node-search input {
+  width: 100%;
+  height: 42px;
+  padding: 0 14px 0 41px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  outline: none;
+  background: var(--field);
+  color: var(--text);
+  font: 500 13px/1 var(--sans);
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.graph-node-search input::placeholder {
+  color: var(--quiet);
+}
+
+.graph-node-search input:hover {
+  border-color: var(--border-strong);
+}
+
+.graph-node-search input:focus {
+  border-color: var(--primary);
+  background: var(--surface);
+  box-shadow: 0 0 0 2px var(--primary-soft);
+}
+
+.graph-node-search:focus-within .graph-node-search-icon {
+  color: var(--primary-strong);
+}
+
+.graph-node-search-results {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  left: 0;
+  z-index: 12;
+  max-height: 292px;
+  overflow-y: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.graph-node-search-result {
   display: flex;
-  flex-wrap: wrap;
+  width: 100%;
+  min-height: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border-quiet);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.graph-node-search-result:last-child {
+  border-bottom: 0;
+}
+
+.graph-node-search-result:hover,
+.graph-node-search-result.active {
+  background: var(--primary-soft);
+}
+
+.graph-node-search-result strong {
+  width: 100%;
+  overflow: hidden;
+  font-size: 12.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-node-search-result span {
+  width: 100%;
+  overflow: hidden;
+  color: var(--quiet);
+  font-family: var(--mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-node-search-empty {
+  padding: 14px;
+  color: var(--quiet);
+  font-size: 12px;
+  text-align: center;
+}
+
+.graph-view-menu {
+  position: relative;
+  justify-self: end;
+}
+
+.graph-view-menu > summary {
+  display: inline-flex;
+  min-width: 162px;
+  height: 42px;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+
+.graph-view-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.graph-view-icon {
+  width: 17px;
+  height: 17px;
+  color: var(--quiet);
+}
+
+.graph-view-menu-chevron {
+  width: 14px;
+  height: 14px;
+  transition: transform 150ms ease;
+}
+
+.graph-view-menu[open] .graph-view-menu-chevron {
+  transform: rotate(180deg);
+}
+
+.graph-view-menu[open] > summary {
+  border-color: var(--primary);
+  color: var(--text);
+}
+
+.graph-view-panel {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  z-index: 12;
+  width: min(340px, calc(100vw - 48px));
+  padding: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.graph-view-group {
+  display: block;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-quiet);
+}
+
+.graph-view-group:first-child {
+  padding-top: 0;
+}
+
+.graph-view-group:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.graph-view-group-label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--quiet);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.graph-view-panel .segmented-control {
+  width: 100%;
+}
+
+.graph-view-panel .segment-button {
+  flex: 1;
+}
+
+.graph-view-field select {
+  width: 100%;
+  height: 36px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--field);
+  color: var(--text);
+  font: 500 12px/1 var(--sans);
+}
+
+.graph-view-field select:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.graph-view-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.graph-view-actions button {
+  width: 100%;
+  min-width: 0;
+  padding-right: 8px;
+  padding-left: 8px;
+  white-space: normal;
 }
 
 #graphMeta {
@@ -1146,6 +1379,11 @@ pre {
   margin-top: 4px;
   color: var(--muted);
   font-size: 13px;
+}
+
+#realGraphEmpty {
+  inset: 16px 16px auto auto;
+  transform: none;
 }
 
 .selection {
@@ -2921,6 +3159,53 @@ textarea[aria-invalid="true"] {
   }
 
   .analytics-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .graph-toolbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .graph-node-search {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
+  }
+
+  .graph-view-menu {
+    grid-column: 2;
+    grid-row: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  .graph-toolbar {
+    padding: 14px;
+  }
+
+  .graph-view-menu > summary {
+    min-width: 0;
+    min-height: 44px;
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  .graph-node-search input,
+  .graph-view-panel .segment-button,
+  .graph-view-field select,
+  .graph-view-actions button {
+    min-height: 44px;
+  }
+
+  .graph-view-icon {
+    display: none;
+  }
+
+  .graph-view-actions {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

- VERIFIED: adds client-side node search over the current graph view.
- VERIFIED: selecting a result centers it and opens the existing inspector.
- VERIFIED: moves secondary graph controls into one View menu.
- VERIFIED: keeps desktop and mobile layouts within their viewports.

## Verification

- VERIFIED: `node --check kb/static/app.js` exited 0.
- VERIFIED: `uv run pytest -q tests/test_dashboard_contract_gaps.py tests/test_style_invariants.py` returned `32 passed, 11 warnings`.
- VERIFIED: `git diff --check` exited 0 before commit.
- REPORTED: independent Luna review found no remaining issues after the camera fix.
- REPORTED: agent-browser desktop and mobile checks passed at 1440x900 and 390x844.

## Blind spots

- The local graph had only a dataset presence node. Search behavior against a dense production graph remains unverified.
- No production data was changed.