### PR TITLE
fix(lifecycle): attest effective stage models in the projection digest

### DIFF
--- a/kb/lifecycle.py
+++ b/kb/lifecycle.py
@@ -854,7 +854,9 @@ class LifecycleStore:
             ):
                 raise LifecycleConflictError(
                     "projection configuration changed within an existing generation; "
-                    "set a new CITADEL_GENERATION_ID"
+                    "verify CITADEL_PROJECTION_DIGEST_V2 matches the generation's "
+                    "digest mode, then set a new CITADEL_GENERATION_ID if the "
+                    "change is intentional"
                 )
         stored_providers = {
             (str(row["backend"]), str(row["provider"]))

--- a/kb/model_routing.py
+++ b/kb/model_routing.py
@@ -106,6 +106,17 @@ def activate_cognee_free_router_fallback(error: BaseException) -> bool:
 
     if not cognee_free_router_fallback_enabled():
         return False
+    if os.getenv("CITADEL_PROJECTION_DIGEST_V2", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        # v2 pins the projection models per generation: a silent mid-process
+        # model swap would let receipts attest a model that did not run
+        # (check-at-accept, mutate-at-execute). Fail the provider call
+        # honestly instead; the operator migrates with a new generation.
+        return False
     if not routing_enabled() or is_free_model_daily_quota_error(error):
         return False
     if os.getenv("CITADEL_COGNEE_FREE_ROUTER_ACTIVE", "").strip().lower() == "true":

--- a/kb/server.py
+++ b/kb/server.py
@@ -62,6 +62,7 @@ from kb.linear_sync import LinearSyncer
 from kb.knowledge_mesh import KnowledgeMesh
 from kb.learning import LearningOutcome, LearningProcess
 from kb.lifecycle import (
+    LifecycleConflictError,
     LifecycleNotFoundError,
     LifecycleRequeueDriftError,
     LifecycleRequeueIdentityMismatchError,
@@ -7603,6 +7604,11 @@ async def lifecycle_requeue_failed(
             "expected_count": exc.expected_count,
             "current_count": len(exc.actual_candidate_ids),
         }
+        record("lifecycle.requeue.apply", False, detail)
+        raise HTTPException(status_code=409, detail=detail) from exc
+    except LifecycleConflictError as exc:
+        # Base-class catch LAST: route drift under CITADEL_PROJECTION_DIGEST_V2.
+        detail = {"code": "LIFECYCLE_ROUTE_DRIFT", "message": str(exc)}
         record("lifecycle.requeue.apply", False, detail)
         raise HTTPException(status_code=409, detail=detail) from exc
 

--- a/kb/service.py
+++ b/kb/service.py
@@ -32,6 +32,7 @@ from kb.logging_utils import safe_log_value
 from kb.lifecycle import (
     CaptureContext,
     LIFECYCLE_CHUNK_SOURCE_PREFIX,
+    LifecycleConflictError,
     LifecycleNotFoundError,
     LifecycleRequeueDriftError,
     LifecycleRequeueIdentityMismatchError,
@@ -97,11 +98,18 @@ def _canary_timeout_seconds() -> float:
     return value
 
 
-def _read_stage_models() -> dict[str, str]:
-    """Snapshot the effective Cognee stage-model routes for digest attestation."""
+def _read_llm_routes() -> dict[str, str]:
+    """Snapshot the effective LLM routes for digest attestation.
+
+    Covers every LLM field the digest hashes AND every field
+    ``activate_cognee_free_router_fallback`` rewrites at runtime, so the
+    frozen snapshot and the fallback mutation set stay in lockstep.
+    """
     return {
         name: os.getenv(name, "")
         for name in (
+            "LLM_PROVIDER",
+            "LLM_MODEL",
             "LLM_EXTRACTION_MODEL",
             "LLM_SUMMARIZATION_MODEL",
             "LLM_QUERY_MODEL",
@@ -126,14 +134,14 @@ class Citadel:
         self._lifecycle_projection_gate = asyncio.Event()
         self._lifecycle_projection_gate.set()
         self._lifecycle_vector_only = False
-        # Freeze the digest-gate decision AND the attested stage-model values
-        # for this process: a mid-process env change (operator or the free
-        # router fallback rewriting LLM_* at runtime) must not let ingest()
-        # accept jobs whose digest the already bound worker will never claim.
+        # Freeze the digest-gate decision AND the attested LLM routes for this
+        # process: a mid-process env change (operator edit or the free-router
+        # fallback rewriting LLM_* at runtime) must not let ingest() accept
+        # jobs whose digest the already bound worker will never claim.
         self._projection_digest_v2 = os.getenv(
             "CITADEL_PROJECTION_DIGEST_V2", ""
         ).strip().lower() in {"1", "true", "yes", "on"}
-        self._projection_stage_models = _read_stage_models()
+        self._projection_llm_routes = _read_llm_routes()
         if self.config.lifecycle_enabled:
             prepare_cognee_environment = getattr(
                 self.cognee, "_prepare_cognee_environment", None
@@ -142,8 +150,8 @@ class Citadel:
                 # Bind the lifecycle identity after Cognee applies its routed defaults.
                 prepare_cognee_environment()
             # Re-freeze AFTER routing so the binding attests the effective
-            # routed stage models, not the raw pre-routing environment.
-            self._projection_stage_models = _read_stage_models()
+            # routed models, not the raw pre-routing environment.
+            self._projection_llm_routes = _read_llm_routes()
             self.lifecycle_store = LifecycleStore(self.config.lifecycle_store_path)
             lifecycle_projection = self._lifecycle_projection_request()
             self.lifecycle_store.assert_generation_binding(lifecycle_projection)
@@ -486,12 +494,26 @@ class Citadel:
             "vector": os.getenv("VECTOR_DB_PROVIDER", "qdrant").strip().lower(),
             "graph": os.getenv("GRAPH_DATABASE_PROVIDER", "ladybug").strip().lower(),
         }
+        if self._projection_digest_v2:
+            live_routes = _read_llm_routes()
+            if live_routes != self._projection_llm_routes:
+                # Fail fast instead of stranding jobs (frozen digest, live
+                # worker) or lying (receipts attesting a model that did not run):
+                # under v2 the models are generation-pinned, so a runtime route
+                # change requires a restart, and a new generation if the change
+                # is intentional.
+                raise LifecycleConflictError(
+                    "LLM routes changed at runtime (free-router fallback or "
+                    "operator edit) while CITADEL_PROJECTION_DIGEST_V2 pins "
+                    "them per generation; restart the node to re-bind, and set "
+                    "a new CITADEL_GENERATION_ID if the change is intentional"
+                )
         digest_fields = {
             "generation_id": generation_id,
             "projection_version": projection_version,
             "providers": providers,
-            "llm_provider": os.getenv("LLM_PROVIDER", ""),
-            "llm_model": os.getenv("LLM_MODEL", ""),
+            "llm_provider": self._projection_llm_routes["LLM_PROVIDER"],
+            "llm_model": self._projection_llm_routes["LLM_MODEL"],
             "embedding_provider": os.getenv("EMBEDDING_PROVIDER", ""),
             "embedding_model": os.getenv("EMBEDDING_MODEL", ""),
             "embedding_dimensions": os.getenv("EMBEDDING_DIMENSIONS", ""),
@@ -513,13 +535,13 @@ class Citadel:
             digest_fields.update(
                 {
                     "digest_version": 2,
-                    "llm_extraction_model": self._projection_stage_models[
+                    "llm_extraction_model": self._projection_llm_routes[
                         "LLM_EXTRACTION_MODEL"
                     ],
-                    "llm_summarization_model": self._projection_stage_models[
+                    "llm_summarization_model": self._projection_llm_routes[
                         "LLM_SUMMARIZATION_MODEL"
                     ],
-                    "llm_query_model": self._projection_stage_models[
+                    "llm_query_model": self._projection_llm_routes[
                         "LLM_QUERY_MODEL"
                     ],
                 }

--- a/kb/service.py
+++ b/kb/service.py
@@ -469,19 +469,39 @@ class Citadel:
             "providers": providers,
             "llm_provider": os.getenv("LLM_PROVIDER", ""),
             "llm_model": os.getenv("LLM_MODEL", ""),
-            # Cognee routes the actual LLM calls through the stage vars
-            # (model_routing.configure_cognee_model_routes), so receipts must
-            # attest the models that really produced the projection. Changing
-            # any of them is a projection config change: the generation binding
-            # rejects it until a new CITADEL_GENERATION_ID is set.
-            "llm_extraction_model": os.getenv("LLM_EXTRACTION_MODEL", ""),
-            "llm_summarization_model": os.getenv("LLM_SUMMARIZATION_MODEL", ""),
-            "llm_query_model": os.getenv("LLM_QUERY_MODEL", ""),
             "embedding_provider": os.getenv("EMBEDDING_PROVIDER", ""),
             "embedding_model": os.getenv("EMBEDDING_MODEL", ""),
             "embedding_dimensions": os.getenv("EMBEDDING_DIMENSIONS", ""),
             "chunk_budget_tokens": chunk_window.resolve_chunk_budget(),
         }
+        if os.getenv("CITADEL_PROJECTION_DIGEST_V2", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            # Expand/migrate/contract: v2 is opt-in so this code deploys green
+            # against existing generation bindings (expand). The migration flips
+            # CITADEL_PROJECTION_DIGEST_V2 together with a new
+            # CITADEL_GENERATION_ID in one variable change (migrate); a later
+            # change makes v2 unconditional (contract). Rollback is the same
+            # variable change reversed: the old binding still matches v1.
+            #
+            # Why v2 exists: Cognee routes the actual LLM calls through the
+            # stage vars (model_routing.configure_cognee_model_routes), so
+            # receipts must attest the models that really produced the
+            # projection. Changing any of them is a projection config change:
+            # the generation binding rejects it until a new generation is set.
+            digest_fields.update(
+                {
+                    "digest_version": 2,
+                    "llm_extraction_model": os.getenv("LLM_EXTRACTION_MODEL", ""),
+                    "llm_summarization_model": os.getenv(
+                        "LLM_SUMMARIZATION_MODEL", ""
+                    ),
+                    "llm_query_model": os.getenv("LLM_QUERY_MODEL", ""),
+                }
+            )
         config_digest = sha256(
             json.dumps(digest_fields, sort_keys=True, separators=(",", ":")).encode(
                 "utf-8"

--- a/kb/service.py
+++ b/kb/service.py
@@ -469,6 +469,14 @@ class Citadel:
             "providers": providers,
             "llm_provider": os.getenv("LLM_PROVIDER", ""),
             "llm_model": os.getenv("LLM_MODEL", ""),
+            # Cognee routes the actual LLM calls through the stage vars
+            # (model_routing.configure_cognee_model_routes), so receipts must
+            # attest the models that really produced the projection. Changing
+            # any of them is a projection config change: the generation binding
+            # rejects it until a new CITADEL_GENERATION_ID is set.
+            "llm_extraction_model": os.getenv("LLM_EXTRACTION_MODEL", ""),
+            "llm_summarization_model": os.getenv("LLM_SUMMARIZATION_MODEL", ""),
+            "llm_query_model": os.getenv("LLM_QUERY_MODEL", ""),
             "embedding_provider": os.getenv("EMBEDDING_PROVIDER", ""),
             "embedding_model": os.getenv("EMBEDDING_MODEL", ""),
             "embedding_dimensions": os.getenv("EMBEDDING_DIMENSIONS", ""),

--- a/kb/service.py
+++ b/kb/service.py
@@ -415,7 +415,10 @@ class Citadel:
         """Tombstone current exact and optional chunk revisions for one source."""
         if self.lifecycle_store is None:
             raise LifecycleNotFoundError("lifecycle v1 is disabled")
-        self._assert_projection_routes_stable()
+        # Tombstones are deliberately NOT route-guarded: they run through the
+        # route-independent worker path (no LLM), and blocking them under v2
+        # route drift would leave deleted content searchable (the Obsidian
+        # delete path does not retry a failed tombstone).
         projection = self._lifecycle_projection_request()
         current = self.lifecycle_store.current_revisions_for_source(
             dataset,
@@ -887,7 +890,6 @@ class Citadel:
         candidate_ids: tuple[str, ...],
     ) -> dict[str, Any]:
         """Apply one exact active-generation recovery preview."""
-        self._assert_projection_routes_stable()
         projection = self._lifecycle_requeue_projection()
         if (
             generation_id != projection.generation_id
@@ -895,6 +897,9 @@ class Citadel:
             or config_digest != projection.config_digest
         ):
             raise LifecycleRequeueIdentityMismatchError(projection)
+        # Drift check AFTER identity validation so stale previews keep their
+        # 409 identity-mismatch contract; the guard protects only the write.
+        self._assert_projection_routes_stable()
         assert self.lifecycle_store is not None
         requeued_ids = self.lifecycle_store.requeue_failed_projections(
             projection,

--- a/kb/service.py
+++ b/kb/service.py
@@ -97,6 +97,18 @@ def _canary_timeout_seconds() -> float:
     return value
 
 
+def _read_stage_models() -> dict[str, str]:
+    """Snapshot the effective Cognee stage-model routes for digest attestation."""
+    return {
+        name: os.getenv(name, "")
+        for name in (
+            "LLM_EXTRACTION_MODEL",
+            "LLM_SUMMARIZATION_MODEL",
+            "LLM_QUERY_MODEL",
+        )
+    }
+
+
 class Citadel:
     def __init__(
         self,
@@ -114,6 +126,14 @@ class Citadel:
         self._lifecycle_projection_gate = asyncio.Event()
         self._lifecycle_projection_gate.set()
         self._lifecycle_vector_only = False
+        # Freeze the digest-gate decision AND the attested stage-model values
+        # for this process: a mid-process env change (operator or the free
+        # router fallback rewriting LLM_* at runtime) must not let ingest()
+        # accept jobs whose digest the already bound worker will never claim.
+        self._projection_digest_v2 = os.getenv(
+            "CITADEL_PROJECTION_DIGEST_V2", ""
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        self._projection_stage_models = _read_stage_models()
         if self.config.lifecycle_enabled:
             prepare_cognee_environment = getattr(
                 self.cognee, "_prepare_cognee_environment", None
@@ -121,6 +141,9 @@ class Citadel:
             if callable(prepare_cognee_environment):
                 # Bind the lifecycle identity after Cognee applies its routed defaults.
                 prepare_cognee_environment()
+            # Re-freeze AFTER routing so the binding attests the effective
+            # routed stage models, not the raw pre-routing environment.
+            self._projection_stage_models = _read_stage_models()
             self.lifecycle_store = LifecycleStore(self.config.lifecycle_store_path)
             lifecycle_projection = self._lifecycle_projection_request()
             self.lifecycle_store.assert_generation_binding(lifecycle_projection)
@@ -474,12 +497,7 @@ class Citadel:
             "embedding_dimensions": os.getenv("EMBEDDING_DIMENSIONS", ""),
             "chunk_budget_tokens": chunk_window.resolve_chunk_budget(),
         }
-        if os.getenv("CITADEL_PROJECTION_DIGEST_V2", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }:
+        if self._projection_digest_v2:
             # Expand/migrate/contract: v2 is opt-in so this code deploys green
             # against existing generation bindings (expand). The migration flips
             # CITADEL_PROJECTION_DIGEST_V2 together with a new
@@ -495,11 +513,15 @@ class Citadel:
             digest_fields.update(
                 {
                     "digest_version": 2,
-                    "llm_extraction_model": os.getenv("LLM_EXTRACTION_MODEL", ""),
-                    "llm_summarization_model": os.getenv(
-                        "LLM_SUMMARIZATION_MODEL", ""
-                    ),
-                    "llm_query_model": os.getenv("LLM_QUERY_MODEL", ""),
+                    "llm_extraction_model": self._projection_stage_models[
+                        "LLM_EXTRACTION_MODEL"
+                    ],
+                    "llm_summarization_model": self._projection_stage_models[
+                        "LLM_SUMMARIZATION_MODEL"
+                    ],
+                    "llm_query_model": self._projection_stage_models[
+                        "LLM_QUERY_MODEL"
+                    ],
                 }
             )
         config_digest = sha256(

--- a/kb/service.py
+++ b/kb/service.py
@@ -415,6 +415,7 @@ class Citadel:
         """Tombstone current exact and optional chunk revisions for one source."""
         if self.lifecycle_store is None:
             raise LifecycleNotFoundError("lifecycle v1 is disabled")
+        self._assert_projection_routes_stable()
         projection = self._lifecycle_projection_request()
         current = self.lifecycle_store.current_revisions_for_source(
             dataset,
@@ -886,6 +887,7 @@ class Citadel:
         candidate_ids: tuple[str, ...],
     ) -> dict[str, Any]:
         """Apply one exact active-generation recovery preview."""
+        self._assert_projection_routes_stable()
         projection = self._lifecycle_requeue_projection()
         if (
             generation_id != projection.generation_id

--- a/kb/service.py
+++ b/kb/service.py
@@ -303,6 +303,7 @@ class Citadel:
                 capture_metadata["session_id"] = session_id
             if attestation:
                 capture_metadata["attestation"] = dict(attestation)
+            self._assert_projection_routes_stable()
             acceptance = self.lifecycle_store.accept_source(
                 data.encode("utf-8"),
                 capture=CaptureContext(
@@ -494,20 +495,6 @@ class Citadel:
             "vector": os.getenv("VECTOR_DB_PROVIDER", "qdrant").strip().lower(),
             "graph": os.getenv("GRAPH_DATABASE_PROVIDER", "ladybug").strip().lower(),
         }
-        if self._projection_digest_v2:
-            live_routes = _read_llm_routes()
-            if live_routes != self._projection_llm_routes:
-                # Fail fast instead of stranding jobs (frozen digest, live
-                # worker) or lying (receipts attesting a model that did not run):
-                # under v2 the models are generation-pinned, so a runtime route
-                # change requires a restart, and a new generation if the change
-                # is intentional.
-                raise LifecycleConflictError(
-                    "LLM routes changed at runtime (free-router fallback or "
-                    "operator edit) while CITADEL_PROJECTION_DIGEST_V2 pins "
-                    "them per generation; restart the node to re-bind, and set "
-                    "a new CITADEL_GENERATION_ID if the change is intentional"
-                )
         digest_fields = {
             "generation_id": generation_id,
             "projection_version": projection_version,
@@ -556,6 +543,26 @@ class Citadel:
             projection_version=projection_version or "lifecycle-v1:cognee-1.4.1",
             config_digest=f"sha256:{config_digest}",
             providers=providers,
+        )
+
+    def _assert_projection_routes_stable(self) -> None:
+        """Refuse NEW projection work after a runtime route change under v2.
+
+        Write-path only: the digest builder itself must stay read-safe (search,
+        readyz, tombstone, and requeue also build projection identities), so a
+        route drift must never take read paths down. Accepting NEW jobs would
+        either strand them (frozen digest, live worker) or lie (receipts
+        attesting a model that did not run), so ingest and rebuild fail fast.
+        """
+        if not self._projection_digest_v2:
+            return
+        if _read_llm_routes() == self._projection_llm_routes:
+            return
+        raise LifecycleConflictError(
+            "LLM routes changed at runtime (free-router fallback or "
+            "operator edit) while CITADEL_PROJECTION_DIGEST_V2 pins "
+            "them per generation; restart the node to re-bind, and set "
+            "a new CITADEL_GENERATION_ID if the change is intentional"
         )
 
     @staticmethod
@@ -1059,6 +1066,7 @@ class Citadel:
             raise LifecycleNotFoundError("lifecycle v1 is disabled")
         if not generation_id.strip():
             raise ValueError("generation_id must be a non-empty string")
+        self._assert_projection_routes_stable()
         projection = self._lifecycle_projection_request(
             generation_id=generation_id,
             projection_version=projection_version,

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -105,3 +105,17 @@ def test_cognee_fallback_uses_same_litellm_route(monkeypatch) -> None:
     assert activate_cognee_free_router_fallback(error) is True
     assert os.environ["LLM_MODEL"] == DEFAULT_COGNEE_FREE_ROUTER_MODEL
     assert os.environ["LLM_EXTRACTION_MODEL"] == DEFAULT_COGNEE_FREE_ROUTER_MODEL
+
+
+def test_cognee_fallback_never_rewrites_routes_under_digest_v2(monkeypatch) -> None:
+    """v2 pins projection models per generation: a mid-projection fallback
+    rewrite would let receipts attest a model that did not run (TOCTOU past
+    the accept-time drift guard). The fallback must refuse to activate.
+    """
+    _clear_routing_env(monkeypatch)
+    monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
+    monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/pinned:free")
+
+    assert activate_cognee_free_router_fallback(RuntimeError("provider quota")) is False
+    assert os.environ["LLM_EXTRACTION_MODEL"] == "openrouter/vendor/pinned:free"
+    assert os.environ.get("CITADEL_COGNEE_FREE_ROUTER_ACTIVE", "") != "true"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -502,13 +502,14 @@ def test_lifecycle_digest_gate_is_frozen_at_init(
     assert kb._lifecycle_projection_request().config_digest == before
 
 
-def test_lifecycle_stage_model_values_are_frozen_at_init(
+def test_lifecycle_v2_rejects_runtime_route_drift(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
-    """With v2 on, a mid-process stage-var change (operator or the free-router
-    fallback) must not change the digest, or ingest() would mint jobs the
-    bound worker never claims on an empty generation.
+    """With v2 on, a mid-process route change (operator edit or the
+    free-router fallback) must fail fast with an actionable error: a silently
+    frozen digest would strand jobs, and a moving digest would let receipts
+    attest a model that did not run.
     """
     monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/frozen:free")
@@ -519,8 +520,31 @@ def test_lifecycle_stage_model_values_are_frozen_at_init(
         ),
         cognee=FakeCognee(),
     )
-    before = kb._lifecycle_projection_request().config_digest
+    kb._lifecycle_projection_request()
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/flipped:free")
+    with pytest.raises(LifecycleConflictError, match="restart the node"):
+        kb._lifecycle_projection_request()
+
+
+def test_lifecycle_v1_freezes_llm_model_against_fallback_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Under the default v1 digest, the free-router fallback rewriting
+    LLM_MODEL at runtime must not move the digest: jobs accepted after the
+    rewrite would otherwise never match the bound worker's digest.
+    """
+    monkeypatch.delenv("CITADEL_PROJECTION_DIGEST_V2", raising=False)
+    monkeypatch.setenv("LLM_MODEL", "openrouter/vendor/primary:free")
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    before = kb._lifecycle_projection_request().config_digest
+    monkeypatch.setenv("LLM_MODEL", "openrouter/free/fallback:free")
     assert kb._lifecycle_projection_request().config_digest == before
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -423,24 +422,29 @@ def test_lifecycle_config_digest_tracks_effective_stage_models(
     """Receipts must attest the models that produced them. Cognee routes
     extraction/summarization/query through the stage vars, so under the v2
     digest a stage-model swap is a projection config change and must move the
-    digest instead of hiding inside an existing generation binding.
+    digest instead of hiding inside an existing generation binding. Values are
+    frozen per process, so each variant binds through a fresh instance.
     """
     monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
-    kb = Citadel(
-        CitadelConfig(
-            lifecycle_enabled=True,
-            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
-        ),
-        cognee=FakeCognee(),
-    )
-    digests = [kb._lifecycle_projection_request().config_digest]
+
+    def digest_for() -> str:
+        kb = Citadel(
+            CitadelConfig(
+                lifecycle_enabled=True,
+                lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+            ),
+            cognee=FakeCognee(),
+        )
+        return kb._lifecycle_projection_request().config_digest
+
+    digests = [digest_for()]
     for name in (
         "LLM_EXTRACTION_MODEL",
         "LLM_SUMMARIZATION_MODEL",
         "LLM_QUERY_MODEL",
     ):
         monkeypatch.setenv(name, f"openrouter/test/{name.lower()}:free")
-        digests.append(kb._lifecycle_projection_request().config_digest)
+        digests.append(digest_for())
 
     assert len(set(digests)) == len(digests), digests
 
@@ -452,9 +456,9 @@ def test_lifecycle_config_digest_tracks_effective_stage_models(
         "LLM_QUERY_MODEL",
     ):
         monkeypatch.setenv(name, "openrouter/vendor/model-aaaa:free")
-        before = kb._lifecycle_projection_request().config_digest
+        before = digest_for()
         monkeypatch.setenv(name, "openrouter/vendor/model-bbbb:free")
-        assert kb._lifecycle_projection_request().config_digest != before, name
+        assert digest_for() != before, name
 
 
 def test_lifecycle_config_digest_v1_default_keeps_existing_bindings(
@@ -475,6 +479,48 @@ def test_lifecycle_config_digest_v1_default_keeps_existing_bindings(
     )
     before = kb._lifecycle_projection_request().config_digest
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/test/other:free")
+    assert kb._lifecycle_projection_request().config_digest == before
+
+
+def test_lifecycle_digest_gate_is_frozen_at_init(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """A mid-process gate flip must not change the digest: otherwise ingest()
+    would accept jobs whose digest the already-bound worker never claims.
+    """
+    monkeypatch.delenv("CITADEL_PROJECTION_DIGEST_V2", raising=False)
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    before = kb._lifecycle_projection_request().config_digest
+    monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
+    assert kb._lifecycle_projection_request().config_digest == before
+
+
+def test_lifecycle_stage_model_values_are_frozen_at_init(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """With v2 on, a mid-process stage-var change (operator or the free-router
+    fallback) must not change the digest, or ingest() would mint jobs the
+    bound worker never claims on an empty generation.
+    """
+    monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
+    monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/frozen:free")
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    before = kb._lifecycle_projection_request().config_digest
+    monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/flipped:free")
     assert kb._lifecycle_projection_request().config_digest == before
 
 
@@ -508,7 +554,9 @@ async def test_lifecycle_binding_attests_routed_stage_models(
                 "LLM_SUMMARIZATION_MODEL",
                 "LLM_QUERY_MODEL",
             ):
-                os.environ[name] = self.routed_model
+                # Write through monkeypatch so the variables are restored after
+                # this test even though they were absent before it.
+                monkeypatch.setenv(name, self.routed_model)
 
     original = Citadel(
         CitadelConfig(lifecycle_enabled=True, lifecycle_store_path=store_path),
@@ -527,7 +575,9 @@ async def test_lifecycle_binding_attests_routed_stage_models(
 
     changed = RoutedCognee()
     changed.routed_model = "openrouter/vendor/routed-bbbb:free"
-    with pytest.raises(LifecycleConflictError, match="CITADEL_GENERATION_ID"):
+    with pytest.raises(
+        LifecycleConflictError, match="CITADEL_PROJECTION_DIGEST_V2"
+    ):
         Citadel(
             CitadelConfig(lifecycle_enabled=True, lifecycle_store_path=store_path),
             cognee=changed,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -510,9 +510,9 @@ async def test_lifecycle_v2_rejects_runtime_route_drift_on_writes_only(
     """With v2 on, a mid-process route change (operator edit or the
     free-router fallback) must fail NEW projection work fast: a silently
     frozen digest would strand jobs, and a moving digest would let receipts
-    attest a model that did not run. Read paths (search, readyz, tombstone)
-    build projection identities through the same builder and must keep
-    working, so the builder itself never raises.
+    attest a model that did not run. Read paths (search, readyz) and
+    route-independent tombstones keep working: the builder never raises, and
+    a blocked tombstone would leave deleted content searchable.
     """
     monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/frozen:free")
@@ -523,6 +523,7 @@ async def test_lifecycle_v2_rejects_runtime_route_drift_on_writes_only(
         ),
         cognee=FakeCognee(),
     )
+    preview = kb.lifecycle_requeue_failed_preview()
     before = kb._lifecycle_projection_request().config_digest
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/flipped:free")
     # Read-safe: the builder still answers, with the frozen attestation.
@@ -532,18 +533,21 @@ async def test_lifecycle_v2_rejects_runtime_route_drift_on_writes_only(
         await kb.ingest("drifted source", source_key="manual:drift")
     with pytest.raises(LifecycleConflictError, match="restart the node"):
         kb.queue_lifecycle_rebuild(generation_id="generation-drift-target")
-    with pytest.raises(LifecycleConflictError, match="restart the node"):
-        await kb.tombstone_source(
-            dataset="notes", source_key="manual:drift", reason="test"
-        )
+    # Requeue apply validates the preview identity FIRST (its 409 contract),
+    # then refuses the drifted write.
     with pytest.raises(LifecycleConflictError, match="restart the node"):
         kb.lifecycle_requeue_failed(
-            generation_id="generation-any",
-            projection_version="lifecycle-v1:cognee-1.4.1",
-            config_digest="sha256:any",
+            generation_id=preview["generation_id"],
+            projection_version=preview["projection_version"],
+            config_digest=preview["config_digest"],
             expected_count=0,
             candidate_ids=(),
         )
+    # Tombstones are route-independent and must stay available under drift.
+    tombstoned = await kb.tombstone_source(
+        dataset="notes", source_key="manual:absent", reason="test"
+    )
+    assert tombstoned == ()
 
 
 def test_lifecycle_v1_freezes_llm_model_against_fallback_rewrite(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -415,6 +415,46 @@ def test_lifecycle_config_digest_tracks_projection_affecting_environment(
     assert budget_changed != provider_changed
 
 
+def test_lifecycle_config_digest_tracks_effective_stage_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Receipts must attest the models that produced them. Cognee routes
+    extraction/summarization/query through the stage vars, so a stage-model
+    swap is a projection config change and must move the digest instead of
+    hiding inside an existing generation binding.
+    """
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    digests = [kb._lifecycle_projection_request().config_digest]
+    for name in (
+        "LLM_EXTRACTION_MODEL",
+        "LLM_SUMMARIZATION_MODEL",
+        "LLM_QUERY_MODEL",
+    ):
+        monkeypatch.setenv(name, f"openrouter/test/{name.lower()}:free")
+        digests.append(kb._lifecycle_projection_request().config_digest)
+
+    assert len(set(digests)) == len(digests), digests
+
+    # Equal-length replacement per field: the digest must attest the exact
+    # value, so a length-preserving model swap still moves it.
+    for name in (
+        "LLM_EXTRACTION_MODEL",
+        "LLM_SUMMARIZATION_MODEL",
+        "LLM_QUERY_MODEL",
+    ):
+        monkeypatch.setenv(name, "openrouter/vendor/model-aaaa:free")
+        before = kb._lifecycle_projection_request().config_digest
+        monkeypatch.setenv(name, "openrouter/vendor/model-bbbb:free")
+        assert kb._lifecycle_projection_request().config_digest != before, name
+
+
 @pytest.mark.asyncio
 async def test_lifecycle_restart_rejects_config_drift_until_generation_changes(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -420,10 +421,11 @@ def test_lifecycle_config_digest_tracks_effective_stage_models(
     tmp_path: Any,
 ) -> None:
     """Receipts must attest the models that produced them. Cognee routes
-    extraction/summarization/query through the stage vars, so a stage-model
-    swap is a projection config change and must move the digest instead of
-    hiding inside an existing generation binding.
+    extraction/summarization/query through the stage vars, so under the v2
+    digest a stage-model swap is a projection config change and must move the
+    digest instead of hiding inside an existing generation binding.
     """
+    monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
     kb = Citadel(
         CitadelConfig(
             lifecycle_enabled=True,
@@ -453,6 +455,83 @@ def test_lifecycle_config_digest_tracks_effective_stage_models(
         before = kb._lifecycle_projection_request().config_digest
         monkeypatch.setenv(name, "openrouter/vendor/model-bbbb:free")
         assert kb._lifecycle_projection_request().config_digest != before, name
+
+
+def test_lifecycle_config_digest_v1_default_keeps_existing_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Expand phase: without the v2 opt-in, stage vars must NOT move the
+    digest, so this code deploys green against every existing generation
+    binding and rollback is a pure variable change.
+    """
+    monkeypatch.delenv("CITADEL_PROJECTION_DIGEST_V2", raising=False)
+    kb = Citadel(
+        CitadelConfig(
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=FakeCognee(),
+    )
+    before = kb._lifecycle_projection_request().config_digest
+    monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/test/other:free")
+    assert kb._lifecycle_projection_request().config_digest == before
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_binding_attests_routed_stage_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """The binding must track the EFFECTIVE routed models: Citadel.__init__
+    runs the cognee client's _prepare_cognee_environment (which rewrites the
+    stage vars) BEFORE computing the binding digest, so a change in the routed
+    value trips the generation binding even when the raw pre-init environment
+    never changed.
+    """
+    monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-routed")
+    for name in (
+        "LLM_EXTRACTION_MODEL",
+        "LLM_SUMMARIZATION_MODEL",
+        "LLM_QUERY_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    store_path = str(tmp_path / "lifecycle.sqlite3")
+
+    class RoutedCognee(FakeCognee):
+        routed_model = "openrouter/vendor/routed-aaaa:free"
+
+        def _prepare_cognee_environment(self) -> None:
+            for name in (
+                "LLM_EXTRACTION_MODEL",
+                "LLM_SUMMARIZATION_MODEL",
+                "LLM_QUERY_MODEL",
+            ):
+                os.environ[name] = self.routed_model
+
+    original = Citadel(
+        CitadelConfig(lifecycle_enabled=True, lifecycle_store_path=store_path),
+        cognee=RoutedCognee(),
+    )
+    accepted = await original.ingest(
+        "routed-model bound source", source_key="manual:routed"
+    )
+    await original.wait_for_lifecycle_operation(accepted.projection_job_id)
+
+    # Same routed values rebind cleanly on restart.
+    Citadel(
+        CitadelConfig(lifecycle_enabled=True, lifecycle_store_path=store_path),
+        cognee=RoutedCognee(),
+    )
+
+    changed = RoutedCognee()
+    changed.routed_model = "openrouter/vendor/routed-bbbb:free"
+    with pytest.raises(LifecycleConflictError, match="CITADEL_GENERATION_ID"):
+        Citadel(
+            CitadelConfig(lifecycle_enabled=True, lifecycle_store_path=store_path),
+            cognee=changed,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -502,14 +502,17 @@ def test_lifecycle_digest_gate_is_frozen_at_init(
     assert kb._lifecycle_projection_request().config_digest == before
 
 
-def test_lifecycle_v2_rejects_runtime_route_drift(
+@pytest.mark.asyncio
+async def test_lifecycle_v2_rejects_runtime_route_drift_on_writes_only(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
 ) -> None:
     """With v2 on, a mid-process route change (operator edit or the
-    free-router fallback) must fail fast with an actionable error: a silently
+    free-router fallback) must fail NEW projection work fast: a silently
     frozen digest would strand jobs, and a moving digest would let receipts
-    attest a model that did not run.
+    attest a model that did not run. Read paths (search, readyz, tombstone)
+    build projection identities through the same builder and must keep
+    working, so the builder itself never raises.
     """
     monkeypatch.setenv("CITADEL_PROJECTION_DIGEST_V2", "true")
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/frozen:free")
@@ -520,10 +523,15 @@ def test_lifecycle_v2_rejects_runtime_route_drift(
         ),
         cognee=FakeCognee(),
     )
-    kb._lifecycle_projection_request()
+    before = kb._lifecycle_projection_request().config_digest
     monkeypatch.setenv("LLM_EXTRACTION_MODEL", "openrouter/vendor/flipped:free")
+    # Read-safe: the builder still answers, with the frozen attestation.
+    assert kb._lifecycle_projection_request().config_digest == before
+    # Write paths refuse new work with an actionable error.
     with pytest.raises(LifecycleConflictError, match="restart the node"):
-        kb._lifecycle_projection_request()
+        await kb.ingest("drifted source", source_key="manual:drift")
+    with pytest.raises(LifecycleConflictError, match="restart the node"):
+        kb.queue_lifecycle_rebuild(generation_id="generation-drift-target")
 
 
 def test_lifecycle_v1_freezes_llm_model_against_fallback_rewrite(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -532,6 +532,18 @@ async def test_lifecycle_v2_rejects_runtime_route_drift_on_writes_only(
         await kb.ingest("drifted source", source_key="manual:drift")
     with pytest.raises(LifecycleConflictError, match="restart the node"):
         kb.queue_lifecycle_rebuild(generation_id="generation-drift-target")
+    with pytest.raises(LifecycleConflictError, match="restart the node"):
+        await kb.tombstone_source(
+            dataset="notes", source_key="manual:drift", reason="test"
+        )
+    with pytest.raises(LifecycleConflictError, match="restart the node"):
+        kb.lifecycle_requeue_failed(
+            generation_id="generation-any",
+            projection_version="lifecycle-v1:cognee-1.4.1",
+            config_digest="sha256:any",
+            expected_count=0,
+            candidate_ids=(),
+        )
 
 
 def test_lifecycle_v1_freezes_llm_model_against_fallback_rewrite(


### PR DESCRIPTION
## Goal

Make projection receipts attest the models that actually produced them. Cognee routes the real LLM calls through `LLM_EXTRACTION_MODEL` / `LLM_SUMMARIZATION_MODEL` / `LLM_QUERY_MODEL` (kb/model_routing.py `configure_cognee_model_routes`), but the generation-binding digest hashed only `LLM_MODEL`. That gap allowed a stage-model swap to run inside an existing generation while receipts attested a digest computed from a different model — observed live on 2026-08-28 and reverted the same hour.

## Included

- `kb/service.py` `_lifecycle_projection_request`: an opt-in **digest v2** (`CITADEL_PROJECTION_DIGEST_V2`) adds `digest_version`, `llm_extraction_model`, `llm_summarization_model`, `llm_query_model` to the binding digest. Default off: the digest is byte-identical to today's, so this deploys green against every existing generation binding.
- `tests/test_service.py`:
  - v2 test proves each stage var moves the digest, including equal-length model replacements (guards partial or length-only hashing).
  - Routed-binding test proves the binding tracks the EFFECTIVE models: a stub `_prepare_cognee_environment` rewrites the stage vars pre-binding, and a changed routed model trips `LifecycleConflictError` even though the raw pre-init environment never changed.
  - v1-compat test pins expand-phase digest stability (stage vars do NOT move the default digest).

## Expand / migrate / contract

1. **Expand (this PR):** merge; deploys green; no behavior change (gate off).
2. **Migrate (one Railway variable change, after merge):** set `CITADEL_PROJECTION_DIGEST_V2=true` + a new `CITADEL_GENERATION_ID` + all four model vars to the verified `openrouter/nvidia/nemotron-3-super-120b-a12b:free` (the configured `nemotron-nano-9b-v2:free` is delisted; the replacement returned 200 with the production key on 2026-08-28). The redeploy binds the new generation under v2 and queues the full rebuild; receipts from then on attest the true stage models. This also re-projects the two sources whose graph receipts completed inside the 2026-08-28 risk window (`e275101d-…`, `e00cdb3b-…`).
3. **Contract (follow-up PR):** make v2 unconditional and drop the gate once all nodes run migrated generations.

**Rollback:** reverse the migrate variable change (gate off + previous `CITADEL_GENERATION_ID` + previous models). The old binding still matches the v1 digest shape, so the node boots on the previous generation unchanged.

## Verification

- [VERIFIED local] Red first (`1 == 4` distinct digests) before the fix; green after.
- [VERIFIED local] `uv run pytest -q`: `2488 passed, 6 skipped` (pytest exit 0); Ruff clean.
- [VERIFIED local] Adversarial fresh-eyes review: data-safe; its two findings (deployment ordering, equal-length test gap) are both addressed by the gate and the strengthened tests.

## Notes

- The migrate step re-projects vectors/relational/graph for all sources (same automated path as the 2026-08-27 FastEmbed cutover; search stays up on retained snapshots during the drain).
- Graph enrichment drains 9,810+ deferred jobs on the $0 free route, throttled by OpenRouter free-tier limits.

Refs #228

## Stack declaration

- Base/parent: `main` (no parent PR; independent single-slice change).
- Affected paths: `kb/service.py`, `tests/test_service.py`.
- Affected service: Citadel-Archive (Railway web service); no schema, UI, or dependency changes.
- Focused verification: `uv run pytest -q tests/test_service.py -k 'config_digest or routed_stage'`
- Rollback: revert the migrate variable change (gate off + previous generation + previous models); expand phase is a no-op, so reverting the merge itself is also safe.
