### PR TITLE
fix: harden runtime readiness and graph probes

### DIFF
--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -3224,6 +3224,8 @@ class CogneePublicClient:
         requested = {str(document_id) for document_id in document_ids}
         query_text = """
         MATCH (n:Node)
+        WHERE n.type = 'DocumentChunk'
+          AND json_valid(n.properties)
         WITH n.type AS node_type,
              CAST(json_extract(n.properties, '$.document_id') AS STRING) AS document_id_json
         WHERE node_type = 'DocumentChunk'

--- a/kb/server.py
+++ b/kb/server.py
@@ -5018,8 +5018,8 @@ async def _bounded_corpus_health() -> dict[str, Any]:
     A zero timeout keeps the previous unbounded behavior for operators that need
     the full measurement. The normal setting is finite. A timed-out probe is
     shielded so it can finish and populate the shared cache after the request
-    returns; callers use the last cached result when one exists, otherwise the
-    existing uptime-counter fallback.
+    returns; callers retain cached measurements for diagnostics, but timeout
+    results remain explicitly not ready.
     """
     try:
         if _CORPUS_HEALTH_TIMEOUT_SECONDS <= 0:
@@ -5034,6 +5034,7 @@ async def _bounded_corpus_health() -> dict[str, Any]:
         cached = _CORPUS_HEALTH_CACHE
         if cached is not None:
             result = dict(cached[2])
+            result["ok"] = False
             result["degraded"] = (
                 f"corpus health timed out after {timeout:g}s; serving cached result"
             )
@@ -5051,7 +5052,7 @@ async def _bounded_corpus_health() -> dict[str, Any]:
 async def readyz(request: Request) -> Any:
     require_access(request, "reader", "kb:read")
     config = get_citadel().config
-    corpus = await _corpus_health()
+    corpus = await _bounded_corpus_health()
     canary = _LAST_CANARY
     lifecycle = lifecycle_health(get_citadel())
     # RED when the corpus gate trips or the last end-to-end canary failed.

--- a/kb/server.py
+++ b/kb/server.py
@@ -160,10 +160,10 @@ _INDEXED_FLOOR = 1
 _CORPUS_HEALTH_PROBE_LIMIT = 64
 try:
     _CORPUS_HEALTH_CACHE_TTL_SECONDS = max(
-        0.0, float(os.getenv("CITADEL_CORPUS_HEALTH_CACHE_TTL_SECONDS", "5"))
+        0.0, float(os.getenv("CITADEL_CORPUS_HEALTH_CACHE_TTL_SECONDS", "30"))
     )
 except ValueError:
-    _CORPUS_HEALTH_CACHE_TTL_SECONDS = 5.0
+    _CORPUS_HEALTH_CACHE_TTL_SECONDS = 30.0
 # /api/mesh and /api/indexes already degrade to restart-scoped counters when
 # corpus measurement fails. Bound that dependency so a slow graph read follows
 # the existing response contract instead of holding the dashboard request open.
@@ -173,9 +173,24 @@ try:
     )
 except ValueError:
     _CORPUS_HEALTH_TIMEOUT_SECONDS = 2.0
+try:
+    _LIFECYCLE_HEALTH_TIMEOUT_SECONDS = max(
+        0.0, float(os.getenv("CITADEL_LIFECYCLE_HEALTH_TIMEOUT_SECONDS", "2"))
+    )
+except ValueError:
+    _LIFECYCLE_HEALTH_TIMEOUT_SECONDS = 2.0
+_LIFECYCLE_HEALTH_CACHE_TTL_SECONDS = max(
+    30.0, _CORPUS_HEALTH_CACHE_TTL_SECONDS
+)
 _CORPUS_HEALTH_CACHE: tuple[float, tuple[int, ...], dict[str, Any]] | None = None
 _CORPUS_HEALTH_LOCK = asyncio.Lock()
 _CORPUS_HEALTH_TASK: asyncio.Task[dict[str, Any]] | None = None
+_LIFECYCLE_HEALTH_CACHE: tuple[float, int, dict[str, Any]] | None = None
+_LIFECYCLE_HEALTH_TASK: tuple[
+    int,
+    asyncio.AbstractEventLoop,
+    asyncio.Task[dict[str, Any]],
+] | None = None
 
 # In-flight counts for the soft concurrency cap / 429 backpressure contract
 # (#50). Single-loop server → increment/decrement need no lock. Search and the
@@ -4622,6 +4637,17 @@ def lifecycle_health(citadel: Any) -> dict[str, Any]:
             for backend in ("relational", "vector", "graph")
         ):
             invariant_errors.append("current_generation_backend_census_mismatch")
+        searchable_by_backend = current_generation.get(
+            "current_searchable_by_backend"
+        )
+        if not isinstance(searchable_by_backend, dict) or any(
+            int(searchable_by_backend.get(backend, 0)) != current_sources
+            or int(searchable_by_backend.get(backend, 0)) != current_jobs
+            for backend in ("relational", "vector", "graph")
+        ):
+            invariant_errors.append(
+                "current_generation_searchable_census_mismatch"
+            )
     if failed_jobs or failed_receipts:
         invariant_errors.append("failed_projection")
     return {
@@ -4706,7 +4732,7 @@ async def public_state(request: Request, response: Response) -> dict[str, Any]:
         }
 
     docs_total = sum(int(s.get("documents") or 0) for s in sources)
-    lifecycle = lifecycle_health(get_citadel())
+    lifecycle = await _bounded_lifecycle_health(get_citadel())
     return {
         "ok": True,
         "service": "Citadel Archive",
@@ -5048,20 +5074,106 @@ async def _bounded_corpus_health() -> dict[str, Any]:
         }
 
 
-@app.get("/readyz")
-async def readyz(request: Request) -> Any:
-    require_access(request, "reader", "kb:read")
-    config = get_citadel().config
-    corpus = await _bounded_corpus_health()
+def _complete_lifecycle_health_task(
+    citadel_id: int,
+    task: asyncio.Task[dict[str, Any]],
+) -> None:
+    """Cache a completed census at completion time and release its shared slot."""
+    global _LIFECYCLE_HEALTH_CACHE, _LIFECYCLE_HEALTH_TASK
+
+    current = _LIFECYCLE_HEALTH_TASK
+    if current is None or current[0] != citadel_id or current[2] is not task:
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+        return
+    _LIFECYCLE_HEALTH_TASK = None
+    try:
+        result = task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception as exc:  # noqa: BLE001 - consume background task failures
+        logger.warning("lifecycle health task failed: %s", exc.__class__.__name__)
+        return
+    if _LIFECYCLE_HEALTH_CACHE_TTL_SECONDS > 0:
+        _LIFECYCLE_HEALTH_CACHE = (time.monotonic(), citadel_id, dict(result))
+
+
+def _lifecycle_health_task(citadel: Any) -> asyncio.Task[dict[str, Any]]:
+    """Return one shared lifecycle census task for this process and event loop."""
+    global _LIFECYCLE_HEALTH_TASK
+
+    loop = asyncio.get_running_loop()
+    current = _LIFECYCLE_HEALTH_TASK
+    if current is None or current[0] != id(citadel) or current[1] is not loop:
+        task = asyncio.create_task(asyncio.to_thread(lifecycle_health, citadel))
+        _LIFECYCLE_HEALTH_TASK = (id(citadel), loop, task)
+        task.add_done_callback(
+            lambda completed: _complete_lifecycle_health_task(id(citadel), completed)
+        )
+        return task
+    return current[2]
+
+
+async def _bounded_lifecycle_health(citadel: Any) -> dict[str, Any]:
+    """Return lifecycle health without letting SQLite hold readiness open."""
+    global _LIFECYCLE_HEALTH_CACHE, _LIFECYCLE_HEALTH_TASK
+
+    if not citadel.config.lifecycle_enabled:
+        return lifecycle_health(citadel)
+    cached = _LIFECYCLE_HEALTH_CACHE
+    if (
+        cached is not None
+        and cached[1] == id(citadel)
+        and _LIFECYCLE_HEALTH_CACHE_TTL_SECONDS > 0
+        and time.monotonic() - cached[0] < _LIFECYCLE_HEALTH_CACHE_TTL_SECONDS
+    ):
+        return dict(cached[2])
+    task = _lifecycle_health_task(citadel)
+    try:
+        if _LIFECYCLE_HEALTH_TIMEOUT_SECONDS <= 0:
+            result = await asyncio.shield(task)
+        else:
+            result = await asyncio.wait_for(
+                asyncio.shield(task),
+                timeout=_LIFECYCLE_HEALTH_TIMEOUT_SECONDS,
+            )
+        return result
+    except asyncio.TimeoutError:
+        timeout = _LIFECYCLE_HEALTH_TIMEOUT_SECONDS
+        logger.warning("bounded lifecycle health timed out after %.2fs", timeout)
+        return {
+            "enabled": bool(citadel.config.lifecycle_enabled),
+            "ok": False,
+            "error_type": "TimeoutError",
+        }
+    except Exception as exc:  # noqa: BLE001 - readiness returns a typed failure
+        return {
+            "enabled": bool(citadel.config.lifecycle_enabled),
+            "ok": False,
+            "error_type": exc.__class__.__name__,
+        }
+    finally:
+        if task.done():
+            _complete_lifecycle_health_task(id(citadel), task)
+
+
+async def _readiness_payload() -> dict[str, Any]:
+    """Return the detailed readiness state used by authenticated operators."""
+    citadel = get_citadel()
+    config = citadel.config
+    corpus, lifecycle = await asyncio.gather(
+        _bounded_corpus_health(),
+        _bounded_lifecycle_health(citadel),
+    )
     canary = _LAST_CANARY
-    lifecycle = lifecycle_health(get_citadel())
-    # RED when the corpus gate trips or the last end-to-end canary failed.
     ok = (
         corpus["ok"]
         and lifecycle["ok"]
         and (canary is None or bool(canary.get("ok", True)))
     )
-    payload = {
+    return {
         "ok": ok,
         "service": "citadel",
         "tenant_id": config.tenant_id,
@@ -5072,7 +5184,32 @@ async def readyz(request: Request) -> Any:
         "lifecycle": lifecycle,
         "canary": canary,
     }
-    return JSONResponse(payload, status_code=200 if ok else 503)
+
+
+@app.get("/health/ready")
+async def deployment_readiness() -> Any:
+    """Return detail-free dependency readiness for the Railway deploy gate."""
+    if _CORPUS_HEALTH_CACHE_TTL_SECONDS <= 0:
+        return JSONResponse(
+            {"ok": False, "service": "citadel"},
+            status_code=503,
+        )
+    payload = await _readiness_payload()
+    dependency_ok = (
+        "degraded" not in payload["corpus"]
+        and "error_type" not in payload["lifecycle"]
+    )
+    return JSONResponse(
+        {"ok": dependency_ok, "service": "citadel"},
+        status_code=200 if dependency_ok else 503,
+    )
+
+
+@app.get("/readyz")
+async def readyz(request: Request) -> Any:
+    require_access(request, "reader", "kb:read")
+    payload = await _readiness_payload()
+    return JSONResponse(payload, status_code=200 if payload["ok"] else 503)
 
 
 def _mesh_dataset_visible(

--- a/railway.toml
+++ b/railway.toml
@@ -11,8 +11,8 @@ builder = "DOCKERFILE"
 # FastAPI Organization Vault. Other Railway services select scripts.run_railway
 # modes such as github-sync, backup-mirror, and pipeline in their own config.
 startCommand = "python -m kb.lite_runtime"
-healthcheckPath = "/healthz"
-# Cold boot initialises cognee + Ladybug before /healthz answers, which can
+healthcheckPath = "/health/ready"
+# Cold boot initialises cognee + Ladybug before /health/ready answers, which can
 # exceed 30s on a fresh volume. The embedding model is baked into the image
 # since 2026-08-12, so no model download happens at boot any more.
 healthcheckTimeout = 300

--- a/tests/test_get_document_drilldown.py
+++ b/tests/test_get_document_drilldown.py
@@ -32,6 +32,7 @@ metadata.assembled_from == "chunk_store".
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -48,6 +49,8 @@ pytestmark = pytest.mark.asyncio
 DOC_ID = str(uuid5(NAMESPACE_OID, "drilldown-doc"))
 CHUNK_IDS = [str(uuid5(NAMESPACE_OID, f"{DOC_ID}-{index}")) for index in range(3)]
 ENTITY_ID = str(uuid5(NAMESPACE_OID, "drilldown-entity"))
+MALFORMED_NODE_ID = str(uuid5(NAMESPACE_OID, "malformed-document-chunk"))
+MALFORMED_DOCUMENT_ID = str(uuid5(NAMESPACE_OID, "malformed-document"))
 # In the chunk store but never written to the graph (the measured 404 class).
 ORPHAN_DOC_ID = str(uuid5(NAMESPACE_OID, "orphan-doc"))
 ORPHAN_CHUNK_IDS = [
@@ -139,6 +142,34 @@ def real_graph(tmp_path_factory: pytest.TempPathFactory) -> Any:
                     }
                 ),
             ]
+        )
+        valid_properties = json.dumps(
+            {"document_id": MALFORMED_DOCUMENT_ID, "padding": ""},
+            separators=(",", ":"),
+        )
+        valid_properties = json.dumps(
+            {
+                "document_id": MALFORMED_DOCUMENT_ID,
+                "padding": "x" * (675 - len(valid_properties)),
+            },
+            separators=(",", ":"),
+        )
+        assert len(valid_properties) == 675
+        await adapter.query(
+            """
+            CREATE (n:Node {
+                id: $id,
+                name: $name,
+                type: $type,
+                properties: $properties
+            })
+            """,
+            {
+                "id": MALFORMED_NODE_ID,
+                "name": "DocumentChunk",
+                "type": "DocumentChunk",
+                "properties": valid_properties + "{}",
+            },
         )
         await adapter.add_edges(
             [
@@ -293,6 +324,13 @@ async def test_textless_entity_still_resolves_none(real_graph: Any) -> None:
     _install_chunk_store(client, _empty_store())
 
     assert await client.get_document(ENTITY_ID) is None
+
+
+async def test_graph_presence_ignores_malformed_unrelated_chunk(real_graph: Any) -> None:
+    """A malformed unrelated chunk must not abort requested graph presence."""
+    client = _client_over(real_graph)
+
+    assert await client.corpus_graph_presence([DOC_ID]) == {DOC_ID}
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_railway_entrypoint.py
+++ b/tests/test_railway_entrypoint.py
@@ -20,6 +20,7 @@ def test_railway_toml_boots_the_published_image_entrypoint() -> None:
         config = tomllib.load(file)
 
     assert config["deploy"]["startCommand"] == "python -m kb.lite_runtime"
+    assert config["deploy"]["healthcheckPath"] == "/health/ready"
     assert importlib.util.find_spec("kb.lite_runtime") is not None
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -406,6 +406,110 @@ def test_healthz() -> None:
     assert response.json() == {"ok": True, "service": "citadel"}
 
 
+def test_deployment_readiness_allows_recoverable_data_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def backlog_corpus() -> dict[str, Any]:
+        return {"ok": False, "tracked_sources": 50, "indexed_docs": 40}
+
+    async def backlog_lifecycle(_citadel: Any) -> dict[str, Any]:
+        return {"enabled": True, "ok": False, "invariant_errors": ["failed_projection"]}
+
+    app.state.citadel = FakeCitadel()
+    monkeypatch.setattr(server_module, "_bounded_corpus_health", backlog_corpus)
+    monkeypatch.setattr(server_module, "_bounded_lifecycle_health", backlog_lifecycle)
+    client = TestClient(app)
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "service": "citadel"}
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.parametrize(
+    ("corpus", "lifecycle"),
+    [
+        (
+            {"ok": False, "degraded": "TimeoutError"},
+            {"enabled": True, "ok": True},
+        ),
+        (
+            {"ok": True},
+            {"enabled": True, "ok": False, "error_type": "TimeoutError"},
+        ),
+    ],
+)
+def test_deployment_readiness_rejects_dependency_failures_without_details(
+    monkeypatch: pytest.MonkeyPatch,
+    corpus: dict[str, Any],
+    lifecycle: dict[str, Any],
+) -> None:
+    async def corpus_health() -> dict[str, Any]:
+        return corpus
+
+    async def lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        return lifecycle
+
+    app.state.citadel = FakeCitadel()
+    monkeypatch.setattr(server_module, "_bounded_corpus_health", corpus_health)
+    monkeypatch.setattr(server_module, "_bounded_lifecycle_health", lifecycle_health)
+    client = TestClient(app)
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"ok": False, "service": "citadel"}
+
+
+def test_deployment_readiness_caches_serial_lifecycle_probes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"enabled": True, "ok": True}
+
+    async def corpus_health() -> dict[str, Any]:
+        return {"ok": True}
+
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(lifecycle_enabled=True)
+    app.state.citadel = citadel
+    monkeypatch.setattr(server_module, "lifecycle_health", lifecycle_health)
+    monkeypatch.setattr(server_module, "_bounded_corpus_health", corpus_health)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE_TTL_SECONDS", 30.0)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+    client = TestClient(app)
+
+    first = client.get("/health/ready")
+    second = client.get("/health/ready")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert calls == 1
+
+
+def test_deployment_readiness_rejects_disabled_corpus_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unexpected_corpus() -> dict[str, Any]:
+        raise AssertionError("public readiness must not run an uncached corpus probe")
+
+    app.state.citadel = FakeCitadel()
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE_TTL_SECONDS", 0.0)
+    monkeypatch.setattr(server_module, "_bounded_corpus_health", unexpected_corpus)
+    client = TestClient(app)
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"ok": False, "service": "citadel"}
+
+
 def test_public_state_uses_the_package_source_version() -> None:
     client = authed_client("test-reader")
     response = client.get("/api/state")
@@ -446,9 +550,9 @@ def test_public_state_and_readyz_report_lifecycle_census(
                         "vector": 3,
                     },
                     "current_searchable_by_backend": {
-                        "graph": 2,
+                        "graph": 3,
                         "relational": 3,
-                        "vector": 2,
+                        "vector": 3,
                     },
                 },
             }
@@ -468,6 +572,64 @@ def test_public_state_and_readyz_report_lifecycle_census(
     assert state.json()["lifecycle"]["ok"] is True
     assert ready.status_code == 200
     assert ready.json()["lifecycle"]["projection_receipts"] == 12
+
+
+def test_public_state_uses_bounded_lifecycle_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def bounded_lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        return {"enabled": True, "ok": True, "marker": "bounded"}
+
+    def unbounded_lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        raise AssertionError("public state must not block on a synchronous census")
+
+    app.state.citadel = FakeCitadel()
+    monkeypatch.setattr(
+        server_module, "_bounded_lifecycle_health", bounded_lifecycle_health
+    )
+    monkeypatch.setattr(server_module, "lifecycle_health", unbounded_lifecycle_health)
+    client = TestClient(app)
+
+    response = client.get("/api/state?cache-bust=bounded-lifecycle")
+
+    assert response.status_code == 200
+    assert response.json()["lifecycle"]["marker"] == "bounded"
+
+
+def test_lifecycle_health_rejects_unsearchable_current_generation() -> None:
+    class UnsearchableGenerationCitadel(FakeCitadel):
+        config = CitadelConfig(lifecycle_enabled=True)
+
+        def lifecycle_census(self) -> dict[str, Any]:
+            return {
+                "source_revisions": 1,
+                "projection_jobs": 1,
+                "projection_receipts": 3,
+                "job_states": {"completed": 1},
+                "receipt_states": {"searchable": 3},
+                "current_generation": {
+                    "current_sources": 1,
+                    "current_projection_jobs": 1,
+                    "current_projection_receipts": 3,
+                    "current_receipts_by_backend": {
+                        "graph": 1,
+                        "relational": 1,
+                        "vector": 1,
+                    },
+                    "current_searchable_by_backend": {
+                        "graph": 0,
+                        "relational": 1,
+                        "vector": 1,
+                    },
+                },
+            }
+
+    result = server_module.lifecycle_health(UnsearchableGenerationCitadel())
+
+    assert result["ok"] is False
+    assert result["invariant_errors"] == [
+        "current_generation_searchable_census_mismatch"
+    ]
 
 
 def test_lifecycle_health_rejects_incomplete_current_generation() -> None:
@@ -3328,6 +3490,332 @@ def test_readyz_fails_closed_when_timeout_uses_cached_health(
     assert ready.json()["corpus"]["degraded"] == (
         "corpus health timed out after 0.01s; serving cached result"
     )
+
+
+def test_readyz_reuses_corpus_cache_across_docker_poll_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = authed_client("test-reader")
+
+    class UnexpectedSyncer:
+        async def status(self) -> dict[str, Any]:
+            raise AssertionError("cached readiness must not start another probe")
+
+    citadel = FakeCitadel()
+    github_syncer = UnexpectedSyncer()
+    repo_content_syncer = UnexpectedSyncer()
+    linear_syncer = UnexpectedSyncer()
+    app.state.citadel = citadel
+    app.state.github_syncer = github_syncer
+    app.state.repo_content_syncer = repo_content_syncer
+    app.state.linear_syncer = linear_syncer
+    cache_key = (
+        id(citadel),
+        id(github_syncer),
+        id(repo_content_syncer),
+        id(linear_syncer),
+    )
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE_TTL_SECONDS", 30.0)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    monkeypatch.setattr(
+        server_module,
+        "_CORPUS_HEALTH_CACHE",
+        (
+            time.monotonic() - 16.0,
+            cache_key,
+            {
+                "ok": True,
+                "tracked_sources": 50,
+                "indexed_docs": 65,
+                "indexed_edges": 64,
+            },
+        ),
+    )
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 200
+    assert ready.json()["corpus"]["indexed_docs"] == 65
+
+
+def test_readyz_refreshes_corpus_cache_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = authed_client("test-reader")
+
+    class CountingCitadel(FakeCitadel):
+        graph_calls = 0
+
+        async def _graph_counts(self) -> dict[str, int]:
+            self.graph_calls += 1
+            return {"nodes": 65, "edges": 64}
+
+    class Syncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    citadel = CountingCitadel()
+    github_syncer = Syncer()
+    repo_content_syncer = Syncer()
+    linear_syncer = Syncer()
+    app.state.citadel = citadel
+    app.state.github_syncer = github_syncer
+    app.state.repo_content_syncer = repo_content_syncer
+    app.state.linear_syncer = linear_syncer
+    cache_key = (
+        id(citadel),
+        id(github_syncer),
+        id(repo_content_syncer),
+        id(linear_syncer),
+    )
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE_TTL_SECONDS", 30.0)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    monkeypatch.setattr(
+        server_module,
+        "_CORPUS_HEALTH_CACHE",
+        (
+            time.monotonic() - 31.0,
+            cache_key,
+            {
+                "ok": True,
+                "tracked_sources": 50,
+                "indexed_docs": 1,
+                "indexed_edges": 0,
+            },
+        ),
+    )
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 200
+    assert ready.json()["corpus"]["indexed_docs"] == 65
+    assert citadel.graph_calls == 1
+
+
+def test_readyz_bounds_a_slow_lifecycle_census(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = authed_client("test-reader")
+
+    class SlowLifecycleCitadel(FakeCitadel):
+        config = CitadelConfig(
+            tenant_id="test",
+            default_dataset="notes",
+            admin_key="test-admin",
+            reader_keys=("test-reader",),
+            lifecycle_enabled=True,
+        )
+
+        def lifecycle_census(self) -> dict[str, Any]:
+            time.sleep(0.1)
+            return {
+                "source_revisions": 0,
+                "projection_jobs": 0,
+                "projection_receipts": 0,
+                "job_states": {},
+                "receipt_states": {},
+                "current_generation": {
+                    "current_sources": 0,
+                    "current_projection_jobs": 0,
+                    "current_projection_receipts": 0,
+                    "current_receipts_by_backend": {
+                        "graph": 0,
+                        "relational": 0,
+                        "vector": 0,
+                    },
+                    "current_searchable_by_backend": {
+                        "graph": 0,
+                        "relational": 0,
+                        "vector": 0,
+                    },
+                },
+            }
+
+    async def healthy_corpus() -> dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setattr(server_module, "_bounded_corpus_health", healthy_corpus)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+    app.state.citadel = SlowLifecycleCitadel()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["lifecycle"] == {
+        "enabled": True,
+        "ok": False,
+        "error_type": "TimeoutError",
+    }
+
+
+def test_bounded_lifecycle_health_shares_a_timed_out_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SlowLifecycleCitadel(FakeCitadel):
+        config = CitadelConfig(lifecycle_enabled=True)
+        calls = 0
+
+        def lifecycle_census(self) -> dict[str, Any]:
+            self.calls += 1
+            time.sleep(0.1)
+            return {
+                "source_revisions": 0,
+                "projection_jobs": 0,
+                "projection_receipts": 0,
+                "job_states": {},
+                "receipt_states": {},
+                "current_generation": {
+                    "current_sources": 0,
+                    "current_projection_jobs": 0,
+                    "current_projection_receipts": 0,
+                    "current_receipts_by_backend": {
+                        "graph": 0,
+                        "relational": 0,
+                        "vector": 0,
+                    },
+                    "current_searchable_by_backend": {
+                        "graph": 0,
+                        "relational": 0,
+                        "vector": 0,
+                    },
+                },
+            }
+
+    citadel = SlowLifecycleCitadel()
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+
+    async def exercise() -> None:
+        first = await server_module._bounded_lifecycle_health(citadel)
+        second = await server_module._bounded_lifecycle_health(citadel)
+        assert first["error_type"] == "TimeoutError"
+        assert second["error_type"] == "TimeoutError"
+        assert citadel.calls == 1
+        current = server_module._LIFECYCLE_HEALTH_TASK
+        assert current is not None
+        assert current[2].done() is False
+        await asyncio.sleep(0.11)
+        completed = await server_module._bounded_lifecycle_health(citadel)
+        assert completed["ok"] is True
+        assert citadel.calls == 1
+        assert server_module._LIFECYCLE_HEALTH_TASK is None
+
+    asyncio.run(exercise())
+
+
+def test_bounded_lifecycle_health_refreshes_an_expired_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"enabled": True, "ok": True, "fresh": True}
+
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(lifecycle_enabled=True)
+    monkeypatch.setattr(server_module, "lifecycle_health", lifecycle_health)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE_TTL_SECONDS", 30.0)
+    monkeypatch.setattr(
+        server_module,
+        "_LIFECYCLE_HEALTH_CACHE",
+        (time.monotonic() - 31.0, id(citadel), {"enabled": True, "ok": True}),
+    )
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+
+    result = asyncio.run(server_module._bounded_lifecycle_health(citadel))
+
+    assert result["fresh"] is True
+    assert calls == 1
+
+
+def test_bounded_lifecycle_health_does_not_refresh_a_late_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.01)
+        return {"enabled": True, "ok": True}
+
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(lifecycle_enabled=True)
+    monkeypatch.setattr(server_module, "lifecycle_health", lifecycle_health)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TIMEOUT_SECONDS", 0.001)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE_TTL_SECONDS", 0.02)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+
+    async def exercise() -> None:
+        timed_out = await server_module._bounded_lifecycle_health(citadel)
+        assert timed_out["error_type"] == "TimeoutError"
+        await asyncio.sleep(0.04)
+        timed_out_again = await server_module._bounded_lifecycle_health(citadel)
+        assert timed_out_again["error_type"] == "TimeoutError"
+        assert calls == 2
+        await asyncio.sleep(0.02)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("failure", [RuntimeError, TimeoutError])
+def test_bounded_lifecycle_health_clears_a_failed_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: type[Exception],
+) -> None:
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(lifecycle_enabled=True)
+    calls = 0
+
+    def flaky_lifecycle_health(_citadel: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise failure("probe failed")
+        return {"enabled": True, "ok": True}
+
+    monkeypatch.setattr(server_module, "lifecycle_health", flaky_lifecycle_health)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+
+    async def exercise() -> None:
+        failed = await server_module._bounded_lifecycle_health(citadel)
+        assert failed == {
+            "enabled": True,
+            "ok": False,
+            "error_type": failure.__name__,
+        }
+        assert server_module._LIFECYCLE_HEALTH_TASK is None
+        recovered = await server_module._bounded_lifecycle_health(citadel)
+        assert recovered == {"enabled": True, "ok": True}
+        assert calls == 2
+
+    asyncio.run(exercise())
+
+
+def test_bounded_lifecycle_health_clears_a_cancelled_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    citadel = FakeCitadel()
+    citadel.config = CitadelConfig(lifecycle_enabled=True)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_LIFECYCLE_HEALTH_TASK", None)
+
+    async def exercise() -> None:
+        task = server_module._lifecycle_health_task(citadel)
+        task.cancel()
+        await asyncio.sleep(0)
+        with pytest.raises(asyncio.CancelledError):
+            await server_module._bounded_lifecycle_health(citadel)
+        assert server_module._LIFECYCLE_HEALTH_TASK is None
+
+    asyncio.run(exercise())
 
 
 def test_readyz_rejects_inconsistent_complete_corpus_probe(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ import re
 import secrets
 import logging
 import tempfile
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -3253,6 +3254,80 @@ def test_readyz_accepts_a_complete_multi_page_corpus_probe(
 
     assert ready.status_code == 200
     assert ready.json()["corpus"]["probe_documents"] == 65
+
+
+def test_readyz_bounds_a_slow_corpus_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SlowCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            await asyncio.sleep(0.2)
+            return {"nodes": 65, "edges": 64}
+
+    class Syncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    client = authed_client("test-reader")
+    app.state.citadel = SlowCitadel()
+    app.state.github_syncer = Syncer()
+    app.state.repo_content_syncer = Syncer()
+    app.state.linear_syncer = Syncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["corpus"]["degraded"] == (
+        "corpus health timed out after 0.01s"
+    )
+
+
+def test_readyz_fails_closed_when_timeout_uses_cached_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SlowCitadel(FakeCitadel):
+        async def _graph_counts(self) -> dict[str, int]:
+            await asyncio.sleep(0.2)
+            return {"nodes": 65, "edges": 64}
+
+    class Syncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    monkeypatch.setattr(
+        server_module,
+        "_CORPUS_HEALTH_CACHE",
+        (
+            time.monotonic(),
+            (1,),
+            {
+                "ok": True,
+                "tracked_sources": 50,
+                "indexed_docs": 65,
+                "indexed_edges": 64,
+            },
+        ),
+    )
+    client = authed_client("test-reader")
+    app.state.citadel = SlowCitadel()
+    app.state.github_syncer = Syncer()
+    app.state.repo_content_syncer = Syncer()
+    app.state.linear_syncer = Syncer()
+
+    ready = client.get("/readyz")
+
+    assert ready.status_code == 503
+    assert ready.json()["ok"] is False
+    assert ready.json()["corpus"]["ok"] is False
+    assert ready.json()["corpus"]["indexed_docs"] == 65
+    assert ready.json()["corpus"]["degraded"] == (
+        "corpus health timed out after 0.01s; serving cached result"
+    )
 
 
 def test_readyz_rejects_inconsistent_complete_corpus_probe(


### PR DESCRIPTION
## Scope

- VERIFIED: Filters malformed Ladybug JSON before `json_extract` runs.
- VERIFIED: Bounds corpus and lifecycle readiness work.
- VERIFIED: Shares timed-out lifecycle work and caches results at completion time.
- VERIFIED: Requires current relational, vector, and graph receipts to be searchable for authenticated `/readyz`.
- VERIFIED: Adds a detail-free Railway dependency gate at `/health/ready`.
- VERIFIED: Moves public `/api/state` lifecycle work off the event loop.

## Evidence

- VERIFIED: `uv run pytest -q tests/test_server.py tests/test_get_document_drilldown.py tests/test_railway_entrypoint.py tests/test_lite_runtime.py` returned `355 passed, 12 warnings in 15.04s`.
- VERIFIED: `uv run ruff check kb/server.py tests/test_server.py` returned `All checks passed!`.
- VERIFIED: `git diff --check` returned no output.
- REPORTED: Fresh-eyes review returned `SHIP. No P0/P1 findings.`
- REPORTED: Prove-it ran `19 passed` and `14/14` negative controls went red.

## Release boundary

- VERIFIED: Railway dependency readiness permits existing lifecycle backlog so the recovery deployment can activate.
- VERIFIED: Authenticated `/readyz` remains strict and reports corpus, lifecycle, and canary state.
- REPORTED: No Railway deployment or authenticated production probe ran for this branch.
- REPORTED: Cognee import rotated files under the local user log directory during proof. No repository file was changed by that rotation.
