### PR TITLE
Fix knowledge inspector connection overflow in dense graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+- **Knowledge-graph inspector now supports long connection lists.** Selected
+  nodes render up to 8 neighbor links and a `Show all N connections` control.
+  Expanded mode shows the full set with a scrollable list so users can reach
+  all relations in dense graphs.
+
 - **Public tiles** quote self-host cost as a range (`~$23–$58/mo`): 24h
   Railway average 2026-08-17 about $23, trailing-7-day 2026-08-14 about
   $58. Memory dominates. Not a fixed bill. Search 25 s stays in the

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -2178,33 +2178,52 @@ function renderKnowledgeInspector(node) {
 
   const neighbors = knowledgeNeighbors(node.id);
   if (!neighbors.length) return;
+
   const container = document.createElement("div");
   container.className = "node-connections";
   const heading = document.createElement("strong");
   heading.textContent = "Connections";
-  container.append(heading);
-  neighbors.slice(0, MAX_INSPECTOR_NEIGHBORS).forEach((item) => {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "node-connection";
-    button.textContent = `${item.relationship} · ${item.node.label || item.node.id}`;
-    // Resolve by id at click time: a graph refresh replaces state.realGraph
-    // while this button persists, so the captured node object may be stale.
-    const targetId = item.node.id;
-    button.addEventListener("click", () => {
-      const target = state.realGraph?.nodes.get(targetId);
-      if (!target) return;
-      focusGraphNode(targetId);
-      selectNode(target);
+  const list = document.createElement("div");
+  list.className = "node-connections-list";
+  const more = document.createElement("button");
+  more.type = "button";
+  more.className = "node-connections-more";
+
+  container.append(heading, list);
+
+  const renderConnections = (showAll) => {
+    list.innerHTML = "";
+    const visibleNeighbors = showAll
+      ? neighbors
+      : neighbors.slice(0, MAX_INSPECTOR_NEIGHBORS);
+    visibleNeighbors.forEach((item) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "node-connection";
+      button.textContent = `${item.relationship} · ${item.node.label || item.node.id}`;
+      // Resolve by id at click time: a graph refresh replaces state.realGraph
+      // while this button persists, so the captured node object may be stale.
+      const targetId = item.node.id;
+      button.addEventListener("click", () => {
+        const target = state.realGraph?.nodes.get(targetId);
+        if (!target) return;
+        focusGraphNode(targetId);
+        selectNode(target);
+      });
+      list.append(button);
     });
-    container.append(button);
-  });
-  if (neighbors.length > MAX_INSPECTOR_NEIGHBORS) {
-    const more = document.createElement("span");
-    more.className = "node-connections-more";
-    more.textContent = `+${neighbors.length - MAX_INSPECTOR_NEIGHBORS} more`;
-    container.append(more);
-  }
+
+    if (neighbors.length > MAX_INSPECTOR_NEIGHBORS) {
+      more.textContent = showAll ? "Show fewer" : `Show all ${neighbors.length} connections`;
+      more.hidden = false;
+      more.onclick = () => renderConnections(!showAll);
+    } else {
+      more.hidden = true;
+    }
+  };
+
+  container.append(more);
+  renderConnections(false);
   selectedNode.append(container);
 }
 

--- a/kb/static/styles.css
+++ b/kb/static/styles.css
@@ -1467,6 +1467,15 @@ pre {
   font-size: 12px;
 }
 
+.selection .node-connections-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: min(280px, 40vh);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .selection .node-connection {
   display: block;
   width: 100%;
@@ -1493,8 +1502,19 @@ pre {
 .selection .node-connections-more {
   display: block;
   margin-top: 4px;
-  color: var(--quiet);
+  color: var(--primary);
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
   font-size: 11px;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.selection .node-connections-more:hover,
+.selection .node-connections-more:focus-visible {
+  color: var(--text);
 }
 
 /* Kind legend overlaid on the knowledge-graph canvas; chips toggle kinds


### PR DESCRIPTION
## Summary\n- Make knowledge inspector show long node connections via scrollable list\n- Add expand/collapse control to reveal hidden connections\n- Add changelog note under Unreleased\n\n## Testing\n- Not run in this change request; manual UI verification needed\n\n## Commits\n- 0155b6f Fix knowledge inspector connection overflow\n- 8ddef24 docs: note knowledge inspector connection list