### PR TITLE
fix(lifecycle): remove destructive auto-tombstone; missing-path errors bounded-fail

### DIFF
--- a/kb/lifecycle_worker.py
+++ b/kb/lifecycle_worker.py
@@ -11,12 +11,10 @@ import re
 from typing import Any, Protocol
 
 from kb.lifecycle import (
-    CaptureContext,
     LifecycleStore,
     ProjectionLease,
     ProjectionLeaseError,
     ProjectionOperation,
-    ProjectionRequest,
 )
 
 
@@ -121,20 +119,6 @@ def _safe_error_message(exc: BaseException) -> str:
     if _is_provider_error(exc):
         return f"{exc.__class__.__name__}: model provider request failed"
     return str(exc)
-
-
-def _is_missing_local_path_error(exc: BaseException) -> bool:
-    """True when Cognee failed because a path-string note is not on disk."""
-    seen: set[int] = set()
-    current: BaseException | None = exc
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        if isinstance(current, FileNotFoundError):
-            return True
-        if "Storage directory does not exist" in str(current):
-            return True
-        current = current.__cause__ or current.__context__
-    return False
 
 
 def _is_malformed_graph_output_error(exc: BaseException) -> bool:
@@ -344,13 +328,6 @@ class LifecycleProjectionWorker:
         now: datetime,
     ) -> bool:
         """Record a failure and return whether the caller should re-raise it."""
-        if _is_missing_local_path_error(exc):
-            # Path-string notes (citadel ingest used to store the path, not
-            # the file). Cognee then tries to open that local path on the Node
-            # and retries forever. Missing paths are not retryable; tombstone
-            # the current head so requeue cannot resurrect them.
-            self._tombstone_missing_path(lease, exc, now=now)
-            return False
         try:
             if self.deferred_only and _is_malformed_graph_output_error(exc):
                 self.store.reschedule_job(
@@ -664,59 +641,6 @@ class LifecycleProjectionWorker:
             self.generation_id == generation_id
             and self.projection_version == projection_version
             and self.config_digest == config_digest
-        )
-
-    def _tombstone_missing_path(
-        self,
-        lease: ProjectionLease,
-        exc: BaseException,
-        *,
-        now: datetime,
-    ) -> None:
-        """Fail the poison job, then replace the current head with a tombstone."""
-        self.store.fail_job(
-            lease,
-            error_code="FileNotFoundError",
-            error_message=str(exc),
-            now=now,
-        )
-        operation = self.store.get_operation(lease.projection_job_id)
-        source = operation.source_revision
-        if source.tombstone:
-            return
-        self.store.accept_tombstone(
-            reason=f"FileNotFoundError: {str(exc)[:200]}",
-            capture=CaptureContext(
-                dataset=source.dataset,
-                source_key=source.source_key,
-                source_locator=source.source_locator,
-                media_type=source.media_type,
-                capture_actor_id=source.capture_actor_id,
-                capture_run_id=source.capture_run_id,
-                captured_at=now,
-                metadata=dict(source.capture_metadata),
-            ),
-            projection=self._projection_request(operation),
-            now=now,
-        )
-        logger.warning(
-            "tombstoned source %s after non-retryable FileNotFoundError: %s",
-            source.source_key,
-            exc,
-        )
-
-    @staticmethod
-    def _projection_request(operation: ProjectionOperation) -> ProjectionRequest:
-        job = operation.job
-        return ProjectionRequest(
-            generation_id=job.generation_id,
-            projection_version=job.projection_version,
-            config_digest=job.config_digest,
-            providers={
-                receipt.backend: receipt.provider
-                for receipt in operation.receipts
-                if receipt.backend and receipt.provider
-            },
         )
 
     async def _project(

--- a/tests/test_lifecycle_worker.py
+++ b/tests/test_lifecycle_worker.py
@@ -1015,11 +1015,13 @@ async def test_worker_marks_job_failed_after_bounded_attempts(
     assert {receipt.state for receipt in retried.operation.receipts} == {"pending"}
 
 
-async def test_worker_tombstones_missing_local_path_without_retry(
+async def test_worker_does_not_tombstone_missing_path_when_content_retained(
     tmp_path: Path,
 ) -> None:
-    """A path-string note dies on FileNotFoundError. Requeue cannot succeed.
-    Treat it as a non-retryable terminal tombstone on the first attempt.
+    """A missing local file must not tombstone a source whose durable
+    retained_content is still stored. accept_tombstone replaces the head
+    globally and rollback cannot restore it, so a systemic FileNotFoundError
+    during a bulk rebuild (or a path-string note) bounded-fails instead.
     """
     store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
     projection = ProjectionRequest(
@@ -1051,30 +1053,96 @@ async def test_worker_tombstones_missing_local_path_without_retry(
         store,
         MissingLocalPathGateway(),
         worker_id="worker-pathfile",
-        max_attempts=5,
+        max_attempts=1,
     )
 
-    assert await worker.run_once(now=T0) is True
+    with pytest.raises(FileNotFoundError):
+        await worker.run_once(now=T0)
 
-    poison = store.get_operation(accepted.projection_job_id)
-    assert poison.job.state == "stale"
-    assert poison.job.last_error_code == "FileNotFoundError"
+    operation = store.get_operation(accepted.projection_job_id)
+    assert operation.job.state == "failed"
+    assert operation.job.last_error_code == "FileNotFoundError"
     current = store.current_revisions_for_source(
         capture.dataset,
         capture.source_key,
         include_chunks=False,
     )
     assert len(current) == 1
-    assert current[0].tombstone is True
-    current_jobs = store.generation_census(
-        generation_id=projection.generation_id,
-        projection_version=projection.projection_version,
-        config_digest=projection.config_digest,
+    assert current[0].tombstone is False
+    assert store.read_retained_content(current[0].source_revision_id) == (
+        b"/private/tmp/claude-501/marker3_pathfile.txt"
     )
-    assert current_jobs.current_job_states.get("failed", 0) == 0
-    assert current_jobs.current_job_states.get("pending", 0) == 1
-    assert store.failed_projection_candidates(projection) == ()
-    assert store.next_wakeup_delay(now=T0) is not None
+
+
+async def test_worker_does_not_tombstone_on_reconcile_graph_filenotfound(
+    tmp_path: Path,
+) -> None:
+    """The real bulk-rebuild shape: an existing Cognee Data row reconciles at
+    the relational stage, then the graph-presence read raises a nested
+    FileNotFoundError (e.g. an uncreated Ladybug storage dir). The current head
+    must be preserved, not tombstoned, because rollback cannot restore it.
+    """
+
+    class ReconcileGraphMissingGateway(FakeProjectionGateway):
+        async def corpus_graph_presence(
+            self, document_ids: list[str], *, datasets: list[str] | None = None
+        ) -> set[str]:
+            raise FileNotFoundError(
+                "Storage directory does not exist: '/data/ladybug-home/graph_db'"
+            )
+
+    store = LifecycleStore(tmp_path / "lifecycle.sqlite3")
+    projection = ProjectionRequest(
+        generation_id="generation-1",
+        projection_version="projection-v1",
+        config_digest="sha256:config-1",
+        providers={
+            "relational": "sqlite",
+            "vector": "qdrant",
+            "graph": "ladybug",
+        },
+    )
+    capture = CaptureContext(
+        dataset="seat:alice",
+        source_key="manual:existing-row",
+        source_locator=None,
+        media_type="text/plain",
+        capture_actor_id="alice",
+        capture_run_id="run-existing-row",
+        captured_at=T0,
+    )
+    accepted = store.accept_source(
+        b"the actual note body",
+        capture=capture,
+        projection=projection,
+        now=T0,
+    )
+    gateway = ReconcileGraphMissingGateway()
+    # Present the source as an existing Data row so the relational stage
+    # reconciles without an add; the failure then arises in the graph-presence
+    # read, exactly as a bulk rebuild would hit it.
+    gateway.document_ids = [accepted.source_revision_id]
+    worker = LifecycleProjectionWorker(
+        store,
+        gateway,
+        worker_id="worker-existing-row",
+        max_attempts=1,
+    )
+
+    with pytest.raises(FileNotFoundError):
+        await worker.run_once(now=T0)
+
+    assert gateway.remember_calls == []
+    current = store.current_revisions_for_source(
+        capture.dataset,
+        capture.source_key,
+        include_chunks=False,
+    )
+    assert len(current) == 1
+    assert current[0].tombstone is False
+    operation = store.get_operation(accepted.projection_job_id)
+    assert operation.job.state == "failed"
+    assert operation.job.last_error_code == "FileNotFoundError"
 
 
 async def test_worker_projects_tombstone_as_provider_neutral_exclusion(


### PR DESCRIPTION
## What

Removes the automatic destructive tombstone in the lifecycle projection worker. A missing-path projection
error (`FileNotFoundError` or "Storage directory does not exist") now bounded-fails (reschedule up to
`max_attempts`, then `fail_job`) instead of calling `accept_tombstone`, which globally replaced the current
source head and could not be rolled back.

## Why

During a bulk reprojection a systemic miss (FastEmbed cache, Ladybug/graph storage, or an uncreated Cognee
storage dir) could tombstone many valid heads, and the mutation was non-atomic: an old job could tombstone a
newer head. Safety prerequisite for the FastEmbed embedding cutover that restores vector search.

## Changes

- `kb/lifecycle_worker.py`: net -76 lines. Removes the guard, `_source_content_retained`,
  `_tombstone_missing_path`, `_is_missing_local_path_error`, `_projection_request`, and now-unused imports.
- `tests/test_lifecycle_worker.py`: two pins that fail if the removal is reverted (remember-path and the
  reconcile -> `corpus_graph_presence` path); obsolete tombstone-fires tests removed.

## Verification

- `29 passed` in `tests/test_lifecycle_worker.py`; `ruff check` clean.
- Proven both directions: restoring HEAD's tombstoning worker makes the two pins fail.
- Fresh-eyes adversarial review (context-clean, stable tree): correct, confidence 0.99, no findings.

Context: `docs/handoffs/2026-08-27-search-restore-handoff.md`.

Refs #228, #247


## Small Stacked PR declarations

- Base: `main` (off `origin/main` 4a940e3). Standalone slice, no parent PR.
- Affected paths: `kb/lifecycle_worker.py`, `tests/test_lifecycle_worker.py`. Service: Citadel-Archive (lifecycle projection worker).
- Verification: `uv run pytest -q tests/test_lifecycle_worker.py` -> 29 passed; `uv run ruff check` on both files -> clean. Proven both directions: restoring the old tombstoning worker fails the two pins.
- Rollback: `git revert` this commit (pure code removal; restores prior auto-tombstone behaviour). No schema, migration, or data change.
- Runs independently: CI green on this commit (aggregate `CI gate` success).
