### PR TITLE
fix: scope lifecycle recovery

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -223,6 +223,10 @@ Admin:
 - `GET /api/audit?view=all|mcp|access|failures&limit=50`
 - `GET /api/backup-mirror`, `POST /api/backup-mirror/run`
 - `GET /api/linear-sync`, `POST /api/linear-sync/run`
+- `POST /api/lifecycle/requeue-failed` previews active-generation failures by
+  default. Apply requires the returned generation identity, exact ordered
+  `candidate_ids`, and `expected_count`. A changed preview returns HTTP 409
+  without resetting any job. The route requires admin role and `sources:sync`.
 
 Examples:
 

--- a/kb/lifecycle.py
+++ b/kb/lifecycle.py
@@ -36,6 +36,30 @@ class LifecycleConflictError(LifecycleError):
     """Raised when one deterministic operation ID has conflicting inputs."""
 
 
+class LifecycleRequeueIdentityMismatchError(LifecycleConflictError):
+    """Raised when a recovery request does not match the active worker."""
+
+    def __init__(self, projection: ProjectionRequest) -> None:
+        self.generation_id = projection.generation_id
+        self.projection_version = projection.projection_version
+        self.config_digest = projection.config_digest
+        super().__init__("recovery identity does not match the active lifecycle worker")
+
+
+class LifecycleRequeueDriftError(LifecycleConflictError):
+    """Raised when failed jobs changed after the recovery preview."""
+
+    def __init__(
+        self,
+        *,
+        expected_count: int,
+        actual_candidate_ids: tuple[str, ...],
+    ) -> None:
+        self.expected_count = expected_count
+        self.actual_candidate_ids = actual_candidate_ids
+        super().__init__("failed projection candidates changed after preview")
+
+
 class LifecycleNotFoundError(LifecycleError):
     """Raised when a requested lifecycle record does not exist."""
 
@@ -169,6 +193,8 @@ class GenerationCensus:
     current_sources: int
     current_projection_jobs: int
     current_projection_receipts: int
+    current_job_states: Mapping[str, int]
+    current_receipt_states: Mapping[str, int]
     current_receipts_by_backend: Mapping[str, int]
     current_searchable_by_backend: Mapping[str, int]
 
@@ -965,27 +991,64 @@ class LifecycleStore:
                 raise
         return tuple(self.get_operation(job_id) for job_id in job_ids)
 
-    def requeue_failed_projections(self, *, now: datetime | None = None) -> int:
-        """Reset every failed projection job (and its receipts) to pending.
+    @staticmethod
+    def _failed_projection_candidates(
+        connection: sqlite3.Connection,
+        projection: ProjectionRequest,
+    ) -> tuple[str, ...]:
+        rows = connection.execute(
+            """
+            SELECT DISTINCT job.projection_job_id
+            FROM source_heads AS head
+            JOIN projection_jobs AS job
+              ON job.source_revision_id = head.source_revision_id
+            WHERE job.state = 'failed'
+              AND job.generation_id = ?
+              AND job.projection_version = ?
+              AND job.config_digest = ?
+            ORDER BY job.projection_job_id
+            """,
+            (
+                projection.generation_id,
+                projection.projection_version,
+                projection.config_digest,
+            ),
+        ).fetchall()
+        return tuple(str(row["projection_job_id"]) for row in rows)
 
-        The heal-on-recapture path in accept_source only fires when the same
-        bytes are re-submitted, and the sync layer skips unchanged content
-        before submitting, so a failed job for content that never changes
-        again stays failed forever (2026-08-12: 235 jobs failed while the
-        embedding engine was down, with no path back). This is the manual
-        path: the same reset accept_source applies, over all failed jobs.
-        The worker then drains them via claim_next_job.
-        """
+    def failed_projection_candidates(
+        self,
+        projection: ProjectionRequest,
+    ) -> tuple[str, ...]:
+        """Preview failed current-head jobs for one projection identity."""
+        with self._connect() as connection:
+            return self._failed_projection_candidates(connection, projection)
+
+    def requeue_failed_projections(
+        self,
+        projection: ProjectionRequest,
+        *,
+        expected_count: int,
+        candidate_ids: tuple[str, ...],
+        now: datetime | None = None,
+    ) -> tuple[str, ...]:
+        """Reset one exact preview of active failed jobs to pending."""
+        if expected_count < 0:
+            raise ValueError("expected_count must not be negative")
+        if any(not candidate_id.strip() for candidate_id in candidate_ids):
+            raise ValueError("candidate_ids must contain non-empty strings")
+        if candidate_ids != tuple(sorted(set(candidate_ids))):
+            raise ValueError("candidate_ids must be sorted and unique")
         changed_text = _utc_text(now or datetime.now(UTC))
         with self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
-                failed_jobs = [
-                    str(row["projection_job_id"])
-                    for row in connection.execute(
-                        "SELECT projection_job_id FROM projection_jobs WHERE state = 'failed'"
-                    ).fetchall()
-                ]
+                failed_jobs = self._failed_projection_candidates(connection, projection)
+                if expected_count != len(failed_jobs) or candidate_ids != failed_jobs:
+                    raise LifecycleRequeueDriftError(
+                        expected_count=expected_count,
+                        actual_candidate_ids=failed_jobs,
+                    )
                 for job_id in failed_jobs:
                     connection.execute(
                         """
@@ -998,6 +1061,7 @@ class LifecycleStore:
                         """,
                         (changed_text, changed_text, job_id),
                     )
+                    self._inject_fault("after_requeue_projection_job")
                     connection.execute(
                         """
                         UPDATE projection_receipts
@@ -1010,11 +1074,13 @@ class LifecycleStore:
                         """,
                         (changed_text, job_id),
                     )
+                    self._inject_fault("after_requeue_projection_receipts")
+                self._inject_fault("before_requeue_commit")
                 connection.execute("COMMIT")
             except BaseException:
                 connection.execute("ROLLBACK")
                 raise
-        return len(failed_jobs)
+        return failed_jobs
 
     def read_retained_content(self, source_revision_id: str) -> bytes:
         with self._connect() as connection:
@@ -2040,6 +2106,18 @@ class LifecycleStore:
                     parameters,
                 ).fetchone()[0]
             )
+            job_rows = connection.execute(
+                """
+                SELECT job.state, COUNT(*) AS count
+                FROM source_heads AS head
+                JOIN projection_jobs AS job
+                  ON job.source_revision_id = head.source_revision_id
+                WHERE job.generation_id = ? AND job.projection_version = ?
+                  AND job.config_digest = ?
+                GROUP BY job.state
+                """,
+                parameters,
+            ).fetchall()
             receipt_rows = connection.execute(
                 """
                 SELECT receipt.backend, receipt.state, COUNT(*) AS count
@@ -2054,13 +2132,20 @@ class LifecycleStore:
                 """,
                 parameters,
             ).fetchall()
+        job_states = {
+            str(row["state"]): int(row["count"])
+            for row in job_rows
+        }
+        receipt_states: dict[str, int] = {}
         receipts_by_backend: dict[str, int] = {}
         searchable_by_backend: dict[str, int] = {}
         for row in receipt_rows:
             backend = str(row["backend"])
+            state = str(row["state"])
             count = int(row["count"])
             receipts_by_backend[backend] = receipts_by_backend.get(backend, 0) + count
-            if row["state"] == "searchable":
+            receipt_states[state] = receipt_states.get(state, 0) + count
+            if state == "searchable":
                 searchable_by_backend[backend] = count
         return GenerationCensus(
             generation_id=generation_id,
@@ -2069,6 +2154,8 @@ class LifecycleStore:
             current_sources=current_sources,
             current_projection_jobs=current_projection_jobs,
             current_projection_receipts=sum(receipts_by_backend.values()),
+            current_job_states=dict(sorted(job_states.items())),
+            current_receipt_states=dict(sorted(receipt_states.items())),
             current_receipts_by_backend=dict(sorted(receipts_by_backend.items())),
             current_searchable_by_backend=dict(sorted(searchable_by_backend.items())),
         )

--- a/kb/server.py
+++ b/kb/server.py
@@ -30,7 +30,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 
 from kb.build_identity import SERVICE_BUILD_IDENTITY, build_identity_from_env
 from kb import chunk_window
@@ -60,7 +60,11 @@ from kb.google_chat import GoogleChatConfigError, GoogleChatDelivery
 from kb.linear_sync import LinearSyncer
 from kb.knowledge_mesh import KnowledgeMesh
 from kb.learning import LearningOutcome, LearningProcess
-from kb.lifecycle import LifecycleNotFoundError
+from kb.lifecycle import (
+    LifecycleNotFoundError,
+    LifecycleRequeueDriftError,
+    LifecycleRequeueIdentityMismatchError,
+)
 from kb.session_trace import enrich_shared_trace, force_shared_trace_author_seat
 from kb.learning_agent import LearningAgent
 from kb.logging_utils import configure_logging
@@ -1113,6 +1117,15 @@ class CorpusReconcileBody(BaseModel):
     recover: bool = False
     # Compatibility switch. The default runs the combined zero/oversized census.
     oversized: bool = False
+
+
+class LifecycleRequeueFailedBody(BaseModel):
+    apply: bool = False
+    generation_id: StrictStr | None = Field(default=None, min_length=1)
+    projection_version: StrictStr | None = Field(default=None, min_length=1)
+    config_digest: StrictStr | None = Field(default=None, min_length=1)
+    expected_count: StrictInt | None = Field(default=None, ge=0)
+    candidate_ids: list[StrictStr] | None = None
 
 
 class GraphCleanupBody(BaseModel):
@@ -4611,8 +4624,6 @@ def lifecycle_health(citadel: Any) -> dict[str, Any]:
     source_revisions = int(census.get("source_revisions", 0))
     projection_jobs = int(census.get("projection_jobs", 0))
     projection_receipts = int(census.get("projection_receipts", 0))
-    failed_jobs = int((census.get("job_states") or {}).get("failed", 0))
-    failed_receipts = int((census.get("receipt_states") or {}).get("failed", 0))
     invariant_errors: list[str] = []
     if projection_jobs < source_revisions:
         invariant_errors.append("source_revision_without_projection_job")
@@ -4626,6 +4637,12 @@ def lifecycle_health(citadel: Any) -> dict[str, Any]:
         )
         current_receipts = int(
             current_generation.get("current_projection_receipts", 0)
+        )
+        current_failed_jobs = int(
+            (current_generation.get("current_job_states") or {}).get("failed", 0)
+        )
+        current_failed_receipts = int(
+            (current_generation.get("current_receipt_states") or {}).get("failed", 0)
         )
         if current_jobs != current_sources:
             invariant_errors.append("current_generation_job_census_mismatch")
@@ -4648,8 +4665,8 @@ def lifecycle_health(citadel: Any) -> dict[str, Any]:
             invariant_errors.append(
                 "current_generation_searchable_census_mismatch"
             )
-    if failed_jobs or failed_receipts:
-        invariant_errors.append("failed_projection")
+        if current_failed_jobs or current_failed_receipts:
+            invariant_errors.append("failed_projection")
     return {
         "enabled": True,
         "ok": not invariant_errors,
@@ -7024,29 +7041,149 @@ async def ingest(body: IngestBody, request: Request) -> Any:
 
 
 @app.post("/api/lifecycle/requeue-failed")
-async def lifecycle_requeue_failed(request: Request) -> dict[str, Any]:
-    """Reset every failed projection job to pending so the worker re-drains it.
-
-    The manual half of the heal design: accept_source heals a failed job only
-    when the same bytes are re-submitted, and sync skips unchanged content, so
-    failed jobs for stable content are otherwise permanent (2026-08-12).
-    """
-    require_access(request, "admin", "access:manage")
+async def lifecycle_requeue_failed(
+    request: Request,
+    body: LifecycleRequeueFailedBody | None = None,
+) -> dict[str, Any]:
+    """Preview or apply recovery for failed jobs owned by the active worker."""
+    actor = require_access(request, "admin", "sources:sync")
+    body = body or LifecycleRequeueFailedBody()
     citadel = get_citadel()
+
+    def record(action: str, success: bool, detail: dict[str, Any]) -> None:
+        get_access_store().record_event(
+            action=action,
+            actor=actor,
+            success=success,
+            detail=detail,
+        )
+
+    if not body.apply:
+        try:
+            result = citadel.lifecycle_requeue_failed_preview()
+        except LifecycleNotFoundError as exc:
+            record(
+                "lifecycle.requeue.preview",
+                False,
+                {"code": "LIFECYCLE_DISABLED"},
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={"code": "LIFECYCLE_DISABLED", "message": str(exc)},
+            ) from exc
+        except LifecycleRequeueIdentityMismatchError as exc:
+            record(
+                "lifecycle.requeue.preview",
+                False,
+                {"code": "LIFECYCLE_WORKER_IDENTITY_MISMATCH"},
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "LIFECYCLE_WORKER_IDENTITY_MISMATCH",
+                    "generation_id": exc.generation_id,
+                    "projection_version": exc.projection_version,
+                    "config_digest": exc.config_digest,
+                },
+            ) from exc
+        record(
+            "lifecycle.requeue.preview",
+            True,
+            {
+                "generation_id": result["generation_id"],
+                "projection_version": result["projection_version"],
+                "candidate_count": result["candidate_count"],
+            },
+        )
+        return result
+
+    required = {
+        "generation_id": body.generation_id,
+        "projection_version": body.projection_version,
+        "config_digest": body.config_digest,
+        "expected_count": body.expected_count,
+        "candidate_ids": body.candidate_ids,
+    }
+    missing = sorted(name for name, value in required.items() if value is None)
+    if missing:
+        detail = {
+            "code": "LIFECYCLE_REQUEUE_CONFIRMATION_REQUIRED",
+            "missing": missing,
+        }
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=422, detail=detail)
+
+    assert body.generation_id is not None
+    assert body.projection_version is not None
+    assert body.config_digest is not None
+    assert body.expected_count is not None
+    assert body.candidate_ids is not None
+    candidate_ids = tuple(body.candidate_ids)
+    if (
+        body.expected_count != len(candidate_ids)
+        or candidate_ids != tuple(sorted(set(candidate_ids)))
+        or any(
+            not candidate_id or candidate_id != candidate_id.strip()
+            for candidate_id in candidate_ids
+        )
+    ):
+        detail = {"code": "LIFECYCLE_REQUEUE_CANDIDATES_INVALID"}
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=422, detail=detail)
+
+    record(
+        "lifecycle.requeue.apply.request",
+        True,
+        {
+            "generation_id": body.generation_id,
+            "projection_version": body.projection_version,
+            "candidate_count": body.expected_count,
+        },
+    )
     try:
-        requeued = citadel.lifecycle_requeue_failed()
+        result = citadel.lifecycle_requeue_failed(
+            generation_id=body.generation_id,
+            projection_version=body.projection_version,
+            config_digest=body.config_digest,
+            expected_count=body.expected_count,
+            candidate_ids=candidate_ids,
+        )
     except LifecycleNotFoundError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    # Resetting rows is not enough on its own. next_wakeup_delay only counts
-    # 'pending' and 'running' jobs, so while every job sat in 'failed' the
-    # drain task had already returned (kb/service.py:424-425) and nothing was
-    # left polling. Without this kick the requeued work waits for the next
-    # caller of resume_lifecycle_queue, which is the hourly evolve pass, so a
-    # 200 here would report success while the corpus stayed frozen.
+        detail = {"code": "LIFECYCLE_DISABLED", "message": str(exc)}
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=409, detail=detail) from exc
+    except LifecycleRequeueIdentityMismatchError as exc:
+        detail = {
+            "code": "LIFECYCLE_WORKER_IDENTITY_MISMATCH",
+            "generation_id": exc.generation_id,
+            "projection_version": exc.projection_version,
+            "config_digest": exc.config_digest,
+        }
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=409, detail=detail) from exc
+    except LifecycleRequeueDriftError as exc:
+        detail = {
+            "code": "LIFECYCLE_REQUEUE_DRIFT",
+            "expected_count": exc.expected_count,
+            "current_count": len(exc.actual_candidate_ids),
+        }
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=409, detail=detail) from exc
+
     resume = getattr(citadel, "resume_lifecycle_queue", None)
-    if callable(resume):
-        resume()
-    return {"ok": True, "requeued": requeued}
+    worker_resumed = bool(resume()) if callable(resume) else False
+    result["worker_resumed"] = worker_resumed
+    record(
+        "lifecycle.requeue.apply",
+        True,
+        {
+            "generation_id": result["generation_id"],
+            "projection_version": result["projection_version"],
+            "requeued": result["requeued"],
+            "worker_resumed": worker_resumed,
+        },
+    )
+    return result
 
 
 @app.get("/api/operations/{projection_job_id}")

--- a/kb/service.py
+++ b/kb/service.py
@@ -26,6 +26,7 @@ from kb.lifecycle import (
     CaptureContext,
     LIFECYCLE_CHUNK_SOURCE_PREFIX,
     LifecycleNotFoundError,
+    LifecycleRequeueIdentityMismatchError,
     LifecycleStore,
     ProjectionRequest,
     lifecycle_chunk_source_key,
@@ -601,11 +602,70 @@ class Citadel:
             ],
         }
 
-    def lifecycle_requeue_failed(self) -> int:
-        """Reset all failed projection jobs to pending; returns the count."""
+    def _lifecycle_requeue_projection(self) -> ProjectionRequest:
         if self.lifecycle_store is None:
             raise LifecycleNotFoundError("lifecycle v1 is disabled")
-        return self.lifecycle_store.requeue_failed_projections()
+        projection = self._lifecycle_projection_request()
+        worker = self.lifecycle_worker
+        if worker is None or not worker.matches_projection(
+            generation_id=projection.generation_id,
+            projection_version=projection.projection_version,
+            config_digest=projection.config_digest,
+        ):
+            raise LifecycleRequeueIdentityMismatchError(projection)
+        return projection
+
+    def lifecycle_requeue_failed_preview(self) -> dict[str, Any]:
+        """Preview failed current-head jobs bound to the active worker."""
+        projection = self._lifecycle_requeue_projection()
+        assert self.lifecycle_store is not None
+        candidate_ids = self.lifecycle_store.failed_projection_candidates(projection)
+        return {
+            "ok": True,
+            "applied": False,
+            "generation_id": projection.generation_id,
+            "projection_version": projection.projection_version,
+            "config_digest": projection.config_digest,
+            "candidate_ids": list(candidate_ids),
+            "candidate_count": len(candidate_ids),
+            "requeued": 0,
+            "worker_resumed": False,
+        }
+
+    def lifecycle_requeue_failed(
+        self,
+        *,
+        generation_id: str,
+        projection_version: str,
+        config_digest: str,
+        expected_count: int,
+        candidate_ids: tuple[str, ...],
+    ) -> dict[str, Any]:
+        """Apply one exact active-generation recovery preview."""
+        projection = self._lifecycle_requeue_projection()
+        if (
+            generation_id != projection.generation_id
+            or projection_version != projection.projection_version
+            or config_digest != projection.config_digest
+        ):
+            raise LifecycleRequeueIdentityMismatchError(projection)
+        assert self.lifecycle_store is not None
+        requeued_ids = self.lifecycle_store.requeue_failed_projections(
+            projection,
+            expected_count=expected_count,
+            candidate_ids=candidate_ids,
+        )
+        return {
+            "ok": True,
+            "applied": True,
+            "generation_id": projection.generation_id,
+            "projection_version": projection.projection_version,
+            "config_digest": projection.config_digest,
+            "candidate_ids": list(requeued_ids),
+            "candidate_count": len(requeued_ids),
+            "requeued": len(requeued_ids),
+            "worker_resumed": False,
+        }
 
     def lifecycle_census(self) -> dict[str, Any]:
         """Return exact SQLite lifecycle counts and state buckets."""

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -14,6 +14,7 @@ from kb.lifecycle import (
     CaptureContext,
     LifecycleConflictError,
     LifecycleNotFoundError,
+    LifecycleRequeueDriftError,
     LifecycleSchemaError,
     LifecycleStore,
     ProjectionLeaseError,
@@ -1032,7 +1033,7 @@ def test_generation_rebuild_rolls_back_every_precommit_fault(
     assert target_census.current_projection_receipts == 0
 
 
-def test_requeue_failed_projections_resets_jobs_and_receipts(tmp_path: Path) -> None:
+def test_requeue_failed_projections_resets_only_active_current_heads(tmp_path: Path) -> None:
     # 2026-08-12: 235 jobs failed while the embedding engine was down. The
     # heal-on-recapture path never fires for unchanged content, so this manual
     # requeue is the only way back for stable sources.
@@ -1052,23 +1053,69 @@ def test_requeue_failed_projections_resets_jobs_and_receipts(tmp_path: Path) -> 
         config_digest="sha256:config-1",
         providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
     )
-    accepted = store.accept_source(b"requeue me", capture=capture, projection=projection, now=T0)
-    lease = store.claim_next_job(worker_id="worker-1", now=T0, lease_seconds=30)
-    assert lease is not None
-    store.fail_job(lease, error_code="model_load", error_message="engine down", now=T0)
-    operation = store.get_operation(accepted.projection_job_id)
-    assert operation.job.state == "failed"
+    accepted = store.accept_source(
+        b"requeue me", capture=capture, projection=projection, now=T0
+    )
+    active = ProjectionRequest(
+        generation_id="generation-2",
+        projection_version="projection-v1",
+        config_digest="sha256:config-2",
+        providers=projection.providers,
+    )
+    rebuilt = store.queue_generation_rebuild(active, now=T0)
+    historical_active_job_id = rebuilt[0].job.projection_job_id
+    current = store.accept_source(
+        b"current revision", capture=capture, projection=active, now=T0
+    )
+    current_active_job_id = current.projection_job_id
+    foreign = ProjectionRequest(
+        generation_id="generation-foreign",
+        projection_version=active.projection_version,
+        config_digest=active.config_digest,
+        providers=active.providers,
+    )
+    foreign_job_id = store.queue_generation_rebuild(foreign, now=T0)[
+        0
+    ].job.projection_job_id
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE projection_jobs SET state = 'failed'")
+        connection.execute("UPDATE projection_receipts SET state = 'failed'")
 
-    assert store.requeue_failed_projections(now=T0) == 1
+    preview = store.failed_projection_candidates(active)
+    assert preview == (current_active_job_id,)
+    assert store.census().job_states["failed"] == 4
+    active_census = store.generation_census(
+        generation_id=active.generation_id,
+        projection_version=active.projection_version,
+        config_digest=active.config_digest,
+    )
+    assert active_census.current_job_states == {"failed": 1}
+    assert active_census.current_receipt_states == {"failed": 3}
 
-    operation = store.get_operation(accepted.projection_job_id)
+    assert store.requeue_failed_projections(
+        active,
+        expected_count=1,
+        candidate_ids=preview,
+        now=T0,
+    ) == preview
+
+    assert store.get_operation(accepted.projection_job_id).job.state == "failed"
+    assert store.get_operation(historical_active_job_id).job.state == "failed"
+    assert store.get_operation(foreign_job_id).job.state == "failed"
+    operation = store.get_operation(current_active_job_id)
     assert operation.job.state == "pending"
     assert operation.job.attempt == 0
     assert {receipt.state for receipt in operation.receipts} == {"pending"}
-    # The worker can claim it again: the reset is not cosmetic.
-    release = store.claim_next_job(worker_id="worker-2", now=T0, lease_seconds=30)
+    release = store.claim_next_job(
+        worker_id="worker-2",
+        generation_id=active.generation_id,
+        projection_version=active.projection_version,
+        config_digest=active.config_digest,
+        now=T0,
+        lease_seconds=30,
+    )
     assert release is not None
-    assert release.projection_job_id == accepted.projection_job_id
+    assert release.projection_job_id == current_active_job_id
 
 
 def test_requeue_failed_projections_ignores_healthy_jobs(tmp_path: Path) -> None:
@@ -1089,7 +1136,228 @@ def test_requeue_failed_projections_ignores_healthy_jobs(tmp_path: Path) -> None
         providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
     )
     store.accept_source(b"leave me queued", capture=capture, projection=projection, now=T0)
-    assert store.requeue_failed_projections(now=T0) == 0
+    assert store.failed_projection_candidates(projection) == ()
+    assert store.requeue_failed_projections(
+        projection,
+        expected_count=0,
+        candidate_ids=(),
+        now=T0,
+    ) == ()
+
+
+def test_requeue_failed_projections_rejects_preview_drift(tmp_path: Path) -> None:
+    store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+
+    def accept_failed(source_key: str) -> str:
+        accepted = store.accept_source(
+            source_key.encode(),
+            capture=CaptureContext(
+                dataset="central",
+                source_key=source_key,
+                source_locator=None,
+                media_type="text/plain",
+                capture_actor_id="test",
+                capture_run_id=source_key,
+                captured_at=T0,
+            ),
+            projection=projection,
+            now=T0,
+        )
+        with sqlite3.connect(store.path) as connection:
+            connection.execute(
+                "UPDATE projection_jobs SET state = 'failed' WHERE projection_job_id = ?",
+                (accepted.projection_job_id,),
+            )
+            connection.execute(
+                "UPDATE projection_receipts SET state = 'failed' WHERE projection_job_id = ?",
+                (accepted.projection_job_id,),
+            )
+        return accepted.projection_job_id
+
+    first_job_id = accept_failed("manual:first")
+    preview = store.failed_projection_candidates(projection)
+    assert preview == (first_job_id,)
+    second_job_id = accept_failed("manual:second")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE projection_jobs SET state = 'pending' WHERE projection_job_id = ?",
+            (first_job_id,),
+        )
+        connection.execute(
+            "UPDATE projection_receipts SET state = 'pending' WHERE projection_job_id = ?",
+            (first_job_id,),
+        )
+    assert store.failed_projection_candidates(projection) == (second_job_id,)
+
+    with pytest.raises(LifecycleRequeueDriftError):
+        store.requeue_failed_projections(
+            projection,
+            expected_count=1,
+            candidate_ids=preview,
+            now=T0,
+        )
+    assert store.get_operation(first_job_id).job.state == "pending"
+    assert store.get_operation(second_job_id).job.state == "failed"
+
+
+def test_requeue_failed_projections_compares_inside_immediate_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+    original_candidates = store._failed_projection_candidates
+    transaction_states: list[bool] = []
+
+    def observed_candidates(
+        connection: sqlite3.Connection,
+        requested: ProjectionRequest,
+    ) -> tuple[str, ...]:
+        transaction_states.append(connection.in_transaction)
+        return original_candidates(connection, requested)
+
+    monkeypatch.setattr(store, "_failed_projection_candidates", observed_candidates)
+
+    assert store.requeue_failed_projections(
+        projection,
+        expected_count=0,
+        candidate_ids=(),
+        now=T0,
+    ) == ()
+    assert transaction_states == [True]
+
+
+def test_requeue_failed_projections_rolls_back_precommit_fault(tmp_path: Path) -> None:
+    path = tmp_path / "lifecycle.sqlite3"
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+    store = LifecycleStore(path)
+    accepted = store.accept_source(
+        b"rollback recovery",
+        capture=CaptureContext(
+            dataset="central",
+            source_key="manual:rollback",
+            source_locator=None,
+            media_type="text/plain",
+            capture_actor_id="test",
+            capture_run_id="rollback",
+            captured_at=T0,
+        ),
+        projection=projection,
+        now=T0,
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute("UPDATE projection_jobs SET state = 'failed'")
+        connection.execute("UPDATE projection_receipts SET state = 'failed'")
+
+    def fail_before_commit(stage: str) -> None:
+        if stage == "before_requeue_commit":
+            raise RuntimeError(stage)
+
+    recovery = LifecycleStore(path, fault_injector=fail_before_commit)
+    preview = recovery.failed_projection_candidates(projection)
+    with pytest.raises(RuntimeError, match="before_requeue_commit"):
+        recovery.requeue_failed_projections(
+            projection,
+            expected_count=1,
+            candidate_ids=preview,
+            now=T0,
+        )
+    operation = LifecycleStore(path).get_operation(accepted.projection_job_id)
+    assert operation.job.state == "failed"
+    assert {receipt.state for receipt in operation.receipts} == {"failed"}
+
+
+def test_requeue_failed_projections_explicitly_rolls_back_on_fault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "lifecycle.sqlite3"
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={"relational": "sqlite", "vector": "qdrant", "graph": "ladybug"},
+    )
+    store = LifecycleStore(path)
+    accepted = store.accept_source(
+        b"explicit rollback",
+        capture=CaptureContext(
+            dataset="central",
+            source_key="manual:explicit-rollback",
+            source_locator=None,
+            media_type="text/plain",
+            capture_actor_id="test",
+            capture_run_id="explicit-rollback",
+            captured_at=T0,
+        ),
+        projection=projection,
+        now=T0,
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute("UPDATE projection_jobs SET state = 'failed'")
+        connection.execute("UPDATE projection_receipts SET state = 'failed'")
+
+    def fail_before_commit(stage: str) -> None:
+        if stage == "before_requeue_commit":
+            raise RuntimeError(stage)
+
+    recovery = LifecycleStore(path, fault_injector=fail_before_commit)
+    preview = recovery.failed_projection_candidates(projection)
+    raw_connection = sqlite3.connect(path, isolation_level=None)
+    raw_connection.row_factory = sqlite3.Row
+
+    class NoImplicitRollbackConnection:
+        @property
+        def in_transaction(self) -> bool:
+            return raw_connection.in_transaction
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback) -> bool:
+            return False
+
+        def execute(self, *args, **kwargs):
+            return raw_connection.execute(*args, **kwargs)
+
+    monkeypatch.setattr(
+        recovery,
+        "_connect",
+        lambda: NoImplicitRollbackConnection(),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="before_requeue_commit"):
+            recovery.requeue_failed_projections(
+                projection,
+                expected_count=1,
+                candidate_ids=preview,
+                now=T0,
+            )
+        assert raw_connection.in_transaction is False
+    finally:
+        if raw_connection.in_transaction:
+            raw_connection.execute("ROLLBACK")
+        raw_connection.close()
+
+    operation = LifecycleStore(path).get_operation(accepted.projection_job_id)
+    assert operation.job.state == "failed"
+    assert {receipt.state for receipt in operation.receipts} == {"failed"}
 
 
 def test_projection_source_revision_states_tracks_active_and_completed_jobs(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@ from kb.access import AccessIdentity, AccessStore, SESSION_TRACES_DATASET
 from kb.config import CitadelConfig
 from kb.conflicts import KnowledgeConflictStore
 from kb.knowledge_mesh import KnowledgeMesh
+from kb.lifecycle import LifecycleRequeueDriftError
 from kb.mesh import MeshState
 from kb.models import FeedbackResult, IngestResult
 from kb.obsidian_sync import ObsidianSyncStore
@@ -1502,15 +1503,39 @@ def test_lifecycle_requeue_failed_requires_admin() -> None:
     assert client.post("/api/lifecycle/requeue-failed").status_code == 403
 
 
-def test_lifecycle_requeue_failed_returns_the_reset_count(monkeypatch) -> None:
+def test_lifecycle_requeue_failed_previews_without_resuming(monkeypatch) -> None:
     client = authed_client()
     import kb.server as server_mod
 
     citadel = server_mod.get_citadel()
-    monkeypatch.setattr(type(citadel), "lifecycle_requeue_failed", lambda self: 7, raising=False)
+    resumed: list[bool] = []
+    monkeypatch.setattr(
+        type(citadel),
+        "lifecycle_requeue_failed_preview",
+        lambda self: {
+            "ok": True,
+            "applied": False,
+            "generation_id": "generation-1",
+            "projection_version": "projection-v1",
+            "config_digest": "sha256:config-1",
+            "candidate_ids": ["job-1"],
+            "candidate_count": 1,
+            "requeued": 0,
+            "worker_resumed": False,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        type(citadel),
+        "resume_lifecycle_queue",
+        lambda self: resumed.append(True),
+        raising=False,
+    )
     response = client.post("/api/lifecycle/requeue-failed")
     assert response.status_code == 200
-    assert response.json() == {"ok": True, "requeued": 7}
+    assert response.json()["candidate_ids"] == ["job-1"]
+    assert response.json()["applied"] is False
+    assert resumed == []
 
 
 def test_lifecycle_requeue_failed_restarts_the_drain(monkeypatch) -> None:
@@ -1524,17 +1549,153 @@ def test_lifecycle_requeue_failed_restarts_the_drain(monkeypatch) -> None:
 
     citadel = server_mod.get_citadel()
     resumed: list[bool] = []
-    monkeypatch.setattr(type(citadel), "lifecycle_requeue_failed", lambda self: 3, raising=False)
+
+    def apply_recovery(self, **kwargs: Any) -> dict[str, Any]:
+        assert kwargs == {
+            "generation_id": "generation-1",
+            "projection_version": "projection-v1",
+            "config_digest": "sha256:config-1",
+            "expected_count": 1,
+            "candidate_ids": ("job-1",),
+        }
+        return {
+            "ok": True,
+            "applied": True,
+            "generation_id": "generation-1",
+            "projection_version": "projection-v1",
+            "config_digest": "sha256:config-1",
+            "candidate_ids": ["job-1"],
+            "candidate_count": 1,
+            "requeued": 1,
+            "worker_resumed": False,
+        }
+
+    monkeypatch.setattr(
+        type(citadel),
+        "lifecycle_requeue_failed",
+        apply_recovery,
+        raising=False,
+    )
     monkeypatch.setattr(
         type(citadel),
         "resume_lifecycle_queue",
-        lambda self: resumed.append(True),
+        lambda self: resumed.append(True) or True,
         raising=False,
     )
-    response = client.post("/api/lifecycle/requeue-failed")
+    response = client.post(
+        "/api/lifecycle/requeue-failed",
+        json={
+            "apply": True,
+            "generation_id": "generation-1",
+            "projection_version": "projection-v1",
+            "config_digest": "sha256:config-1",
+            "expected_count": 1,
+            "candidate_ids": ["job-1"],
+        },
+    )
     assert response.status_code == 200
-    assert response.json() == {"ok": True, "requeued": 3}
+    assert response.json()["requeued"] == 1
+    assert response.json()["worker_resumed"] is True
     assert resumed == [True], "requeue must restart the projection drain"
+    events = app.state.access_store.snapshot()["audit_events"]
+    actions = [event["action"] for event in events]
+    assert "lifecycle.requeue.apply.request" in actions
+    assert "lifecycle.requeue.apply" in actions
+
+
+def test_lifecycle_requeue_failed_requires_exact_confirmation() -> None:
+    client = authed_client()
+    response = client.post(
+        "/api/lifecycle/requeue-failed",
+        json={"apply": True},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == (
+        "LIFECYCLE_REQUEUE_CONFIRMATION_REQUIRED"
+    )
+
+
+def test_lifecycle_requeue_failed_returns_conflict_on_drift(monkeypatch) -> None:
+    client = authed_client()
+    import kb.server as server_mod
+
+    citadel = server_mod.get_citadel()
+
+    def drift(self, **kwargs: Any) -> dict[str, Any]:
+        raise LifecycleRequeueDriftError(
+            expected_count=1,
+            actual_candidate_ids=("job-1", "job-2"),
+        )
+
+    monkeypatch.setattr(
+        type(citadel),
+        "lifecycle_requeue_failed",
+        drift,
+        raising=False,
+    )
+    response = client.post(
+        "/api/lifecycle/requeue-failed",
+        json={
+            "apply": True,
+            "generation_id": "generation-1",
+            "projection_version": "projection-v1",
+            "config_digest": "sha256:config-1",
+            "expected_count": 1,
+            "candidate_ids": ["job-1"],
+        },
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "LIFECYCLE_REQUEUE_DRIFT",
+        "expected_count": 1,
+        "current_count": 2,
+    }
+
+
+def test_lifecycle_health_uses_active_generation_failure_buckets() -> None:
+    class CensusCitadel:
+        config = CitadelConfig(lifecycle_enabled=True)
+
+        def __init__(self) -> None:
+            self.current_job_states = {"completed": 1}
+            self.current_receipt_states = {"searchable": 3}
+
+        def lifecycle_census(self) -> dict[str, Any]:
+            return {
+                "source_revisions": 2,
+                "projection_jobs": 2,
+                "projection_receipts": 6,
+                "job_states": {"completed": 1, "failed": 1},
+                "receipt_states": {"searchable": 3, "failed": 3},
+                "current_generation": {
+                    "current_sources": 1,
+                    "current_projection_jobs": 1,
+                    "current_projection_receipts": 3,
+                    "current_job_states": self.current_job_states,
+                    "current_receipt_states": self.current_receipt_states,
+                    "current_receipts_by_backend": {
+                        "relational": 1,
+                        "vector": 1,
+                        "graph": 1,
+                    },
+                    "current_searchable_by_backend": {
+                        "relational": 1,
+                        "vector": 1,
+                        "graph": 1,
+                    },
+                },
+            }
+
+    citadel = CensusCitadel()
+    healthy = server_module.lifecycle_health(citadel)
+    assert healthy["ok"] is True
+    assert "failed_projection" not in healthy["invariant_errors"]
+
+    citadel.current_job_states = {"failed": 1}
+    citadel.current_receipt_states = {"failed": 3}
+    failed = server_module.lifecycle_health(citadel)
+    assert failed["ok"] is False
+    assert "failed_projection" in failed["invariant_errors"]
 
 
 def test_admin_can_audit_combined_reconciliation_and_writer_cannot() -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,7 +7,11 @@ from typing import Any
 import pytest
 
 from kb.config import CitadelConfig
-from kb.lifecycle import LifecycleConflictError, lifecycle_chunk_source_key
+from kb.lifecycle import (
+    LifecycleConflictError,
+    LifecycleRequeueIdentityMismatchError,
+    lifecycle_chunk_source_key,
+)
 from kb.models import FeedbackRequest
 from kb.repair_journal import RepairJournal
 from kb.security_scan import SecretContentError
@@ -305,6 +309,97 @@ async def test_lifecycle_duplicate_ingest_returns_same_operation(
     assert duplicate.projection_job_id == first.projection_job_id
     assert kb.lifecycle_census()["source_revisions"] == 1
     assert kb.lifecycle_census()["projection_jobs"] == 1
+
+
+def test_lifecycle_requeue_requires_active_worker_identity(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="central",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+
+    preview = kb.lifecycle_requeue_failed_preview()
+    assert preview["candidate_ids"] == []
+    applied = kb.lifecycle_requeue_failed(
+        generation_id=preview["generation_id"],
+        projection_version=preview["projection_version"],
+        config_digest=preview["config_digest"],
+        expected_count=0,
+        candidate_ids=(),
+    )
+    assert applied["applied"] is True
+    assert applied["requeued"] == 0
+
+    assert kb.lifecycle_worker is not None
+    kb.lifecycle_worker.generation_id = "generation-stale"
+    with pytest.raises(LifecycleRequeueIdentityMismatchError):
+        kb.lifecycle_requeue_failed(
+            generation_id=preview["generation_id"],
+            projection_version=preview["projection_version"],
+            config_digest=preview["config_digest"],
+            expected_count=0,
+            candidate_ids=(),
+        )
+
+
+def test_lifecycle_requeue_preview_does_not_mutate_failed_jobs(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+    from datetime import UTC, datetime
+
+    from kb.lifecycle import CaptureContext
+
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="central",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    assert kb.lifecycle_store is not None
+    projection = kb._lifecycle_projection_request()
+    accepted = kb.lifecycle_store.accept_source(
+        b"preview must not mutate",
+        capture=CaptureContext(
+            dataset="central",
+            source_key="manual:preview-no-mutation",
+            source_locator=None,
+            media_type="text/plain",
+            capture_actor_id="test",
+            capture_run_id="preview-no-mutation",
+            captured_at=datetime.now(UTC),
+        ),
+        projection=projection,
+    )
+    with sqlite3.connect(kb.lifecycle_store.path) as connection:
+        connection.execute(
+            "UPDATE projection_jobs SET state = 'failed' WHERE projection_job_id = ?",
+            (accepted.projection_job_id,),
+        )
+        connection.execute(
+            "UPDATE projection_receipts SET state = 'failed' WHERE projection_job_id = ?",
+            (accepted.projection_job_id,),
+        )
+
+    before = kb.lifecycle_store.get_operation(accepted.projection_job_id)
+    preview = kb.lifecycle_requeue_failed_preview()
+    after = kb.lifecycle_store.get_operation(accepted.projection_job_id)
+
+    assert preview["candidate_ids"] == [accepted.projection_job_id]
+    assert before.job.state == after.job.state == "failed"
+    assert {receipt.state for receipt in before.receipts} == {"failed"}
+    assert {receipt.state for receipt in after.receipts} == {"failed"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- [VERIFIED] Recovery preview now lists failed jobs only for current source heads and the active projection identity.
- [VERIFIED] Apply requires the exact candidate IDs and count, then checks both again inside an immediate transaction.
- [VERIFIED] Readiness now uses active-generation job and receipt state buckets.
- [VERIFIED] The admin route keeps empty-body calls safe by returning preview data without mutation.

## Evidence

- [VERIFIED] Focused causal run: `9 collected, 9 passed, 0 failed`.
- [VERIFIED] Eight separate negative controls each failed its target test: `8 collected, 0 passed, 8 failed`.
- [VERIFIED] Final full suite: `2231 passed, 6 skipped, 1 failed, 12 warnings in 65.88s`.
- [VERIFIED] The one failure is `test_installed_cognee_141_metadata_accepts_secure_cryptography`. The same failure occurs on unchanged `origin/main` because Cognee 1.4.1 declares `cryptography<50` while the environment has 50.0.0.
- [VERIFIED] Ruff returned `All checks passed!`. `git diff --check` returned no output.
- [REPORTED] Two fresh-eyes reviews found no P0 or P1 blocker.

## Boundary

- [VERIFIED] No deploy, production recovery request, database write, or corpus mutation occurred.
- [NOT DETERMINED] Live current-generation recovery remains unmeasured until this commit deploys and an admin approves an exact preview.

Refs #228
