### PR TITLE
fix(health): keep /readyz off the full graph load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to `citadel-archive` are documented here. Format follows
   use. Graph totals still fill the shared cache in the background for
   `/api/mesh`.
 
+- **`/api/mesh` no longer publishes projection counts as graph totals
+  while the #280 cache is still unenriched.** The probe stores relational
+  `indexed_docs` and omits `indexed_edges`. Mesh used to map that onto
+  `stats.nodes` / `stats.edges` and fall back to the in-memory projection
+  without saying the graph volume was unknown. Unenriched probe payloads
+  now keep `stats.nodes` and `stats.edges` unknown (`warming`) until
+  enrichment writes the real graph counts.
+
 - **Lifecycle readiness no longer fails while projections are in flight.**
   `current_generation_searchable_census_mismatch` compared searchable
   receipts to every current job, so a pending drain stamped `/readyz` 503.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **/readyz no longer waits on a full graph load (#280).** The bounded
+  relational probe is the readiness signal. `/readyz` used to call
+  `_graph_counts()` after that probe and load every graph node (16k+ live,
+  about 11s) for `indexed_docs` / `indexed_edges` that readiness does not
+  use. Graph totals still fill the shared cache in the background for
+  `/api/mesh`.
+
+- **Lifecycle readiness no longer fails while projections are in flight.**
+  `current_generation_searchable_census_mismatch` compared searchable
+  receipts to every current job, so a pending drain stamped `/readyz` 503.
+  Searchable counts now compare to completed jobs when job states are
+  present. Failed current-generation jobs still fail closed.
+
 ## [0.5.0] (2026-08-15)
 
 ### Added

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -214,7 +214,14 @@ timestamp. Pass it as `Authorization: Bearer <token>`.
 
 ## HTTP API reference
 
-Health: `GET /healthz`, `GET /readyz` (authed).
+Health probes are split on purpose:
+
+- `GET /healthz` is liveness. Unauthenticated. No corpus or canary work.
+- `GET /health/ready` is the Railway deploy gate (`railway.toml`
+  `healthcheckPath`). It checks dependency readiness, not the canary or
+  lifecycle invariants.
+- `GET /readyz` is authenticated readiness (bounded corpus probe, lifecycle
+  census, last canary). The image `HEALTHCHECK` targets this route.
 
 Core:
 

--- a/kb/mesh.py
+++ b/kb/mesh.py
@@ -262,7 +262,16 @@ class MeshState:
         """
         async with self._lock:
             self._ensure_base_graph(config)
-            corpus = corpus or {}
+            corpus = dict(corpus or {})
+            # Probe cache: relational indexed_docs, no indexed_edges yet.
+            # Copy only. Do not mutate the shared /readyz cache.
+            if (
+                corpus.get("measurement") == "bounded_relational_projection_probe"
+                and corpus.get("indexed_edges") is None
+            ):
+                corpus.pop("indexed_docs", None)
+                if not corpus.get("degraded"):
+                    corpus["degraded"] = "graph_totals_pending"
             indexes = self._indexes(config, corpus=corpus)
             since_restart = {
                 "started_at": self.started_at,

--- a/kb/server.py
+++ b/kb/server.py
@@ -4925,7 +4925,9 @@ def _schedule_graph_totals_enrichment(
 
     The bounded relational probe is the readiness signal (#280). `/api/mesh`
     still wants exact graph volume for `stats.edges`, so a background read
-    enriches the same cache after the probe returns.
+    enriches the same cache after the probe returns. Call this after
+    `_CORPUS_HEALTH_LOCK` is released so waiters queued on that probe copy
+    the unenriched snapshot before this task replaces the cache.
     """
     try:
         loop = asyncio.get_running_loop()
@@ -4961,7 +4963,7 @@ def _schedule_graph_totals_enrichment(
     task.add_done_callback(_forget_background_task)
 
 
-async def _corpus_health_impl() -> dict[str, Any]:
+async def _corpus_health_impl() -> tuple[dict[str, Any], tuple[tuple[int, ...], Any] | None]:
     """Data-plane volume gate using exact relational projection measurements. (#27)
 
     A failed measurement is a readiness failure, not an empty or healthy
@@ -4994,7 +4996,7 @@ async def _corpus_health_impl() -> dict[str, Any]:
             and _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0
             and time.monotonic() - cached[0] < _CORPUS_HEALTH_CACHE_TTL_SECONDS
         ):
-            return dict(cached[2])
+            return dict(cached[2]), None
 
         tracked = 0
         github_status = await github_syncer.status()
@@ -5071,9 +5073,11 @@ async def _corpus_health_impl() -> dict[str, Any]:
             }
             if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
                 cached = _cache_corpus_health_result(cache_key, result)
-                _schedule_graph_totals_enrichment(cache_key, citadel)
-                return cached
-            return result
+                # Copy. The live cache entry is replaced when graph totals land.
+                # Schedule that fill after `_CORPUS_HEALTH_LOCK` is released so
+                # waiters queued on this probe copy the same snapshot first.
+                return dict(cached), (cache_key, citadel)
+            return result, None
 
         # Preserve the old method-boundary fallback for local fakes and older
         # clients that do not expose the bounded probe yet.
@@ -5092,8 +5096,8 @@ async def _corpus_health_impl() -> dict[str, Any]:
             "indexed_edges": edges,
         }
         if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
-            return _cache_corpus_health_result(cache_key, result)
-        return result
+            return dict(_cache_corpus_health_result(cache_key, result)), None
+        return result, None
     except Exception as exc:  # noqa: BLE001 - convert dependency failures to readiness state
         # Class name only, in the log and in the payload: /readyz embeds this
         # dict verbatim for any reader-scoped caller, and exception text can
@@ -5110,14 +5114,17 @@ async def _corpus_health_impl() -> dict[str, Any]:
             "degraded": exc.__class__.__name__,
         }
         if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
-            return _cache_corpus_health_result(cache_key, result)
-        return result
+            return dict(_cache_corpus_health_result(cache_key, result)), None
+        return result, None
 
 
 async def _corpus_health() -> dict[str, Any]:
     """Serialize uncached corpus probes so concurrent readiness checks share work."""
     async with _CORPUS_HEALTH_LOCK:
-        return await _corpus_health_impl()
+        result, enrich = await _corpus_health_impl()
+    if enrich is not None:
+        _schedule_graph_totals_enrichment(*enrich)
+    return result
 
 
 def _corpus_health_task() -> asyncio.Task[dict[str, Any]]:

--- a/kb/server.py
+++ b/kb/server.py
@@ -4683,9 +4683,16 @@ def lifecycle_health(citadel: Any) -> dict[str, Any]:
         searchable_by_backend = current_generation.get(
             "current_searchable_by_backend"
         )
+        job_states = current_generation.get("current_job_states")
+        expected_searchable = current_jobs
+        if isinstance(job_states, dict) and job_states:
+            # Pending/running jobs are not a searchable gap (#273/#286 family):
+            # the drain has not written those receipts yet. Compare searchable
+            # counts to completed jobs only. Missing job_states keeps the
+            # fail-closed comparison against current_jobs.
+            expected_searchable = max(0, int(job_states.get("completed") or 0))
         if not isinstance(searchable_by_backend, dict) or any(
-            int(searchable_by_backend.get(backend, 0)) != current_sources
-            or int(searchable_by_backend.get(backend, 0)) != current_jobs
+            int(searchable_by_backend.get(backend, 0)) != expected_searchable
             for backend in ("relational", "vector", "graph")
         ):
             invariant_errors.append(
@@ -4911,6 +4918,49 @@ def _cache_corpus_health_result(
     return _CORPUS_HEALTH_CACHE[2]
 
 
+def _schedule_graph_totals_enrichment(
+    cache_key: tuple[int, ...], citadel: Any
+) -> None:
+    """Fill graph node/edge totals on the shared cache without blocking /readyz.
+
+    The bounded relational probe is the readiness signal (#280). `/api/mesh`
+    still wants exact graph volume for `stats.edges`, so a background read
+    enriches the same cache after the probe returns.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    async def _fill() -> None:
+        global _CORPUS_HEALTH_CACHE
+        try:
+            counts = await citadel._graph_counts()
+        except Exception as exc:  # noqa: BLE001 - enrichment must not fail readiness
+            logger.warning(
+                "graph totals enrichment failed: %s", exc.__class__.__name__
+            )
+            return
+        cached = _CORPUS_HEALTH_CACHE
+        if cached is None or cached[1] != cache_key:
+            return
+        if cached[2].get("degraded"):
+            return
+        nodes = int(counts.get("nodes") or 0)
+        edges = int(counts.get("edges") or 0)
+        enriched = dict(cached[2])
+        # Mesh stats.nodes/edges still want graph volume (#232). Readiness
+        # already returned using the relational probe and does not wait here.
+        enriched["indexed_docs"] = nodes
+        enriched["indexed_graph_nodes"] = nodes
+        enriched["indexed_edges"] = edges
+        _CORPUS_HEALTH_CACHE = (cached[0], cache_key, enriched)
+
+    task = loop.create_task(_fill())
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_forget_background_task)
+
+
 async def _corpus_health_impl() -> dict[str, Any]:
     """Data-plane volume gate using exact relational projection measurements. (#27)
 
@@ -5003,9 +5053,6 @@ async def _corpus_health_impl() -> dict[str, Any]:
                     "complete bounded corpus probe does not cover the relational document total"
                 )
 
-            counts = await citadel._graph_counts()
-            indexed = int(counts.get("nodes") or 0)
-            edges = int(counts.get("edges") or 0)
             result = {
                 **measured,
                 "ok": measured["probe_complete"] is True
@@ -5015,15 +5062,17 @@ async def _corpus_health_impl() -> dict[str, Any]:
                     and measured["relational_documents"] == 0
                 ),
                 "tracked_sources": tracked,
-                # Compatibility for MeshState: graph nodes are not relational
-                # document projections and are not used for readiness.
-                "indexed_docs": indexed,
-                "indexed_graph_nodes": indexed,
-                "indexed_edges": edges,
+                # Relational document count, not graph node volume. /readyz used
+                # to await _graph_counts() here and spend ~11s loading 16k+
+                # nodes (#280). Graph volume is not the readiness signal.
+                "indexed_docs": measured["relational_documents"],
+                "indexed_graph_nodes": measured["probe_graph_documents"],
                 "measurement": "bounded_relational_projection_probe",
             }
             if _CORPUS_HEALTH_CACHE_TTL_SECONDS > 0:
-                return _cache_corpus_health_result(cache_key, result)
+                cached = _cache_corpus_health_result(cache_key, result)
+                _schedule_graph_totals_enrichment(cache_key, citadel)
+                return cached
             return result
 
         # Preserve the old method-boundary fallback for local fakes and older

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -536,6 +536,69 @@ async def test_snapshot_edges_falls_back_to_the_projection_without_a_real_total(
 
 
 @pytest.mark.asyncio
+async def test_snapshot_does_not_treat_unenriched_probe_as_graph_totals() -> None:
+    """#280 probe cache sets indexed_docs to relational volume and omits
+    indexed_edges. That is not graph volume. Mesh must not map it onto
+    stats.nodes or silently fall back to the in-memory projection for
+    stats.edges.
+    """
+    config = CitadelConfig()
+    mesh = MeshState()
+    for i in range(3):
+        mesh.edges[f"e{i}"] = {"id": f"e{i}", "source": "a", "target": "b"}
+
+    snapshot = await mesh.snapshot(
+        config,
+        corpus={
+            "ok": True,
+            "tracked_sources": 308,
+            "indexed_docs": 2,
+            "indexed_graph_nodes": 2,
+            "measurement": "bounded_relational_projection_probe",
+            "relational_documents": 2,
+        },
+    )
+    stats = snapshot["stats"]
+    projection_edges = stats["since_restart"]["projection_edges"]
+
+    assert stats["nodes"] is None
+    assert stats["edges"] is None
+    assert stats["edges"] != projection_edges
+    assert projection_edges == len(mesh.edges)
+    assert stats["tracked_sources"] == 308
+    indexes = {index["id"]: index for index in snapshot["indexes"]}
+    assert indexes["graph"]["status"] == "warming"
+    assert indexes["graph"]["records"] is None
+
+
+@pytest.mark.asyncio
+async def test_snapshot_uses_enriched_graph_totals_after_probe() -> None:
+    config = CitadelConfig()
+    mesh = MeshState()
+    for i in range(3):
+        mesh.edges[f"e{i}"] = {"id": f"e{i}", "source": "a", "target": "b"}
+
+    snapshot = await mesh.snapshot(
+        config,
+        corpus={
+            "ok": True,
+            "tracked_sources": 308,
+            "indexed_docs": 16000,
+            "indexed_graph_nodes": 16000,
+            "indexed_edges": 50000,
+            "measurement": "bounded_relational_projection_probe",
+            "relational_documents": 2,
+        },
+    )
+    stats = snapshot["stats"]
+
+    assert stats["nodes"] == 16000
+    assert stats["edges"] == 50000
+    assert stats["since_restart"]["projection_edges"] == len(mesh.edges)
+    assert stats["since_restart"]["projection_edges"] < stats["edges"]
+
+
+@pytest.mark.asyncio
 async def test_snapshot_drops_indexed_chunks_when_it_only_duplicates_nodes() -> None:
     """indexed_chunks was assigned the same corpus['indexed_docs'] as nodes,
     equal by construction. Removed, not renamed — the same call #206 made for

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -657,6 +657,50 @@ def test_lifecycle_health_rejects_unsearchable_current_generation() -> None:
     ]
 
 
+def test_lifecycle_health_ignores_in_flight_jobs_for_searchable_census() -> None:
+    """Pending current-generation jobs are not a searchable gap.
+
+    Live /readyz went 503 with current_generation_searchable_census_mismatch
+    while the drain still held work. Same family as #273/#286: in-flight is
+    not a hole. Completed-but-unsearchable still fails, covered by the
+    sibling test without job_states.
+    """
+
+    class InFlightGenerationCitadel(FakeCitadel):
+        config = CitadelConfig(lifecycle_enabled=True)
+
+        def lifecycle_census(self) -> dict[str, Any]:
+            return {
+                "source_revisions": 2,
+                "projection_jobs": 2,
+                "projection_receipts": 6,
+                "job_states": {"completed": 1, "pending": 1},
+                "receipt_states": {"searchable": 3, "pending": 3},
+                "current_generation": {
+                    "current_sources": 2,
+                    "current_projection_jobs": 2,
+                    "current_projection_receipts": 6,
+                    "current_job_states": {"completed": 1, "pending": 1},
+                    "current_receipt_states": {"searchable": 3, "pending": 3},
+                    "current_receipts_by_backend": {
+                        "graph": 2,
+                        "relational": 2,
+                        "vector": 2,
+                    },
+                    "current_searchable_by_backend": {
+                        "graph": 1,
+                        "relational": 1,
+                        "vector": 1,
+                    },
+                },
+            }
+
+    result = server_module.lifecycle_health(InFlightGenerationCitadel())
+
+    assert result["ok"] is True
+    assert result["invariant_errors"] == []
+
+
 def test_lifecycle_health_rejects_incomplete_current_generation() -> None:
     class IncompleteGenerationCitadel(FakeCitadel):
         config = CitadelConfig(lifecycle_enabled=True)
@@ -3725,9 +3769,65 @@ def test_readyz_does_not_use_graph_nodes_as_projection_health(
 
     assert ready.status_code == 503
     corpus = ready.json()["corpus"]
-    assert corpus["indexed_docs"] == 280
+    assert corpus["indexed_docs"] == 2
     assert corpus["probe_fully_indexed_documents"] == 0
     assert corpus["probe_ok"] is False
+
+
+def test_readyz_does_not_wait_on_full_graph_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#280: the bounded probe is enough; graph_data() must not hold /readyz."""
+
+    class MeasuredCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 2,
+                "probe_limit": 64,
+                "probe_max_documents": 10000,
+                "probe_documents": 2,
+                "probe_pages": 1,
+                "probe_complete": True,
+                "probe_cap_exceeded": False,
+                "probe_chunked_documents": 2,
+                "probe_graph_documents": 2,
+                "probe_fully_indexed_documents": 2,
+                "probe_ok": True,
+            }
+
+    class SlowGraphCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = MeasuredCorpus()
+
+        async def _graph_counts(self) -> dict[str, int]:
+            await asyncio.sleep(0.2)
+            return {"nodes": 16000, "edges": 50000}
+
+    class IdleSyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    client = authed_client("test-reader")
+    app.state.citadel = SlowGraphCitadel()
+    app.state.github_syncer = IdleSyncer()
+    app.state.repo_content_syncer = IdleSyncer()
+    app.state.linear_syncer = IdleSyncer()
+
+    started = time.perf_counter()
+    ready = client.get("/readyz")
+    elapsed = time.perf_counter() - started
+
+    assert ready.status_code == 200
+    assert elapsed < 0.15
+    corpus = ready.json()["corpus"]
+    assert corpus["ok"] is True
+    assert corpus["indexed_docs"] == 2
+    assert corpus["probe_ok"] is True
+    assert "indexed_edges" not in corpus
 
 
 def test_readyz_rejects_a_partial_corpus_probe(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3830,6 +3830,138 @@ def test_readyz_does_not_wait_on_full_graph_read(
     assert "indexed_edges" not in corpus
 
 
+def test_api_mesh_does_not_publish_projection_counts_before_graph_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unenriched probe cache must not become silent understated mesh totals.
+
+    After #280, /readyz caches relational ``indexed_docs`` and omits
+    ``indexed_edges``, then fills graph volume in the background. /api/mesh
+    used to map that payload onto ``stats.nodes`` / ``stats.edges`` and fall
+    back to the in-memory projection without marking the corpus unknown.
+    """
+
+    class MeasuredCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            assert limit == server_module._CORPUS_HEALTH_PROBE_LIMIT
+            return {
+                "relational_documents": 2,
+                "probe_limit": 64,
+                "probe_max_documents": 10000,
+                "probe_documents": 2,
+                "probe_pages": 1,
+                "probe_complete": True,
+                "probe_cap_exceeded": False,
+                "probe_chunked_documents": 2,
+                "probe_graph_documents": 2,
+                "probe_fully_indexed_documents": 2,
+                "probe_ok": True,
+            }
+
+    class SlowGraphCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = MeasuredCorpus()
+
+        async def _graph_counts(self) -> dict[str, int]:
+            await asyncio.sleep(0.2)
+            return {"nodes": 16000, "edges": 50000}
+
+    class IdleSyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    client = authed_client("test-reader")
+    app.state.citadel = SlowGraphCitadel()
+    app.state.github_syncer = IdleSyncer()
+    app.state.repo_content_syncer = IdleSyncer()
+    app.state.linear_syncer = IdleSyncer()
+    mesh = app.state.mesh
+    for i in range(3):
+        mesh.edges[f"probe-{i}"] = {
+            "id": f"probe-{i}",
+            "source": "a",
+            "target": "b",
+        }
+
+    started = time.perf_counter()
+    ready = client.get("/readyz")
+    ready_elapsed = time.perf_counter() - started
+    mesh_body = client.get("/api/mesh").json()
+    stats = mesh_body["stats"]
+    projection_edges = stats["since_restart"]["projection_edges"]
+
+    assert ready.status_code == 200
+    assert ready_elapsed < 0.15
+    assert "indexed_edges" not in ready.json()["corpus"]
+    assert projection_edges >= 3
+    assert stats["edges"] != projection_edges
+    assert stats["edges"] is None
+    assert stats["nodes"] != 2
+    assert stats["nodes"] is None
+    indexes = {index["id"]: index for index in mesh_body["indexes"]}
+    assert indexes["graph"]["status"] == "warming"
+    assert indexes["graph"]["records"] is None
+
+
+@pytest.mark.asyncio
+async def test_graph_totals_enrichment_unlocks_mesh_stats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MeasuredCorpus:
+        async def corpus_health(self, *, limit: int) -> dict[str, Any]:
+            return {
+                "relational_documents": 2,
+                "probe_limit": 64,
+                "probe_max_documents": 10000,
+                "probe_documents": 2,
+                "probe_pages": 1,
+                "probe_complete": True,
+                "probe_cap_exceeded": False,
+                "probe_chunked_documents": 2,
+                "probe_graph_documents": 2,
+                "probe_fully_indexed_documents": 2,
+                "probe_ok": True,
+            }
+
+    class FastGraphCitadel(FakeCitadel):
+        def __init__(self) -> None:
+            self.cognee = MeasuredCorpus()
+
+        async def _graph_counts(self) -> dict[str, int]:
+            return {"nodes": 16000, "edges": 50000}
+
+    class IdleSyncer:
+        async def status(self) -> dict[str, Any]:
+            return {"tracked_repositories": 0, "tracked_files": 0, "issue_count": 0}
+
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TASK", None)
+    monkeypatch.setattr(server_module, "_CORPUS_HEALTH_TIMEOUT_SECONDS", 0)
+    app.state.citadel = FastGraphCitadel()
+    app.state.mesh = MeshState()
+    app.state.github_syncer = IdleSyncer()
+    app.state.repo_content_syncer = IdleSyncer()
+    app.state.linear_syncer = IdleSyncer()
+
+    unenriched = await server_module._corpus_health()
+    assert "indexed_edges" not in unenriched
+    pending = [task for task in server_module._BACKGROUND_TASKS if not task.done()]
+    if pending:
+        await asyncio.wait(pending)
+
+    enriched = await server_module._corpus_health()
+    assert enriched["indexed_docs"] == 16000
+    assert enriched["indexed_edges"] == 50000
+    snapshot = await app.state.mesh.snapshot(
+        app.state.citadel.config, corpus=enriched
+    )
+    assert snapshot["stats"]["nodes"] == 16000
+    assert snapshot["stats"]["edges"] == 50000
+
+
 def test_readyz_rejects_a_partial_corpus_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3946,9 +3946,14 @@ async def test_graph_totals_enrichment_unlocks_mesh_stats(
     app.state.repo_content_syncer = IdleSyncer()
     app.state.linear_syncer = IdleSyncer()
 
+    before = set(server_module._BACKGROUND_TASKS)
     unenriched = await server_module._corpus_health()
     assert "indexed_edges" not in unenriched
-    pending = [task for task in server_module._BACKGROUND_TASKS if not task.done()]
+    pending = [
+        task
+        for task in server_module._BACKGROUND_TASKS
+        if task not in before and not task.done()
+    ]
     if pending:
         await asyncio.wait(pending)
 
@@ -4519,6 +4524,7 @@ def test_corpus_health_cache_is_shared_by_readyz_and_mesh(
     assert calls == 1
 
 
+@pytest.mark.asyncio
 async def test_corpus_health_deduplicates_concurrent_probes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4552,7 +4558,7 @@ async def test_corpus_health_deduplicates_concurrent_probes(
             self.cognee = MeasuredCorpus()
 
         async def _graph_counts(self) -> dict[str, int]:
-            return {"nodes": 1, "edges": 1}
+            return {"nodes": 16000, "edges": 50000}
 
     monkeypatch.setattr(server_module, "_CORPUS_HEALTH_CACHE", None)
     app.state.citadel = MeasuredCitadel()
@@ -4560,12 +4566,30 @@ async def test_corpus_health_deduplicates_concurrent_probes(
     app.state.repo_content_syncer = Syncer()
     app.state.linear_syncer = Syncer()
 
-    first, second = await asyncio.gather(
-        server_module._corpus_health(), server_module._corpus_health()
-    )
+    before = set(server_module._BACKGROUND_TASKS)
+    try:
+        first, second = await asyncio.gather(
+            server_module._corpus_health(), server_module._corpus_health()
+        )
 
-    assert calls == 1
-    assert first == second
+        assert calls == 1
+        # Graph fill is distinct from the probe. Concurrent waiters must keep
+        # the relational snapshot, not a mix of probe vs enriched cache.
+        assert first["indexed_docs"] == 1
+        assert second["indexed_docs"] == 1
+        assert "indexed_edges" not in first
+        assert "indexed_edges" not in second
+        assert first == second
+    finally:
+        leftover = [
+            task
+            for task in server_module._BACKGROUND_TASKS
+            if task not in before and not task.done()
+        ]
+        for task in leftover:
+            task.cancel()
+        if leftover:
+            await asyncio.gather(*leftover, return_exceptions=True)
 
 
 def test_readyz_rejects_measured_empty_corpus_when_sources_are_tracked(


### PR DESCRIPTION
## Summary
- `/readyz` no longer awaits `_graph_counts()` after the bounded corpus probe (#280). Graph totals still fill the shared cache in the background for `/api/mesh`.
- Lifecycle searchable census compares completed jobs only, so pending/running drain work no longer stamps `current_generation_searchable_census_mismatch` (same family as #273/#286).
- Docs: Railway `/health/ready` vs Docker `HEALTHCHECK` `/readyz` vs `/healthz` liveness.

## Test plan
- [x] `uv run pytest` on the readyz / lifecycle / corpus-health tests in this slice: **25 passed**
- [ ] After merge, confirm live `/readyz` no longer sits near 11s on a warm node
- [ ] Confirm an in-flight projection no longer reds `/readyz` with `current_generation_searchable_census_mismatch`

Closes #280