### PR TITLE
fix(search): propagate Qdrant distance and type search relevance

### DIFF
--- a/kb/cli.py
+++ b/kb/cli.py
@@ -1122,6 +1122,9 @@ async def _search_local(args: argparse.Namespace) -> int:
             dataset=args.dataset,
             session_id=args.session,
             top_k=top_k,
+            repo=getattr(args, "repo", None),
+            path=getattr(args, "path", None),
+            source=getattr(args, "source", None),
         )
     except TimeoutError as exc:
         return _emit_search_timeout(args, note=str(exc) or "local search timed out")

--- a/kb/qdrant_adapter.py
+++ b/kb/qdrant_adapter.py
@@ -611,11 +611,17 @@ class CitadelQdrantAdapter(VectorDBInterface):
         for point in points:
             payload = None
             raw_id = str(point.id)
-            if getattr(point, "payload", None) is not None:
-                raw_id = str(point.payload.get("citadel_original_id", point.id))
-                payload = _serialize({**point.payload, "id": raw_id})
             similarity = getattr(point, "score", None)
             distance = 0.0 if similarity is None else 1.0 - float(similarity)
+            if getattr(point, "payload", None) is not None:
+                raw_id = str(point.payload.get("citadel_original_id", point.id))
+                base = {**point.payload, "id": raw_id}
+                # Only a real query score is a retrieval distance. retrieve() and
+                # scroll() return score-less Records; fabricating distance 0.0
+                # would advertise a perfect match and could clobber a payload key.
+                if similarity is not None:
+                    base["distance"] = distance
+                payload = _serialize(base)
             results.append(
                 ScoredResult(
                     id=parse_id(raw_id),

--- a/kb/search_format.py
+++ b/kb/search_format.py
@@ -264,6 +264,7 @@ CODE_TIMEOUT = "TIMEOUT"
 CODE_AUTH_REQUIRED = "AUTH_REQUIRED"
 CODE_SEARCH_UNAVAILABLE = "SEARCH_UNAVAILABLE"
 CODE_QUERY_CONTEXT_REQUIRED = "QUERY_CONTEXT_REQUIRED"
+CODE_NO_RELEVANT_RESULTS = "NO_RELEVANT_RESULTS"
 QUERY_CONTEXT_REQUIRED_MESSAGE = (
     "Name the issue, repository, file, feature, person, or decision topic you mean. "
     "Citadel did not search because the prompt has no subject."
@@ -1128,6 +1129,17 @@ def _public_search_envelope(envelope: Any) -> dict[str, Any]:
             value = relevance.get(key)
             if _is_finite_number(value):
                 clean_relevance[key] = value
+        kind = relevance.get("retriever_score_kind")
+        if isinstance(kind, str) and kind in {
+            "cosine-distance",
+            "distance",
+            "similarity",
+            "score",
+        }:
+            clean_relevance["retriever_score_kind"] = kind
+        direction = relevance.get("retriever_score_direction")
+        if direction in {"lower-is-better", "higher-is-better", "unknown"}:
+            clean_relevance["retriever_score_direction"] = direction
         matched_terms = relevance.get("matched_terms")
         if isinstance(matched_terms, list):
             clean_relevance["matched_terms"] = [
@@ -1306,15 +1318,74 @@ def shape_public_search_hit(item: Any, *, index: int = 0) -> dict[str, Any]:
     return shaped
 
 
+def _search_hit_retriever_signal(
+    item: dict[str, Any], public_envelope: dict[str, Any]
+) -> tuple[float, str, str] | None:
+    """Return a finite retriever value with its metric meaning."""
+    provenance = (
+        public_envelope.get("provenance")
+        if isinstance(public_envelope.get("provenance"), dict)
+        else {}
+    )
+    if "github_sync_state" in {
+        item.get("source"),
+        item.get("source_type"),
+        provenance.get("source"),
+    }:
+        return None
+    relevance = public_envelope.get("relevance")
+    if isinstance(relevance, dict):
+        value = relevance.get("retriever_score")
+        if _is_finite_number(value):
+            return (
+                float(value),
+                str(relevance.get("retriever_score_kind") or "score"),
+                str(relevance.get("retriever_score_direction") or "unknown"),
+            )
+    lifecycle = item.get("_lifecycle")
+    for key, kind, direction in (
+        ("distance", "distance", "lower-is-better"),
+        ("similarity", "similarity", "higher-is-better"),
+        ("retriever_score", "score", "unknown"),
+        ("score", "score", "unknown"),
+    ):
+        value = item.get(key)
+        if not _is_finite_number(value):
+            continue
+        if key == "score" and isinstance(lifecycle, dict) and lifecycle.get("backend") == "vector":
+            kind = "cosine-distance"
+            direction = "lower-is-better"
+        return float(value), kind, direction
+    return None
+
+
+def _normalized_retriever_score(hit: dict[str, Any]) -> float | None:
+    signal = _search_hit_retriever_signal(hit, _hit_envelope(hit))
+    return signal[0] if signal is not None else None
+
+
+def _retriever_score_fields(
+    signal: tuple[float, str, str] | None,
+) -> dict[str, Any]:
+    if signal is None:
+        return {}
+    score, kind, direction = signal
+    return {
+        "retriever_score": score,
+        "retriever_score_kind": kind,
+        "retriever_score_direction": direction,
+    }
+
+
 def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None) -> dict[str, Any]:
     """Stable agent hit schema for CLI --json output.
 
     With ``query`` given, each hit also carries ``term_coverage`` /
-    ``matched_terms`` (observable lexical overlap — see
-    ``lexical_relevance_summary`` for why there is no retriever score), and the
-    snippet of a LONG text is a window around the densest query-term cluster
-    instead of the head: the head of a repo-content chunk is its provenance
-    header, which is exactly where the answer is not.
+    ``matched_terms`` and, when available, a typed retriever score with its
+    metric meaning and sort direction. The snippet of a LONG text is a window
+    around the densest query-term cluster instead of the head: the head of a
+    repo-content chunk is its provenance header, which is exactly where the
+    answer is not.
     """
     if not isinstance(item, dict):
         text = str(item)
@@ -1400,6 +1471,7 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
     score = item.get("score")
     if not isinstance(score, (int, float)) or isinstance(score, bool):
         score = None
+    retriever_signal = _search_hit_retriever_signal(item, public_envelope)
 
     terms = query_terms(query) if query else []
     snippet_source = text
@@ -1483,6 +1555,7 @@ def normalize_search_hit(item: Any, *, index: int = 0, query: str | None = None)
         normalized["retrieval"] = retrieval
     if references:
         normalized["references"] = references
+    normalized.update(_retriever_score_fields(retriever_signal))
     document_endpoint = public_envelope.get("document_endpoint")
     if isinstance(document_endpoint, str) and document_endpoint:
         normalized["document_endpoint"] = document_endpoint
@@ -1740,6 +1813,13 @@ def shape_search_payload(
         canonical_only=canonical_only,
         exclude_ambient=exclude_ambient,
     )
+    if query_terms(query) and not filters_active:
+        hits = [
+            hit
+            for hit in hits
+            if float(hit.get("term_coverage") or 0) > 0
+            or _normalized_retriever_score(hit) is not None
+        ]
     relevance = lexical_relevance_summary(
         query,
         [
@@ -1747,8 +1827,10 @@ def shape_search_payload(
             for h in hits
             if isinstance(h.get("term_coverage"), (int, float))
         ],
-        scores_available=any(h.get("score") is not None for h in hits),
+        scores_available=any(_normalized_retriever_score(h) is not None for h in hits),
     )
+    if before_filters and not hits and query_terms(query) and not filters_active:
+        relevance["no_lexical_match"] = True
     warnings: list[str] = []
     if payload.get("note"):
         warnings.append(str(payload["note"]))
@@ -1791,6 +1873,13 @@ def shape_search_payload(
         out["code"] = CODE_TIMEOUT
     elif payload.get("code"):
         out["code"] = payload["code"]
+    elif not hits and before_filters and query_terms(query) and not filters_active:
+        out["code"] = CODE_NO_RELEVANT_RESULTS
+        out["answerable"] = False
+        out["message"] = (
+            "No result had verifiable query overlap or a retriever score. "
+            "Add an exact issue key, repository, file, symbol, or topic."
+        )
     return out
 
 

--- a/kb/server.py
+++ b/kb/server.py
@@ -7,6 +7,7 @@ import hmac
 from inspect import isawaitable
 import json
 import logging
+from math import isfinite
 import os
 from pathlib import Path
 import re
@@ -89,6 +90,7 @@ from kb.repo_content_sync import RepoContentSyncer
 from kb.search_feedback import build_search_telemetry, presence_only_telemetry
 from kb.search_format import (
     DOC_TYPE_CANONICAL,
+    CODE_NO_RELEVANT_RESULTS,
     DOC_TYPE_TRACE,
     NO_LEXICAL_MATCH_WARNING,
     apply_query_ranking,
@@ -2990,8 +2992,21 @@ def document_endpoint_for_result(
     return f"/api/documents/{quote(drilldown_id, safe=':._-')}"
 
 
+_RETRIEVER_SCORE_FIELDS = frozenset(
+    {"distance", "similarity", "retriever_score", "score"}
+)
+
+
 def result_content_sha256(result: dict[str, Any]) -> str:
-    content_basis = {key: value for key, value in result.items() if key != "_citadel"}
+    # A content hash must identify the CHUNK, not the query. Retrieval scores
+    # (Qdrant cosine distance, similarity, token-overlap score) vary per query
+    # for the same chunk, so excluding them keeps content_sha256 stable and lets
+    # retrieval_eval.trust_observations still see per-request metadata drift.
+    content_basis = {
+        key: value
+        for key, value in result.items()
+        if key != "_citadel" and key not in _RETRIEVER_SCORE_FIELDS
+    }
     encoded = json.dumps(content_basis, sort_keys=True, default=str).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
@@ -3022,36 +3037,67 @@ def with_result_id(result: dict[str, Any]) -> dict[str, Any]:
     if isinstance(raw_id, str) and raw_id.strip():
         return result
     idless = {key: value for key, value in result.items() if key != "id"}
-    basis = json.dumps(idless, sort_keys=True, default=str)
+    # Derive the fallback id from content only: retrieval scores vary per query
+    # and would otherwise make the same chunk's synthetic id query-dependent.
+    basis_fields = {
+        key: value
+        for key, value in idless.items()
+        if key not in _RETRIEVER_SCORE_FIELDS
+    }
+    basis = json.dumps(basis_fields, sort_keys=True, default=str)
     derived = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
     return {**idless, "id": f"chunk:{derived}"}
 
 
-def _result_retriever_score(result: dict[str, Any]) -> float | None:
-    """A numeric relevance value the retriever itself attached, if any.
-
-    cognee 1.2.2's CHUNKS retriever returns chunk payload dicts without one —
-    the vector engine's ScoredResult carries a cosine distance, but the
-    retriever hands back ``found_chunk.payload`` only, so the distance is
-    dropped upstream of this repo's client boundary. For cognee hits this is
-    therefore always None. It is checked anyway so that the moment the client
-    boundary starts merging the distance into the payload, hits surface it here
-    without another change. Never invented: absent stays absent.
-
-    The one live producer of a ``score`` today is the github digest fallback
-    (``search_github_sync_state``), whose value is a token-overlap COUNT — an
-    unbounded integer in a different unit. Passing it through here would
-    surface it as ``retriever_score`` and flip ``retriever_scores_available``
-    on exactly the pages whose only signal is lexical, so that path is
-    excluded rather than mislabelled.
-    """
+def _result_retriever_signal(
+    result: dict[str, Any],
+    *,
+    include_envelope: bool = False,
+    lifecycle: dict[str, Any] | None = None,
+) -> tuple[float, str, str] | None:
+    """Return a finite retriever value with its metric meaning."""
     if result.get("source") == "github_sync_state":
         return None
-    for key in ("score", "distance", "similarity"):
+    if include_envelope:
+        envelope = result.get("_citadel")
+        if isinstance(envelope, dict):
+            relevance = envelope.get("relevance")
+            if isinstance(relevance, dict):
+                value = relevance.get("retriever_score")
+                if (
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    and isfinite(float(value))
+                ):
+                    return (
+                        float(value),
+                        str(relevance.get("retriever_score_kind") or "score"),
+                        str(relevance.get("retriever_score_direction") or "unknown"),
+                    )
+    for key, kind, direction in (
+        ("distance", "distance", "lower-is-better"),
+        ("similarity", "similarity", "higher-is-better"),
+        ("retriever_score", "score", "unknown"),
+        ("score", "score", "unknown"),
+    ):
         value = result.get(key)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            return float(value)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and isfinite(float(value))
+        ):
+            if key == "score" and (lifecycle or {}).get("backend") == "vector":
+                kind = "cosine-distance"
+                direction = "lower-is-better"
+            return float(value), kind, direction
     return None
+
+
+def _result_retriever_score(
+    result: dict[str, Any], *, include_envelope: bool = False
+) -> float | None:
+    signal = _result_retriever_signal(result, include_envelope=include_envelope)
+    return signal[0] if signal is not None else None
 
 
 def with_result_metadata(
@@ -3074,9 +3120,9 @@ def with_result_metadata(
     the flag falls back to "any id with a backing endpoint" (non-caller-scoped
     callers/tests). Synthetic ``chunk:<hash>`` ids stay non-drillable either way.
 
-    ``query`` (when supplied) adds ``_citadel.relevance``: the retriever's own
-    score when the payload carries one (it does not today — see
-    ``_result_retriever_score``), observable lexical term coverage, and a
+    ``query`` (when supplied) adds ``_citadel.relevance``: lexical term
+    coverage, a typed retriever score when the payload carries one (Qdrant
+    carries cosine distance as ``distance``), and a
     ``match_context`` window around the densest query-term cluster so that a
     caller which truncates ``text`` at the head still shows the part of a long
     document that actually matched.
@@ -3157,9 +3203,15 @@ def with_result_metadata(
             "term_coverage": round(coverage, 3),
             "matched_terms": matched,
         }
-        retriever_score = _result_retriever_score(normalized)
-        if retriever_score is not None:
+        retriever_signal = _result_retriever_signal(
+            normalized,
+            lifecycle=lifecycle if isinstance(lifecycle, dict) else None,
+        )
+        if retriever_signal is not None:
+            retriever_score, retriever_kind, retriever_direction = retriever_signal
             relevance["retriever_score"] = retriever_score
+            relevance["retriever_score_kind"] = retriever_kind
+            relevance["retriever_score_direction"] = retriever_direction
         full_text = first_string(
             normalized.get("text"),
             normalized.get("content"),
@@ -3278,6 +3330,13 @@ def select_public_search_page(
         candidates = apply_query_ranking(candidates, query, mode=mode)
 
     terms = query_terms(query)
+    if ranked_query and filter_kwargs is None:
+        candidates = [
+            candidate
+            for candidate in candidates
+            if hit_term_coverage(candidate, terms)[0] > 0
+            or _result_retriever_score(candidate, include_envelope=True) is not None
+        ]
     coverages = [hit_term_coverage(candidate, terms)[0] for candidate in candidates]
     lexical_evidence = any(coverage > 0 for coverage in coverages)
 
@@ -8599,6 +8658,8 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
     relevance_summary = lexical_relevance_summary(
         body.query, coverages, scores_available=retriever_scores_seen
     )
+    if candidates_matched and not normalized and query_terms(body.query):
+        relevance_summary["no_lexical_match"] = True
     payload: dict[str, Any] = {
         "results": normalized,
         "dataset": primary_dataset,
@@ -8627,8 +8688,12 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
         }
     if len(search_datasets) > 1:
         payload["datasets"] = search_datasets
-    if not clarification_required and not normalized and body.dataset is None and (
-        not filters_active or candidates_fetched == 0
+    if (
+        not clarification_required
+        and not normalized
+        and candidates_matched == 0
+        and body.dataset is None
+        and (not filters_active or candidates_fetched == 0)
     ):
         # With filters active this fires only when retrieval itself came back
         # empty — an empty page whose candidates the filters excluded gets the
@@ -8638,6 +8703,17 @@ async def search(body: SearchBody, request: Request, response: Response) -> Any:
             "specific source; see known_datasets."
         )
         payload["known_datasets"] = known_datasets(citadel.config)
+    if not clarification_required and not normalized and candidates_matched:
+        payload.update(
+            {
+                "code": CODE_NO_RELEVANT_RESULTS,
+                "answerable": False,
+                "message": (
+                    "No result had verifiable query overlap or a retriever score. "
+                    "Add an exact issue key, repository, file, symbol, or topic."
+                ),
+            }
+        )
     warnings: list[str] = []
     if (
         filters_active

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -404,6 +404,43 @@ def test_search_local_json_uses_bounded_agent_payload(monkeypatch, capsys) -> No
     assert len(hit["text"]) < 3006
 
 
+
+def test_search_local_forwards_source_scope_before_recall(monkeypatch, capsys) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeCitadel:
+        async def search(self, *_args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+            captured.update(kwargs)
+            return [
+                {
+                    "id": "hit",
+                    "text": "match",
+                    "repo": "masumi-network/sokosumi",
+                    "path": "docs/retry.md",
+                    "source": "repo-content",
+                }
+            ]
+
+    monkeypatch.setattr("kb.service.Citadel.from_env", lambda: FakeCitadel())
+
+    rc = asyncio.run(
+        _search(
+            _search_args(
+                query="match",
+                local=True,
+                repo="masumi-network/sokosumi",
+                path="docs/retry.md",
+                source="repo-content",
+            )
+        )
+    )
+
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["results"][0]["id"] == "hit"
+    assert captured["repo"] == "masumi-network/sokosumi"
+    assert captured["path"] == "docs/retry.md"
+    assert captured["source"] == "repo-content"
+
 def test_search_human_output_explains_context_required(monkeypatch, capsys) -> None:
     monkeypatch.setattr("kb.cli.capture_token", lambda: "ctdl_x")
     monkeypatch.setattr(

--- a/tests/test_cognee_qdrant_sqlite_live.py
+++ b/tests/test_cognee_qdrant_sqlite_live.py
@@ -118,6 +118,29 @@ def test_cognee_sqlite_qdrant_survives_restart_and_keeps_dataset_scope(
     assert second["lifecycle_texts"] == first["lifecycle_texts"]
     assert second["central_lifecycle_texts"] == first["central_lifecycle_texts"]
     assert (tmp_path / "cognee-system" / "databases" / "cognee.db").is_file()
+    # A fresh capture -> Cognee projection -> Qdrant receipt -> recall carries
+    # the live vector distance end-to-end (a fake client cannot prove the
+    # cognee -> Qdrant boundary), and the public HTTP/MCP formatter
+    # (public_search_result) surfaces it as a typed retriever score.
+    distance = first["central_vector_distance"]
+    assert isinstance(distance, (int, float)) and not isinstance(distance, bool)
+    retriever = first["central_public_retriever"]
+    assert retriever["retriever_score_kind"] in {"distance", "cosine-distance"}
+    assert retriever["retriever_score_direction"] == "lower-is-better"
+    assert retriever["retriever_score"] == pytest.approx(distance)
+    # The public path reports vector retrieval plus the searchable Qdrant receipt.
+    receipt = first["lifecycle_receipt"]
+    assert receipt["provider"] == "qdrant"
+    assert receipt["backend"] == "vector"
+    assert receipt["state"] == "searchable"
+    assert first["lifecycle_public_mode"] == "vector"
+    assert (
+        first["lifecycle_public_retriever"]["retriever_score_direction"]
+        == "lower-is-better"
+    )
+    # Restart: the SAME chunk recalls the SAME vector distance after restart.
+    restart_distance = second["central_vector_distance"]
+    assert restart_distance == pytest.approx(distance)
 
 
 def _result_texts(results: list[Any]) -> list[str]:
@@ -137,11 +160,47 @@ def _matching_texts(results: list[Any], marker: str) -> list[str]:
     return sorted(text for text in _result_texts(results) if marker in text)
 
 
+def _result_hits(results: list[Any]) -> list[dict[str, Any]]:
+    hits: list[dict[str, Any]] = []
+    for result in results:
+        payload = (
+            result.model_dump(mode="json") if hasattr(result, "model_dump") else result
+        )
+        if isinstance(payload, dict) and isinstance(payload.get("search_result"), list):
+            hits.extend(
+                item for item in payload["search_result"] if isinstance(item, dict)
+            )
+        elif isinstance(payload, dict):
+            hits.append(payload)
+    return hits
+
+
+def _first_marker_hit(results: list[Any], marker: str) -> dict[str, Any] | None:
+    for hit in _result_hits(results):
+        if marker in str(hit.get("text") or ""):
+            return hit
+    return None
+
+
+def _public_relevance(shaped: dict[str, Any] | None) -> dict[str, Any]:
+    citadel = shaped.get("_citadel") if isinstance(shaped, dict) else None
+    relevance = citadel.get("relevance") if isinstance(citadel, dict) else None
+    return relevance if isinstance(relevance, dict) else {}
+
+
+def _public_retrieval_mode(shaped: dict[str, Any] | None) -> str | None:
+    citadel = shaped.get("_citadel") if isinstance(shaped, dict) else None
+    retrieval = citadel.get("retrieval") if isinstance(citadel, dict) else None
+    mode = retrieval.get("mode") if isinstance(retrieval, dict) else None
+    return mode if isinstance(mode, str) else None
+
+
 async def _worker() -> None:
     from cognee.infrastructure.llm import LLMGateway
     from cognee.shared.data_models import KnowledgeGraph, Node, SummarizedContent
     from kb.cognee_client import CogneePublicClient, _cognify_data_ids
     from kb.config import CitadelConfig
+    from kb.server import public_search_result
     from kb.service import Citadel
 
     async def mock_llm(text_input: str, system_prompt: str, response_model, **kwargs):
@@ -303,6 +362,20 @@ async def _worker() -> None:
         assert present == set(expected_ids)
         graph_presence[dataset] = sorted(present)
     await lifecycle.stop_lifecycle_queue()
+    central_probe_hit = _first_marker_hit(central_hits, central_marker)
+    lifecycle_probe_hit = _first_marker_hit(lifecycle_hits, lifecycle_marker)
+    central_public = (
+        public_search_result(central_probe_hit, 0, "central", query=central_marker)
+        if central_probe_hit
+        else None
+    )
+    lifecycle_public = (
+        public_search_result(
+            lifecycle_probe_hit, 0, "lifecycle-live", query=lifecycle_marker
+        )
+        if lifecycle_probe_hit
+        else None
+    )
     report = {
         "central_texts": _matching_texts(central_hits, central_marker),
         "central_cross_texts": _matching_texts(central_cross_hits, alice_marker),
@@ -313,6 +386,29 @@ async def _worker() -> None:
             central_lifecycle_marker,
         ),
         "graph_presence": graph_presence,
+        "central_vector_distance": (
+            central_probe_hit.get("distance") if central_probe_hit else None
+        ),
+        "central_public_retriever": {
+            key: _public_relevance(central_public).get(key)
+            for key in (
+                "retriever_score",
+                "retriever_score_kind",
+                "retriever_score_direction",
+            )
+        },
+        "lifecycle_receipt": (
+            lifecycle_probe_hit.get("_lifecycle") if lifecycle_probe_hit else None
+        ),
+        "lifecycle_public_mode": _public_retrieval_mode(lifecycle_public),
+        "lifecycle_public_retriever": {
+            key: _public_relevance(lifecycle_public).get(key)
+            for key in (
+                "retriever_score",
+                "retriever_score_kind",
+                "retriever_score_direction",
+            )
+        },
     }
     print(_REPORT_PREFIX + json.dumps(report, sort_keys=True))
 

--- a/tests/test_qdrant_adapter.py
+++ b/tests/test_qdrant_adapter.py
@@ -564,6 +564,45 @@ async def test_index_payload_preserves_cognee_chunk_provenance() -> None:
     }
 
 
+
+def test_scored_results_copy_cosine_distance_into_chunk_payload() -> None:
+    raw_id = uuid4()
+    client = _FakeClient()
+    adapter = _adapter(client)
+    point = SimpleNamespace(
+        id="stored-point",
+        score=0.88,
+        payload={
+            "citadel_original_id": str(raw_id),
+            "document_id": "document-17",
+        },
+    )
+
+    result = adapter._scored_results([point])[0]
+
+    assert result.score == pytest.approx(0.12)
+    assert result.payload is not None
+    assert result.payload["distance"] == pytest.approx(0.12)
+
+
+def test_scored_results_omit_distance_for_scoreless_records() -> None:
+    # retrieve()/scroll() return Records with no score. A fabricated distance
+    # would advertise a perfect match and could clobber a real payload key.
+    raw_id = uuid4()
+    adapter = _adapter(_FakeClient())
+    record = SimpleNamespace(
+        id="stored-point",
+        payload={
+            "citadel_original_id": str(raw_id),
+            "document_id": "document-17",
+        },
+    )
+
+    result = adapter._scored_results([record])[0]
+
+    assert result.payload is not None
+    assert "distance" not in result.payload
+
 @pytest.mark.asyncio
 async def test_search_uses_shared_collection_and_mandatory_tenant_filter() -> None:
     client = _FakeClient()

--- a/tests/test_result_metadata_trust.py
+++ b/tests/test_result_metadata_trust.py
@@ -9,7 +9,12 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from kb.access import SESSION_TRACES_DATASET, AccessStore
-from kb.server import SHARED_TRACE_MARKER, app, with_result_metadata
+from kb.server import (
+    SHARED_TRACE_MARKER,
+    app,
+    with_result_id,
+    with_result_metadata,
+)
 
 
 def test_with_result_metadata_marks_session_traces() -> None:
@@ -90,3 +95,30 @@ def test_deduped_node_copy_of_a_shared_trace_keeps_reference_only() -> None:
     assert envelope["trust_tier"] == "reference-only"
     # The internal marker must never reach a caller.
     assert SHARED_TRACE_MARKER not in hits[0]
+
+
+def test_content_sha256_stable_across_query_dependent_distance() -> None:
+    """The same chunk served for two queries carries two cosine distances.
+
+    content_sha256 must identify the chunk, not the query, or
+    retrieval_eval.trust_observations stops seeing the same (id, sha) pair
+    across questions and silently loses the metadata-stability check.
+    """
+    base = {"id": "chunk-1", "document_id": "doc-1", "text": "same chunk body"}
+    near = with_result_metadata({**base, "distance": 0.10}, 0, "central")
+    far = with_result_metadata({**base, "distance": 0.90}, 0, "central")
+
+    assert near["_citadel"]["content_sha256"] == far["_citadel"]["content_sha256"]
+    # The distance itself still reaches the caller for ranking.
+    assert near["distance"] == 0.10
+    assert far["distance"] == 0.90
+
+
+def test_chunk_id_fallback_stable_across_query_dependent_distance() -> None:
+    """An id-less hit derives ``chunk:<hash>`` from content, never the query."""
+    near = with_result_id({"text": "same chunk body", "distance": 0.10})
+    far = with_result_id({"text": "same chunk body", "distance": 0.90})
+
+    assert near["id"] == far["id"]
+    assert near["id"].startswith("chunk:")
+    assert near["distance"] == 0.10

--- a/tests/test_search_response_shaping.py
+++ b/tests/test_search_response_shaping.py
@@ -25,6 +25,7 @@ from kb.search_format import (
     normalize_search_hit,
     parse_content_header,
     shape_public_search_hit,
+    shape_search_payload,
 )
 from kb.server import (
     SearchBody,
@@ -831,6 +832,28 @@ def test_retriever_score_is_passed_through_when_the_payload_has_one() -> None:
     assert envelope["relevance"]["retriever_score"] == 0.42
 
 
+def test_local_shape_keeps_distance_only_vector_hit() -> None:
+    from kb.search_format import shape_search_payload
+
+    shaped = shape_search_payload(
+        {
+            "results": [
+                {
+                    "id": "vector-hit",
+                    "text": "semantic result without query words",
+                    "distance": 0.12,
+                },
+                {"id": "unrelated", "text": "other text"},
+            ]
+        },
+        query="Patrick current work",
+    )
+
+    assert [hit["id"] for hit in shaped["results"]] == ["vector-hit"]
+    assert shaped["results"][0]["retriever_score"] == 0.12
+    assert shaped["relevance"]["retriever_scores_available"] is True
+
+
 def test_github_digest_fallback_score_is_not_a_retriever_score() -> None:
     """search_github_sync_state attaches a token-overlap COUNT under ``score``.
 
@@ -872,14 +895,14 @@ def test_absent_content_query_is_flagged_not_confident() -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert len(body["results"]) == 3
+    assert body["results"] == []
+    assert body["code"] == "NO_RELEVANT_RESULTS"
+    assert body["answerable"] is False
     relevance = body["relevance"]
     assert relevance["retriever_scores_available"] is False
     assert relevance["max_term_coverage"] == 0.0
     assert relevance["no_lexical_match"] is True
     assert any("No result contains any query term" in w for w in body["warnings"])
-    for hit in body["results"]:
-        assert hit["_citadel"]["relevance"]["term_coverage"] == 0.0
 
 
 def test_matching_content_is_not_flagged() -> None:
@@ -1211,3 +1234,34 @@ def test_cli_snippet_windows_long_texts_around_the_match() -> None:
     # Short texts keep the whole-head snippet: nothing to window.
     short = normalize_search_hit({"id": "y", "text": "kupo retry policy"}, query="kupo")
     assert short["snippet"] == "kupo retry policy"
+
+
+def test_top_level_retriever_score_reaches_relevance() -> None:
+    # A provider hit that reports its own retriever_score must survive the
+    # server signal dispatch, or the zero-overlap gate drops it as unscored.
+    envelope = with_result_metadata(
+        {
+            "id": "c-retriever",
+            "text": "decode and validate the bearer token",
+            "retriever_score": 0.91,
+        },
+        0,
+        "masumi-network",
+        query="parseJwt",
+    )["_citadel"]
+
+    assert envelope["relevance"]["retriever_score"] == 0.91
+
+
+def test_filtered_out_page_reports_filter_stats_not_missing_relevance() -> None:
+    # A repo filter empties the page: the cause is the filter (in filter_stats),
+    # not missing lexical overlap, so no_lexical_match / NO_RELEVANT_RESULTS must
+    # not misdiagnose it.
+    payload = {"results": [{"id": "h", "text": "rotation runbook", "repo": "org/other"}]}
+
+    out = shape_search_payload(payload, query="rotation", repo="org/target")
+
+    assert out["results"] == []
+    assert out["relevance"]["no_lexical_match"] is False
+    assert out["filter_stats"] == {"before": 1, "after": 0}
+    assert out.get("code") != "NO_RELEVANT_RESULTS"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4956,7 +4956,6 @@ def test_search_selection_prefers_relevant_central_hit_over_dataset_reservation(
         "seat-1",
         "seat-2",
         "seat-3",
-        "seat-4",
     ]
 
 
@@ -4991,7 +4990,7 @@ def test_search_selection_drops_unscored_zero_overlap_hits_from_mixed_page() -> 
     assert [hit["id"] for hit in selected] == ["exact-node", "partial-node"]
 
 
-def test_search_selection_keeps_unscored_zero_overlap_semantic_hit() -> None:
+def test_search_selection_keeps_scored_zero_overlap_semantic_hit() -> None:
     candidates = [
         {
             "id": "lexical",
@@ -5001,6 +5000,12 @@ def test_search_selection_keeps_unscored_zero_overlap_semantic_hit() -> None:
         {
             "id": "semantic",
             "text": "payment recovery design",
+            "score": 0.82,
+            "_citadel": {"dataset": "masumi-network"},
+        },
+        {
+            "id": "noise",
+            "text": "unrelated quarterly planning",
             "_citadel": {"dataset": "masumi-network"},
         },
     ]
@@ -5009,9 +5014,11 @@ def test_search_selection_keeps_unscored_zero_overlap_semantic_hit() -> None:
         candidates,
         query="checkout retries",
         datasets=["seat:sarthi", "masumi-network"],
-        limit=2,
+        limit=5,
     )
 
+    # The scored semantic hit survives; the unscored zero-overlap noise is
+    # dropped even with room to spare, so removing the gate fails this test.
     assert [hit["id"] for hit in selected] == ["lexical", "semantic"]
 
 
@@ -5188,6 +5195,64 @@ def test_search_genuine_empty_is_a_normal_success() -> None:
     assert "code" not in body
     assert body.get("timed_out") in (None, False)
 
+
+def test_search_selection_keeps_scored_semantic_hit_without_token_overlap() -> None:
+    from kb.server import select_public_search_page, with_result_metadata
+    from kb.search_format import shape_public_search_hit
+
+    semantic = shape_public_search_hit(
+        with_result_metadata(
+            {
+                "id": "vector-hit",
+                "document_id": "document-1",
+                "text": "semantic result without query words",
+                "distance": 0.12,
+            },
+            0,
+            "notes",
+            query="Patrick current work",
+        )
+    )
+    unrelated = shape_public_search_hit(
+        with_result_metadata(
+            {"id": "unrelated", "document_id": "document-2", "text": "other text"},
+            1,
+            "notes",
+            query="Patrick current work",
+        )
+    )
+
+    selected, _fetched, _matched = select_public_search_page(
+        [semantic, unrelated],
+        query="Patrick current work",
+        datasets=["notes"],
+        limit=5,
+    )
+
+    assert [hit["id"] for hit in selected] == ["vector-hit"]
+    relevance = selected[0]["_citadel"]["relevance"]
+    assert relevance["retriever_score"] == 0.12
+    assert relevance["retriever_score_kind"] == "distance"
+    assert relevance["retriever_score_direction"] == "lower-is-better"
+
+
+
+def test_search_without_relevance_signal_returns_typed_empty() -> None:
+    class NoSignalCitadel(FakeCitadel):
+        async def search(self, query: str, **kwargs: Any) -> list[Any]:
+            return [{"id": "noise", "document_id": "doc-1", "text": "unrelated text"}]
+
+    client = authed_client("test-reader")
+    app.state.citadel = NoSignalCitadel()
+
+    response = client.post("/search", json={"query": "Patrick current work", "top_k": 3})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["results"] == []
+    assert body["code"] == "NO_RELEVANT_RESULTS"
+    assert body["answerable"] is False
+    assert body["relevance"]["no_lexical_match"] is True
 
 def test_search_qdrant_outage_is_a_typed_failure() -> None:
     class UnavailableCitadel(FakeCitadel):
@@ -6608,7 +6673,7 @@ def test_knowledge_alias_returns_flat_agent_friendly_results() -> None:
     alias_keys = [set(result) for result in payload["results"]]
     search_keys = [set(result) for result in search.json()["results"]]
     assert all(left <= right for left, right in zip(alias_keys, search_keys))
-    assert len(payload["results"]) == 2
+    assert len(payload["results"]) == 1
     assert payload["results"][0]["text"] == "Rotate keys quarterly"
     assert payload["results"][0]["source"] == "https://example.com/runbook"
     assert payload["results"][0]["score"] == 0.92
@@ -6616,8 +6681,6 @@ def test_knowledge_alias_returns_flat_agent_friendly_results() -> None:
     assert payload["results"][0]["document_id"] == "rotate-keys-document"
     assert "metadata" not in payload["results"][0]
     assert "source_user" not in payload["results"][0]
-    assert payload["results"][1]["text"] == "bare string result"
-    assert payload["results"][1]["source"] is None
 
 
 def test_knowledge_alias_validates_query_and_limit() -> None:


### PR DESCRIPTION
## Goal

Make Citadel search retrieval trustworthy end to end: Qdrant cosine distance survives into search hits, relevance is typed, and HTTP, CLI, and MCP agree.

## Included

- `kb/qdrant_adapter.py`: `_scored_results` copies the query cosine distance into the chunk payload. Score-less `retrieve()`/`scroll()` rows get no fabricated distance.
- `kb/server.py`: the typed retriever signal (`distance`, `similarity`, `retriever_score`, `score`) feeds `_citadel.relevance`; unfiltered zero-overlap unscored candidates are dropped with a typed `NO_RELEVANT_RESULTS` instead of a silent empty page; `content_sha256` and `chunk:<hash>` fallback ids exclude query-dependent retriever fields, so one chunk keeps one identity across queries.
- `kb/search_format.py`: typed `retriever_score_kind` / `retriever_score_direction` on shaped hits; filter-emptied pages report `filter_stats` instead of a false `no_lexical_match` / `NO_RELEVANT_RESULTS`.
- `kb/cli.py`: `--repo` / `--path` / `--source` forward to in-process local search, matching HTTP and MCP.
- Tests: mutation-sensitive regressions for every fix (each fails with its fix reverted). The live acceptance test proves fresh capture -> Cognee projection -> Qdrant vector receipt -> recall through the shared public DTO (`public_search_result`), with a typed retriever score, `retrieval.mode=vector`, and exact restart-distance equality.

## Verification

- [VERIFIED local] `uv run pytest -q`: `2485 passed, 6 skipped` (pytest exit 0).
- [VERIFIED local] `uv run ruff check kb scripts tests`: clean (exit 0).
- [VERIFIED local] Live acceptance against a real Qdrant v1.19 container: `1 passed`.
- [VERIFIED local] Prove-it both directions: content-hash stability, score-less distance omission, `retriever_score` dispatch, filter diagnostics, and the relevance gate each FAIL with their fix reverted and pass restored.
- Two independent adversarial reviewers (code + test-validity) ran against the diff; all contained findings fixed, remaining ones below.

## Deferred follow-ups (from adversarial review)

- Cross-dataset merges keep provider order for zero-lexical pages: the typed lower-is-better distance is not yet a ranking key (`apply_query_ranking`). Changing it alters the tested "keep provider order for semantic ties" contract and needs a deliberate ranking decision.
- Search telemetry `_hit_score` (`kb/search_feedback.py`) does not read `_citadel.relevance.retriever_score`, so vector hits still log `low_score=True`. Pre-existing gap; needs direction-aware handling.

Refs #228