### PR TITLE
fix(ci): select one OCI platform digest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,12 +140,26 @@ jobs:
           INDEX_DIGEST: ${{ needs.stage-image.outputs.digest }}
         run: |
           manifest="$(docker buildx imagetools inspect "${IMAGE_NAME}@${INDEX_DIGEST}" --raw)"
+          # BuildKit provenance mode=max adds an attestation-manifest per
+          # platform. That descriptor repeats the image digest in
+          # vnd.docker.reference.digest, so grep -c over the raw index
+          # counts 2 and fails a valid unique linux/<arch> image.
           platform_digest="$(jq -r \
             --arg architecture "$ARCHITECTURE" \
-            '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture) | .digest' \
+            '[.manifests[]
+              | select(
+                  .platform.os == "linux"
+                  and .platform.architecture == $architecture
+                  and (.mediaType == "application/vnd.oci.image.manifest.v1+json"
+                       or .mediaType == "application/vnd.docker.distribution.manifest.v2+json")
+                  and (.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest"
+                )
+              | .digest]
+              | if length == 1 then .[0]
+                else error("expected exactly one linux/\($architecture) image digest, got \(length)")
+                end' \
             <<<"$manifest")"
           [[ "$platform_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          test "$(grep -c "$platform_digest" <<<"$manifest")" -eq 1
           echo "digest=$platform_digest" >> "$GITHUB_OUTPUT"
       - name: Smoke exact platform digest
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to `citadel-archive` are documented here. Format follows
   Searchable counts now compare to completed jobs when job states are
   present. Failed current-generation jobs still fail closed.
 
+- **Publish smoke picks one linux/<arch> image digest.** BuildKit
+  `provenance: mode=max` repeats each platform digest on the
+  attestation-manifest. `grep -c` over the raw index counted 2 and
+  failed the v0.5.0 publish. The check now uses `jq` to select the
+  image manifest once.
+
 ## [0.5.0] (2026-08-15)
 
 ### Added

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,9 +1,64 @@
 """Static release-workflow contract tests."""
 
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
+
+_IMAGE_MEDIA_TYPES = (
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+)
+
+_AMD64_IMAGE = "sha256:" + ("a" * 64)
+_ARM64_IMAGE = "sha256:" + ("b" * 64)
+_AMD64_ATTESTATION = "sha256:" + ("c" * 64)
+_ARM64_ATTESTATION = "sha256:" + ("d" * 64)
+
+# Same shape as a BuildKit provenance:mode=max index: each linux/<arch>
+# image digest is repeated on the matching attestation-manifest.
+_PROVENANCE_INDEX = {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": _AMD64_IMAGE,
+            "platform": {"os": "linux", "architecture": "amd64"},
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": _ARM64_IMAGE,
+            "platform": {"os": "linux", "architecture": "arm64"},
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": _AMD64_ATTESTATION,
+            "annotations": {
+                "vnd.docker.reference.type": "attestation-manifest",
+                "vnd.docker.reference.digest": _AMD64_IMAGE,
+            },
+            "platform": {"os": "unknown", "architecture": "unknown"},
+        },
+        {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": _ARM64_ATTESTATION,
+            "annotations": {
+                "vnd.docker.reference.type": "attestation-manifest",
+                "vnd.docker.reference.digest": _ARM64_IMAGE,
+            },
+            "platform": {"os": "unknown", "architecture": "unknown"},
+        },
+    ],
+}
 
 
 def _workflow() -> str:
@@ -15,6 +70,28 @@ def _job(workflow: str, name: str, next_name: str | None = None) -> str:
     if next_name is None:
         return start
     return start.split(f"\n  {next_name}:\n", 1)[0]
+
+
+def _linux_image_digests(index: dict[str, Any], architecture: str) -> list[str]:
+    found: list[str] = []
+    for manifest in index["manifests"]:
+        platform = manifest.get("platform") or {}
+        annotations = manifest.get("annotations") or {}
+        if (
+            platform.get("os") == "linux"
+            and platform.get("architecture") == architecture
+            and manifest.get("mediaType") in _IMAGE_MEDIA_TYPES
+            and annotations.get("vnd.docker.reference.type") != "attestation-manifest"
+        ):
+            found.append(manifest["digest"])
+    return found
+
+
+def _smoke_digest_jq_program() -> str:
+    smoke = _job(_workflow(), "smoke-image", "attest-image")
+    start = smoke.index("[.manifests[]")
+    end = smoke.index("end'", start)
+    return smoke[start : end + 3]
 
 
 def test_release_trigger_guard_and_python_build_gate() -> None:
@@ -54,7 +131,14 @@ def test_each_platform_digest_is_resolved_and_smoked() -> None:
     assert "platform: linux/arm64" in smoke
     assert "architecture: arm64" in smoke
     assert '"${IMAGE_NAME}@${INDEX_DIGEST}" --raw' in smoke
+    assert ".platform.os == \"linux\"" in smoke
     assert ".platform.architecture == $architecture" in smoke
+    assert "application/vnd.oci.image.manifest.v1+json" in smoke
+    assert "application/vnd.docker.distribution.manifest.v2+json" in smoke
+    assert 'vnd.docker.reference.type' in smoke
+    assert "attestation-manifest" in smoke
+    assert "length == 1" in smoke
+    assert 'test "$(grep -c "$platform_digest"' not in smoke
     assert 'docker pull --platform "$PLATFORM" "${IMAGE_NAME}@${PLATFORM_DIGEST}"' in smoke
     assert '"${IMAGE_NAME}@${PLATFORM_DIGEST}"' in smoke
     assert "import cognee" in smoke
@@ -67,6 +151,54 @@ def test_each_platform_digest_is_resolved_and_smoked() -> None:
     assert "count_adr_records() > 0" in smoke
     assert "CITADEL_EXPECTED_VERSION" in smoke
     assert 'Path("/src").exists()' in smoke
+
+
+def test_platform_digest_uniqueness_ignores_provenance_duplicate() -> None:
+    raw = json.dumps(_PROVENANCE_INDEX)
+    assert raw.count(_AMD64_IMAGE) == 2
+    assert raw.count(_ARM64_IMAGE) == 2
+    assert _linux_image_digests(_PROVENANCE_INDEX, "amd64") == [_AMD64_IMAGE]
+    assert _linux_image_digests(_PROVENANCE_INDEX, "arm64") == [_ARM64_IMAGE]
+
+
+def test_attestation_on_linux_platform_is_not_selected() -> None:
+    index = {
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": _AMD64_IMAGE,
+                "platform": {"os": "linux", "architecture": "amd64"},
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": _AMD64_ATTESTATION,
+                "annotations": {
+                    "vnd.docker.reference.type": "attestation-manifest",
+                    "vnd.docker.reference.digest": _AMD64_IMAGE,
+                },
+                "platform": {"os": "linux", "architecture": "amd64"},
+            },
+        ]
+    }
+    assert _linux_image_digests(index, "amd64") == [_AMD64_IMAGE]
+
+
+def test_workflow_jq_selects_one_image_digest_under_provenance() -> None:
+    jq = shutil.which("jq")
+    if jq is None:
+        pytest.skip("jq is required to execute the publish smoke filter")
+    raw = json.dumps(_PROVENANCE_INDEX)
+    program = _smoke_digest_jq_program()
+    for architecture, expected in (("amd64", _AMD64_IMAGE), ("arm64", _ARM64_IMAGE)):
+        completed = subprocess.run(
+            [jq, "-r", "--arg", "architecture", architecture, program],
+            input=raw,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert completed.stdout.strip() == expected
 
 
 def test_keyless_attestation_and_pypi_fail_closed_on_oci_gates() -> None:


### PR DESCRIPTION
## What

Publish smoke now selects the `linux/<arch>` image manifest digest once with `jq`. It no longer runs `grep -c` over the raw OCI index.

## Why

The v0.5.0 publish failed on `Smoke staged image (linux/amd64)` and `Smoke staged image (linux/arm64)` at `Resolve staged platform digest`.

Failed run: https://github.com/masumi-network/Citadel/actions/runs/31878456162

BuildKit `provenance: mode=max` adds an `attestation-manifest` per platform. That descriptor repeats the image digest in `vnd.docker.reference.digest`. `grep -c` over the raw index counted 2 for a valid unique image.

Staged index `sha256:13d35ba65af366ba6779a16ed09c2625ad765186ff7b6eb7ddf7d5762fb8ec0a` (`ghcr.io/masumi-network/citadel:sha-fb47665522d67256d2f36f1cf80f1800d324d1da`): amd64 and arm64 each appear twice.

PyPI is still 0.4.0. No GitHub Release `v0.5.0`. No `ghcr.io/masumi-network/citadel:0.5.0`. Re-run of the failed jobs stays safe after this lands, then cut `v0.5.1`. Do not retag `v0.5.0`.

Refs #128

## How it was verified

- `python3 -m pytest tests/test_publish_workflow.py -q` -> `8 passed`
- `python3 -m ruff check tests/test_publish_workflow.py` -> `All checks passed!`
- Live staged index: old `grep -c` is 2 for amd64 and arm64. New `jq` filter returns one image digest each.
- `kb.__version__` left at `0.5.0`. `v0.5.0` still points at `fb47665522d67256d2f36f1cf80f1800d324d1da`.

## Checklist

- [x] Commits are signed off (`git commit -s`) — the DCO check enforces this
- [x] PR title follows Conventional Commits
- [x] Tests added or updated for the behaviour changed
- [x] `python3 -m pytest tests/test_publish_workflow.py -q` passes locally
- [x] `python3 -m ruff check tests/test_publish_workflow.py` is clean
- [x] No secrets, tokens, `.env` contents or vault exports in the diff
- [x] Documentation updated if behaviour or interfaces changed
