### PR TITLE
fix(ci): fetch full main history in publish release guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
       - name: Require the tagged commit to be on main
         run: |
-          git fetch origin main --depth=1
+          git fetch origin main
           git merge-base --is-ancestor HEAD "origin/main"
       - name: Require a successful CI gate for the tagged commit
         env:

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -103,6 +103,8 @@ def test_release_trigger_guard_and_python_build_gate() -> None:
     assert "workflow_dispatch:" in workflow
     assert "cancel-in-progress: false" in workflow
     assert r"^v[0-9]+\.[0-9]+\.[0-9]+$" in guard
+    assert "git fetch origin main" in guard
+    assert "git fetch origin main --depth=1" not in guard
     assert 'git merge-base --is-ancestor HEAD "origin/main"' in guard
     assert "commits/${commit}/check-runs" in guard
     assert 'select(.name == "CI gate" and .conclusion == "success")' in guard


### PR DESCRIPTION
## Summary
- Dispatch [32034608781](https://github.com/masumi-network/Citadel/actions/runs/32034608781) failed at Release guard step `Require the tagged commit to be on main`.
- Tag `v0.5.1` is `caf8eb99520b9eaf459c3009924238c242bd0df1`, which is an ancestor of `origin/main` in full history. The guard ran `git fetch origin main --depth=1`, so Git only had main's tip and `git merge-base --is-ancestor HEAD origin/main` exited 1.
- Fetch `origin/main` without `--depth=1`. Tag checkout, CI-gate check, attest docker login, idempotent GitHub Release, and `workflow_dispatch` `tag` are unchanged. Does not retag `v0.5.0` or `v0.5.1`.

Refs #128

## Test plan
- [x] `python -m pytest tests/test_publish_workflow.py` locally (`8 passed`)
- [ ] After merge, dispatch Publish release with existing tag `v0.5.1` (do not retag)
- [ ] Confirm PyPI `citadel-archive==0.5.1` exists, then `pipx install citadel-archive==0.5.1`