### PR TITLE
fix(ci): login ghcr before attest publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing git tag to publish (does not create or move tags)
+        required: true
+        type: string
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -18,6 +24,7 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/masumi-network/citadel
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
 jobs:
   release-guard:
@@ -30,19 +37,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
       - name: Require an exact semantic-version tag
         run: |
-          [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
       - name: Require the tagged commit to be on main
         run: |
           git fetch origin main --depth=1
-          git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"
+          git merge-base --is-ancestor HEAD "origin/main"
       - name: Require a successful CI gate for the tagged commit
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          commit="$(git rev-parse HEAD)"
           successful_gates="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs?per_page=100" \
+            "repos/${GITHUB_REPOSITORY}/commits/${commit}/check-runs?per_page=100" \
             --jq '[.check_runs[] | select(.name == "CI gate" and .conclusion == "success")] | length')"
           test "$successful_gates" -ge 1
 
@@ -52,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Verify tag matches package version
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           test "${RELEASE_TAG#v}" = "$(python -c 'from kb import __version__; print(__version__)')"
       - name: Build distributions
@@ -83,6 +92,7 @@ jobs:
   stage-image:
     name: Stage production OCI index
     needs: release-guard
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -227,6 +237,11 @@ jobs:
       artifact-metadata: write
       packages: write
     steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create keyless GitHub provenance attestation
         uses: actions/attest@v4
         with:
@@ -237,6 +252,13 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: [build, attest-image]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.build.result == 'success'
+      && (needs.attest-image.result == 'success'
+          || (github.event_name == 'workflow_dispatch'
+              && needs.attest-image.result == 'skipped'))
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -310,10 +332,27 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          gh release create "${GITHUB_REF_NAME}"
-          dist/*
-          citadel-image-receipt.txt
-          --repo "${GITHUB_REPOSITORY}"
-          --title "citadel-archive ${GITHUB_REF_NAME}"
-          --generate-notes
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            existing="$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')"
+            for f in dist/* citadel-image-receipt.txt; do
+              name="$(basename "$f")"
+              if grep -Fxq "$name" <<<"$existing"; then
+                echo "asset already present: $name"
+              else
+                gh release upload "${GITHUB_REF_NAME}" "$f" --repo "${GITHUB_REPOSITORY}"
+              fi
+            done
+            body="$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json body --jq '.body')"
+            if [[ -z "$body" ]]; then
+              notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -f tag_name="${GITHUB_REF_NAME}" --jq '.body')"
+              gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --notes "$notes"
+            fi
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              dist/* \
+              citadel-image-receipt.txt \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "citadel-archive ${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -100,10 +100,11 @@ def test_release_trigger_guard_and_python_build_gate() -> None:
     build = _job(workflow, "build", "stage-image")
 
     assert 'tags:\n      - "v*"' in workflow
+    assert "workflow_dispatch:" in workflow
     assert "cancel-in-progress: false" in workflow
     assert r"^v[0-9]+\.[0-9]+\.[0-9]+$" in guard
-    assert 'git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"' in guard
-    assert "commits/${GITHUB_SHA}/check-runs" in guard
+    assert 'git merge-base --is-ancestor HEAD "origin/main"' in guard
+    assert "commits/${commit}/check-runs" in guard
     assert 'select(.name == "CI gate" and .conclusion == "success")' in guard
     assert "needs: release-guard" in build
     assert 'test "${RELEASE_TAG#v}" =' in build
@@ -210,6 +211,7 @@ def test_keyless_attestation_and_pypi_fail_closed_on_oci_gates() -> None:
     assert "id-token: write" in attestation
     assert "attestations: write" in attestation
     assert "artifact-metadata: write" in attestation
+    assert "uses: docker/login-action@v3" in attestation
     assert "uses: actions/attest@v4" in attestation
     assert "subject-digest: ${{ needs.stage-image.outputs.digest }}" in attestation
     assert "push-to-registry: true" in attestation
@@ -234,6 +236,7 @@ def test_promotion_and_release_use_only_the_exact_immutable_version() -> None:
     assert "needs: [build, stage-image, promote-image]" in release
     assert "citadel-image-receipt.txt" in release
     assert '"$IMAGE_NAME" "$VERSION" "$INDEX_DIGEST" "$GITHUB_SHA"' in release
+    assert 'gh release view "${GITHUB_REF_NAME}"' in release
     assert 'gh release create "${GITHUB_REF_NAME}"' in release
     assert ":latest" not in workflow.lower()
     assert "${VERSION%.*}" not in workflow


### PR DESCRIPTION
## What

`attest-image` logs into `ghcr.io` before `actions/attest@v4` with `push-to-registry: true`. `github-release` is idempotent when the tag already has a GitHub Release. `workflow_dispatch` with a `tag` input publishes that existing tag to PyPI without moving it.

## Why

PyPI `citadel-archive` is still `0.4.0` ([pypi json](https://pypi.org/pypi/citadel-archive/json)). Tag `v0.5.1` already has a GitHub Release: https://github.com/masumi-network/Citadel/releases/tag/v0.5.1

Failed run: https://github.com/masumi-network/Citadel/actions/runs/32028709867

Attest failed with `Error: No credentials found for registry ghcr.io`. That job used `push-to-registry: true` and had no `docker/login-action`. `stage-image` and smoke jobs logged in; `attest-image` did not. Publish to PyPI, promote, and Create GitHub Release were skipped.

Re-running the tag workflow cannot pick up this YAML. GitHub Actions uses the workflow file frozen at the tagged commit (`v0.5.1` = `caf8eb99520b9eaf459c3009924238c242bd0df1`). Create GitHub Release would also fail because the release already exists.

After this PR merges, do not retag `v0.5.0` or `v0.5.1`. From `main`:

```bash
gh workflow run "Publish release" --ref main -f tag=v0.5.1
```

That checks out `v0.5.1`, rebuilds sdist+wheel, and publishes through the existing `pypi` environment OIDC job. Docker jobs are skipped on dispatch.

Refs #128

Refs https://github.com/masumi-network/Citadel/actions/runs/32028709867

## How it was verified

- `curl https://pypi.org/pypi/citadel-archive/json` -> `info.version=0.4.0` (no 0.5.1 release)
- `gh run view 32028709867` -> Attest staged OCI index failed; Publish to PyPI / Promote / Create GitHub Release skipped
- `gh release view v0.5.1` -> release exists with `citadel_archive-0.5.1-py3-none-any.whl` and `citadel_archive-0.5.1.tar.gz`
- YAML load of `.github/workflows/publish.yml` succeeded
- `uv run pytest tests/test_publish_workflow.py -q` -> 8 passed
- Did not retag `v0.5.0` (`fb47665`) or `v0.5.1` (`caf8eb9`). Did not push `main`.

## Checklist

- [x] Commits are signed off (`git commit -s`) — the DCO check enforces this
- [x] PR title follows Conventional Commits
- [x] Tests added or updated for the behaviour changed
- [x] `uv run pytest tests/test_publish_workflow.py -q` passes locally (8 passed)
- [ ] `uv run ruff check .` is clean (not run; test-string change only)
- [x] No secrets, tokens, `.env` contents or vault exports in the diff
- [ ] Documentation updated if behaviour or interfaces changed (not needed)