### PR TITLE
fix: sanitize public search results

### DIFF
--- a/kb/mcp_server.py
+++ b/kb/mcp_server.py
@@ -21,6 +21,7 @@ from kb.access import ROLE_ORDER
 from kb.build_identity import SERVICE_BUILD_IDENTITY
 from kb.capture_config import load_capture_config
 from kb.retry import run_with_retries
+from kb.search_format import is_search_content_hit, shape_public_search_hit
 from kb.security_scan import redact_secrets
 from kb.session_trace_distill import (
     distill_trace,
@@ -672,7 +673,11 @@ def _compact_search_for_agent(payload: Any) -> Any:
     sections = payload.get("sections")
     if isinstance(sections, dict):
         compacted["section_counts"] = {
-            str(name): len(items) if isinstance(items, list) else 0
+            str(name): (
+                sum(1 for item in items if is_search_content_hit(item))
+                if isinstance(items, list)
+                else 0
+            )
             for name, items in sections.items()
         }
         compacted.pop("sections", None)
@@ -682,8 +687,17 @@ def _compact_search_for_agent(payload: Any) -> Any:
     # its own.
     limit = _max_hit_text_chars()
     results = payload.get("results")
-    if isinstance(results, list) and limit > 0:
-        compacted["results"] = [_truncate_hit_text(hit, limit) for hit in results]
+    if isinstance(results, list):
+        public_results = [
+            shape_public_search_hit(hit, index=index)
+            for index, hit in enumerate(results)
+            if is_search_content_hit(hit)
+        ]
+        compacted["results"] = (
+            [_truncate_hit_text(hit, limit) for hit in public_results]
+            if limit > 0
+            else public_results
+        )
     return compacted
 
 

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 from functools import lru_cache
+from math import isfinite
 from typing import Any
 
 SPEC_QUERY_RE = re.compile(
@@ -574,6 +575,14 @@ def _first_str(*values: Any) -> str | None:
     return None
 
 
+def _is_finite_number(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    return isinstance(value, float) and isfinite(value)
+
+
 # Epoch windows for _first_timestamp. A number is read in whichever unit puts
 # it inside [2001-09-09, 2096-10-02]; the two windows are three orders of
 # magnitude apart, so no value is valid in both and a unit can never be
@@ -763,7 +772,7 @@ def _public_search_envelope(envelope: Any) -> dict[str, Any]:
         clean_relevance: dict[str, Any] = {}
         for key in ("term_coverage", "retriever_score"):
             value = relevance.get(key)
-            if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if _is_finite_number(value):
                 clean_relevance[key] = value
         matched_terms = relevance.get("matched_terms")
         if isinstance(matched_terms, list):
@@ -837,7 +846,7 @@ def shape_public_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
         else []
     )
     score = raw.get("score")
-    if not isinstance(score, (int, float)) or isinstance(score, bool):
+    if not _is_finite_number(score):
         score = None
     chunk_index = _hit_chunk_index(raw)
     if not isinstance(chunk_index, int) or isinstance(chunk_index, bool):

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -641,10 +641,10 @@ _PUBLIC_PROVENANCE_KEYS = frozenset(
 def is_search_content_hit(item: Any) -> bool:
     """True when a retrieved row carries user-facing content.
 
-    Qdrant content chunks use ``IndexSchema`` too, so that type alone cannot
-    distinguish a document from an engine row. A valid IndexSchema hit needs
-    both text and its parent document id. Other retrieval paths, including the
-    GitHub digest fallback, may carry text without a document id.
+    Qdrant content chunks use ``IndexSchema`` and ``DocumentChunk``. A valid
+    typed hit needs both text and its parent document id. Other retrieval
+    paths, including the GitHub digest fallback, may carry untyped text without
+    a document id.
     """
     if isinstance(item, str):
         return bool(item.strip())
@@ -653,7 +653,11 @@ def is_search_content_hit(item: Any) -> bool:
     raw_type = item.get("type")
     if raw_type is not None and not isinstance(raw_type, str):
         return False
-    if raw_type is not None and raw_type.strip().lower() != "indexschema":
+    normalized_type = raw_type.strip().lower() if isinstance(raw_type, str) else None
+    if normalized_type is not None and normalized_type not in {
+        "indexschema",
+        "documentchunk",
+    }:
         return False
     text = _first_str(
         item.get("text"),
@@ -667,7 +671,7 @@ def is_search_content_hit(item: Any) -> bool:
     )
     if not text:
         return False
-    if isinstance(raw_type, str) and raw_type.strip().lower() == "indexschema":
+    if normalized_type in {"indexschema", "documentchunk"}:
         return bool(_first_str(item.get("document_id")))
     return True
 

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -621,6 +621,239 @@ def _hit_chunk_index(hit: dict[str, Any]) -> Any:
 
 SNIPPET_CHARS = 500
 
+_PUBLIC_PROVENANCE_KEYS = frozenset(
+    {
+        "source",
+        "source_url",
+        "source_type",
+        "path",
+        "repo",
+        "commit",
+        "blob",
+        "issue",
+        "title",
+        "basis",
+        "session_id",
+    }
+)
+
+
+def is_search_content_hit(item: Any) -> bool:
+    """True when a retrieved row carries user-facing content.
+
+    Qdrant content chunks use ``IndexSchema`` too, so that type alone cannot
+    distinguish a document from an engine row. A valid IndexSchema hit needs
+    both text and its parent document id. Other retrieval paths, including the
+    GitHub digest fallback, may carry text without a document id.
+    """
+    if isinstance(item, str):
+        return bool(item.strip())
+    if not isinstance(item, dict):
+        return False
+    raw_type = item.get("type")
+    if raw_type is not None and not isinstance(raw_type, str):
+        return False
+    if raw_type is not None and raw_type.strip().lower() != "indexschema":
+        return False
+    text = _first_str(
+        item.get("text"),
+        item.get("content"),
+        item.get("chunk"),
+        item.get("body"),
+        item.get("summary"),
+        item.get("title"),
+        item.get("answer"),
+        item.get("result"),
+    )
+    if not text:
+        return False
+    if isinstance(raw_type, str) and raw_type.strip().lower() == "indexschema":
+        return bool(_first_str(item.get("document_id")))
+    return True
+
+
+def _public_search_envelope(envelope: Any) -> dict[str, Any]:
+    """Copy only documented scalar and nested Citadel search metadata."""
+    if not isinstance(envelope, dict):
+        return {}
+    public: dict[str, Any] = {}
+    rank = envelope.get("rank")
+    if isinstance(rank, int) and not isinstance(rank, bool) and rank > 0:
+        public["rank"] = rank
+    for key in (
+        "dataset",
+        "result_id",
+        "content_sha256",
+        "trust",
+        "author_seat",
+        "created_at",
+        "doc_type",
+        "content_hint",
+        "trust_tier",
+    ):
+        value = envelope.get(key)
+        if isinstance(value, str) and value:
+            public[key] = value
+    endpoint = envelope.get("document_endpoint")
+    if isinstance(endpoint, str) and endpoint.startswith("/api/documents/"):
+        public["document_endpoint"] = endpoint
+
+    provenance = envelope.get("provenance")
+    if isinstance(provenance, dict):
+        clean_provenance = {
+            key: value
+            for key, value in provenance.items()
+            if key in _PUBLIC_PROVENANCE_KEYS and isinstance(value, str) and value
+        }
+        public["provenance"] = clean_provenance
+
+    retrieval = envelope.get("retrieval")
+    if isinstance(retrieval, dict):
+        public["retrieval"] = {
+            key: retrieval[key]
+            for key in (
+                "untrusted_context",
+                "citation_required",
+                "document_drilldown_available",
+            )
+            if isinstance(retrieval.get(key), bool)
+        }
+
+    relevance = envelope.get("relevance")
+    if isinstance(relevance, dict):
+        clean_relevance: dict[str, Any] = {}
+        for key in ("term_coverage", "retriever_score"):
+            value = relevance.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                clean_relevance[key] = value
+        matched_terms = relevance.get("matched_terms")
+        if isinstance(matched_terms, list):
+            clean_relevance["matched_terms"] = [
+                term for term in matched_terms if isinstance(term, str)
+            ]
+        match_context = relevance.get("match_context")
+        if isinstance(match_context, dict):
+            offset = match_context.get("offset")
+            text = match_context.get("text")
+            if (
+                isinstance(offset, int)
+                and not isinstance(offset, bool)
+                and offset >= 0
+                and isinstance(text, str)
+            ):
+                clean_relevance["match_context"] = {"offset": offset, "text": text}
+        public["relevance"] = clean_relevance
+    return public
+
+
+def shape_public_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
+    """Return one explicit public search-result shape.
+
+    Retrieval engines may attach storage and pipeline fields to their rows.
+    This allowlist keeps the content, source links, drill-down identity, and
+    Citadel metadata while preventing those engine fields from crossing the
+    HTTP or MCP boundary.
+    """
+    raw = item if isinstance(item, dict) else {"text": str(item)}
+    envelope = raw.get("_citadel") if isinstance(raw.get("_citadel"), dict) else {}
+    public_envelope = _public_search_envelope(envelope)
+    provenance = (
+        public_envelope.get("provenance")
+        if isinstance(public_envelope.get("provenance"), dict)
+        else {}
+    )
+    metadata = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+    text = _first_str(
+        raw.get("text"),
+        raw.get("content"),
+        raw.get("chunk"),
+        raw.get("body"),
+        raw.get("summary"),
+        raw.get("answer"),
+        raw.get("result"),
+        raw.get("title"),
+    ) or ""
+    title = _first_str(
+        raw.get("title"),
+        provenance.get("title"),
+        metadata.get("title"),
+    )
+    if not title:
+        title = text.split("\n", 1)[0][:120] if text else "Untitled result"
+    source_url = _first_str(
+        raw.get("url"),
+        raw.get("source_url"),
+        provenance.get("source_url"),
+    )
+    source = _first_str(
+        source_url,
+        raw.get("source"),
+        provenance.get("source"),
+        provenance.get("path"),
+    )
+    tags_value = raw.get("tags") or metadata.get("citadel_tags") or metadata.get("tags")
+    tags = (
+        [str(tag) for tag in tags_value if isinstance(tag, (str, int, float))]
+        if isinstance(tags_value, list)
+        else []
+    )
+    score = raw.get("score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        score = None
+    chunk_index = _hit_chunk_index(raw)
+    if not isinstance(chunk_index, int) or isinstance(chunk_index, bool):
+        chunk_index = None
+    result_id = _first_str(raw.get("id"), public_envelope.get("result_id"))
+    document_id = _first_str(raw.get("document_id"))
+    qa_id = _first_str(
+        raw.get("qa_id"),
+        raw.get("qaId"),
+        raw.get("answer_id"),
+        metadata.get("qa_id"),
+        metadata.get("qaId"),
+        metadata.get("answer_id"),
+        result_id,
+    )
+    rank = public_envelope.get("rank")
+    if not isinstance(rank, int) or isinstance(rank, bool) or rank < 1:
+        rank = index + 1
+    dataset = _first_str(public_envelope.get("dataset"), raw.get("dataset"))
+    doc_type = _first_str(public_envelope.get("doc_type")) or infer_doc_type(raw)
+    content_hint = (
+        _first_str(public_envelope.get("content_hint"))
+        or infer_content_hint(raw, doc_type)
+    )
+    trust_tier = (
+        _first_str(public_envelope.get("trust_tier"), public_envelope.get("trust"))
+        or infer_trust_tier(raw, doc_type)
+    )
+    return {
+        "id": result_id,
+        "document_id": document_id,
+        "qa_id": qa_id,
+        "title": title,
+        "text": text,
+        "source": source,
+        "source_url": source_url,
+        "url": source_url,
+        "repo": _first_str(raw.get("repo"), provenance.get("repo"), metadata.get("repo")),
+        "path": _first_str(raw.get("path"), provenance.get("path"), metadata.get("path")),
+        "tags": tags,
+        "score": score,
+        "chunk_index": chunk_index,
+        "doc_type": doc_type,
+        "content_hint": content_hint,
+        "trust_tier": trust_tier,
+        "updated_at": _first_timestamp(
+            raw.get("updated_at"),
+            public_envelope.get("created_at"),
+            metadata.get("updated_at"),
+        ),
+        "rank": rank,
+        "dataset": dataset,
+        "_citadel": public_envelope,
+    }
+
 
 def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None) -> dict[str, Any]:
     """Stable agent hit schema for CLI --json output.

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -694,6 +694,8 @@ def _public_search_envelope(envelope: Any) -> dict[str, Any]:
         "doc_type",
         "content_hint",
         "trust_tier",
+        "source_revision_id",
+        "projection_receipt_id",
     ):
         value = envelope.get(key)
         if isinstance(value, str) and value:
@@ -701,6 +703,26 @@ def _public_search_envelope(envelope: Any) -> dict[str, Any]:
     endpoint = envelope.get("document_endpoint")
     if isinstance(endpoint, str) and endpoint.startswith("/api/documents/"):
         public["document_endpoint"] = endpoint
+
+    projection = envelope.get("projection")
+    if (
+        "source_revision_id" in public
+        and "projection_receipt_id" in public
+        and isinstance(projection, dict)
+    ):
+        clean_projection = {
+            key: value
+            for key in (
+                "generation_id",
+                "backend",
+                "provider",
+                "projection_version",
+                "state",
+            )
+            if isinstance((value := projection.get(key)), str) and value
+        }
+        if clean_projection:
+            public["projection"] = clean_projection
 
     provenance = envelope.get("provenance")
     if isinstance(provenance, dict):

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -688,18 +688,31 @@ def _public_search_envelope(envelope: Any) -> dict[str, Any]:
         "dataset",
         "result_id",
         "content_sha256",
-        "trust",
         "author_seat",
         "created_at",
         "doc_type",
         "content_hint",
-        "trust_tier",
         "source_revision_id",
         "projection_receipt_id",
     ):
         value = envelope.get(key)
         if isinstance(value, str) and value:
             public[key] = value
+
+    # Trust is a closed public contract, not an arbitrary provider string.
+    # ``reference-only`` is a safe downgrade and is also how the server marks
+    # the Node-side copy of a shared trace. Unknown legacy claims such as
+    # ``canonical`` or ``verified`` must not cross the public boundary.
+    if envelope.get("trust") == TRUST_REFERENCE:
+        public["trust"] = TRUST_REFERENCE
+    if envelope.get("trust_tier") == TRUST_REFERENCE:
+        public["trust_tier"] = TRUST_REFERENCE
+    else:
+        # Re-derive from the sanitized envelope. This preserves an attested
+        # session-traces dataset and the safe trust downgrade above; every other
+        # missing, invalid, or unknown claim resolves to ``unattested``.
+        public["trust_tier"] = infer_trust_tier({"_citadel": public})
+
     endpoint = envelope.get("document_endpoint")
     if isinstance(endpoint, str) and endpoint.startswith("/api/documents/"):
         public["document_endpoint"] = endpoint

--- a/kb/server.py
+++ b/kb/server.py
@@ -2131,8 +2131,8 @@ async def search_across_datasets(
 ) -> list[tuple[str, Any]]:
     # Query every dataset before merging so a result-rich primary node can never
     # short-circuit (and thereby silently drop) Central. The primary still wins
-    # dedup and takes the bulk of the slots; a reserved slice keeps room for the
-    # secondary datasets when more than one is in scope. Sessions are resolved per
+    # dedup. Final ranking, filtering, and dataset reservation happen after public
+    # shaping, over this full per-dataset candidate pool. Sessions are resolved per
     # dataset: a seat's private session must not scope shared datasets like Central
     # (see resolve_search_sessions), or it would hide org-wide hits.
     # Query datasets concurrently (the reads are independent and touch no Kuzu
@@ -2152,11 +2152,10 @@ async def search_across_datasets(
     per_dataset: list[tuple[str, list[Any]]] = [
         (
             dataset,
-            [result for result in results if is_search_content_hit(result)],
+            [result for result in results if is_search_content_hit(result)][:top_k],
         )
         for dataset, results in zip(datasets, results_per)
     ]
-    literal_query = len(query_terms(query)) == 1
 
     merged: list[tuple[str, Any]] = []
     seen: set[str] = set()
@@ -2171,13 +2170,8 @@ async def search_across_datasets(
         if dataset == SESSION_TRACES_DATASET
         for result in results
     }
-
-    merge_limit = top_k * len(per_dataset) if literal_query else top_k
-
-    def take(dataset: str, results: list[Any], budget: int) -> None:
+    for dataset, results in per_dataset:
         for result in results:
-            if budget <= 0 or len(merged) >= merge_limit:
-                return
             key = search_result_dedup_key(result)
             if key in seen:
                 continue
@@ -2189,26 +2183,6 @@ async def search_across_datasets(
             ):
                 result = {**result, SHARED_TRACE_MARKER: True}
             merged.append((dataset, result))
-            budget -= 1
-
-    if not per_dataset:
-        return merged
-
-    if literal_query:
-        # Single-token searches are commonly exact identifiers. Preserve the
-        # candidate page from every dataset so response shaping can place an
-        # observable literal match above unrelated cross-dataset hits (#106).
-        for dataset, results in per_dataset:
-            take(dataset, results, top_k)
-        return merged
-
-    reserve = max(1, top_k // 5) if len(per_dataset) > 1 else 0
-    primary_dataset, primary_results = per_dataset[0]
-    take(primary_dataset, primary_results, top_k - reserve)
-    for dataset, results in per_dataset[1:]:
-        take(dataset, results, top_k - len(merged))
-    # Backfill any slots the secondaries left unused from the primary node.
-    take(primary_dataset, primary_results, top_k - len(merged))
     return merged
 
 
@@ -3001,6 +2975,60 @@ def public_search_result(
         query=query,
     )
     return shape_public_search_hit(enriched, index=index)
+
+
+def select_public_search_page(
+    shaped_hits: list[dict[str, Any]],
+    *,
+    query: str,
+    datasets: list[str],
+    limit: int,
+    mode: str | None = None,
+    filter_kwargs: Mapping[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Rank, filter, and select one public page from shaped candidates."""
+    candidates = list(shaped_hits)
+    candidates_fetched = len(candidates)
+    ranked_query = (
+        is_docs_mode_query(query, mode=mode)
+        or is_spec_mode_query(query)
+        or len(query_terms(query)) == 1
+    )
+    if ranked_query:
+        candidates = apply_query_ranking(candidates, query, mode=mode)
+    if filter_kwargs is not None:
+        candidates = filter_hits(candidates, **dict(filter_kwargs))
+    candidates_matched = len(candidates)
+
+    if ranked_query or limit <= 1 or len(datasets) <= 1:
+        selected = candidates[:limit]
+    else:
+        primary_dataset = datasets[0]
+        reserve = min(max(1, limit // 5), limit - 1)
+
+        def hit_dataset(hit: dict[str, Any]) -> Any:
+            envelope = hit.get("_citadel")
+            return envelope.get("dataset") if isinstance(envelope, dict) else None
+
+        primary = [hit for hit in candidates if hit_dataset(hit) == primary_dataset]
+        secondary = [
+            hit
+            for dataset in datasets[1:]
+            for hit in candidates
+            if hit_dataset(hit) == dataset
+        ]
+        selected = primary[: limit - reserve]
+        selected.extend(secondary[: limit - len(selected)])
+        if len(selected) < limit:
+            selected.extend(primary[limit - reserve : limit - len(selected) + limit - reserve])
+
+    for rank, hit in enumerate(selected, start=1):
+        if "rank" in hit:
+            hit["rank"] = rank
+        envelope = hit.get("_citadel")
+        if isinstance(envelope, dict):
+            envelope["rank"] = rank
+    return selected, candidates_fetched, candidates_matched
 
 
 def _trace_author_seat(result: dict[str, Any]) -> str | None:
@@ -7345,7 +7373,7 @@ async def knowledge(
                 "message": "Search exceeded the configured server budget.",
             },
         )
-    public_pairs: list[tuple[str, dict[str, Any]]] = []
+    public_candidates: list[dict[str, Any]] = []
     for index, (search_dataset, result) in enumerate(merged):
         shaped = public_search_result(
             result,
@@ -7358,21 +7386,26 @@ async def knowledge(
             query=query,
         )
         if shaped is not None:
-            public_pairs.append((search_dataset, shaped))
-    public_pairs = public_pairs[:limit]
-    for rank, (_, result) in enumerate(public_pairs, start=1):
-        result["rank"] = rank
-        result["_citadel"]["rank"] = rank
+            public_candidates.append(shaped)
+    public_results, _, _ = select_public_search_page(
+        public_candidates,
+        query=query,
+        datasets=search_datasets,
+        limit=limit,
+    )
     latency_ms = (time.perf_counter() - started) * 1000.0
     for search_dataset in search_datasets:
         await mesh_state.record_search(
             citadel.config,
             query=query,
             dataset=search_dataset,
-            result_count=sum(1 for ds, _ in public_pairs if ds == search_dataset),
+            result_count=sum(
+                1
+                for result in public_results
+                if result.get("_citadel", {}).get("dataset") == search_dataset
+            ),
         )
     primary_dataset = search_datasets[0]
-    public_results = [result for _, result in public_pairs]
     telemetry = await capture_search_feedback(
         mesh_state=mesh_state,
         config=citadel.config,
@@ -7550,7 +7583,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             },
         )
 
-    # Shaping order: envelope -> rank -> filter -> trim -> drilldown. The
+    # Shaping order: envelope -> rank -> filter -> select -> drilldown. The
     # drill-down hints are resolved LAST, over the final page only, because
     # each scoped resolution costs a get_document call and over-fetching for
     # filters would otherwise triple that cost for hits the caller never sees.
@@ -7572,22 +7605,14 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             normalized.append(shaped)
     cleaned_mode = body.cleaned_mode()
     docs_mode = is_docs_mode_query(body.query, mode=cleaned_mode)
-    if docs_mode or is_spec_mode_query(body.query) or len(query_terms(body.query)) == 1:
-        normalized = apply_query_ranking(normalized, body.query, mode=cleaned_mode)
-    candidates_fetched = len(normalized)
-    if filters_active:
-        dict_hits = [item for item in normalized if isinstance(item, dict)]
-        other = [item for item in normalized if not isinstance(item, dict)]
-        normalized = filter_hits(dict_hits, **filter_kw) + other
-    candidates_matched = len(normalized)
-    if len(normalized) > body.top_k:
-        normalized = normalized[: body.top_k]
-    # Refresh rank numbers after re-order / filter / trim so agents see
-    # consistent ordering.
-    for index, item in enumerate(normalized):
-        if isinstance(item, dict) and isinstance(item.get("_citadel"), dict):
-            item["_citadel"]["rank"] = index + 1
-            item["rank"] = index + 1
+    normalized, candidates_fetched, candidates_matched = select_public_search_page(
+        normalized,
+        query=body.query,
+        datasets=search_datasets,
+        limit=body.top_k,
+        mode=cleaned_mode,
+        filter_kwargs=filter_kw if filters_active else None,
+    )
 
     # Honest drill-down hint (ADR-0009): the document_drilldown_available flag
     # (and the document_endpoint URL) must be TRUE only when /api/documents would

--- a/kb/server.py
+++ b/kb/server.py
@@ -2158,7 +2158,6 @@ async def search_across_datasets(
     ]
 
     merged: list[tuple[str, Any]] = []
-    seen: set[str] = set()
     # A volunteered trace is dual-written to the author's Node and to
     # session-traces (resolve_write_targets_for_share). The Node copy wins dedup
     # below, and ``reference-only`` is stamped off the dataset alone — so without
@@ -2173,9 +2172,6 @@ async def search_across_datasets(
     for dataset, results in per_dataset:
         for result in results:
             key = search_result_dedup_key(result)
-            if key in seen:
-                continue
-            seen.add(key)
             if (
                 dataset != SESSION_TRACES_DATASET
                 and key in trace_keys
@@ -2780,11 +2776,13 @@ def with_result_id(result: dict[str, Any]) -> dict[str, Any]:
     (``search_github_sync_state``) supplies its own ``id`` and no
     ``document_id``, because a digest section is not a stored document.
     """
-    if result.get("id"):
+    raw_id = result.get("id")
+    if isinstance(raw_id, str) and raw_id.strip():
         return result
-    basis = json.dumps(result, sort_keys=True, default=str)
+    idless = {key: value for key, value in result.items() if key != "id"}
+    basis = json.dumps(idless, sort_keys=True, default=str)
     derived = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
-    return {"id": f"chunk:{derived}", **result}
+    return {**idless, "id": f"chunk:{derived}"}
 
 
 def _result_retriever_score(result: dict[str, Any]) -> float | None:
@@ -2994,11 +2992,24 @@ def select_public_search_page(
         or is_spec_mode_query(query)
         or len(query_terms(query)) == 1
     )
-    if ranked_query:
-        candidates = apply_query_ranking(candidates, query, mode=mode)
     if filter_kwargs is not None:
         candidates = filter_hits(candidates, **dict(filter_kwargs))
+
+    # Keep collision alternatives through filtering. A primary Node hit that a
+    # request filter rejects must not erase an eligible Central copy with the
+    # same text. Dataset order still decides the winner when both remain.
+    unique_candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = search_result_dedup_key(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_candidates.append(candidate)
+    candidates = unique_candidates
     candidates_matched = len(candidates)
+    if ranked_query:
+        candidates = apply_query_ranking(candidates, query, mode=mode)
 
     if ranked_query or limit <= 1 or len(datasets) <= 1:
         selected = candidates[:limit]

--- a/kb/server.py
+++ b/kb/server.py
@@ -2150,7 +2150,11 @@ async def search_across_datasets(
         ]
     )
     per_dataset: list[tuple[str, list[Any]]] = [
-        (dataset, list(results)) for dataset, results in zip(datasets, results_per)
+        (
+            dataset,
+            [result for result in results if is_search_content_hit(result)],
+        )
+        for dataset, results in zip(datasets, results_per)
     ]
     literal_query = len(query_terms(query)) == 1
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -95,11 +95,13 @@ from kb.search_format import (
     infer_content_hint,
     infer_doc_type,
     infer_trust_tier,
+    is_search_content_hit,
     is_docs_mode_query,
     is_spec_mode_query,
     lexical_relevance_summary,
     parse_content_header,
     query_terms,
+    shape_public_search_hit,
     token_asset_authority_warning,
 )
 from kb.security_scan import (
@@ -2973,6 +2975,28 @@ def with_result_metadata(
     metadata["content_hint"] = infer_content_hint(preview, doc_type)
     metadata["trust_tier"] = infer_trust_tier(preview, doc_type)
     return {**normalized, "_citadel": metadata}
+
+
+def public_search_result(
+    result: Any,
+    index: int,
+    dataset: str,
+    *,
+    drilldown_predicate: Callable[[str], bool] | None = None,
+    query: str | None = None,
+) -> dict[str, Any] | None:
+    """Reject non-content rows and return the shared public result DTO."""
+    if not is_search_content_hit(result):
+        return None
+    candidate = result if isinstance(result, dict) else {"text": result}
+    enriched = with_result_metadata(
+        candidate,
+        index,
+        dataset,
+        drilldown_predicate=drilldown_predicate,
+        query=query,
+    )
+    return shape_public_search_hit(enriched, index=index)
 
 
 def _trace_author_seat(result: dict[str, Any]) -> str | None:
@@ -7253,41 +7277,6 @@ async def contribute(body: ContributeBody, request: Request) -> Any:
     )
 
 
-def flat_knowledge_result(result: Any) -> dict[str, Any]:
-    """Flatten one search hit into the agent-friendly knowledge shape."""
-    if not isinstance(result, dict):
-        return {"text": str(result), "source": None}
-    provenance = result_provenance(result)
-    text = first_string(
-        result.get("text"),
-        result.get("content"),
-        result.get("chunk"),
-        result.get("body"),
-        result.get("summary"),
-        result.get("title"),
-    )
-    if not text:
-        text = json.dumps(
-            {key: value for key, value in result.items() if key != "_citadel"},
-            sort_keys=True,
-            default=str,
-        )[:500]
-    payload: dict[str, Any] = {
-        "text": text,
-        "source": provenance.get("source_url")
-        or provenance.get("source")
-        or provenance.get("path"),
-    }
-    score = result.get("score")
-    if isinstance(score, (int, float)) and not isinstance(score, bool):
-        payload["score"] = score
-    metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else {}
-    tags = result.get("tags") or metadata.get("citadel_tags") or metadata.get("tags")
-    if isinstance(tags, list):
-        payload["tags"] = [str(tag) for tag in tags if isinstance(tag, (str, int, float))]
-    return payload
-
-
 @app.get("/api/knowledge")
 async def knowledge(
     request: Request,
@@ -7307,6 +7296,7 @@ async def knowledge(
     mesh_state = get_mesh()
     search_datasets = resolve_search_datasets(identity, dataset, citadel.config)
     search_sessions = resolve_search_sessions(identity, None, search_datasets)
+    fetch_k = min(max(limit * 3, limit + 10), 100)
     max_concurrency = citadel.config.search_max_concurrency
     timed_out = False
     started = time.perf_counter()
@@ -7319,7 +7309,7 @@ async def knowledge(
                 query=query,
                 datasets=search_datasets,
                 sessions=search_sessions,
-                top_k=limit,
+                top_k=fetch_k,
             )
         except QdrantProviderError as exc:
             await mesh_state.record_error(
@@ -7351,23 +7341,41 @@ async def knowledge(
                 "message": "Search exceeded the configured server budget.",
             },
         )
+    public_pairs: list[tuple[str, dict[str, Any]]] = []
+    for index, (search_dataset, result) in enumerate(merged):
+        shaped = public_search_result(
+            result,
+            index,
+            search_dataset,
+            # The compatibility alias has never advertised document previews.
+            # Keep the safe under-promise for every role instead of claiming a
+            # scoped document is reachable without running the ownership pass.
+            drilldown_predicate=lambda _result_id: False,
+            query=query,
+        )
+        if shaped is not None:
+            public_pairs.append((search_dataset, shaped))
+    public_pairs = public_pairs[:limit]
+    for rank, (_, result) in enumerate(public_pairs, start=1):
+        result["rank"] = rank
+        result["_citadel"]["rank"] = rank
     latency_ms = (time.perf_counter() - started) * 1000.0
-    for search_dataset, _ in merged:
+    for search_dataset in search_datasets:
         await mesh_state.record_search(
             citadel.config,
             query=query,
             dataset=search_dataset,
-            result_count=sum(1 for ds, _ in merged if ds == search_dataset),
+            result_count=sum(1 for ds, _ in public_pairs if ds == search_dataset),
         )
     primary_dataset = search_datasets[0]
-    flat_results = [flat_knowledge_result(result) for _, result in merged]
+    public_results = [result for _, result in public_pairs]
     telemetry = await capture_search_feedback(
         mesh_state=mesh_state,
         config=citadel.config,
         request=request,
         actor=identity,
         query=query,
-        results=flat_results,
+        results=public_results,
         search_datasets=search_datasets,
         primary_dataset=primary_dataset,
         top_k=limit,
@@ -7380,7 +7388,7 @@ async def knowledge(
         "query": query,
         "dataset": primary_dataset,
         "datasets": search_datasets if len(search_datasets) > 1 else None,
-        "results": flat_results,
+        "results": public_results,
     }
     if telemetry:
         payload["search_id"] = telemetry.get("search_id")
@@ -7448,7 +7456,9 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     # candidates when filters are active and trim back to top_k after
     # filtering; 100 is SearchBody's own top_k ceiling, so a filtered call can
     # never fetch more than an unfiltered one is allowed to ask for.
-    fetch_k = min(max(body.top_k * 3, body.top_k + 10), 100) if filters_active else body.top_k
+    # The public boundary drops non-content engine rows. Over-fetch even when
+    # request filters are absent so those rows cannot consume the whole page.
+    fetch_k = min(max(body.top_k * 3, body.top_k + 10), 100)
     limit = citadel.config.search_max_concurrency
     timed_out = False
     started = time.perf_counter()
@@ -7541,8 +7551,9 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     # each scoped resolution costs a get_document call and over-fetching for
     # filters would otherwise triple that cost for hits the caller never sees.
     bypass_drilldown = can_bypass_dataset_allowlist(actor)
-    normalized = [
-        with_result_metadata(
+    normalized: list[dict[str, Any]] = []
+    for index, (dataset, result) in enumerate(merged):
+        shaped = public_search_result(
             result,
             index,
             dataset,
@@ -7553,8 +7564,8 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             drilldown_predicate=None if bypass_drilldown else (lambda _result_id: False),
             query=body.query,
         )
-        for index, (dataset, result) in enumerate(merged)
-    ]
+        if shaped is not None:
+            normalized.append(shaped)
     cleaned_mode = body.cleaned_mode()
     docs_mode = is_docs_mode_query(body.query, mode=cleaned_mode)
     if docs_mode or is_spec_mode_query(body.query) or len(query_terms(body.query)) == 1:
@@ -7572,6 +7583,7 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     for index, item in enumerate(normalized):
         if isinstance(item, dict) and isinstance(item.get("_citadel"), dict):
             item["_citadel"]["rank"] = index + 1
+            item["rank"] = index + 1
 
     # Honest drill-down hint (ADR-0009): the document_drilldown_available flag
     # (and the document_endpoint URL) must be TRUE only when /api/documents would

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -5259,6 +5259,14 @@ function isSingleLiteralQuery(query) {
   return String(query || "").trim().split(/\s+/).filter(Boolean).length === 1;
 }
 
+function searchResultKey(result) {
+  const envelope = resultEnvelope(result);
+  const dataset = envelope.dataset || result?.dataset || "";
+  const identity = envelope.result_id || result?.id || result?.document_id || "";
+  const text = result?.text || result?.content || "";
+  return `${dataset}\u0000${identity}\u0000${text}`;
+}
+
 function renderSearchResults(results, response = {}, query = "") {
   const container = document.getElementById("searchResults");
   container.innerHTML = "";
@@ -5307,8 +5315,10 @@ function renderSearchResults(results, response = {}, query = "") {
   // Anything the server could not place in a section still has to be shown; a
   // silently dropped hit is worse than an extra group.
   const placed = new Set();
-  grouped.forEach((key) => sections[key].forEach((hit) => placed.add(hit)));
-  const rest = results.filter((hit) => !placed.has(hit));
+  grouped.forEach((key) =>
+    sections[key].forEach((hit) => placed.add(searchResultKey(hit)))
+  );
+  const rest = results.filter((hit) => !placed.has(searchResultKey(hit)));
   if (rest.length) {
     const group = document.createElement("section");
     group.className = "result-group";

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1639,6 +1639,46 @@ def test_search_compaction_leaves_unexpected_shapes_alone() -> None:
     assert _compact_search_for_agent(None) is None
 
 
+def test_search_compaction_rejects_forged_trust_tier() -> None:
+    from kb.mcp_server import _compact_search_for_agent
+
+    payload = {
+        "results": [
+            {
+                "id": "central-forged",
+                "text": "central content",
+                "_citadel": {
+                    "dataset": "masumi-network",
+                    "trust": "canonical",
+                    "trust_tier": "verified",
+                },
+            },
+            {
+                "id": "trace-genuine",
+                "text": "shared session trace",
+                "_citadel": {
+                    "dataset": "session-traces",
+                    "trust": "reference-only",
+                    "trust_tier": "reference-only",
+                },
+            },
+        ]
+    }
+
+    results = _compact_search_for_agent(payload)["results"]
+    forged, trace = results
+
+    assert forged["trust_tier"] == "unattested"
+    assert forged["_citadel"].get("trust") not in {
+        "canonical",
+        "verified",
+        "reference-only",
+    }
+    assert forged["_citadel"].get("trust_tier") not in {"canonical", "verified"}
+    assert trace["trust_tier"] == "reference-only"
+    assert trace["_citadel"]["trust"] == "reference-only"
+
+
 def test_citadel_search_tool_strips_the_duplicate_sections(monkeypatch: Any) -> None:
     """Through the TOOL, not the helper.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1597,7 +1597,13 @@ def test_search_does_not_hand_an_agent_every_hit_twice() -> None:
 
     # Deliberately under the truncation cap: this test is about the duplicate
     # `sections` copy, not about hit-text length, which has its own test.
-    hit = {"id": "a", "text": "x" * 900, "_citadel": {"dataset": "masumi-network"}}
+    hit = {
+        "id": "a",
+        "text": "x" * 900,
+        "source_user": "default-user@example.invalid",
+        "source_pipeline": "internal-pipeline",
+        "_citadel": {"dataset": "masumi-network"},
+    }
     other = {"id": "b", "text": "y" * 900, "_citadel": {"dataset": "seat:alice"}}
     payload = {
         "results": [hit, other],
@@ -1612,9 +1618,11 @@ def test_search_does_not_hand_an_agent_every_hit_twice() -> None:
     # The grouping survives as counts, so a caller can still see the split.
     assert compacted["section_counts"] == {"central": 1, "node": 1, "session_traces": 0}
     # Nothing a caller actually reads was dropped.
-    assert compacted["results"] == [hit, other]
+    assert [item["id"] for item in compacted["results"]] == ["a", "b"]
+    assert "source_user" not in compacted["results"][0]
+    assert "source_pipeline" not in compacted["results"][0]
     assert compacted["search_id"] == "s-1"
-    assert len(json.dumps(compacted)) < before / 1.8, "payload was not meaningfully reduced"
+    assert len(json.dumps(compacted)) < before * 0.75, "payload was not meaningfully reduced"
 
 
 def test_search_compaction_leaves_unexpected_shapes_alone() -> None:
@@ -1665,7 +1673,8 @@ def test_citadel_search_tool_strips_the_duplicate_sections(monkeypatch: Any) -> 
 
     assert "sections" not in result, "the tool handed the agent every hit twice"
     assert result["section_counts"] == {"central": 1, "node": 0, "session_traces": 0}
-    assert result["results"] == [hit]
+    assert result["results"][0]["id"] == "a"
+    assert result["results"][0]["text"] == "x" * 900
     assert result["search_id"] == "s-9"
 
 
@@ -1704,7 +1713,9 @@ def test_search_leaves_short_hits_and_honours_the_override(monkeypatch: Any) -> 
 
     monkeypatch.delenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", raising=False)
     short = {"id": "s", "text": "brief answer"}
-    assert _compact_search_for_agent({"results": [short]})["results"][0] == short
+    assert _compact_search_for_agent({"results": [short]})["results"][0]["text"] == (
+        "brief answer"
+    )
 
     long_text = "x" * 9000
     monkeypatch.setenv("CITADEL_MCP_MAX_HIT_TEXT_CHARS", "0")

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -138,11 +138,16 @@ def test_public_search_hit_drops_engine_fields_and_keeps_drilldown() -> None:
     assert "projection" not in shaped["_citadel"]
 
 
-def test_index_schema_content_requires_a_document_identity() -> None:
-    valid = {
+def test_typed_search_content_requires_a_document_identity() -> None:
+    valid_index = {
         "type": "IndexSchema",
         "document_id": "document-1",
         "text": "A source-backed chunk.",
+    }
+    valid_chunk = {
+        "type": "DocumentChunk",
+        "document_id": "document-1",
+        "text": "A production source-backed chunk.",
     }
     engine_row = {
         "type": "IndexSchema",
@@ -155,10 +160,48 @@ def test_index_schema_content_requires_a_document_identity() -> None:
         "text": "Internal document node",
     }
 
-    assert is_search_content_hit(valid) is True
+    assert is_search_content_hit(valid_index) is True
+    assert is_search_content_hit(valid_chunk) is True
     assert is_search_content_hit(engine_row) is False
     assert is_search_content_hit(other_typed_row) is False
     assert is_search_content_hit({"type": "IndexSchema", "document_id": "document-1"}) is False
+
+
+def test_search_endpoint_keeps_recorded_document_chunk_shape() -> None:
+    document_id = "0c9d5df0-0000-4000-8000-000000000002"
+    raw = {
+        "id": "0c9d5df0-0000-4000-8000-000000000001",
+        "created_at": 1782742208187,
+        "updated_at": 1782742208187,
+        "version": 1,
+        "type": "DocumentChunk",
+        "text": "synthetic chunk body",
+        "chunk_index": 0,
+        "document_id": document_id,
+        "document_name": "text_0123456789abcdef0123456789abcdef",
+        "metadata": {"index_fields": ["text"]},
+        "_citadel": {
+            "content_hint": "unclassified",
+            "content_sha256": "0" * 64,
+            "dataset": "seat:synthetic",
+            "doc_type": "other",
+            "document_endpoint": f"/api/documents/{document_id}",
+            "provenance": {},
+            "rank": 1,
+            "result_id": "0c9d5df0-0000-4000-8000-000000000001",
+        },
+    }
+
+    response = shaped_client(PageCitadel([raw])).post(
+        "/search",
+        json={"query": "synthetic chunk", "top_k": 5},
+    )
+
+    assert response.status_code == 200
+    hits = response.json()["results"]
+    assert hits
+    assert hits[0]["text"] == "synthetic chunk body"
+    assert hits[0]["document_id"] == document_id
 
 
 def test_public_search_shape_rejects_malformed_engine_values() -> None:

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -157,6 +157,36 @@ def test_public_search_hit_drops_engine_fields_and_keeps_drilldown() -> None:
     assert "projection" not in shaped["_citadel"]
 
 
+def test_public_search_hit_drops_nonfinite_relevance_and_keeps_finite_values() -> None:
+    finite = shape_public_search_hit(
+        {
+            "text": "finite relevance",
+            "_citadel": {
+                "relevance": {"term_coverage": 0.5, "retriever_score": 0.42}
+            },
+        }
+    )
+    assert finite["_citadel"]["relevance"] == {
+        "term_coverage": 0.5,
+        "retriever_score": 0.42,
+    }
+
+    nonfinite = shape_public_search_hit(
+        {
+            "text": "nonfinite relevance",
+            "_citadel": {
+                "relevance": {
+                    "term_coverage": float("inf"),
+                    "retriever_score": float("nan"),
+                }
+            },
+        }
+    )
+    relevance = nonfinite["_citadel"]["relevance"]
+    assert "term_coverage" not in relevance
+    assert "retriever_score" not in relevance
+
+
 def test_typed_search_content_requires_a_document_identity() -> None:
     valid_index = {
         "type": "IndexSchema",

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -20,8 +20,10 @@ from kb.mesh import MeshState
 from kb.search_format import (
     apply_query_ranking,
     filter_hits,
+    is_search_content_hit,
     normalize_search_hit,
     parse_content_header,
+    shape_public_search_hit,
 )
 from kb.server import app, result_provenance, with_result_metadata
 
@@ -89,6 +91,93 @@ def shaped_client(citadel: Any) -> TestClient:
     response = client.post("/admin/session", json={"access_key": "test-admin"})
     assert response.status_code == 200
     return client
+
+
+def test_public_search_hit_drops_engine_fields_and_keeps_drilldown() -> None:
+    raw = {
+        "id": "chunk-1",
+        "document_id": "document-1",
+        "type": "IndexSchema",
+        "text": "Rotate keys quarterly.",
+        "source_url": "https://example.com/runbook",
+        "source_pipeline": "internal-pipeline",
+        "source_task": "internal-task",
+        "source_node_set": "internal-node-set",
+        "source_user": "default-user@example.invalid",
+        "metadata": {"citadel_tags": ["ops"], "private": "internal"},
+        "_citadel": {
+            "rank": 1,
+            "dataset": "masumi-network",
+            "result_id": "chunk-1",
+            "document_endpoint": "/api/documents/document-1",
+            "retrieval": {"document_drilldown_available": True},
+            "unexpected_internal": "drop-me",
+        },
+    }
+
+    shaped = shape_public_search_hit(raw)
+
+    assert shaped["id"] == "chunk-1"
+    assert shaped["document_id"] == "document-1"
+    assert shaped["qa_id"] == "chunk-1"
+    assert shaped["text"] == "Rotate keys quarterly."
+    assert shaped["source"] == "https://example.com/runbook"
+    assert shaped["tags"] == ["ops"]
+    assert shaped["dataset"] == "masumi-network"
+    assert shaped["_citadel"]["document_endpoint"] == "/api/documents/document-1"
+    forbidden = {
+        "type",
+        "metadata",
+        "source_pipeline",
+        "source_task",
+        "source_node_set",
+        "source_user",
+    }
+    assert forbidden.isdisjoint(shaped)
+    assert "unexpected_internal" not in shaped["_citadel"]
+    assert "projection" not in shaped["_citadel"]
+
+
+def test_index_schema_content_requires_a_document_identity() -> None:
+    valid = {
+        "type": "IndexSchema",
+        "document_id": "document-1",
+        "text": "A source-backed chunk.",
+    }
+    engine_row = {
+        "type": "IndexSchema",
+        "text": "Internal index schema row",
+        "source_user": "default-user@example.invalid",
+    }
+    other_typed_row = {
+        "type": "TextDocument",
+        "document_id": "document-1",
+        "text": "Internal document node",
+    }
+
+    assert is_search_content_hit(valid) is True
+    assert is_search_content_hit(engine_row) is False
+    assert is_search_content_hit(other_typed_row) is False
+    assert is_search_content_hit({"type": "IndexSchema", "document_id": "document-1"}) is False
+
+
+def test_public_search_shape_rejects_malformed_engine_values() -> None:
+    for value in (None, 7, ["internal"], {"type": ["IndexSchema"], "text": "internal"}):
+        assert is_search_content_hit(value) is False
+
+    malformed = shape_public_search_hit(
+        {
+            "id": {"private": "value"},
+            "document_id": ["private"],
+            "text": "public content",
+            "_citadel": {"rank": "first", "dataset": ["private"]},
+        },
+        index=2,
+    )
+    assert malformed["id"] is None
+    assert malformed["document_id"] is None
+    assert malformed["rank"] == 3
+    assert malformed["dataset"] is None
 
 
 # --- defect 1: provenance was empty on 117 of 117 hits ----------------------

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -8,6 +8,7 @@ call down to its ``search_id``. Each test here fails on the pre-fix code.
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,12 @@ from kb.search_format import (
     parse_content_header,
     shape_public_search_hit,
 )
-from kb.server import app, result_provenance, with_result_metadata
+from kb.server import (
+    app,
+    result_provenance,
+    search_across_datasets,
+    with_result_metadata,
+)
 
 
 def repo_doc_text(repo: str, path: str, body: str) -> str:
@@ -79,6 +85,19 @@ class PageCitadel:
 
     async def get_document(self, document_id: str) -> dict[str, Any] | None:
         return None
+
+
+class CollisionCitadel:
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        if kwargs["dataset"] == "seat:alice":
+            return [{"type": "IndexSchema", "text": "shared answer"}]
+        return [
+            {
+                "type": "DocumentChunk",
+                "document_id": "central-document",
+                "text": "shared answer",
+            }
+        ]
 
 
 def shaped_client(citadel: Any) -> TestClient:
@@ -167,6 +186,29 @@ def test_typed_search_content_requires_a_document_identity() -> None:
     assert is_search_content_hit({"type": "IndexSchema", "document_id": "document-1"}) is False
 
 
+def test_invalid_primary_row_cannot_hide_valid_secondary_hit() -> None:
+    merged = asyncio.run(
+        search_across_datasets(
+            CollisionCitadel(),
+            query="shared answer",
+            datasets=["seat:alice", "central"],
+            sessions={},
+            top_k=5,
+        )
+    )
+
+    assert merged == [
+        (
+            "central",
+            {
+                "type": "DocumentChunk",
+                "document_id": "central-document",
+                "text": "shared answer",
+            },
+        )
+    ]
+
+
 def test_search_endpoint_keeps_recorded_document_chunk_shape() -> None:
     document_id = "0c9d5df0-0000-4000-8000-000000000002"
     raw = {
@@ -202,6 +244,41 @@ def test_search_endpoint_keeps_recorded_document_chunk_shape() -> None:
     assert hits
     assert hits[0]["text"] == "synthetic chunk body"
     assert hits[0]["document_id"] == document_id
+
+
+def test_public_shape_keeps_validated_lifecycle_receipt_identity() -> None:
+    promoted = with_result_metadata(
+        {
+            "type": "DocumentChunk",
+            "document_id": "document-1",
+            "text": "projected content",
+            "_lifecycle": {
+                "source_revision_id": "source-1",
+                "projection_receipt_id": "receipt-1",
+                "generation_id": "generation-1",
+                "backend": "vector",
+                "provider": "qdrant",
+                "projection_version": "projection-v1",
+                "state": "searchable",
+                "private": "drop-me",
+            },
+        },
+        0,
+        "notes",
+    )
+
+    shaped = shape_public_search_hit(promoted)
+    envelope = shaped["_citadel"]
+    assert envelope["source_revision_id"] == "source-1"
+    assert envelope["projection_receipt_id"] == "receipt-1"
+    assert envelope["projection"] == {
+        "generation_id": "generation-1",
+        "backend": "vector",
+        "provider": "qdrant",
+        "projection_version": "projection-v1",
+        "state": "searchable",
+    }
+    assert "private" not in envelope["projection"]
 
 
 def test_public_search_shape_rejects_malformed_engine_values() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3461,7 +3461,7 @@ def test_search_across_datasets_runs_concurrently() -> None:
             order.append(("start", dataset))
             await aio.sleep(0.05)
             order.append(("end", dataset))
-            return [{"id": dataset}]
+            return [{"id": dataset, "text": dataset}]
 
     merged = aio.run(
         search_across_datasets(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5052,6 +5052,40 @@ class MultiSearchCitadel(FakeCitadel):
         ]
 
 
+class FinalPageCitadel(FakeCitadel):
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        dataset = kwargs["dataset"]
+
+        def chunk(identifier: str, text: str) -> dict[str, Any]:
+            return {
+                "id": identifier,
+                "document_id": f"document-{identifier}",
+                "type": "DocumentChunk",
+                "text": text,
+            }
+
+        if query == "needle":
+            if dataset == "masumi-network":
+                rows = [chunk("central-exact", "needle central exact match")]
+            elif dataset.startswith("seat:"):
+                rows = [chunk("node-unrelated", "unrelated node material")]
+            else:
+                rows = []
+        elif dataset == "masumi-network":
+            rows = [
+                chunk(f"central-{index}", f"architecture central {index}")
+                for index in range(8)
+            ]
+        elif dataset.startswith("seat:"):
+            rows = [
+                chunk(f"node-{index}", f"architecture node {index}")
+                for index in range(8)
+            ]
+        else:
+            rows = []
+        return rows[: kwargs["top_k"]]
+
+
 class TrackingCitadel(FakeCitadel):
     def __init__(self) -> None:
         self.ingest_calls: list[dict[str, Any]] = []
@@ -5441,6 +5475,66 @@ def test_seat_token_searches_node_and_central(tmp_path: Any) -> None:
     ]
     assert "sections" in payload
     assert payload["sections"]["session_traces"]
+
+
+def test_seat_search_pages_include_central_results(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = FinalPageCitadel()
+    api_client = TestClient(app, base_url="https://testserver")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    search = api_client.post(
+        "/search", json={"query": "architecture patterns", "top_k": 5}, headers=headers
+    )
+    knowledge = api_client.get(
+        "/api/knowledge",
+        params={"q": "architecture patterns", "limit": 5},
+        headers=headers,
+    )
+
+    assert search.status_code == 200
+    assert knowledge.status_code == 200
+    for response in (search, knowledge):
+        results = response.json()["results"]
+        assert len(results) == 5
+        assert any(result["dataset"] == "masumi-network" for result in results)
+        assert len({result["id"] for result in results}) == 5
+
+
+def test_seat_search_top_one_prefers_exact_central_result(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = FinalPageCitadel()
+    api_client = TestClient(app, base_url="https://testserver")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    search = api_client.post(
+        "/search", json={"query": "needle", "top_k": 1}, headers=headers
+    )
+    knowledge = api_client.get(
+        "/api/knowledge", params={"q": "needle", "limit": 1}, headers=headers
+    )
+
+    assert search.status_code == 200
+    assert knowledge.status_code == 200
+    search_result = search.json()["results"]
+    knowledge_result = knowledge.json()["results"]
+    assert len(search_result) == len(knowledge_result) == 1
+    assert (search_result[0]["id"], search_result[0]["dataset"]) == (
+        "central-exact",
+        "masumi-network",
+    )
+    assert (knowledge_result[0]["id"], knowledge_result[0]["dataset"]) == (
+        "central-exact",
+        "masumi-network",
+    )
 
 
 def test_seat_cannot_recall_another_seats_session(tmp_path: Any) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5071,6 +5071,34 @@ class FinalPageCitadel(FakeCitadel):
                 rows = [chunk("node-unrelated", "unrelated node material")]
             else:
                 rows = []
+        elif query == "filter dedup":
+            if dataset == "masumi-network":
+                central = chunk("central-filter", "shared filtered text")
+                central["repo"] = "masumi-network/central"
+                rows = [central]
+            elif dataset.startswith("seat:"):
+                rows = [chunk("node-filter", "shared filtered text")]
+            else:
+                rows = []
+        elif query == "nested identity":
+            if dataset.startswith("seat:"):
+                nested = chunk("nested-result", "nested identity content")
+                nested["id"] = {"private_marker": "PRIVATE_MARKER"}
+                rows = [nested]
+            else:
+                rows = []
+        elif query == "nonfinite values":
+            if dataset.startswith("seat:"):
+                nan_row = chunk("nan-result", "nonfinite nan content")
+                nan_row["score"] = float("nan")
+                nan_row["_citadel"] = {
+                    "relevance": {"term_coverage": float("inf")}
+                }
+                infinite_row = chunk("infinite-result", "nonfinite infinite content")
+                infinite_row["score"] = float("inf")
+                rows = [nan_row, infinite_row]
+            else:
+                rows = []
         elif dataset == "masumi-network":
             rows = [
                 chunk(f"central-{index}", f"architecture central {index}")
@@ -5535,6 +5563,96 @@ def test_seat_search_top_one_prefers_exact_central_result(tmp_path: Any) -> None
         "central-exact",
         "masumi-network",
     )
+
+
+def test_search_filter_keeps_central_duplicate_when_node_lacks_identity(
+    tmp_path: Any,
+) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = FinalPageCitadel()
+    api_client = TestClient(app, base_url="https://testserver")
+
+    response = api_client.post(
+        "/search",
+        json={
+            "query": "filter dedup",
+            "top_k": 1,
+            "repo": "masumi-network/central",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()["results"]
+    assert len(result) == 1
+    assert (result[0]["id"], result[0]["dataset"]) == (
+        "central-filter",
+        "masumi-network",
+    )
+
+
+def test_search_sanitizes_nested_result_identity(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = FinalPageCitadel()
+    api_client = TestClient(app, base_url="https://testserver")
+
+    response = api_client.post(
+        "/search",
+        json={"query": "nested identity", "top_k": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    result = payload["results"][0]
+    assert isinstance(result["id"], str)
+    assert isinstance(result["qa_id"], str)
+    assert isinstance(result["_citadel"]["result_id"], str)
+    assert "PRIVATE_MARKER" not in response.text
+    assert "PRIVATE_MARKER" not in json.dumps(payload)
+
+
+def test_search_omits_nonfinite_values_on_both_read_routes(tmp_path: Any) -> None:
+    app.state.access_store = AccessStore(tmp_path / "access.json")
+    admin = authed_client()
+    token = admin.post(
+        "/api/access/seats", json={"name": "Bob", "slug": "bob"}
+    ).json()["token"]
+    app.state.citadel = FinalPageCitadel()
+    api_client = TestClient(app, base_url="https://testserver")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    responses = [
+        api_client.post(
+            "/search",
+            json={"query": "nonfinite values", "top_k": 5},
+            headers=headers,
+        ),
+        api_client.get(
+            "/api/knowledge",
+            params={"q": "nonfinite values", "limit": 5},
+            headers=headers,
+        ),
+    ]
+
+    for response in responses:
+        assert response.status_code == 200
+        payload = response.json()
+        assert "NaN" not in response.text
+        assert "Infinity" not in response.text
+        assert payload["results"]
+        for result in payload["results"]:
+            assert result.get("score") is None
+            relevance = result.get("_citadel", {}).get("relevance", {})
+            assert "retriever_score" not in relevance
 
 
 def test_seat_cannot_recall_another_seats_session(tmp_path: Any) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -76,7 +76,14 @@ class FakeCitadel:
         }
 
     async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
-        return [{"query": query, "dataset": kwargs["dataset"], "top_k": kwargs["top_k"]}]
+        return [
+            {
+                "query": query,
+                "dataset": kwargs["dataset"],
+                "top_k": kwargs["top_k"],
+                "text": f"{query} result",
+            }
+        ]
 
     documents: dict[str, dict[str, Any]] = {}
 
@@ -1177,7 +1184,9 @@ def test_api_uses_configured_citadel_service() -> None:
     assert ingest.json()["tags"] == ["research"]
     assert search.status_code == 200
     search_hit = search.json()["results"][0]
-    assert search_hit["top_k"] == 3
+    assert search_hit["text"] == "useful result"
+    assert "query" not in search_hit
+    assert "top_k" not in search_hit
     assert search_hit["id"].startswith("chunk:")
     assert search_hit["_citadel"]["rank"] == 1
     assert search_hit["_citadel"]["dataset"] == "notes"
@@ -1912,6 +1921,8 @@ def test_search_view_groups_central_before_node() -> None:
     assert '"/api/access/self"' in app_js
     assert '"/api/access/self/tokens"' in app_js
     assert "/api/access/self/tokens/${encodeURIComponent(tokenId)}/revoke" in app_js
+    assert "placed.add(searchResultKey(hit))" in app_js
+    assert "!placed.has(searchResultKey(hit))" in app_js
     assert "Search results" in app_page
 
 
@@ -4748,10 +4759,21 @@ class KnowledgeCitadel(FakeCitadel):
     async def search(self, query: str, **kwargs: Any) -> list[Any]:
         return [
             {
+                "id": "rotate-keys-chunk",
+                "document_id": "rotate-keys-document",
                 "text": "Rotate keys quarterly",
                 "source_url": "https://example.com/runbook",
                 "score": 0.92,
-                "metadata": {"citadel_tags": ["ops"]},
+                "metadata": {"citadel_tags": ["ops"], "private": "internal"},
+                "source_pipeline": "internal-pipeline",
+                "source_task": "internal-task",
+                "source_node_set": "internal-node-set",
+                "source_user": "default-user@example.invalid",
+            },
+            {
+                "type": "IndexSchema",
+                "text": "Internal index schema row",
+                "source_user": "default-user@example.invalid",
             },
             "bare string result",
         ]
@@ -4933,17 +4955,24 @@ def test_knowledge_alias_returns_flat_agent_friendly_results() -> None:
     app.state.citadel = KnowledgeCitadel()
 
     response = client.get("/api/knowledge", params={"q": "rotate keys", "limit": 5})
+    search = client.post("/search", json={"query": "rotate keys", "top_k": 5})
 
     assert response.status_code == 200
+    assert search.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
     assert payload["query"] == "rotate keys"
-    assert payload["results"][0] == {
-        "text": "Rotate keys quarterly",
-        "source": "https://example.com/runbook",
-        "score": 0.92,
-        "tags": ["ops"],
-    }
+    assert [set(result) for result in payload["results"]] == [
+        set(result) for result in search.json()["results"]
+    ]
+    assert len(payload["results"]) == 2
+    assert payload["results"][0]["text"] == "Rotate keys quarterly"
+    assert payload["results"][0]["source"] == "https://example.com/runbook"
+    assert payload["results"][0]["score"] == 0.92
+    assert payload["results"][0]["tags"] == ["ops"]
+    assert payload["results"][0]["document_id"] == "rotate-keys-document"
+    assert "metadata" not in payload["results"][0]
+    assert "source_user" not in payload["results"][0]
     assert payload["results"][1]["text"] == "bare string result"
     assert payload["results"][1]["source"] is None
 
@@ -5375,7 +5404,7 @@ def test_seat_token_searches_node_and_central(tmp_path: Any) -> None:
     )
     knowledge = api_client.get(
         "/api/knowledge",
-        params={"q": "architecture", "limit": 5},
+        params={"q": "architecture", "limit": 2},
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -5401,6 +5430,8 @@ def test_seat_token_searches_node_and_central(tmp_path: Any) -> None:
     }
 
     assert knowledge.status_code == 200
+    assert len(knowledge.json()["results"]) == 2
+    assert [result["rank"] for result in knowledge.json()["results"]] == [1, 2]
     assert knowledge.json()["datasets"] == [
         "seat:bob",
         "masumi-network",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5044,6 +5044,8 @@ class MultiSearchCitadel(FakeCitadel):
             {
                 "query": query,
                 "dataset": dataset,
+                "type": "DocumentChunk",
+                "document_id": f"document-{dataset}",
                 "text": f"{query} in {dataset}",
                 "top_k": kwargs["top_k"],
             }


### PR DESCRIPTION
## Summary

- Route `/search`, `/api/knowledge`, and MCP search results through one explicit public DTO.
- Remove raw pipeline, user, metadata, ontology, and lifecycle fields from public results.
- Drop malformed rows and typed non-content rows before returning results.
- Preserve indexed document hits, legacy string hits, public provenance, feedback IDs, limits, and ranks.
- Deduplicate grouped legacy UI results by stable identity.

## Verification

- VERIFIED: focused search matrix returned `367 passed`.
- VERIFIED: Ruff, JavaScript syntax, and diff checks passed.
- VERIFIED: three fresh reviewers found no P0 or P1 issue after corrections.
- VERIFIED: the known Cognee dependency metadata failure also occurs outside this branch.

Closes #281