### PR TITLE
fix(evolve): kick the drain before Phase 2 and bound the cognify pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to `citadel-archive` are documented here. Format follows
 
 ## [Unreleased]
 
+- **Boot now aborts when startup cognify recovery cannot be verified.** The
+  gateway runs its own stale-run recovery at boot, before any writer starts:
+  every cognify run whose own latest status row is `DATASET_PROCESSING_STARTED`
+  is rolled back (run-scoped, via cognee's `cognify_rollback_handler`) and its
+  event stream closed with a terminal row. This catches runs cognee's own
+  per-dataset startup repair can never see — a run buried under a newer
+  terminal run in the same dataset. Any recovery failure, or a run left
+  dangling (including one whose dataset row is gone), raises
+  `CogneeStartupRecoveryError` and aborts boot; the platform restart policy
+  retries. Previously the failure was swallowed and the writers started on
+  top of unrecovered partial writes.
+
 - **Knowledge-graph inspector now supports long connection lists.** Selected
   nodes render up to 8 neighbor links and a `Show all N connections` control.
   Expanded mode shows the full set with a scrollable list so users can reach

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4827,6 +4827,20 @@ class CogneePublicClient:
         (run_tasks), and startup recovery stamps the same terminal row after
         a successful rollback, so a run whose event stream still ends
         STARTED has partial writes nothing has cleaned up.
+
+        Results come back newest-first (by each run's latest created_at) so
+        the recovery loop clears a dataset's newer dangling runs before its
+        older ones. Once a newer dangling run is rolled back its stream ends
+        ERRORED, so it no longer trips the older sibling's newer-COMPLETED
+        guard in _recover_dangling_cognify_run.
+
+        Equal created_at values leave the per-run ranking unspecified:
+        PipelineRun 1.4.1 has no monotonic tiebreak column (its primary key
+        is ``id = Column(UUID, primary_key=True, default=uuid4)`` — random,
+        not ordered), so two status rows written in the same microsecond may
+        rank either way. Cognee writes each run's rows sequentially with
+        microsecond timestamps, so the residual risk is documented here
+        rather than papered over with a fake ordering column.
         """
         from sqlalchemy import func, select
         from sqlalchemy.orm import aliased
@@ -4856,21 +4870,37 @@ class CogneePublicClient:
                 .where(
                     latest_row.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
                 )
+                .order_by(latest_row.created_at.desc())
             )
             return list(result.scalars().all())
 
     async def _recover_dangling_cognify_run(self, run: Any) -> bool:
         """Roll back ONE dangling cognify run and close its event stream.
 
-        Rollback is safe on a run that is no longer its dataset's latest:
-        cognee 1.4.1 scopes both rollback paths to the given
-        pipeline_run_id's own artifacts. The graph-provenance path removes
-        only the source refs the run attached and hard-deletes artifacts
-        only when left unowned
+        Rollback is REFUSED (returns False) when a NEWER run in the same
+        dataset has its own latest status DATASET_PROCESSING_COMPLETED.
+        Cognee 1.4.1 never transfers source-ref ownership: a later run that
+        re-touches an existing source ref does not attach its own ref, so
+        the old run keeps the SOLE ref, and rolling the old run back removes
+        that ref and hard-deletes the graph/vector artifacts the completed
+        run still reuses. Cognee's own provenance contract demonstrates the
+        sole-ref deletion (installed package,
+        cognee/tests/integration/tasks/test_graph_provenance_delete_default_stack.py:126-151).
+        Ref ownership cannot be verified from here, so this fails closed:
+        the run stays dangling, the caller's backstop names it, and boot
+        aborts for the operator to decide.
+
+        Rollback IS safe when no newer run completed — the run is its
+        dataset's newest, every newer run ended ERRORED (its inline rollback
+        already ran) or INITIATED (no processing happened), or a newer
+        dangling run was rolled back earlier in this boot's newest-first
+        loop and now ends ERRORED. Cognee scopes both rollback paths to the
+        given pipeline_run_id's own artifacts: the graph-provenance path
+        removes only the source refs the run attached and hard-deletes
+        artifacts only when left unowned
         (unified_store_engine.rollback_by_pipeline_run_id); the legacy path
         selects Node/Edge rows by pipeline_run_id and keeps any slug another
         run also wrote (cognify_rollback_handler's shared-slug exclusion).
-        Newer runs' state survives.
 
         The terminal DATASET_PROCESSING_ERRORED event is written for the
         SAME pipeline_run_id — cognee's own convention for a rolled-back run
@@ -4891,6 +4921,8 @@ class CogneePublicClient:
         Every failure propagates. Swallowing here is what created the blind
         spot this recovery exists to close.
         """
+        from sqlalchemy import func, select
+
         from cognee.context_global_variables import (
             set_database_global_context_variables,
         )
@@ -4898,6 +4930,7 @@ class CogneePublicClient:
         from cognee.modules.cognify.rollback import cognify_rollback_handler
         from cognee.modules.data.models import Dataset
         from cognee.modules.pipelines.methods import reset_pipeline_run_status
+        from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
         from cognee.modules.pipelines.operations.log_pipeline_run_error import (
             log_pipeline_run_error,
         )
@@ -4905,6 +4938,33 @@ class CogneePublicClient:
         db_engine = get_relational_engine()
         async with db_engine.get_async_session() as session:
             dataset = await session.get(Dataset, run.dataset_id)
+            latest_per_run = (
+                select(
+                    PipelineRun.status,
+                    PipelineRun.created_at,
+                    func.row_number()
+                    .over(
+                        partition_by=PipelineRun.pipeline_run_id,
+                        order_by=PipelineRun.created_at.desc(),
+                    )
+                    .label("rn"),
+                )
+                .where(PipelineRun.pipeline_name == "cognify_pipeline")
+                .where(PipelineRun.dataset_id == run.dataset_id)
+                .subquery()
+            )
+            newer_completed = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(latest_per_run)
+                    .where(latest_per_run.c.rn == 1)
+                    .where(
+                        latest_per_run.c.status
+                        == PipelineRunStatus.DATASET_PROCESSING_COMPLETED
+                    )
+                    .where(latest_per_run.c.created_at > run.created_at)
+                )
+            ).scalar_one()
 
         if dataset is None:
             logger.error(
@@ -4913,6 +4973,19 @@ class CogneePublicClient:
                 "leaving it dangling so boot aborts",
                 run.pipeline_run_id,
                 run.dataset_id,
+            )
+            return False
+
+        if newer_completed:
+            logger.error(
+                "dangling cognify run %s (dataset=%s) is buried under %d newer "
+                "COMPLETED run(s); cognee never transfers source-ref ownership, "
+                "so rolling it back could delete graph/vector artifacts the "
+                "completed run(s) still reuse — leaving it dangling so boot "
+                "aborts",
+                run.pipeline_run_id,
+                run.dataset_id,
+                newer_completed,
             )
             return False
 
@@ -4967,20 +5040,26 @@ class CogneePublicClient:
         So recovery happens here: enumerate every dangling run (per-run
         latest row STARTED), roll each back with cognee's own run-scoped
         cognify_rollback_handler, and close each stream with a terminal
-        ERRORED event for the same run id. No age guard is needed: cognee's
-        STALE_RUN_MIN_AGE_SECONDS exists for multi-replica deployments
-        where a young STARTED run may belong to another live worker, but
-        this gateway is the sole writer (Kuzu's exclusive lock, node-local
-        /data storage) and recovery runs under the maintenance lock before
-        either queue starts, so no run can be live.
+        ERRORED event for the same run id. The loop runs NEWEST-first
+        (_stale_cognify_runs orders it so): rolling back a dataset's newer
+        dangling run first closes its stream as ERRORED, so an older
+        dangling sibling behind it is not mistaken for a run buried under a
+        live successor and both recover in one boot. No age guard is
+        needed: cognee's STALE_RUN_MIN_AGE_SECONDS exists for multi-replica
+        deployments where a young STARTED run may belong to another live
+        worker, but this gateway is the sole writer (Kuzu's exclusive lock,
+        node-local /data storage) and recovery runs under the maintenance
+        lock before either queue starts, so no run can be live.
 
         Any failure propagates and aborts boot. Afterwards the per-run
-        probe re-runs as a backstop: any run still dangling — including one
-        whose Dataset row is gone, which cannot be safely rolled back or
-        stamped terminal — raises CogneeStartupRecoveryError for operator
-        inspection, because starting writers on top of an unrecovered
-        partial run is how the corpus silently rots. Returns the (always
-        empty) list of still-dangling runs on the healthy path.
+        probe re-runs as a backstop: any run still dangling — one whose
+        Dataset row is gone, or one buried under a newer COMPLETED run
+        whose artifacts a rollback could delete
+        (_recover_dangling_cognify_run refuses both) — raises
+        CogneeStartupRecoveryError for operator inspection, because
+        starting writers on top of an unrecovered partial run is how the
+        corpus silently rots. Returns the (always empty) list of
+        still-dangling runs on the healthy path.
         """
         self._prepare_cognee_environment()
         import cognee

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4881,7 +4881,9 @@ class CogneePublicClient:
         has its own latest status DATASET_PROCESSING_COMPLETED at a
         created_at newer than OR EQUAL to this run's dangling STARTED row
         (equal timestamps cannot prove ordering, so equality is unsafe; the
-        dangling run itself never matches because its ranked row is STARTED).
+        dangling run's own STARTED row is excluded by the COMPLETED filter,
+        though with a same-timestamp STARTED and COMPLETED row in ONE run
+        the ranking itself is ambiguous — either pick still fails closed).
         Cognee 1.4.1 never transfers source-ref ownership: a later run that
         re-touches an existing source ref does not attach its own ref, so
         the old run keeps the SOLE ref, and rolling the old run back removes
@@ -4981,8 +4983,9 @@ class CogneePublicClient:
 
         if newer_completed:
             logger.error(
-                "dangling cognify run %s (dataset=%s) is buried under %d newer "
-                "COMPLETED run(s); cognee never transfers source-ref ownership, "
+                "dangling cognify run %s (dataset=%s) has %d COMPLETED run(s) "
+                "at a newer or equal timestamp (not provably older); cognee "
+                "never transfers source-ref ownership, "
                 "so rolling it back could delete graph/vector artifacts the "
                 "completed run(s) still reuse — leaving it dangling so boot "
                 "aborts",

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -31,6 +31,19 @@ DEFAULT_COGNIFY_QUEUE_PATH = Path(".citadel/cognify_queue.json")
 COGNIFY_EXECUTION_LOCK_POLL_SECONDS = 1.0
 _PREPARED_COGNEE_STORAGE_SIGNATURE: tuple[str, ...] | None = None
 
+
+class CogneeStartupRecoveryError(RuntimeError):
+    """Boot-time stale cognify-run recovery could not be verified clean.
+
+    cognee's recover_stale_cognify_runs_on_startup swallows every failure
+    (candidate-query errors and per-run rollback errors are logged and
+    dropped), so its return proves nothing. When the post-recovery probe
+    still finds a dataset whose latest cognify run is
+    DATASET_PROCESSING_STARTED, that run holds unrecovered partial writes;
+    a new cognify would bury it as no-longer-latest forever.
+    """
+
+
 def _float_env(name: str, default: float) -> float:
     raw = os.getenv(name)
     if raw is None:
@@ -4798,7 +4811,49 @@ class CogneePublicClient:
             finally:
                 _COGNEE_MAINTENANCE_HELD.reset(token)
 
-    async def recover_stale_cognify_runs(self) -> None:
+    async def _stale_cognify_latest_runs(self) -> list[Any]:
+        """Latest-per-dataset cognify runs still stuck DATASET_PROCESSING_STARTED.
+
+        Mirrors the candidate query in cognee's
+        recover_stale_cognify_runs_on_startup exactly (row_number over
+        dataset_id ordered by created_at desc, rn == 1, status STARTED,
+        pipeline_name 'cognify_pipeline'), so an empty result means the set
+        recovery selected from is now empty. Sound as a post-recovery probe
+        because a failed rollback also skips reset_pipeline_run_status,
+        leaving the failed run the dataset's latest row.
+        """
+        from sqlalchemy import func, select
+        from sqlalchemy.orm import aliased
+
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+
+        db_engine = get_relational_engine()
+        async with db_engine.get_async_session() as session:
+            latest_per_dataset = (
+                select(
+                    PipelineRun,
+                    func.row_number()
+                    .over(
+                        partition_by=PipelineRun.dataset_id,
+                        order_by=PipelineRun.created_at.desc(),
+                    )
+                    .label("rn"),
+                )
+                .where(PipelineRun.pipeline_name == "cognify_pipeline")
+                .subquery()
+            )
+            latest_run = aliased(PipelineRun, latest_per_dataset)
+            result = await session.execute(
+                select(latest_run)
+                .where(latest_per_dataset.c.rn == 1)
+                .where(
+                    latest_run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+                )
+            )
+            return list(result.scalars().all())
+
+    async def recover_stale_cognify_runs(self) -> list[Any]:
         """Roll back cognify runs a previous process left mid-write.
 
         Process teardown is the one remaining path that cancels an in-flight
@@ -4824,6 +4879,15 @@ class CogneePublicClient:
         recover_stale_cognify_runs_on_startup takes no age parameter and the
         env var is read at import time into a module constant, so the
         constant itself is set and restored around the call.
+
+        cognee's recovery swallows its own failures (candidate-query errors
+        return early; per-run rollback errors log and continue), so the call
+        returning is not proof of repair. Re-run its candidate query after
+        the call: any dataset whose latest cognify run is still
+        DATASET_PROCESSING_STARTED raises CogneeStartupRecoveryError, and a
+        probe that itself fails propagates: swallowing it would recreate the
+        exact blind spot this verification exists to close. Returns the
+        (always empty) list of still-stale runs on the healthy path.
         """
         self._prepare_cognee_environment()
         import cognee
@@ -4838,6 +4902,20 @@ class CogneePublicClient:
                 await cognify_recovery.recover_stale_cognify_runs_on_startup()
             finally:
                 cognify_recovery.STALE_RUN_MIN_AGE_SECONDS = original_min_age
+
+            still_stale = await self._stale_cognify_latest_runs()
+            if still_stale:
+                datasets = ", ".join(
+                    sorted(
+                        str(getattr(run, "dataset_id", run)) for run in still_stale
+                    )
+                )
+                raise CogneeStartupRecoveryError(
+                    "stale cognify-run recovery left "
+                    f"{len(still_stale)} dataset(s) with their latest run still "
+                    f"DATASET_PROCESSING_STARTED: {datasets}"
+                )
+            return still_stale
 
     async def cognify(self, *, datasets: list[str], force: bool = False) -> Any:
         """Cognify under the maintenance lock unless a repair already holds it."""

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4877,13 +4877,22 @@ class CogneePublicClient:
     async def _recover_dangling_cognify_run(self, run: Any) -> bool:
         """Roll back ONE dangling cognify run and close its event stream.
 
-        Rollback is REFUSED (returns False) when a run in the same dataset
-        has its own latest status DATASET_PROCESSING_COMPLETED at a
-        created_at newer than OR EQUAL to this run's dangling STARTED row
-        (equal timestamps cannot prove ordering, so equality is unsafe; the
-        dangling run's own STARTED row is excluded by the COMPLETED filter,
-        though with a same-timestamp STARTED and COMPLETED row in ONE run
-        the ranking itself is ambiguous — either pick still fails closed).
+        Rollback is REFUSED (returns False) when ANY cognify status row in
+        the same dataset is DATASET_PROCESSING_COMPLETED at a created_at
+        newer than OR EQUAL to this run's dangling STARTED row (equal
+        timestamps cannot prove ordering, so equality is unsafe). The check
+        deliberately counts raw rows — no per-run ranking and no
+        self-vs-sibling distinction. Ranking is what makes a same-run tie
+        dangerous: one run carrying a STARTED and a COMPLETED row at the
+        SAME created_at has an unspecified rn==1 pick (PipelineRun 1.4.1
+        has no monotonic tiebreak column), so a guard that re-runs the
+        ranking can pick STARTED, drop the COMPLETED sibling behind its
+        rn==1 filter, and roll back a run that COMPLETED — deleting its
+        artifacts. Counting rows means that COMPLETED sibling always
+        blocks, whichever way the ranking fell. The trade is deliberate
+        fail-closed over-blocking: a COMPLETED row whose own run later
+        logged newer rows still blocks (a ranked check would have dropped
+        it), which only ever refuses a rollback, never permits one.
         Cognee 1.4.1 never transfers source-ref ownership: a later run that
         re-touches an existing source ref does not attach its own ref, so
         the old run keeps the SOLE ref, and rolling the old run back removes
@@ -4895,9 +4904,10 @@ class CogneePublicClient:
         the run stays dangling, the caller's backstop names it, and boot
         aborts for the operator to decide.
 
-        Rollback IS safe when no newer run completed — the run is its
-        dataset's newest, every newer run ended ERRORED (its inline rollback
-        already ran) or INITIATED (no processing happened), or a newer
+        Rollback IS safe when no COMPLETED row exists at a newer-or-equal
+        timestamp — the run is its dataset's newest, every newer run ended
+        ERRORED (its inline rollback already ran) or INITIATED (no
+        processing happened), or a newer
         dangling run was rolled back earlier in this boot's newest-first
         loop and now ends ERRORED. Cognee scopes both rollback paths to the
         given pipeline_run_id's own artifacts: the graph-provenance path
@@ -4943,31 +4953,17 @@ class CogneePublicClient:
         db_engine = get_relational_engine()
         async with db_engine.get_async_session() as session:
             dataset = await session.get(Dataset, run.dataset_id)
-            latest_per_run = (
-                select(
-                    PipelineRun.status,
-                    PipelineRun.created_at,
-                    func.row_number()
-                    .over(
-                        partition_by=PipelineRun.pipeline_run_id,
-                        order_by=PipelineRun.created_at.desc(),
-                    )
-                    .label("rn"),
-                )
-                .where(PipelineRun.pipeline_name == "cognify_pipeline")
-                .where(PipelineRun.dataset_id == run.dataset_id)
-                .subquery()
-            )
-            newer_completed = (
+            completed_rows = (
                 await session.execute(
                     select(func.count())
-                    .select_from(latest_per_run)
-                    .where(latest_per_run.c.rn == 1)
+                    .select_from(PipelineRun)
+                    .where(PipelineRun.pipeline_name == "cognify_pipeline")
+                    .where(PipelineRun.dataset_id == run.dataset_id)
                     .where(
-                        latest_per_run.c.status
+                        PipelineRun.status
                         == PipelineRunStatus.DATASET_PROCESSING_COMPLETED
                     )
-                    .where(latest_per_run.c.created_at >= run.created_at)
+                    .where(PipelineRun.created_at >= run.created_at)
                 )
             ).scalar_one()
 
@@ -4981,17 +4977,17 @@ class CogneePublicClient:
             )
             return False
 
-        if newer_completed:
+        if completed_rows:
             logger.error(
-                "dangling cognify run %s (dataset=%s) has %d COMPLETED run(s) "
+                "dangling cognify run %s (dataset=%s) has %d COMPLETED row(s) "
                 "at a newer or equal timestamp (not provably older); cognee "
                 "never transfers source-ref ownership, "
-                "so rolling it back could delete graph/vector artifacts the "
-                "completed run(s) still reuse — leaving it dangling so boot "
+                "so rolling it back could delete graph/vector artifacts a "
+                "completed run still reuses — leaving it dangling so boot "
                 "aborts",
                 run.pipeline_run_id,
                 run.dataset_id,
-                newer_completed,
+                completed_rows,
             )
             return False
 

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4877,8 +4877,11 @@ class CogneePublicClient:
     async def _recover_dangling_cognify_run(self, run: Any) -> bool:
         """Roll back ONE dangling cognify run and close its event stream.
 
-        Rollback is REFUSED (returns False) when a NEWER run in the same
-        dataset has its own latest status DATASET_PROCESSING_COMPLETED.
+        Rollback is REFUSED (returns False) when a run in the same dataset
+        has its own latest status DATASET_PROCESSING_COMPLETED at a
+        created_at newer than OR EQUAL to this run's dangling STARTED row
+        (equal timestamps cannot prove ordering, so equality is unsafe; the
+        dangling run itself never matches because its ranked row is STARTED).
         Cognee 1.4.1 never transfers source-ref ownership: a later run that
         re-touches an existing source ref does not attach its own ref, so
         the old run keeps the SOLE ref, and rolling the old run back removes
@@ -4962,7 +4965,7 @@ class CogneePublicClient:
                         latest_per_run.c.status
                         == PipelineRunStatus.DATASET_PROCESSING_COMPLETED
                     )
-                    .where(latest_per_run.c.created_at > run.created_at)
+                    .where(latest_per_run.c.created_at >= run.created_at)
                 )
             ).scalar_one()
 

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -35,12 +35,12 @@ _PREPARED_COGNEE_STORAGE_SIGNATURE: tuple[str, ...] | None = None
 class CogneeStartupRecoveryError(RuntimeError):
     """Boot-time stale cognify-run recovery could not be verified clean.
 
-    cognee's recover_stale_cognify_runs_on_startup swallows every failure
-    (candidate-query errors and per-run rollback errors are logged and
-    dropped), so its return proves nothing. When the post-recovery probe
-    still finds a dataset whose latest cognify run is
-    DATASET_PROCESSING_STARTED, that run holds unrecovered partial writes;
-    a new cognify would bury it as no-longer-latest forever.
+    Raised when, after the startup recovery loop, some cognify run's own
+    latest status row is still DATASET_PROCESSING_STARTED: that run holds
+    unrecovered partial writes (including a run whose Dataset row is gone,
+    which cannot be rolled back without its ownership context). Starting the
+    writers anyway would stack new writes on top of the partial run, so boot
+    aborts for operator inspection.
     """
 
 
@@ -4811,16 +4811,22 @@ class CogneePublicClient:
             finally:
                 _COGNEE_MAINTENANCE_HELD.reset(token)
 
-    async def _stale_cognify_latest_runs(self) -> list[Any]:
-        """Latest-per-dataset cognify runs still stuck DATASET_PROCESSING_STARTED.
+    async def _stale_cognify_runs(self) -> list[Any]:
+        """EVERY cognify run whose own latest status row is STARTED.
 
-        Mirrors the candidate query in cognee's
-        recover_stale_cognify_runs_on_startup exactly (row_number over
-        dataset_id ordered by created_at desc, rn == 1, status STARTED,
-        pipeline_name 'cognify_pipeline'), so an empty result means the set
-        recovery selected from is now empty. Sound as a post-recovery probe
-        because a failed rollback also skips reset_pipeline_run_status,
-        leaving the failed run the dataset's latest row.
+        Ranks status rows per pipeline_run_id (each run's own latest row),
+        NOT per dataset. The gateway cognifies with use_pipeline_cache=False,
+        so a newer run B in the same dataset can end
+        DATASET_PROCESSING_ERRORED and bury an older abandoned run A: any
+        per-dataset ranking — cognee's own startup-recovery candidate query
+        included — selects only B, filters it out, and reports clean while
+        A's partial graph/vector/relational writes remain unrecovered.
+
+        Per-run STARTED-as-latest means exactly "not rolled back": cognee
+        writes DATASET_PROCESSING_ERRORED after its inline rollback
+        (run_tasks), and startup recovery stamps the same terminal row after
+        a successful rollback, so a run whose event stream still ends
+        STARTED has partial writes nothing has cleaned up.
         """
         from sqlalchemy import func, select
         from sqlalchemy.orm import aliased
@@ -4830,12 +4836,12 @@ class CogneePublicClient:
 
         db_engine = get_relational_engine()
         async with db_engine.get_async_session() as session:
-            latest_per_dataset = (
+            latest_per_run = (
                 select(
                     PipelineRun,
                     func.row_number()
                     .over(
-                        partition_by=PipelineRun.dataset_id,
+                        partition_by=PipelineRun.pipeline_run_id,
                         order_by=PipelineRun.created_at.desc(),
                     )
                     .label("rn"),
@@ -4843,77 +4849,160 @@ class CogneePublicClient:
                 .where(PipelineRun.pipeline_name == "cognify_pipeline")
                 .subquery()
             )
-            latest_run = aliased(PipelineRun, latest_per_dataset)
+            latest_row = aliased(PipelineRun, latest_per_run)
             result = await session.execute(
-                select(latest_run)
-                .where(latest_per_dataset.c.rn == 1)
+                select(latest_row)
+                .where(latest_per_run.c.rn == 1)
                 .where(
-                    latest_run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+                    latest_row.status == PipelineRunStatus.DATASET_PROCESSING_STARTED
                 )
             )
             return list(result.scalars().all())
 
+    async def _recover_dangling_cognify_run(self, run: Any) -> bool:
+        """Roll back ONE dangling cognify run and close its event stream.
+
+        Rollback is safe on a run that is no longer its dataset's latest:
+        cognee 1.4.1 scopes both rollback paths to the given
+        pipeline_run_id's own artifacts. The graph-provenance path removes
+        only the source refs the run attached and hard-deletes artifacts
+        only when left unowned
+        (unified_store_engine.rollback_by_pipeline_run_id); the legacy path
+        selects Node/Edge rows by pipeline_run_id and keeps any slug another
+        run also wrote (cognify_rollback_handler's shared-slug exclusion).
+        Newer runs' state survives.
+
+        The terminal DATASET_PROCESSING_ERRORED event is written for the
+        SAME pipeline_run_id — cognee's own convention for a rolled-back run
+        (run_tasks logs ERRORED after its inline rollback) — so the per-run
+        probe sees the stream closed, this boot and every later one.
+        reset_pipeline_run_status then logs a fresh INITIATED run so
+        cognee's run qualification does not report the dataset "already
+        being processed".
+
+        A run whose Dataset row is GONE is left dangling (returns False):
+        the missing row does not prove the run left no graph/vector
+        artifacts, and rollback needs the dataset's id and owner_id to
+        address them, so there is no preserved context to perform — or
+        verify — a rollback. Stamping it terminal would hide unknown
+        partial writes behind a clean probe; instead the caller's
+        verification names it and boot aborts for operator inspection.
+
+        Every failure propagates. Swallowing here is what created the blind
+        spot this recovery exists to close.
+        """
+        from cognee.context_global_variables import (
+            set_database_global_context_variables,
+        )
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.cognify.rollback import cognify_rollback_handler
+        from cognee.modules.data.models import Dataset
+        from cognee.modules.pipelines.methods import reset_pipeline_run_status
+        from cognee.modules.pipelines.operations.log_pipeline_run_error import (
+            log_pipeline_run_error,
+        )
+
+        db_engine = get_relational_engine()
+        async with db_engine.get_async_session() as session:
+            dataset = await session.get(Dataset, run.dataset_id)
+
+        if dataset is None:
+            logger.error(
+                "dangling cognify run %s references missing dataset %s; "
+                "cannot roll back without the dataset's ownership context — "
+                "leaving it dangling so boot aborts",
+                run.pipeline_run_id,
+                run.dataset_id,
+            )
+            return False
+
+        async with set_database_global_context_variables(
+            dataset.id, dataset.owner_id
+        ):
+            await cognify_rollback_handler(
+                pipeline_run_id=run.pipeline_run_id,
+                dataset=dataset,
+            )
+            await log_pipeline_run_error(
+                run.pipeline_run_id,
+                run.pipeline_id,
+                run.pipeline_name,
+                run.dataset_id,
+                None,
+                RuntimeError("recovered at startup"),
+            )
+            await reset_pipeline_run_status(
+                dataset.owner_id, dataset.id, "cognify_pipeline"
+            )
+        logger.info(
+            "startup recovery rolled back dangling cognify run %s (dataset=%s)",
+            run.pipeline_run_id,
+            run.dataset_id,
+        )
+        return True
+
     async def recover_stale_cognify_runs(self) -> list[Any]:
-        """Roll back cognify runs a previous process left mid-write.
+        """Roll back every cognify run a previous process left mid-write.
 
         Process teardown is the one remaining path that cancels an in-flight
         cognify, and cognee's pipeline rollback fires on Exception only
         (run_tasks catches Exception, not BaseException), so a cancelled run
-        strands partial graph/vector/relational writes with its pipeline run
-        row stuck DATASET_PROCESSING_STARTED. Cognee ships its own repair for
-        exactly this, but only wires it into its own API server, never into
-        this gateway. Run it at boot, under the maintenance lock, before any
-        queue starts.
+        strands partial graph/vector/relational writes with its latest
+        pipeline-run row stuck DATASET_PROCESSING_STARTED.
 
-        The min-age guard is neutralized (set to 0) for the duration of the
-        call. Cognee's guard exists for multi-replica deployments where a
-        young DATASET_PROCESSING_STARTED run may belong to another live
-        worker; here there is none: this gateway is the sole writer (Kuzu's
-        exclusive lock, node-local /data storage), and recovery runs before
-        either queue starts, under the maintenance lock, so no run can be
-        live. Age 0 closes both failure modes the guard would otherwise
-        leave open: an immediate restart skipping the run the previous
-        process cancelled seconds ago (younger than the 3600s default), and
-        that skipped run being buried forever once the next cognify makes it
-        no-longer-latest (recovery only examines each dataset's latest run).
-        recover_stale_cognify_runs_on_startup takes no age parameter and the
-        env var is read at import time into a module constant, so the
-        constant itself is set and restored around the call.
+        cognee ships its own startup repair
+        (recover_stale_cognify_runs_on_startup) but this gateway cannot use
+        it, for three verified 1.4.1 reasons. First, its candidate query
+        ranks per DATASET, so an abandoned run buried under a newer terminal
+        run in the same dataset is invisible to it forever — with
+        use_pipeline_cache=False that burial is routine. Second, it swallows
+        every failure (candidate-query errors return early; per-run rollback
+        errors log and continue), so its return proves nothing. Third, its
+        success path never closes the recovered run's own event stream:
+        reset_pipeline_run_status logs INITIATED under a FRESH uuid4
+        pipeline_run_id, leaving the repaired run's latest row STARTED,
+        which any sound per-run verification would flag on every later
+        boot.
 
-        cognee's recovery swallows its own failures (candidate-query errors
-        return early; per-run rollback errors log and continue), so the call
-        returning is not proof of repair. Re-run its candidate query after
-        the call: any dataset whose latest cognify run is still
-        DATASET_PROCESSING_STARTED raises CogneeStartupRecoveryError, and a
-        probe that itself fails propagates: swallowing it would recreate the
-        exact blind spot this verification exists to close. Returns the
-        (always empty) list of still-stale runs on the healthy path.
+        So recovery happens here: enumerate every dangling run (per-run
+        latest row STARTED), roll each back with cognee's own run-scoped
+        cognify_rollback_handler, and close each stream with a terminal
+        ERRORED event for the same run id. No age guard is needed: cognee's
+        STALE_RUN_MIN_AGE_SECONDS exists for multi-replica deployments
+        where a young STARTED run may belong to another live worker, but
+        this gateway is the sole writer (Kuzu's exclusive lock, node-local
+        /data storage) and recovery runs under the maintenance lock before
+        either queue starts, so no run can be live.
+
+        Any failure propagates and aborts boot. Afterwards the per-run
+        probe re-runs as a backstop: any run still dangling — including one
+        whose Dataset row is gone, which cannot be safely rolled back or
+        stamped terminal — raises CogneeStartupRecoveryError for operator
+        inspection, because starting writers on top of an unrecovered
+        partial run is how the corpus silently rots. Returns the (always
+        empty) list of still-dangling runs on the healthy path.
         """
         self._prepare_cognee_environment()
         import cognee
 
         await self._ensure_cognee_ready(cognee)
         async with self.maintenance():
-            from cognee.modules.cognify import recovery as cognify_recovery
+            for run in await self._stale_cognify_runs():
+                await self._recover_dangling_cognify_run(run)
 
-            original_min_age = cognify_recovery.STALE_RUN_MIN_AGE_SECONDS
-            cognify_recovery.STALE_RUN_MIN_AGE_SECONDS = 0
-            try:
-                await cognify_recovery.recover_stale_cognify_runs_on_startup()
-            finally:
-                cognify_recovery.STALE_RUN_MIN_AGE_SECONDS = original_min_age
-
-            still_stale = await self._stale_cognify_latest_runs()
+            still_stale = await self._stale_cognify_runs()
             if still_stale:
-                datasets = ", ".join(
+                runs_desc = ", ".join(
                     sorted(
-                        str(getattr(run, "dataset_id", run)) for run in still_stale
+                        f"{getattr(run, 'pipeline_run_id', run)} "
+                        f"(dataset {getattr(run, 'dataset_id', 'unknown')})"
+                        for run in still_stale
                     )
                 )
                 raise CogneeStartupRecoveryError(
                     "stale cognify-run recovery left "
-                    f"{len(still_stale)} dataset(s) with their latest run still "
-                    f"DATASET_PROCESSING_STARTED: {datasets}"
+                    f"{len(still_stale)} run(s) with their latest status "
+                    f"still DATASET_PROCESSING_STARTED: {runs_desc}"
                 )
             return still_stale
 

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4808,19 +4808,36 @@ class CogneePublicClient:
         row stuck DATASET_PROCESSING_STARTED. Cognee ships its own repair for
         exactly this, but only wires it into its own API server, never into
         this gateway. Run it at boot, under the maintenance lock, before any
-        queue starts. Runs younger than COGNEE_STALE_RUN_RECOVERY_MIN_AGE_SECONDS
-        (default 3600) are skipped by cognee as possibly live.
+        queue starts.
+
+        The min-age guard is neutralized (set to 0) for the duration of the
+        call. Cognee's guard exists for multi-replica deployments where a
+        young DATASET_PROCESSING_STARTED run may belong to another live
+        worker; here there is none: this gateway is the sole writer (Kuzu's
+        exclusive lock, node-local /data storage), and recovery runs before
+        either queue starts, under the maintenance lock, so no run can be
+        live. Age 0 closes both failure modes the guard would otherwise
+        leave open: an immediate restart skipping the run the previous
+        process cancelled seconds ago (younger than the 3600s default), and
+        that skipped run being buried forever once the next cognify makes it
+        no-longer-latest (recovery only examines each dataset's latest run).
+        recover_stale_cognify_runs_on_startup takes no age parameter and the
+        env var is read at import time into a module constant, so the
+        constant itself is set and restored around the call.
         """
         self._prepare_cognee_environment()
         import cognee
 
         await self._ensure_cognee_ready(cognee)
         async with self.maintenance():
-            from cognee.modules.cognify.recovery import (
-                recover_stale_cognify_runs_on_startup,
-            )
+            from cognee.modules.cognify import recovery as cognify_recovery
 
-            await recover_stale_cognify_runs_on_startup()
+            original_min_age = cognify_recovery.STALE_RUN_MIN_AGE_SECONDS
+            cognify_recovery.STALE_RUN_MIN_AGE_SECONDS = 0
+            try:
+                await cognify_recovery.recover_stale_cognify_runs_on_startup()
+            finally:
+                cognify_recovery.STALE_RUN_MIN_AGE_SECONDS = original_min_age
 
     async def cognify(self, *, datasets: list[str], force: bool = False) -> Any:
         """Cognify under the maintenance lock unless a repair already holds it."""

--- a/kb/cognee_client.py
+++ b/kb/cognee_client.py
@@ -4798,6 +4798,30 @@ class CogneePublicClient:
             finally:
                 _COGNEE_MAINTENANCE_HELD.reset(token)
 
+    async def recover_stale_cognify_runs(self) -> None:
+        """Roll back cognify runs a previous process left mid-write.
+
+        Process teardown is the one remaining path that cancels an in-flight
+        cognify, and cognee's pipeline rollback fires on Exception only
+        (run_tasks catches Exception, not BaseException), so a cancelled run
+        strands partial graph/vector/relational writes with its pipeline run
+        row stuck DATASET_PROCESSING_STARTED. Cognee ships its own repair for
+        exactly this, but only wires it into its own API server, never into
+        this gateway. Run it at boot, under the maintenance lock, before any
+        queue starts. Runs younger than COGNEE_STALE_RUN_RECOVERY_MIN_AGE_SECONDS
+        (default 3600) are skipped by cognee as possibly live.
+        """
+        self._prepare_cognee_environment()
+        import cognee
+
+        await self._ensure_cognee_ready(cognee)
+        async with self.maintenance():
+            from cognee.modules.cognify.recovery import (
+                recover_stale_cognify_runs_on_startup,
+            )
+
+            await recover_stale_cognify_runs_on_startup()
+
     async def cognify(self, *, datasets: list[str], force: bool = False) -> Any:
         """Cognify under the maintenance lock unless a repair already holds it."""
         if _COGNEE_MAINTENANCE_HELD.get():

--- a/kb/server.py
+++ b/kb/server.py
@@ -987,21 +987,25 @@ async def lifespan(app: FastAPI) -> Any:
         # Repair cognify runs a previous process abandoned mid-write: teardown
         # cancellation bypasses cognee's Exception-only rollback, stranding
         # partial writes and a DATASET_PROCESSING_STARTED run row. Cognee's own
-        # startup recovery handles exactly this; run it before either queue
-        # starts so nothing races the rollback. Boot must never fail on it.
-        try:
-            recover = getattr(
-                getattr(get_citadel(), "cognee", None),
-                "recover_stale_cognify_runs",
-                None,
-            )
-            if callable(recover):
-                await recover()
-        except Exception:
-            logger.exception(
-                "Stale cognify-run recovery failed; continuing boot with any "
-                "partial writes left in place"
-            )
+        # startup recovery handles exactly this; run it before any worker
+        # starts so nothing races the rollback. A failed or unverified
+        # recovery ABORTS boot (the raise propagates out of lifespan): cognee
+        # swallows its own recovery failures, so the client re-probes and
+        # raises CogneeStartupRecoveryError when a latest run is still
+        # STARTED. Skipping the boot-time starters instead would not be
+        # fail-closed, because live write paths restart writers while the API
+        # is up (legacy remember() -> schedule_cognify() ->
+        # _start_cognify_queue_drain(); /api/linear-sync/run schedules
+        # cognify), and any new cognify run would bury the unrecovered latest
+        # run as no-longer-latest forever. A dead process retried by the
+        # platform restart policy IS the signal.
+        recover = getattr(
+            getattr(get_citadel(), "cognee", None),
+            "recover_stale_cognify_runs",
+            None,
+        )
+        if callable(recover):
+            await recover()
         _start_cognify_queue()
         _start_lifecycle_queue()
         evolve_task = _start_evolve_scheduler()
@@ -1009,11 +1013,18 @@ async def lifespan(app: FastAPI) -> Any:
         try:
             yield
         finally:
-            await _stop_lifecycle_queue()
-            await _stop_cognify_queue()
+            # Cancel the schedulers BEFORE stopping the queues: cancelling the
+            # evolve scheduler while it waits in maintenance/Phase 1 hits its
+            # CancelledError handler, which resumes the lifecycle queue
+            # (include_deferred=True) before re-raising. The old order
+            # (lifecycle -> cognify -> evolve) let that resume restart
+            # vector/graph lane tasks after stop_lifecycle_queue had already
+            # returned.
             await _stop_evolve_scheduler(evolve_task)
             # Same cancel-and-await shutdown; the helper is not evolve specific.
             await _stop_evolve_scheduler(repo_stats_task)
+            await _stop_lifecycle_queue()
+            await _stop_cognify_queue()
 
 
 # Single-source the service version and captured deployment identity. The Railway

--- a/kb/server.py
+++ b/kb/server.py
@@ -123,7 +123,7 @@ from kb.security_scan import (
     redact_secrets,
     scan_text_entries,
 )
-from kb.service import Citadel
+from kb.service import Citadel, _canary_timeout_seconds
 from kb.skills import skill_catalog, skill_integrity, skill_path
 from kb.source_search import GITHUB_DOC_ID_PREFIX, github_section_document
 
@@ -372,7 +372,7 @@ def _resume_lifecycle_queue(citadel: Any, *, include_deferred: bool = False) -> 
     try:
         resume(include_deferred=include_deferred)
     except TypeError as exc:
-        if include_deferred and "include_deferred" in str(exc):
+        if "include_deferred" in str(exc):
             resume()
             return
         raise
@@ -384,9 +384,37 @@ def _evolve_cognify_timeout_seconds() -> float:
     Must exceed the canary wait (default 600s) with room for the cognify queue
     itself; an unbounded Phase 2 parks the completion stamp and, before the
     post-stages kick existed, the whole projection drain.
+
+    Floored at the canary budget plus 300s. Phase 2 contains the canary wait
+    itself, both cognify calls, and possibly one FIFO'd graph-lane job, so any
+    smaller bound guarantees a mid-pass timeout on every verify pass. The
+    formula, not the constant, is the contract: raise
+    CITADEL_CANARY_TIMEOUT_SECONDS and the floor tracks it.
     """
+    floor = _canary_timeout_seconds() + 300.0
     raw = os.getenv("CITADEL_EVOLVE_COGNIFY_TIMEOUT_SECONDS", "").strip()
     default = 1800.0
+    if not raw:
+        return max(default, floor)
+    try:
+        value = float(raw)
+    except ValueError:
+        return max(default, floor)
+    if not isfinite(value) or value <= 0:
+        return max(default, floor)
+    return max(value, floor)
+
+
+def _evolve_maintenance_acquire_timeout_seconds() -> float:
+    """Bound for Phase 1's maintenance-lock acquire.
+
+    A hung Phase 2 orphan (or any other holder) must not park the next pass's
+    Phase 1 forever: past this bound the pass defers itself to the next
+    interval instead. Floored at 60s: a too-small value only postpones a pass,
+    it can never corrupt, so the floor is about not thrashing.
+    """
+    raw = os.getenv("CITADEL_EVOLVE_MAINTENANCE_TIMEOUT_SECONDS", "").strip()
+    default = 900.0
     if not raw:
         return default
     try:
@@ -395,7 +423,40 @@ def _evolve_cognify_timeout_seconds() -> float:
         return default
     if not isfinite(value) or value <= 0:
         return default
-    return value
+    return max(value, 60.0)
+
+
+def _evolve_orphan_max_skips() -> int:
+    """How many passes an un-cancelled Phase 2 orphan may skip before the
+    canary flips unhealthy so /readyz escalates to a restart (#27)."""
+    raw = os.getenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "").strip()
+    default = 2
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(value, 1)
+
+
+async def _acquire_maintenance(citadel: Any, timeout_seconds: float) -> Any | None:
+    """Enter ``citadel.cognee.maintenance()`` with a bound; None means busy.
+
+    The caller owns ``await ctx.__aexit__(None, None, None)`` in a finally.
+    Cancelling ``__aenter__`` on timeout is safe: the @asynccontextmanager
+    generator (kb/cognee_client.py maintenance) is cancelled inside its
+    ``async with self.maintenance_lock`` — before the lock is held nothing is
+    acquired, and after it the async-with releases the lock on unwind.
+    Non-timeout failures (including fakes without ``maintenance``) propagate to
+    the caller's existing ``maintenance_exception`` branch.
+    """
+    ctx = citadel.cognee.maintenance()
+    try:
+        await asyncio.wait_for(ctx.__aenter__(), timeout_seconds)
+    except TimeoutError:
+        return None
+    return ctx
 
 
 async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None:
@@ -428,11 +489,52 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
         "Evolve scheduler: first pass in %.0fs of a %ss interval (last pass: %s)",
         delay, interval_seconds, last or "none recorded",
     )
+    orphan: asyncio.Task[Any] | None = None
+    orphan_started = 0.0
+    orphan_skips = 0
     while True:
         await asyncio.sleep(delay)
         delay = float(interval_seconds)
         logger.info("Evolve scheduler: starting scheduled pass")
         citadel = get_citadel()
+        # ORPHAN GUARD — before the pause and before Phase 1. A previous
+        # pass's Phase 2 timed out and was deliberately left running:
+        # cancelling it in-process could land inside a cognee write path,
+        # whose rollback fires on Exception only (run_tasks catches Exception,
+        # not BaseException), stranding partial writes. While the orphan lives
+        # it may hold the maintenance lock, so running Phase 1 would wedge on
+        # entry and pausing the queue here would park the drain for nothing.
+        # Skip the pass: no pause, no stamp (the pass did not run).
+        if orphan is not None and not orphan.done():
+            orphan_skips += 1
+            max_skips = _evolve_orphan_max_skips()
+            logger.error(
+                "Evolve scheduler: pass skipped, Phase 2 orphan %s from a "
+                "previous pass is still running after %.0fs (skip %d/%d)",
+                orphan.get_name(),
+                time.monotonic() - orphan_started,
+                orphan_skips,
+                max_skips,
+            )
+            if orphan_skips >= max_skips:
+                logger.critical(
+                    "Evolve scheduler: Phase 2 orphan exceeded its skip "
+                    "budget; flipping the canary unhealthy so /readyz "
+                    "escalates to an operator or healthcheck restart (#27)"
+                )
+                _record_canary_verdict(ok=False, error="Phase2OrphanWedged")
+            continue
+        if orphan is not None:
+            orphan_exc = None if orphan.cancelled() else orphan.exception()
+            logger.warning(
+                "Evolve scheduler: orphaned Phase 2 task %s finished after "
+                "%.0fs (%s); resuming normal passes",
+                orphan.get_name(),
+                time.monotonic() - orphan_started,
+                orphan_exc if orphan_exc is not None else "ok",
+            )
+            orphan = None
+            orphan_skips = 0
         pause = getattr(citadel, "pause_lifecycle_queue", None)
         if callable(pause):
             pause()
@@ -440,50 +542,59 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
         phase1_reason: str | None = None
         # Phase 1 - heavy stages, in this loop. Hold the maintenance lock before
         # the writer lock so lifecycle cannot claim a lease and then wait inside
-        # Cognee while this pass owns the graph.
+        # Cognee while this pass owns the graph. Entry is bounded: a holder
+        # that never releases (e.g. a hung graph-lane job) must defer this
+        # pass to the next interval, not wedge the scheduler on the lock.
+        maintenance_ctx = None
         try:
-            async with citadel.cognee.maintenance():
-                writer_lock = getattr(
-                    getattr(citadel, "cognee", None), "writer_lock", None
-                )
-                acquired = False
+            maintenance_ctx = await _acquire_maintenance(
+                citadel, _evolve_maintenance_acquire_timeout_seconds()
+            )
+            if maintenance_ctx is not None:
                 try:
-                    if writer_lock is not None:
-                        await writer_lock.acquire()
-                        acquired = True
-                    # Phase 1 runs HERE, in the web's own loop, not in a subprocess (#88).
-                    # A second process can never open the graph: cognee holds an exclusive
-                    # OS file lock on cognee_graph_kuzu for the lifetime of whichever
-                    # process opens it, and that is always this one. github_sync and
-                    # linear_sync died on "Could not set lock on file" every hour because
-                    # of it. Add-only for the duration so the per-ingest background
-                    # cognify does not storm the writer lock; Phase 2 below cognifies once
-                    # as the sole writer (#47).
-                    with suppress_inline_cognify():
-                        code = await run_evolve_in_loop()
-                    if code == 0:
-                        logger.info("Evolve scheduler: stages finished (exit=0)")
-                    else:
+                    writer_lock = getattr(
+                        getattr(citadel, "cognee", None), "writer_lock", None
+                    )
+                    acquired = False
+                    try:
+                        if writer_lock is not None:
+                            await writer_lock.acquire()
+                            acquired = True
+                        # Phase 1 runs HERE, in the web's own loop, not in a subprocess (#88).
+                        # A second process can never open the graph: cognee holds an exclusive
+                        # OS file lock on cognee_graph_kuzu for the lifetime of whichever
+                        # process opens it, and that is always this one. github_sync and
+                        # linear_sync died on "Could not set lock on file" every hour because
+                        # of it. Add-only for the duration so the per-ingest background
+                        # cognify does not storm the writer lock; Phase 2 below cognifies once
+                        # as the sole writer (#47).
+                        with suppress_inline_cognify():
+                            code = await run_evolve_in_loop()
+                        if code == 0:
+                            logger.info("Evolve scheduler: stages finished (exit=0)")
+                        else:
+                            phase1_ok = False
+                            phase1_reason = f"stages_exit_{code}"
+                            # A partial failure is the normal broken case, not an edge one:
+                            # the stage names are already on the "Evolve finished: ...
+                            # failed=..." line, so log at ERROR here to make the cycle
+                            # visibly bad rather than an INFO nobody reads (#89).
+                            logger.error(
+                                "Evolve scheduler: stages finished with failures (exit=%s) - "
+                                "see the 'Evolve finished' line above for which stages failed",
+                                code,
+                            )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
                         phase1_ok = False
-                        phase1_reason = f"stages_exit_{code}"
-                        # A partial failure is the normal broken case, not an edge one:
-                        # the stage names are already on the "Evolve finished: ...
-                        # failed=..." line, so log at ERROR here to make the cycle
-                        # visibly bad rather than an INFO nobody reads (#89).
-                        logger.error(
-                            "Evolve scheduler: stages finished with failures (exit=%s) - "
-                            "see the 'Evolve finished' line above for which stages failed",
-                            code,
-                        )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    phase1_ok = False
-                    phase1_reason = "stages_exception"
-                    logger.exception("Evolve scheduler: stages failed")
+                        phase1_reason = "stages_exception"
+                        logger.exception("Evolve scheduler: stages failed")
+                    finally:
+                        if acquired:
+                            writer_lock.release()
                 finally:
-                    if acquired:
-                        writer_lock.release()
+                    await maintenance_ctx.__aexit__(None, None, None)
         except asyncio.CancelledError:
             _resume_lifecycle_queue(citadel, include_deferred=True)
             raise
@@ -491,13 +602,39 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             phase1_ok = False
             phase1_reason = "maintenance_exception"
             logger.exception("Evolve scheduler: maintenance entry failed")
+        if maintenance_ctx is None and phase1_ok:
+            # Bounded Phase 1 entry timed out: another holder still owns
+            # maintenance. Phase 1 did not run, so the pass must not stamp;
+            # resume the paused queue and defer the whole pass.
+            logger.error(
+                "Evolve scheduler: maintenance busy after %.0fs; pass "
+                "deferred to the next interval",
+                _evolve_maintenance_acquire_timeout_seconds(),
+            )
+            try:
+                _resume_lifecycle_queue(citadel, include_deferred=True)
+            except Exception:
+                logger.exception(
+                    "Evolve scheduler: deferred-pass projection resume failed"
+                )
+            continue
         # Kick the projection drain NOW, before Phase 2: the pass paused the
         # queue above, and a hung Phase 2 (observed live 2026-08-28: cognify
         # emitted nothing for 25+ minutes) must never park a 12k-job rebuild
-        # behind it. The post-pass kick in the finally below stays as a
-        # belt-and-braces no-op when the drain is already running.
+        # behind it. include_deferred=False, and both halves of that matter:
+        # (i) the baseline relational/vector lanes take neither the
+        # maintenance nor the writer lock (kb/cognee_client.py vector_project
+        # is deliberately run_unlocked), so the drain this kick starts can
+        # never park behind Phase 2 — the 2026-08-28 incident closed; (ii)
+        # False does NOT stop an already-running graph-lane task from waking
+        # on the shared projection gate — that interleaving is handled by the
+        # Phase 2 budget (FIFO maintenance lock: at most one graph-lane job
+        # ahead) and the orphan guard, not by this flag. The graph lane is
+        # deliberately (re)started only by cognify_dataset's own
+        # post-graph-write resume (kb/service.py) and the post-pass kick in
+        # the finally below, which stays include_deferred=True.
         try:
-            _resume_lifecycle_queue(citadel, include_deferred=True)
+            _resume_lifecycle_queue(citadel, include_deferred=False)
         except Exception:
             logger.exception("Evolve scheduler: post-stages projection resume failed")
         # Phase 2 — cognify in-loop; the web process is the sole Kuzu writer now.
@@ -510,12 +647,23 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
         cancelled = False
         phase2_ok = False
         phase2_reason: str | None = None
+        # verify=True runs the end-to-end ingest+cognify+search canary and
+        # records its verdict for /readyz (#27). Bounded by wait_for, but the
+        # cognify itself is shielded: cognee's pipeline rollback fires on
+        # Exception only, so an in-process cancellation here would strand
+        # partial graph/vector/relational writes with the run row stuck
+        # DATASET_PROCESSING_STARTED (P1-B). On timeout the task is left
+        # running as this loop's single orphan and the guard at the top of the
+        # pass takes over.
+        phase2_task = asyncio.create_task(
+            citadel.cognify_dataset(force=force, verify=True),
+            name="evolve-phase2-cognify",
+        )
+        _BACKGROUND_TASKS.add(phase2_task)
+        phase2_task.add_done_callback(_forget_background_task)
         try:
-            # verify=True runs the end-to-end ingest+cognify+search canary and
-            # records its verdict for /readyz (#27). Bounded: an unbounded hang
-            # here would block the completion stamp and the next interval.
             result = await asyncio.wait_for(
-                citadel.cognify_dataset(force=force, verify=True),
+                asyncio.shield(phase2_task),
                 timeout=_evolve_cognify_timeout_seconds(),
             )
             verification = result.get("verification") or {}
@@ -545,17 +693,31 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             # NOT run to completion, so stamping it would make the next boot
             # wait a full interval instead of re-running the interrupted pass,
             # and kicking a drain task on a loop being torn down helps nobody.
+            # Teardown DOES cancel the inner task (unchanged semantics from
+            # before the shield): the process is going away either way, and
+            # the next boot repairs any stranded partial write via
+            # recover_stale_cognify_runs.
+            phase2_task.cancel()
             cancelled = True
             raise
         except TimeoutError:
             # The bound above fired: Phase 2 hung past its budget (observed
-            # live 2026-08-28). The drain already got its post-stages kick, the
-            # canary flips unhealthy, and the stamp below lets the next
-            # interval run instead of waiting behind a dead cognify.
+            # live 2026-08-28). The drain already got its post-stages kick and
+            # the canary flips unhealthy; the stamp below lets the next
+            # interval run instead of waiting behind a dead cognify. The task
+            # is NOT cancelled: cancellation could land inside a cognee write
+            # path whose rollback never runs on CancelledError. It becomes the
+            # loop's single orphan; the guard at the top of the pass skips
+            # passes (bounded by CITADEL_EVOLVE_ORPHAN_MAX_SKIPS) while it
+            # lives.
             phase2_reason = "cognify_timeout"
+            orphan = phase2_task
+            orphan_started = time.monotonic()
             logger.error(
-                "Evolve scheduler: cognify timed out after %.0fs",
+                "Evolve scheduler: cognify timed out after %.0fs; task %s "
+                "left running un-cancelled",
                 _evolve_cognify_timeout_seconds(),
+                phase2_task.get_name(),
             )
             _record_canary_verdict(ok=False, error="TimeoutError")
         except Exception as exc:
@@ -758,6 +920,24 @@ async def lifespan(app: FastAPI) -> Any:
             logger.exception(
                 "Seat dataset backfill failed; seats created before provisioning "
                 "may still fail every search (#147)"
+            )
+        # Repair cognify runs a previous process abandoned mid-write: teardown
+        # cancellation bypasses cognee's Exception-only rollback, stranding
+        # partial writes and a DATASET_PROCESSING_STARTED run row. Cognee's own
+        # startup recovery handles exactly this; run it before either queue
+        # starts so nothing races the rollback. Boot must never fail on it.
+        try:
+            recover = getattr(
+                getattr(get_citadel(), "cognee", None),
+                "recover_stale_cognify_runs",
+                None,
+            )
+            if callable(recover):
+                await recover()
+        except Exception:
+            logger.exception(
+                "Stale cognify-run recovery failed; continuing boot with any "
+                "partial writes left in place"
             )
         _start_cognify_queue()
         _start_lifecycle_queue()

--- a/kb/server.py
+++ b/kb/server.py
@@ -986,19 +986,20 @@ async def lifespan(app: FastAPI) -> Any:
             )
         # Repair cognify runs a previous process abandoned mid-write: teardown
         # cancellation bypasses cognee's Exception-only rollback, stranding
-        # partial writes and a DATASET_PROCESSING_STARTED run row. Cognee's own
-        # startup recovery handles exactly this; run it before any worker
+        # partial writes and a DATASET_PROCESSING_STARTED run row. The client
+        # runs its own recovery loop (cognee's startup repair ranks per
+        # dataset, so it never sees a run buried under a newer terminal run,
+        # and it swallows its own failures): every run whose own latest
+        # status row is STARTED is rolled back and closed, before any worker
         # starts so nothing races the rollback. A failed or unverified
-        # recovery ABORTS boot (the raise propagates out of lifespan): cognee
-        # swallows its own recovery failures, so the client re-probes and
-        # raises CogneeStartupRecoveryError when a latest run is still
-        # STARTED. Skipping the boot-time starters instead would not be
-        # fail-closed, because live write paths restart writers while the API
-        # is up (legacy remember() -> schedule_cognify() ->
-        # _start_cognify_queue_drain(); /api/linear-sync/run schedules
-        # cognify), and any new cognify run would bury the unrecovered latest
-        # run as no-longer-latest forever. A dead process retried by the
-        # platform restart policy IS the signal.
+        # recovery ABORTS boot (the raise propagates out of lifespan) with
+        # CogneeStartupRecoveryError naming the dangling runs. Skipping the
+        # boot-time starters instead would not be fail-closed, because live
+        # write paths restart writers while the API is up (legacy remember()
+        # -> schedule_cognify() -> _start_cognify_queue_drain();
+        # /api/linear-sync/run schedules cognify), and any new cognify run
+        # would stack writes on top of the unrecovered partial run. A dead
+        # process retried by the platform restart policy IS the signal.
         recover = getattr(
             getattr(get_citadel(), "cognee", None),
             "recover_stale_cognify_runs",

--- a/kb/server.py
+++ b/kb/server.py
@@ -378,6 +378,26 @@ def _resume_lifecycle_queue(citadel: Any, *, include_deferred: bool = False) -> 
         raise
 
 
+def _evolve_cognify_timeout_seconds() -> float:
+    """Upper bound for one Phase 2 cognify pass (canary included).
+
+    Must exceed the canary wait (default 600s) with room for the cognify queue
+    itself; an unbounded Phase 2 parks the completion stamp and, before the
+    post-stages kick existed, the whole projection drain.
+    """
+    raw = os.getenv("CITADEL_EVOLVE_COGNIFY_TIMEOUT_SECONDS", "").strip()
+    default = 1800.0
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if not isfinite(value) or value <= 0:
+        return default
+    return value
+
+
 async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None:
     """Run every evolve stage and Cognify on the web server's event loop.
 
@@ -471,6 +491,15 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             phase1_ok = False
             phase1_reason = "maintenance_exception"
             logger.exception("Evolve scheduler: maintenance entry failed")
+        # Kick the projection drain NOW, before Phase 2: the pass paused the
+        # queue above, and a hung Phase 2 (observed live 2026-08-28: cognify
+        # emitted nothing for 25+ minutes) must never park a 12k-job rebuild
+        # behind it. The post-pass kick in the finally below stays as a
+        # belt-and-braces no-op when the drain is already running.
+        try:
+            _resume_lifecycle_queue(citadel, include_deferred=True)
+        except Exception:
+            logger.exception("Evolve scheduler: post-stages projection resume failed")
         # Phase 2 — cognify in-loop; the web process is the sole Kuzu writer now.
         force = os.getenv("CITADEL_EVOLVE_COGNIFY_FORCE", "").strip().lower() in {
             "1",
@@ -483,8 +512,12 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
         phase2_reason: str | None = None
         try:
             # verify=True runs the end-to-end ingest+cognify+search canary and
-            # records its verdict for /readyz (#27).
-            result = await citadel.cognify_dataset(force=force, verify=True)
+            # records its verdict for /readyz (#27). Bounded: an unbounded hang
+            # here would block the completion stamp and the next interval.
+            result = await asyncio.wait_for(
+                citadel.cognify_dataset(force=force, verify=True),
+                timeout=_evolve_cognify_timeout_seconds(),
+            )
             verification = result.get("verification") or {}
             _record_canary_verdict(
                 ok=bool(result.get("ok")),
@@ -514,6 +547,17 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
             # and kicking a drain task on a loop being torn down helps nobody.
             cancelled = True
             raise
+        except TimeoutError:
+            # The bound above fired: Phase 2 hung past its budget (observed
+            # live 2026-08-28). The drain already got its post-stages kick, the
+            # canary flips unhealthy, and the stamp below lets the next
+            # interval run instead of waiting behind a dead cognify.
+            phase2_reason = "cognify_timeout"
+            logger.error(
+                "Evolve scheduler: cognify timed out after %.0fs",
+                _evolve_cognify_timeout_seconds(),
+            )
+            _record_canary_verdict(ok=False, error="TimeoutError")
         except Exception as exc:
             phase2_reason = "cognify_exception"
             logger.exception("Evolve scheduler: cognify failed")

--- a/kb/server.py
+++ b/kb/server.py
@@ -427,8 +427,12 @@ def _evolve_maintenance_acquire_timeout_seconds() -> float:
 
 
 def _evolve_orphan_max_skips() -> int:
-    """How many passes an un-cancelled Phase 2 orphan may skip before the
-    canary flips unhealthy so /readyz escalates to a restart (#27)."""
+    """Budget of consecutive skipped passes before the canary flips unhealthy.
+
+    Shared by both skip causes: a live un-cancelled Phase 2 orphan and a
+    maintenance acquire that keeps timing out. Either way the scheduler is
+    not running passes, and past this budget /readyz must escalate to an
+    operator or healthcheck restart (#27)."""
     raw = os.getenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "").strip()
     default = 2
     if not raw:
@@ -450,10 +454,19 @@ async def _acquire_maintenance(citadel: Any, timeout_seconds: float) -> Any | No
     acquired, and after it the async-with releases the lock on unwind.
     Non-timeout failures (including fakes without ``maintenance``) propagate to
     the caller's existing ``maintenance_exception`` branch.
+
+    ``asyncio.timeout``, not ``wait_for``: on Python 3.11 ``wait_for`` can
+    SWALLOW an outer cancellation that lands just as the inner future
+    completes (returns the result instead of raising CancelledError; fixed in
+    3.12 by reimplementing ``wait_for`` on ``asyncio.timeout``, gh-96764).
+    ``__aenter__`` here completes near-instantly on the happy path, so the
+    swallow window is hit in practice and the scheduler loop would survive
+    ``_stop_evolve_scheduler`` forever.
     """
     ctx = citadel.cognee.maintenance()
     try:
-        await asyncio.wait_for(ctx.__aenter__(), timeout_seconds)
+        async with asyncio.timeout(timeout_seconds):
+            await ctx.__aenter__()
     except TimeoutError:
         return None
     return ctx
@@ -491,272 +504,322 @@ async def _evolve_scheduler_loop(interval_seconds: int, state_path: str) -> None
     )
     orphan: asyncio.Task[Any] | None = None
     orphan_started = 0.0
-    orphan_skips = 0
-    while True:
-        await asyncio.sleep(delay)
-        delay = float(interval_seconds)
-        logger.info("Evolve scheduler: starting scheduled pass")
-        citadel = get_citadel()
-        # ORPHAN GUARD — before the pause and before Phase 1. A previous
-        # pass's Phase 2 timed out and was deliberately left running:
-        # cancelling it in-process could land inside a cognee write path,
-        # whose rollback fires on Exception only (run_tasks catches Exception,
-        # not BaseException), stranding partial writes. While the orphan lives
-        # it may hold the maintenance lock, so running Phase 1 would wedge on
-        # entry and pausing the queue here would park the drain for nothing.
-        # Skip the pass: no pause, no stamp (the pass did not run).
-        if orphan is not None and not orphan.done():
-            orphan_skips += 1
-            max_skips = _evolve_orphan_max_skips()
-            logger.error(
-                "Evolve scheduler: pass skipped, Phase 2 orphan %s from a "
-                "previous pass is still running after %.0fs (skip %d/%d)",
-                orphan.get_name(),
-                time.monotonic() - orphan_started,
-                orphan_skips,
-                max_skips,
-            )
-            if orphan_skips >= max_skips:
-                logger.critical(
-                    "Evolve scheduler: Phase 2 orphan exceeded its skip "
-                    "budget; flipping the canary unhealthy so /readyz "
-                    "escalates to an operator or healthcheck restart (#27)"
+    consecutive_skips = 0
+    phase2_task: asyncio.Task[Any] | None = None
+    try:
+        while True:
+            await asyncio.sleep(delay)
+            delay = float(interval_seconds)
+            logger.info("Evolve scheduler: starting scheduled pass")
+            citadel = get_citadel()
+            # ORPHAN GUARD — before the pause and before Phase 1. A previous
+            # pass's Phase 2 timed out and was deliberately left running:
+            # cancelling it in-process could land inside a cognee write path,
+            # whose rollback fires on Exception only (run_tasks catches Exception,
+            # not BaseException), stranding partial writes. While the orphan lives
+            # it may hold the maintenance lock, so running Phase 1 would wedge on
+            # entry and pausing the queue here would park the drain for nothing.
+            # Skip the pass: no pause, no stamp (the pass did not run).
+            if orphan is not None and not orphan.done():
+                consecutive_skips += 1
+                max_skips = _evolve_orphan_max_skips()
+                logger.error(
+                    "Evolve scheduler: pass skipped, Phase 2 orphan %s from a "
+                    "previous pass is still running after %.0fs (skip %d/%d)",
+                    orphan.get_name(),
+                    time.monotonic() - orphan_started,
+                    consecutive_skips,
+                    max_skips,
                 )
-                _record_canary_verdict(ok=False, error="Phase2OrphanWedged")
-            continue
-        if orphan is not None:
-            orphan_exc = None if orphan.cancelled() else orphan.exception()
-            logger.warning(
-                "Evolve scheduler: orphaned Phase 2 task %s finished after "
-                "%.0fs (%s); resuming normal passes",
-                orphan.get_name(),
-                time.monotonic() - orphan_started,
-                orphan_exc if orphan_exc is not None else "ok",
-            )
-            orphan = None
-            orphan_skips = 0
-        pause = getattr(citadel, "pause_lifecycle_queue", None)
-        if callable(pause):
-            pause()
-        phase1_ok = True
-        phase1_reason: str | None = None
-        # Phase 1 - heavy stages, in this loop. Hold the maintenance lock before
-        # the writer lock so lifecycle cannot claim a lease and then wait inside
-        # Cognee while this pass owns the graph. Entry is bounded: a holder
-        # that never releases (e.g. a hung graph-lane job) must defer this
-        # pass to the next interval, not wedge the scheduler on the lock.
-        maintenance_ctx = None
-        try:
-            maintenance_ctx = await _acquire_maintenance(
-                citadel, _evolve_maintenance_acquire_timeout_seconds()
-            )
-            if maintenance_ctx is not None:
-                try:
-                    writer_lock = getattr(
-                        getattr(citadel, "cognee", None), "writer_lock", None
+                if consecutive_skips >= max_skips:
+                    logger.critical(
+                        "Evolve scheduler: Phase 2 orphan exceeded its skip "
+                        "budget; flipping the canary unhealthy so /readyz "
+                        "escalates to an operator or healthcheck restart (#27)"
                     )
-                    acquired = False
-                    try:
-                        if writer_lock is not None:
-                            await writer_lock.acquire()
-                            acquired = True
-                        # Phase 1 runs HERE, in the web's own loop, not in a subprocess (#88).
-                        # A second process can never open the graph: cognee holds an exclusive
-                        # OS file lock on cognee_graph_kuzu for the lifetime of whichever
-                        # process opens it, and that is always this one. github_sync and
-                        # linear_sync died on "Could not set lock on file" every hour because
-                        # of it. Add-only for the duration so the per-ingest background
-                        # cognify does not storm the writer lock; Phase 2 below cognifies once
-                        # as the sole writer (#47).
-                        with suppress_inline_cognify():
-                            code = await run_evolve_in_loop()
-                        if code == 0:
-                            logger.info("Evolve scheduler: stages finished (exit=0)")
-                        else:
-                            phase1_ok = False
-                            phase1_reason = f"stages_exit_{code}"
-                            # A partial failure is the normal broken case, not an edge one:
-                            # the stage names are already on the "Evolve finished: ...
-                            # failed=..." line, so log at ERROR here to make the cycle
-                            # visibly bad rather than an INFO nobody reads (#89).
-                            logger.error(
-                                "Evolve scheduler: stages finished with failures (exit=%s) - "
-                                "see the 'Evolve finished' line above for which stages failed",
-                                code,
-                            )
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception:
-                        phase1_ok = False
-                        phase1_reason = "stages_exception"
-                        logger.exception("Evolve scheduler: stages failed")
-                    finally:
-                        if acquired:
-                            writer_lock.release()
-                finally:
-                    await maintenance_ctx.__aexit__(None, None, None)
-        except asyncio.CancelledError:
-            _resume_lifecycle_queue(citadel, include_deferred=True)
-            raise
-        except Exception:
-            phase1_ok = False
-            phase1_reason = "maintenance_exception"
-            logger.exception("Evolve scheduler: maintenance entry failed")
-        if maintenance_ctx is None and phase1_ok:
-            # Bounded Phase 1 entry timed out: another holder still owns
-            # maintenance. Phase 1 did not run, so the pass must not stamp;
-            # resume the paused queue and defer the whole pass.
-            logger.error(
-                "Evolve scheduler: maintenance busy after %.0fs; pass "
-                "deferred to the next interval",
-                _evolve_maintenance_acquire_timeout_seconds(),
-            )
+                    _record_canary_verdict(ok=False, error="Phase2OrphanWedged")
+                continue
+            if orphan is not None:
+                orphan_exc = None if orphan.cancelled() else orphan.exception()
+                logger.warning(
+                    "Evolve scheduler: orphaned Phase 2 task %s finished after "
+                    "%.0fs (%s); resuming normal passes",
+                    orphan.get_name(),
+                    time.monotonic() - orphan_started,
+                    orphan_exc if orphan_exc is not None else "ok",
+                )
+                orphan = None
+            pause = getattr(citadel, "pause_lifecycle_queue", None)
+            if callable(pause):
+                pause()
+            phase1_ok = True
+            phase1_reason: str | None = None
+            # Phase 1 - heavy stages, in this loop. Hold the maintenance lock before
+            # the writer lock so lifecycle cannot claim a lease and then wait inside
+            # Cognee while this pass owns the graph. Entry is bounded: a holder
+            # that never releases (e.g. a hung graph-lane job) must defer this
+            # pass to the next interval, not wedge the scheduler on the lock.
+            maintenance_ctx = None
             try:
+                maintenance_ctx = await _acquire_maintenance(
+                    citadel, _evolve_maintenance_acquire_timeout_seconds()
+                )
+                if maintenance_ctx is not None:
+                    # Phase 1 can run: the pass is no longer a consecutive skip.
+                    consecutive_skips = 0
+                    try:
+                        writer_lock = getattr(
+                            getattr(citadel, "cognee", None), "writer_lock", None
+                        )
+                        acquired = False
+                        try:
+                            if writer_lock is not None:
+                                await writer_lock.acquire()
+                                acquired = True
+                            # Phase 1 runs HERE, in the web's own loop, not in a subprocess (#88).
+                            # A second process can never open the graph: cognee holds an exclusive
+                            # OS file lock on cognee_graph_kuzu for the lifetime of whichever
+                            # process opens it, and that is always this one. github_sync and
+                            # linear_sync died on "Could not set lock on file" every hour because
+                            # of it. Add-only for the duration so the per-ingest background
+                            # cognify does not storm the writer lock; Phase 2 below cognifies once
+                            # as the sole writer (#47).
+                            with suppress_inline_cognify():
+                                code = await run_evolve_in_loop()
+                            if code == 0:
+                                logger.info("Evolve scheduler: stages finished (exit=0)")
+                            else:
+                                phase1_ok = False
+                                phase1_reason = f"stages_exit_{code}"
+                                # A partial failure is the normal broken case, not an edge one:
+                                # the stage names are already on the "Evolve finished: ...
+                                # failed=..." line, so log at ERROR here to make the cycle
+                                # visibly bad rather than an INFO nobody reads (#89).
+                                logger.error(
+                                    "Evolve scheduler: stages finished with failures (exit=%s) - "
+                                    "see the 'Evolve finished' line above for which stages failed",
+                                    code,
+                                )
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            phase1_ok = False
+                            phase1_reason = "stages_exception"
+                            logger.exception("Evolve scheduler: stages failed")
+                        finally:
+                            if acquired:
+                                writer_lock.release()
+                    finally:
+                        await maintenance_ctx.__aexit__(None, None, None)
+            except asyncio.CancelledError:
                 _resume_lifecycle_queue(citadel, include_deferred=True)
+                raise
             except Exception:
-                logger.exception(
-                    "Evolve scheduler: deferred-pass projection resume failed"
+                phase1_ok = False
+                phase1_reason = "maintenance_exception"
+                logger.exception("Evolve scheduler: maintenance entry failed")
+            if maintenance_ctx is None and phase1_ok:
+                # Bounded Phase 1 entry timed out: another holder still owns
+                # maintenance. Phase 1 did not run, so the pass must not stamp;
+                # resume the paused queue and defer the whole pass. Deferral
+                # consumes the SAME consecutive-skip budget as the orphan guard:
+                # any pass that cannot run Phase 1 is a skip, and without a bound
+                # the scheduler could defer forever while /readyz keeps serving
+                # the last green canary.
+                consecutive_skips += 1
+                max_skips = _evolve_orphan_max_skips()
+                logger.error(
+                    "Evolve scheduler: maintenance busy after %.0fs; pass "
+                    "deferred to the next interval (skip %d/%d)",
+                    _evolve_maintenance_acquire_timeout_seconds(),
+                    consecutive_skips,
+                    max_skips,
                 )
-            continue
-        # Kick the projection drain NOW, before Phase 2: the pass paused the
-        # queue above, and a hung Phase 2 (observed live 2026-08-28: cognify
-        # emitted nothing for 25+ minutes) must never park a 12k-job rebuild
-        # behind it. include_deferred=False, and both halves of that matter:
-        # (i) the baseline relational/vector lanes take neither the
-        # maintenance nor the writer lock (kb/cognee_client.py vector_project
-        # is deliberately run_unlocked), so the drain this kick starts can
-        # never park behind Phase 2 — the 2026-08-28 incident closed; (ii)
-        # False does NOT stop an already-running graph-lane task from waking
-        # on the shared projection gate — that interleaving is handled by the
-        # Phase 2 budget (FIFO maintenance lock: at most one graph-lane job
-        # ahead) and the orphan guard, not by this flag. The graph lane is
-        # deliberately (re)started only by cognify_dataset's own
-        # post-graph-write resume (kb/service.py) and the post-pass kick in
-        # the finally below, which stays include_deferred=True.
-        try:
-            _resume_lifecycle_queue(citadel, include_deferred=False)
-        except Exception:
-            logger.exception("Evolve scheduler: post-stages projection resume failed")
-        # Phase 2 — cognify in-loop; the web process is the sole Kuzu writer now.
-        force = os.getenv("CITADEL_EVOLVE_COGNIFY_FORCE", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
-        cancelled = False
-        phase2_ok = False
-        phase2_reason: str | None = None
-        # verify=True runs the end-to-end ingest+cognify+search canary and
-        # records its verdict for /readyz (#27). Bounded by wait_for, but the
-        # cognify itself is shielded: cognee's pipeline rollback fires on
-        # Exception only, so an in-process cancellation here would strand
-        # partial graph/vector/relational writes with the run row stuck
-        # DATASET_PROCESSING_STARTED (P1-B). On timeout the task is left
-        # running as this loop's single orphan and the guard at the top of the
-        # pass takes over.
-        phase2_task = asyncio.create_task(
-            citadel.cognify_dataset(force=force, verify=True),
-            name="evolve-phase2-cognify",
-        )
-        _BACKGROUND_TASKS.add(phase2_task)
-        phase2_task.add_done_callback(_forget_background_task)
-        try:
-            result = await asyncio.wait_for(
-                asyncio.shield(phase2_task),
-                timeout=_evolve_cognify_timeout_seconds(),
-            )
-            verification = result.get("verification") or {}
-            _record_canary_verdict(
-                ok=bool(result.get("ok")),
-                search_hit=verification.get("search_hit"),
-                graph_grew=result.get("graph_grew"),
-                marker=verification.get("marker"),
-                projection_chain_ok=verification.get("projection_chain_ok"),
-                projection_receipt_count=len(verification.get("projection_receipts") or []),
-            )
-            projection_chain_ok = verification.get(
-                "projection_chain_ok", verification.get("ok", True)
-            )
-            phase2_ok = bool(result.get("ok")) and projection_chain_ok is not False
-            if not phase2_ok:
-                phase2_reason = "cognify_verification_failed"
-            logger.info(
-                "Evolve scheduler: cognify finished (graph_after=%s grew=%s canary_ok=%s)",
-                result.get("graph_after"),
-                result.get("graph_grew"),
-                _LAST_CANARY["ok"] if _LAST_CANARY is not None else None,
-            )
-        except asyncio.CancelledError:
-            # Teardown landing mid-Phase-2 (the canary can now wait minutes on
-            # its marker's projection, so this window is wide): the pass did
-            # NOT run to completion, so stamping it would make the next boot
-            # wait a full interval instead of re-running the interrupted pass,
-            # and kicking a drain task on a loop being torn down helps nobody.
-            # Teardown DOES cancel the inner task (unchanged semantics from
-            # before the shield): the process is going away either way, and
-            # the next boot repairs any stranded partial write via
-            # recover_stale_cognify_runs.
-            phase2_task.cancel()
-            cancelled = True
-            raise
-        except TimeoutError:
-            # The bound above fired: Phase 2 hung past its budget (observed
-            # live 2026-08-28). The drain already got its post-stages kick and
-            # the canary flips unhealthy; the stamp below lets the next
-            # interval run instead of waiting behind a dead cognify. The task
-            # is NOT cancelled: cancellation could land inside a cognee write
-            # path whose rollback never runs on CancelledError. It becomes the
-            # loop's single orphan; the guard at the top of the pass skips
-            # passes (bounded by CITADEL_EVOLVE_ORPHAN_MAX_SKIPS) while it
-            # lives.
-            phase2_reason = "cognify_timeout"
-            orphan = phase2_task
-            orphan_started = time.monotonic()
-            logger.error(
-                "Evolve scheduler: cognify timed out after %.0fs; task %s "
-                "left running un-cancelled",
-                _evolve_cognify_timeout_seconds(),
-                phase2_task.get_name(),
-            )
-            _record_canary_verdict(ok=False, error="TimeoutError")
-        except Exception as exc:
-            phase2_reason = "cognify_exception"
-            logger.exception("Evolve scheduler: cognify failed")
-            # A crash in the cognify pass is precisely the failure #27's canary
-            # exists to surface. Recording only clean passes above would leave
-            # the previous verdict standing, so /readyz would read GREEN through
-            # the exact break it is meant to catch. Stamp it unhealthy.
-            _record_canary_verdict(ok=False, error=exc.__class__.__name__)
-        finally:
-            if not cancelled:
-                # Stamp the pass even when a stage failed. This records that the
-                # cycle RAN, which is what the next boot needs to resume the
-                # interval; whether the stages succeeded is already on the
-                # "Evolve finished" line and in /readyz. Recording only clean
-                # passes would make a node with one broken stage restart its
-                # clock forever, which is the bug this fixes (#153). A CANCELLED
-                # pass is the one exception: it did not run, so it must not
-                # stamp (see the CancelledError branch above).
-                cycle_ok = phase1_ok and phase2_ok
-                record_completed(
-                    state_path,
-                    ok=cycle_ok,
-                    reason=None
-                    if cycle_ok
-                    else (phase1_reason or phase2_reason or "scheduled_cycle_failed"),
-                )
-                # Drain whatever the pass deferred. Projection starts are
-                # suppressed while Phase 1 holds the writer lock, and Phase 2
-                # cognifies directly without touching the lifecycle queue, so
-                # without this kick a job accepted mid-pass waits for the next
-                # external ingest or the next pass. The lock is free and the
-                # suppression scope has ended by this point, and the call is a
-                # no-op when a drain is already running.
+                if consecutive_skips >= max_skips:
+                    logger.critical(
+                        "Evolve scheduler: maintenance stayed busy past the skip "
+                        "budget; flipping the canary unhealthy so /readyz "
+                        "escalates to an operator or healthcheck restart (#27)"
+                    )
+                    _record_canary_verdict(ok=False, error="MaintenanceWedged")
                 try:
                     _resume_lifecycle_queue(citadel, include_deferred=True)
                 except Exception:
-                    logger.exception("Evolve scheduler: post-pass projection resume failed")
+                    logger.exception(
+                        "Evolve scheduler: deferred-pass projection resume failed"
+                    )
+                continue
+            # Kick the projection drain NOW, before Phase 2: the pass paused the
+            # queue above, and a hung Phase 2 (observed live 2026-08-28: cognify
+            # emitted nothing for 25+ minutes) must never park a 12k-job rebuild
+            # behind it. include_deferred=False, and both halves of that matter:
+            # (i) the baseline relational/vector lanes take neither the
+            # maintenance nor the writer lock (kb/cognee_client.py vector_project
+            # is deliberately run_unlocked), so the drain this kick starts can
+            # never park behind Phase 2 — the 2026-08-28 incident closed; (ii)
+            # False does NOT stop an already-running graph-lane task from waking
+            # on the shared projection gate — that interleaving is handled by the
+            # Phase 2 budget (FIFO maintenance lock: at most one graph-lane job
+            # ahead) and the orphan guard, not by this flag. The graph lane is
+            # deliberately (re)started only by cognify_dataset's own
+            # post-graph-write resume (kb/service.py) and the post-pass kick in
+            # the finally below, which stays include_deferred=True.
+            try:
+                _resume_lifecycle_queue(citadel, include_deferred=False)
+            except Exception:
+                logger.exception("Evolve scheduler: post-stages projection resume failed")
+            # Phase 2 — cognify in-loop; the web process is the sole Kuzu writer now.
+            force = os.getenv("CITADEL_EVOLVE_COGNIFY_FORCE", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+            cancelled = False
+            phase2_ok = False
+            phase2_reason: str | None = None
+            # verify=True runs the end-to-end ingest+cognify+search canary and
+            # records its verdict for /readyz (#27). Bounded by wait_for, but the
+            # cognify itself is shielded: cognee's pipeline rollback fires on
+            # Exception only, so an in-process cancellation here would strand
+            # partial graph/vector/relational writes with the run row stuck
+            # DATASET_PROCESSING_STARTED (P1-B). On timeout the task is left
+            # running as this loop's single orphan and the guard at the top of the
+            # pass takes over.
+            phase2_task = asyncio.create_task(
+                citadel.cognify_dataset(force=force, verify=True),
+                name="evolve-phase2-cognify",
+            )
+            _BACKGROUND_TASKS.add(phase2_task)
+            phase2_task.add_done_callback(_forget_background_task)
+            try:
+                # asyncio.timeout, not wait_for: see _acquire_maintenance —
+                # 3.11's wait_for can swallow the teardown cancellation when
+                # the (fast) cognify completes in the same tick, leaving the
+                # loop alive past _stop_evolve_scheduler.
+                async with asyncio.timeout(_evolve_cognify_timeout_seconds()):
+                    result = await asyncio.shield(phase2_task)
+                verification = result.get("verification") or {}
+                _record_canary_verdict(
+                    ok=bool(result.get("ok")),
+                    search_hit=verification.get("search_hit"),
+                    graph_grew=result.get("graph_grew"),
+                    marker=verification.get("marker"),
+                    projection_chain_ok=verification.get("projection_chain_ok"),
+                    projection_receipt_count=len(verification.get("projection_receipts") or []),
+                )
+                projection_chain_ok = verification.get(
+                    "projection_chain_ok", verification.get("ok", True)
+                )
+                phase2_ok = bool(result.get("ok")) and projection_chain_ok is not False
+                if not phase2_ok:
+                    phase2_reason = "cognify_verification_failed"
+                logger.info(
+                    "Evolve scheduler: cognify finished (graph_after=%s grew=%s canary_ok=%s)",
+                    result.get("graph_after"),
+                    result.get("graph_grew"),
+                    _LAST_CANARY["ok"] if _LAST_CANARY is not None else None,
+                )
+            except asyncio.CancelledError:
+                # Teardown landing mid-Phase-2 (the canary can now wait minutes on
+                # its marker's projection, so this window is wide): the pass did
+                # NOT run to completion, so stamping it would make the next boot
+                # wait a full interval instead of re-running the interrupted pass,
+                # and kicking a drain task on a loop being torn down helps nobody.
+                # Teardown DOES cancel the inner task (unchanged semantics from
+                # before the shield): the process is going away either way, and
+                # the next boot repairs any stranded partial write via
+                # recover_stale_cognify_runs.
+                phase2_task.cancel()
+                cancelled = True
+                raise
+            except TimeoutError:
+                # The bound above fired: Phase 2 hung past its budget (observed
+                # live 2026-08-28). The drain already got its post-stages kick and
+                # the canary flips unhealthy; the stamp below lets the next
+                # interval run instead of waiting behind a dead cognify. The task
+                # is NOT cancelled: cancellation could land inside a cognee write
+                # path whose rollback never runs on CancelledError. It becomes the
+                # loop's single orphan; the guard at the top of the pass skips
+                # passes (bounded by CITADEL_EVOLVE_ORPHAN_MAX_SKIPS) while it
+                # lives.
+                phase2_reason = "cognify_timeout"
+                orphan = phase2_task
+                orphan_started = time.monotonic()
+                logger.error(
+                    "Evolve scheduler: cognify timed out after %.0fs; task %s "
+                    "left running un-cancelled",
+                    _evolve_cognify_timeout_seconds(),
+                    phase2_task.get_name(),
+                )
+                _record_canary_verdict(ok=False, error="TimeoutError")
+            except Exception as exc:
+                phase2_reason = "cognify_exception"
+                logger.exception("Evolve scheduler: cognify failed")
+                # A crash in the cognify pass is precisely the failure #27's canary
+                # exists to surface. Recording only clean passes above would leave
+                # the previous verdict standing, so /readyz would read GREEN through
+                # the exact break it is meant to catch. Stamp it unhealthy.
+                _record_canary_verdict(ok=False, error=exc.__class__.__name__)
+            finally:
+                if not cancelled:
+                    # Stamp the pass even when a stage failed. This records that the
+                    # cycle RAN, which is what the next boot needs to resume the
+                    # interval; whether the stages succeeded is already on the
+                    # "Evolve finished" line and in /readyz. Recording only clean
+                    # passes would make a node with one broken stage restart its
+                    # clock forever, which is the bug this fixes (#153). A CANCELLED
+                    # pass is the one exception: it did not run, so it must not
+                    # stamp (see the CancelledError branch above).
+                    cycle_ok = phase1_ok and phase2_ok
+                    record_completed(
+                        state_path,
+                        ok=cycle_ok,
+                        reason=None
+                        if cycle_ok
+                        else (phase1_reason or phase2_reason or "scheduled_cycle_failed"),
+                    )
+                    # Drain whatever the pass deferred. Projection starts are
+                    # suppressed while Phase 1 holds the writer lock, and Phase 2
+                    # cognifies directly without touching the lifecycle queue, so
+                    # without this kick a job accepted mid-pass waits for the next
+                    # external ingest or the next pass. The lock is free and the
+                    # suppression scope has ended by this point, and the call is a
+                    # no-op when a drain is already running.
+                    try:
+                        _resume_lifecycle_queue(citadel, include_deferred=True)
+                    except Exception:
+                        logger.exception("Evolve scheduler: post-pass projection resume failed")
+    finally:
+        # Reap the detached Phase 2 task on the way out. Lifespan awaits only
+        # this scheduler task (_stop_evolve_scheduler), so an in-flight or
+        # orphaned evolve-phase2-cognify left running here would keep writing
+        # (or unwind its cancellation) overlapping shutdown and a later
+        # lifespan. Cancelling an in-flight cognify at shutdown is acceptable
+        # BECAUSE boot-time recover_stale_cognify_runs (min-age guard
+        # neutralized) rolls back the partial run at the next start.
+        for leftover in {t for t in (phase2_task, orphan) if t is not None}:
+            if leftover.done():
+                if not leftover.cancelled():
+                    # Consume so a completed orphan never logs "exception was
+                    # never retrieved" after the loop is gone.
+                    leftover.exception()
+            else:
+                leftover.cancel()
+                try:
+                    # asyncio.timeout, not wait_for: 3.11's wait_for could
+                    # swallow a second teardown cancellation here (see
+                    # _acquire_maintenance).
+                    async with asyncio.timeout(10.0):
+                        await leftover
+                except (asyncio.CancelledError, TimeoutError):
+                    pass
+                except Exception:
+                    logger.exception(
+                        "Evolve scheduler: reaped Phase 2 task %s raised",
+                        leftover.get_name(),
+                    )
+            _BACKGROUND_TASKS.discard(leftover)
 
 
 def _start_evolve_scheduler() -> "asyncio.Task[Any] | None":

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5824,6 +5824,147 @@ async def test_recovery_is_a_no_op_on_a_clean_store(monkeypatch: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_recovery_fails_closed_when_a_newer_run_completed(
+    monkeypatch: Any,
+) -> None:
+    """Round-5 P1: dangling run A buried by a newer COMPLETED run B must NOT
+    be rolled back. Cognee 1.4.1 never gives a later re-touch of an existing
+    source ref its own run ownership, so A holds the SOLE ref and rolling A
+    back would delete graph/vector artifacts B still reuses (cognee's own
+    provenance contract,
+    cognee/tests/integration/tasks/test_graph_provenance_delete_default_stack.py:126-151).
+    Boot must abort naming A so an operator decides.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, run_b, pipe = uuid4(), uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        started = PipelineRunStatus.DATASET_PROCESSING_STARTED
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base,
+                ),
+                _run_event(
+                    run_a, dataset_id, pipe, started, base + timedelta(minutes=1)
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base + timedelta(minutes=10),
+                ),
+                _run_event(
+                    run_b, dataset_id, pipe, started, base + timedelta(minutes=11)
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+                    base + timedelta(minutes=12),
+                ),
+            ],
+        )
+
+        with pytest.raises(CogneeStartupRecoveryError) as excinfo:
+            await client.recover_stale_cognify_runs()
+
+        assert str(run_a) in str(excinfo.value), (
+            "the abort must name the run buried under the completed run"
+        )
+        assert calls["rollback"] == [], (
+            "rolling A back could delete source refs the completed run B "
+            "still reuses; recovery must not touch it"
+        )
+        a_events = await _run_events(sessions, run_a)
+        assert (
+            a_events[-1].status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+        ), "the run must stay dangling for the operator, not be stamped terminal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_rolls_back_two_dangling_runs_newest_first(
+    monkeypatch: Any,
+) -> None:
+    """Two dangling runs in one dataset (both latest-STARTED) are both safe to
+    recover, newest first: once the newer run B is rolled back its stream ends
+    ERRORED, so it no longer looks like a completed successor and the older
+    run A recovers behind it in the same loop. No abort.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, run_b, pipe = uuid4(), uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        started = PipelineRunStatus.DATASET_PROCESSING_STARTED
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base,
+                ),
+                _run_event(
+                    run_a, dataset_id, pipe, started, base + timedelta(minutes=1)
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base + timedelta(minutes=10),
+                ),
+                _run_event(
+                    run_b, dataset_id, pipe, started, base + timedelta(minutes=11)
+                ),
+            ],
+        )
+
+        assert await client.recover_stale_cognify_runs() == []
+
+        assert [rid for rid, _ in calls["rollback"]] == [run_b, run_a], (
+            "both dangling runs must be recovered, newest first, so the "
+            "newer one is already rolled back when the older one is checked"
+        )
+        for run_id in (run_a, run_b):
+            events = await _run_events(sessions, run_id)
+            assert (
+                events[-1].status == PipelineRunStatus.DATASET_PROCESSING_ERRORED
+            ), "each recovered run's own stream must end terminal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_stale_run_recovery_raises_when_a_dangling_run_survives_the_loop(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5965,6 +5965,108 @@ async def test_recovery_fails_closed_when_a_completed_run_ties_on_timestamp(
 
 
 @pytest.mark.asyncio
+async def test_recovery_fails_closed_on_a_same_run_started_completed_tie(
+    monkeypatch: Any,
+) -> None:
+    """Round-7 P1: ONE run carries a STARTED and a COMPLETED row at the SAME
+    created_at. sqlite breaks the created_at tie by insert order (the
+    first-inserted row wins rn==1), so with STARTED inserted first the run
+    ranks dangling even though it COMPLETED. A guard that re-runs the per-run
+    ranking drops the COMPLETED sibling behind its rn==1 filter and rolls
+    back a run that COMPLETED, deleting its artifacts. The guard must count
+    COMPLETED rows directly — no ranking — so the run's own COMPLETED
+    sibling blocks rollback and boot aborts naming the run.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, pipe = uuid4(), uuid4()
+        tie = datetime.now(UTC) - timedelta(hours=2)
+        started = PipelineRunStatus.DATASET_PROCESSING_STARTED
+        completed = PipelineRunStatus.DATASET_PROCESSING_COMPLETED
+        # Two sequential commits pin the insert order: STARTED first, so the
+        # tie ranking picks STARTED as the run's rn==1 row.
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(run_a, dataset_id, pipe, started, tie),
+            ],
+        )
+        await _seed(sessions, [_run_event(run_a, dataset_id, pipe, completed, tie)])
+
+        flagged = await client._stale_cognify_runs()
+        assert [r.pipeline_run_id for r in flagged] == [run_a], (
+            "precondition: the tie ranking must pick STARTED as the run's "
+            "latest row; otherwise this test exercises the benign branch"
+        )
+
+        with pytest.raises(CogneeStartupRecoveryError) as excinfo:
+            await client.recover_stale_cognify_runs()
+
+        assert str(run_a) in str(excinfo.value), "the abort must name the tied run"
+        assert calls["rollback"] == [], (
+            "the run COMPLETED; rolling it back would delete its artifacts"
+        )
+        a_events = await _run_events(sessions, run_a)
+        assert len(a_events) == 2 and not any(
+            e.status == PipelineRunStatus.DATASET_PROCESSING_ERRORED
+            for e in a_events
+        ), "recovery must not stamp the completed run terminal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_same_run_tie_with_completed_ranked_first_is_a_no_op(
+    monkeypatch: Any,
+) -> None:
+    """The benign order of the same tie: COMPLETED inserted first wins rn==1,
+    so the run's latest row is terminal and it is never flagged dangling —
+    no rollback, no abort.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, pipe = uuid4(), uuid4()
+        tie = datetime.now(UTC) - timedelta(hours=2)
+        started = PipelineRunStatus.DATASET_PROCESSING_STARTED
+        completed = PipelineRunStatus.DATASET_PROCESSING_COMPLETED
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(run_a, dataset_id, pipe, completed, tie),
+            ],
+        )
+        await _seed(sessions, [_run_event(run_a, dataset_id, pipe, started, tie)])
+
+        assert await client._stale_cognify_runs() == [], (
+            "precondition: the tie ranking must pick COMPLETED as the run's "
+            "latest row, so the run is never flagged"
+        )
+
+        assert await client.recover_stale_cognify_runs() == []
+        assert calls["rollback"] == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_recovery_rolls_back_two_dangling_runs_newest_first(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5445,27 +5445,18 @@ async def test_cognify_violations_fail_even_when_missing_ids_are_in_flight(
     assert "still in lifecycle projection" in message
 
 
-@pytest.mark.asyncio
-async def test_stale_run_recovery_neutralizes_the_age_guard(
-    monkeypatch: Any,
-) -> None:
-    """Boot recovery must roll back the run the PREVIOUS process cancelled at
-    teardown even on an immediate restart: cognee's STALE_RUN_MIN_AGE_SECONDS
-    (env read at import time, default 3600) would otherwise skip the young
-    run, and the next cognify would bury it as no-longer-latest forever. The
-    gateway is the sole writer at that point, so age 0 is safe; the constant
-    must be restored after the call.
+def _stub_cognee_recovery_modules(
+    monkeypatch: Any, fake_recover: Any
+) -> Any:
+    """Install a stub cognee package whose startup recovery is ``fake_recover``.
+
+    Returns the stub recovery module so tests can read its
+    STALE_RUN_MIN_AGE_SECONDS constant.
     """
     import types
 
-    seen_ages: list[int] = []
-
     recovery_mod = types.ModuleType("cognee.modules.cognify.recovery")
     recovery_mod.STALE_RUN_MIN_AGE_SECONDS = 3600  # type: ignore[attr-defined]
-
-    async def fake_recover() -> None:
-        seen_ages.append(recovery_mod.STALE_RUN_MIN_AGE_SECONDS)  # type: ignore[attr-defined]
-
     recovery_mod.recover_stale_cognify_runs_on_startup = fake_recover  # type: ignore[attr-defined]
     cognify_mod = types.ModuleType("cognee.modules.cognify")
     cognify_mod.recovery = recovery_mod  # type: ignore[attr-defined]
@@ -5479,7 +5470,11 @@ async def test_stale_run_recovery_neutralizes_the_age_guard(
     monkeypatch.setitem(
         sys.modules, "cognee.modules.cognify.recovery", recovery_mod
     )
+    return recovery_mod
 
+
+def _recovery_client(monkeypatch: Any) -> CogneePublicClient:
+    """A client whose environment/readiness plumbing is neutralized."""
     client = CogneePublicClient()
     monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
 
@@ -5487,9 +5482,36 @@ async def test_stale_run_recovery_neutralizes_the_age_guard(
         return None
 
     monkeypatch.setattr(client, "_ensure_cognee_ready", ensure_ready)
+    return client
 
-    await client.recover_stale_cognify_runs()
 
+@pytest.mark.asyncio
+async def test_stale_run_recovery_neutralizes_the_age_guard(
+    monkeypatch: Any,
+) -> None:
+    """Boot recovery must roll back the run the PREVIOUS process cancelled at
+    teardown even on an immediate restart: cognee's STALE_RUN_MIN_AGE_SECONDS
+    (env read at import time, default 3600) would otherwise skip the young
+    run, and the next cognify would bury it as no-longer-latest forever. The
+    gateway is the sole writer at that point, so age 0 is safe; the constant
+    must be restored after the call.
+    """
+    seen_ages: list[int] = []
+
+    async def fake_recover() -> None:
+        seen_ages.append(recovery_mod.STALE_RUN_MIN_AGE_SECONDS)  # type: ignore[attr-defined]
+
+    recovery_mod = _stub_cognee_recovery_modules(monkeypatch, fake_recover)
+    client = _recovery_client(monkeypatch)
+
+    async def clean_probe() -> list[Any]:
+        return []
+
+    monkeypatch.setattr(client, "_stale_cognify_latest_runs", clean_probe)
+
+    still_stale = await client.recover_stale_cognify_runs()
+
+    assert still_stale == [], "a verified-clean recovery must report no leftovers"
     assert seen_ages == [0], (
         "recovery must run with the min-age guard neutralized so the run the "
         "previous process abandoned seconds ago is rolled back"
@@ -5497,3 +5519,66 @@ async def test_stale_run_recovery_neutralizes_the_age_guard(
     assert recovery_mod.STALE_RUN_MIN_AGE_SECONDS == 3600, (  # type: ignore[attr-defined]
         "the module constant must be restored after the call"
     )
+
+
+@pytest.mark.asyncio
+async def test_stale_run_recovery_raises_when_a_started_latest_run_remains(
+    monkeypatch: Any,
+) -> None:
+    """cognee 1.4.1's recover_stale_cognify_runs_on_startup swallows every
+    failure: a candidate-query error logs and returns, and a per-run rollback
+    error logs and skips reset_pipeline_run_status, leaving that run the
+    dataset's LATEST row, still DATASET_PROCESSING_STARTED. Its return value
+    therefore proves nothing. Recovery must re-run the same
+    latest-run-per-dataset probe AFTER the call and raise on any remaining
+    STARTED latest row, so boot can refuse to bury the partial write under
+    the next cognify.
+    """
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    order: list[str] = []
+
+    async def fake_recover() -> None:
+        order.append("recover")
+
+    _stub_cognee_recovery_modules(monkeypatch, fake_recover)
+    client = _recovery_client(monkeypatch)
+
+    async def poisoned_probe() -> list[Any]:
+        order.append("verify")
+        return [SimpleNamespace(dataset_id="dead-beef-dataset")]
+
+    monkeypatch.setattr(client, "_stale_cognify_latest_runs", poisoned_probe)
+
+    with pytest.raises(CogneeStartupRecoveryError) as excinfo:
+        await client.recover_stale_cognify_runs()
+
+    assert order == ["recover", "verify"], (
+        "verification must run after the recovery call, not instead of it"
+    )
+    assert "dead-beef-dataset" in str(excinfo.value), (
+        "the error must name the unrecovered dataset(s)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_run_recovery_verification_error_propagates(
+    monkeypatch: Any,
+) -> None:
+    """A verification probe that cannot run is a failure, not a pass. cognee
+    swallowing exactly this class of error is why the probe exists; swallowing
+    it again here would recreate the blind spot.
+    """
+    async def fake_recover() -> None:
+        return None
+
+    _stub_cognee_recovery_modules(monkeypatch, fake_recover)
+    client = _recovery_client(monkeypatch)
+
+    async def broken_probe() -> list[Any]:
+        raise RuntimeError("relational engine gone")
+
+    monkeypatch.setattr(client, "_stale_cognify_latest_runs", broken_probe)
+
+    with pytest.raises(RuntimeError, match="relational engine gone"):
+        await client.recover_stale_cognify_runs()

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5445,32 +5445,15 @@ async def test_cognify_violations_fail_even_when_missing_ids_are_in_flight(
     assert "still in lifecycle projection" in message
 
 
-def _stub_cognee_recovery_modules(
-    monkeypatch: Any, fake_recover: Any
-) -> Any:
-    """Install a stub cognee package whose startup recovery is ``fake_recover``.
-
-    Returns the stub recovery module so tests can read its
-    STALE_RUN_MIN_AGE_SECONDS constant.
-    """
-    import types
-
-    recovery_mod = types.ModuleType("cognee.modules.cognify.recovery")
-    recovery_mod.STALE_RUN_MIN_AGE_SECONDS = 3600  # type: ignore[attr-defined]
-    recovery_mod.recover_stale_cognify_runs_on_startup = fake_recover  # type: ignore[attr-defined]
-    cognify_mod = types.ModuleType("cognee.modules.cognify")
-    cognify_mod.recovery = recovery_mod  # type: ignore[attr-defined]
-    modules_mod = types.ModuleType("cognee.modules")
-    modules_mod.cognify = cognify_mod  # type: ignore[attr-defined]
-    cognee_mod = types.ModuleType("cognee")
-    cognee_mod.modules = modules_mod  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "cognee", cognee_mod)
-    monkeypatch.setitem(sys.modules, "cognee.modules", modules_mod)
-    monkeypatch.setitem(sys.modules, "cognee.modules.cognify", cognify_mod)
-    monkeypatch.setitem(
-        sys.modules, "cognee.modules.cognify.recovery", recovery_mod
-    )
-    return recovery_mod
+# ---------------------------------------------------------------------------
+# Startup recovery of dangling cognify runs.
+#
+# These tests run cognee's REAL PipelineRun/Dataset models and the client's
+# REAL SQL against an in-memory aiosqlite engine — the round-4 review showed
+# every earlier probe test mocked the query, so nothing pinned its ranking.
+# Only the destructive boundary (cognify_rollback_handler, the dataset
+# context manager) is stubbed.
+# ---------------------------------------------------------------------------
 
 
 def _recovery_client(monkeypatch: Any) -> CogneePublicClient:
@@ -5485,100 +5468,410 @@ def _recovery_client(monkeypatch: Any) -> CogneePublicClient:
     return client
 
 
-@pytest.mark.asyncio
-async def test_stale_run_recovery_neutralizes_the_age_guard(
-    monkeypatch: Any,
-) -> None:
-    """Boot recovery must roll back the run the PREVIOUS process cancelled at
-    teardown even on an immediate restart: cognee's STALE_RUN_MIN_AGE_SECONDS
-    (env read at import time, default 3600) would otherwise skip the young
-    run, and the next cognify would bury it as no-longer-latest forever. The
-    gateway is the sole writer at that point, so age 0 is safe; the constant
-    must be restored after the call.
+async def _pipeline_runs_store(monkeypatch: Any) -> tuple[Any, Any]:
+    """In-memory sqlite carrying cognee's real pipeline_runs/datasets schema.
+
+    Wires the engine into every ``get_relational_engine`` the recovery path
+    consults: the client's call-time imports resolve through the relational
+    module, while cognee's own log_pipeline_run_error/_initiated helpers
+    bound the symbol at import time, so each module is patched directly.
     """
-    seen_ages: list[int] = []
+    import contextlib
 
-    async def fake_recover() -> None:
-        seen_ages.append(recovery_mod.STALE_RUN_MIN_AGE_SECONDS)  # type: ignore[attr-defined]
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-    recovery_mod = _stub_cognee_recovery_modules(monkeypatch, fake_recover)
-    client = _recovery_client(monkeypatch)
+    import importlib
 
-    async def clean_probe() -> list[Any]:
-        return []
+    import cognee.infrastructure.databases.relational as relational_mod
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRun
 
-    monkeypatch.setattr(client, "_stale_cognify_latest_runs", clean_probe)
-
-    still_stale = await client.recover_stale_cognify_runs()
-
-    assert still_stale == [], "a verified-clean recovery must report no leftovers"
-    assert seen_ages == [0], (
-        "recovery must run with the min-age guard neutralized so the run the "
-        "previous process abandoned seconds ago is rolled back"
+    # The operations package __init__ rebinds these submodule names to the
+    # functions they export, so a plain `import a.b.c as m` yields the
+    # FUNCTION; import_module returns the real module to patch.
+    log_error_mod = importlib.import_module(
+        "cognee.modules.pipelines.operations.log_pipeline_run_error"
     )
-    assert recovery_mod.STALE_RUN_MIN_AGE_SECONDS == 3600, (  # type: ignore[attr-defined]
-        "the module constant must be restored after the call"
+    log_init_mod = importlib.import_module(
+        "cognee.modules.pipelines.operations.log_pipeline_run_initiated"
     )
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda sync: PipelineRun.__table__.create(sync))
+        await conn.run_sync(lambda sync: Dataset.__table__.create(sync))
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    class _Engine:
+        @contextlib.asynccontextmanager
+        async def get_async_session(self):
+            async with sessions() as session:
+                yield session
+
+    wrapper = _Engine()
+    for module in (relational_mod, log_error_mod, log_init_mod):
+        monkeypatch.setattr(module, "get_relational_engine", lambda: wrapper)
+    return sessions, engine
+
+
+def _stub_rollback_boundary(monkeypatch: Any) -> dict[str, list[Any]]:
+    """Record rollback/context calls without touching graph or vector stores."""
+    import contextlib
+
+    import cognee.context_global_variables as context_vars_mod
+    import cognee.modules.cognify.rollback as rollback_mod
+
+    calls: dict[str, list[Any]] = {"rollback": [], "context": []}
+
+    async def fake_rollback(*, pipeline_run_id: Any, dataset: Any, **_: Any) -> None:
+        calls["rollback"].append((pipeline_run_id, dataset.id))
+
+    @contextlib.asynccontextmanager
+    async def fake_context(dataset_id: Any, owner_id: Any):
+        calls["context"].append((dataset_id, owner_id))
+        yield
+
+    monkeypatch.setattr(rollback_mod, "cognify_rollback_handler", fake_rollback)
+    monkeypatch.setattr(
+        context_vars_mod, "set_database_global_context_variables", fake_context
+    )
+    return calls
+
+
+def _run_event(
+    run_id: UUID, dataset_id: UUID, pipeline_id: UUID, status: Any, at: datetime
+) -> Any:
+    from cognee.modules.pipelines.models import PipelineRun
+
+    return PipelineRun(
+        pipeline_run_id=run_id,
+        pipeline_name="cognify_pipeline",
+        pipeline_id=pipeline_id,
+        dataset_id=dataset_id,
+        status=status,
+        run_info={},
+        created_at=at,
+    )
+
+
+async def _seed(sessions: Any, rows: list[Any]) -> None:
+    async with sessions() as session:
+        session.add_all(rows)
+        await session.commit()
+
+
+async def _run_events(sessions: Any, run_id: UUID) -> list[Any]:
+    from sqlalchemy import select
+
+    from cognee.modules.pipelines.models import PipelineRun
+
+    async with sessions() as session:
+        result = await session.execute(
+            select(PipelineRun)
+            .where(PipelineRun.pipeline_run_id == run_id)
+            .order_by(PipelineRun.created_at.asc())
+        )
+        return list(result.scalars().all())
 
 
 @pytest.mark.asyncio
-async def test_stale_run_recovery_raises_when_a_started_latest_run_remains(
+async def test_recovery_rolls_back_dangling_run_hidden_behind_newer_errored_run(
     monkeypatch: Any,
 ) -> None:
-    """cognee 1.4.1's recover_stale_cognify_runs_on_startup swallows every
-    failure: a candidate-query error logs and returns, and a per-run rollback
-    error logs and skips reset_pipeline_run_status, leaving that run the
-    dataset's LATEST row, still DATASET_PROCESSING_STARTED. Its return value
-    therefore proves nothing. Recovery must re-run the same
-    latest-run-per-dataset probe AFTER the call and raise on any remaining
-    STARTED latest row, so boot can refuse to bury the partial write under
-    the next cognify.
+    """Round-4 P1 against the real schema: with use_pipeline_cache=False run A
+    can be abandoned STARTED and buried by run B that ends ERRORED in the same
+    dataset. Any per-dataset ranking — cognee's own recovery candidate query
+    included — sees only B, filters it out, and reports clean while A's
+    partial writes rot. Recovery must find A per-run, roll back exactly A
+    (never B, whose inline rollback already ran at error time), close A's own
+    event stream with a terminal ERRORED row, and reset the dataset's
+    pipeline status.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+    from sqlalchemy import select
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, run_b, pipe = uuid4(), uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        started = PipelineRunStatus.DATASET_PROCESSING_STARTED
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base,
+                ),
+                _run_event(
+                    run_a, dataset_id, pipe, started, base + timedelta(minutes=1)
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base + timedelta(minutes=10),
+                ),
+                _run_event(
+                    run_b, dataset_id, pipe, started, base + timedelta(minutes=11)
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_ERRORED,
+                    base + timedelta(minutes=12),
+                ),
+            ],
+        )
+
+        assert await client.recover_stale_cognify_runs() == []
+
+        assert [rid for rid, _ in calls["rollback"]] == [run_a], (
+            "exactly the hidden dangling run must be rolled back; run B was "
+            "already rolled back inline when it errored"
+        )
+        assert calls["context"] == [(dataset_id, owner_id)], (
+            "rollback must run inside the dataset's ownership context"
+        )
+        a_events = await _run_events(sessions, run_a)
+        assert (
+            a_events[-1].status == PipelineRunStatus.DATASET_PROCESSING_ERRORED
+        ), "A's own event stream must end terminal, under the SAME run id"
+        async with sessions() as session:
+            initiated_rows = (
+                (
+                    await session.execute(
+                        select(PipelineRun).where(
+                            PipelineRun.status
+                            == PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                            PipelineRun.pipeline_run_id.notin_([run_a, run_b]),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(initiated_rows) == 1, (
+            "reset_pipeline_run_status must log a fresh INITIATED run so the "
+            "dataset is not reported as already being processed"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_of_a_run_does_not_reflag_it_on_the_next_boot(
+    monkeypatch: Any,
+) -> None:
+    """False-positive regression: cognee's reset logs INITIATED under a FRESH
+    uuid4 run id and never closes the recovered run's own stream, so a naive
+    per-run probe would flag every successfully recovered run forever and
+    wedge boot permanently. After boot 1 recovers A, boot 2 must be a clean
+    no-op: A's stream now ends terminal, nothing is rolled back again.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, pipe = uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_INITIATED,
+                    base,
+                ),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_STARTED,
+                    base + timedelta(minutes=1),
+                ),
+            ],
+        )
+
+        assert await client.recover_stale_cognify_runs() == []
+        assert len(calls["rollback"]) == 1
+
+        assert await client.recover_stale_cognify_runs() == [], (
+            "boot 2 must not flag the run boot 1 recovered"
+        )
+        assert len(calls["rollback"]) == 1, (
+            "boot 2 must not roll the already-recovered run back again"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_fails_closed_when_a_dangling_runs_dataset_is_missing(
+    monkeypatch: Any,
+) -> None:
+    """A dangling run whose Dataset row is GONE cannot be rolled back (the
+    rollback needs the dataset's id and owner_id) and must NOT be stamped
+    terminal — that would hide unknown partial writes behind a clean probe.
+    Boot must abort naming the run so an operator inspects it.
+    """
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        run_a, pipe = uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        await _seed(
+            sessions,
+            [
+                _run_event(
+                    run_a,
+                    uuid4(),
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_STARTED,
+                    base,
+                ),
+            ],
+        )
+
+        with pytest.raises(CogneeStartupRecoveryError) as excinfo:
+            await client.recover_stale_cognify_runs()
+
+        assert str(run_a) in str(excinfo.value), (
+            "the abort must name the uninspectable run"
+        )
+        assert calls["rollback"] == [], (
+            "no rollback without the dataset's ownership context"
+        )
+        a_events = await _run_events(sessions, run_a)
+        assert (
+            a_events[-1].status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+        ), "the run must stay dangling, not be stamped terminal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_a_no_op_on_a_clean_store(monkeypatch: Any) -> None:
+    """Every run stream ending terminal means nothing to recover: no rollback
+    calls, no new status rows, empty result.
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+    from sqlalchemy import func, select
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_c, pipe = uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_c,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_STARTED,
+                    base,
+                ),
+                _run_event(
+                    run_c,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+                    base + timedelta(minutes=5),
+                ),
+            ],
+        )
+
+        assert await client.recover_stale_cognify_runs() == []
+        assert calls["rollback"] == []
+        async with sessions() as session:
+            row_count = (
+                await session.execute(select(func.count(PipelineRun.id)))
+            ).scalar()
+        assert row_count == 2, "a clean store must not gain status rows"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stale_run_recovery_raises_when_a_dangling_run_survives_the_loop(
+    monkeypatch: Any,
+) -> None:
+    """The post-loop probe is a backstop: if a run is still dangling after the
+    recovery loop ran, boot must abort naming it rather than start writers on
+    top of an unrecovered partial run.
     """
     from kb.cognee_client import CogneeStartupRecoveryError
 
     order: list[str] = []
-
-    async def fake_recover() -> None:
-        order.append("recover")
-
-    _stub_cognee_recovery_modules(monkeypatch, fake_recover)
     client = _recovery_client(monkeypatch)
+    dangling = SimpleNamespace(
+        pipeline_run_id="dead-beef-run", dataset_id="dead-beef-dataset"
+    )
 
-    async def poisoned_probe() -> list[Any]:
-        order.append("verify")
-        return [SimpleNamespace(dataset_id="dead-beef-dataset")]
+    async def probe() -> list[Any]:
+        order.append("probe")
+        return [dangling]
 
-    monkeypatch.setattr(client, "_stale_cognify_latest_runs", poisoned_probe)
+    async def recover_one(run: Any) -> bool:
+        order.append("recover")
+        return True
+
+    monkeypatch.setattr(client, "_stale_cognify_runs", probe)
+    monkeypatch.setattr(client, "_recover_dangling_cognify_run", recover_one)
 
     with pytest.raises(CogneeStartupRecoveryError) as excinfo:
         await client.recover_stale_cognify_runs()
 
-    assert order == ["recover", "verify"], (
-        "verification must run after the recovery call, not instead of it"
+    assert order == ["probe", "recover", "probe"], (
+        "verification must re-run the probe after the recovery loop"
     )
-    assert "dead-beef-dataset" in str(excinfo.value), (
-        "the error must name the unrecovered dataset(s)"
-    )
+    assert "dead-beef-run" in str(excinfo.value)
+    assert "dead-beef-dataset" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
-async def test_stale_run_recovery_verification_error_propagates(
-    monkeypatch: Any,
-) -> None:
-    """A verification probe that cannot run is a failure, not a pass. cognee
-    swallowing exactly this class of error is why the probe exists; swallowing
+async def test_stale_run_recovery_probe_error_propagates(monkeypatch: Any) -> None:
+    """A probe that cannot run is a failure, not a pass. cognee's own recovery
+    swallowing exactly this class of error is why this path exists; swallowing
     it again here would recreate the blind spot.
     """
-    async def fake_recover() -> None:
-        return None
-
-    _stub_cognee_recovery_modules(monkeypatch, fake_recover)
     client = _recovery_client(monkeypatch)
 
     async def broken_probe() -> list[Any]:
         raise RuntimeError("relational engine gone")
 
-    monkeypatch.setattr(client, "_stale_cognify_latest_runs", broken_probe)
+    monkeypatch.setattr(client, "_stale_cognify_runs", broken_probe)
 
     with pytest.raises(RuntimeError, match="relational engine gone"):
         await client.recover_stale_cognify_runs()

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5443,3 +5443,57 @@ async def test_cognify_violations_fail_even_when_missing_ids_are_in_flight(
     message = str(excinfo.value)
     assert "doc-oversized" in message
     assert "still in lifecycle projection" in message
+
+
+@pytest.mark.asyncio
+async def test_stale_run_recovery_neutralizes_the_age_guard(
+    monkeypatch: Any,
+) -> None:
+    """Boot recovery must roll back the run the PREVIOUS process cancelled at
+    teardown even on an immediate restart: cognee's STALE_RUN_MIN_AGE_SECONDS
+    (env read at import time, default 3600) would otherwise skip the young
+    run, and the next cognify would bury it as no-longer-latest forever. The
+    gateway is the sole writer at that point, so age 0 is safe; the constant
+    must be restored after the call.
+    """
+    import types
+
+    seen_ages: list[int] = []
+
+    recovery_mod = types.ModuleType("cognee.modules.cognify.recovery")
+    recovery_mod.STALE_RUN_MIN_AGE_SECONDS = 3600  # type: ignore[attr-defined]
+
+    async def fake_recover() -> None:
+        seen_ages.append(recovery_mod.STALE_RUN_MIN_AGE_SECONDS)  # type: ignore[attr-defined]
+
+    recovery_mod.recover_stale_cognify_runs_on_startup = fake_recover  # type: ignore[attr-defined]
+    cognify_mod = types.ModuleType("cognee.modules.cognify")
+    cognify_mod.recovery = recovery_mod  # type: ignore[attr-defined]
+    modules_mod = types.ModuleType("cognee.modules")
+    modules_mod.cognify = cognify_mod  # type: ignore[attr-defined]
+    cognee_mod = types.ModuleType("cognee")
+    cognee_mod.modules = modules_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cognee", cognee_mod)
+    monkeypatch.setitem(sys.modules, "cognee.modules", modules_mod)
+    monkeypatch.setitem(sys.modules, "cognee.modules.cognify", cognify_mod)
+    monkeypatch.setitem(
+        sys.modules, "cognee.modules.cognify.recovery", recovery_mod
+    )
+
+    client = CogneePublicClient()
+    monkeypatch.setattr(client, "_prepare_cognee_environment", lambda: None)
+
+    async def ensure_ready(_cognee: Any) -> None:
+        return None
+
+    monkeypatch.setattr(client, "_ensure_cognee_ready", ensure_ready)
+
+    await client.recover_stale_cognify_runs()
+
+    assert seen_ages == [0], (
+        "recovery must run with the min-age guard neutralized so the run the "
+        "previous process abandoned seconds ago is rolled back"
+    )
+    assert recovery_mod.STALE_RUN_MIN_AGE_SECONDS == 3600, (  # type: ignore[attr-defined]
+        "the module constant must be restored after the call"
+    )

--- a/tests/test_cognee_client.py
+++ b/tests/test_cognee_client.py
@@ -5902,6 +5902,69 @@ async def test_recovery_fails_closed_when_a_newer_run_completed(
 
 
 @pytest.mark.asyncio
+async def test_recovery_fails_closed_when_a_completed_run_ties_on_timestamp(
+    monkeypatch: Any,
+) -> None:
+    """Round-6 P1: a COMPLETED run whose latest row shares the exact
+    created_at of the dangling run's STARTED row must still block rollback.
+    Equal timestamps cannot prove ordering, so equality is unsafe; the guard
+    uses >= (the dangling run itself never matches: its ranked row is
+    STARTED, not COMPLETED).
+    """
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.pipelines.models import PipelineRunStatus
+
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    sessions, engine = await _pipeline_runs_store(monkeypatch)
+    try:
+        calls = _stub_rollback_boundary(monkeypatch)
+        client = _recovery_client(monkeypatch)
+
+        dataset_id, owner_id = uuid4(), uuid4()
+        run_a, run_b, pipe = uuid4(), uuid4(), uuid4()
+        base = datetime.now(UTC) - timedelta(hours=2)
+        tie = base + timedelta(minutes=5)
+        await _seed(
+            sessions,
+            [
+                Dataset(id=dataset_id, name="notes", owner_id=owner_id),
+                _run_event(
+                    run_a,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_STARTED,
+                    tie,
+                ),
+                _run_event(
+                    run_b,
+                    dataset_id,
+                    pipe,
+                    PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+                    tie,
+                ),
+            ],
+        )
+
+        with pytest.raises(CogneeStartupRecoveryError) as excinfo:
+            await client.recover_stale_cognify_runs()
+
+        assert str(run_a) in str(excinfo.value), (
+            "the abort must name the run tied with the completed run"
+        )
+        assert calls["rollback"] == [], (
+            "an equal-timestamp completed sibling cannot prove ordering; "
+            "recovery must not roll the dangling run back"
+        )
+        a_events = await _run_events(sessions, run_a)
+        assert (
+            a_events[-1].status == PipelineRunStatus.DATASET_PROCESSING_STARTED
+        ), "the run must stay dangling for the operator, not be stamped terminal"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_recovery_rolls_back_two_dangling_runs_newest_first(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -108,11 +108,13 @@ class _FakeCitadel:
         self.resume_calls: list[bool] = []
         self.cognee = _FakeCognee()
 
-    def resume_lifecycle_queue(self) -> bool:
+    def resume_lifecycle_queue(self, *, include_deferred: bool = False) -> bool:
         # The scheduler kicks the projection drain after every pass, because
         # starts are suppressed while Phase 1 holds the writer lock and Phase 2
-        # never drains the lifecycle queue itself.
-        self.resume_calls.append(True)
+        # never drains the lifecycle queue itself. Recording the kwarg pins the
+        # split: the pre-Phase-2 kick is vector-only (False), the post-pass
+        # kick includes the deferred graph lane (True).
+        self.resume_calls.append(include_deferred)
         return True
 
     async def cognify_dataset(self, *, force: bool = False, verify: bool = False) -> dict[str, Any]:
@@ -136,12 +138,16 @@ class _BlockingCognifyCitadel(_FakeCitadel):
     def __init__(self, cognify_calls: list[bool]) -> None:
         super().__init__(cognify_calls)
         self.cognify_started = asyncio.Event()
+        self.cognify_tasks: list[asyncio.Task[Any]] = []
 
     async def cognify_dataset(
         self, *, force: bool = False, verify: bool = False
     ) -> dict[str, Any]:
         self._cognify_calls.append(force)
         assert verify is True
+        task = asyncio.current_task()
+        if task is not None:
+            self.cognify_tasks.append(task)
         self.cognify_started.set()
         await asyncio.Event().wait()
         return {}
@@ -267,9 +273,11 @@ async def test_drain_resume_fires_before_phase2(
     try:
         await asyncio.wait_for(fake_citadel.cognify_started.wait(), timeout=3)
         # Phase 2 is blocked right now and will never return; the drain must
-        # already have been kicked.
-        assert fake_citadel.resume_calls, (
-            "resume_lifecycle_queue must fire after Phase 1, before Phase 2"
+        # already have been kicked, and vector-only: the pre-Phase-2 kick must
+        # not (re)start the graph lane behind a possibly hung Phase 2.
+        assert fake_citadel.resume_calls == [False], (
+            "resume_lifecycle_queue must fire after Phase 1, before Phase 2, "
+            "with include_deferred=False"
         )
     finally:
         task.cancel()
@@ -288,7 +296,11 @@ async def test_hung_phase2_is_bounded_and_still_stamps(
 
     import kb.server as server
 
-    monkeypatch.setenv("CITADEL_EVOLVE_COGNIFY_TIMEOUT_SECONDS", "0.05")
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    # Keep the orphan-skip budget out of the way: this test pins the timeout
+    # verdict, not the wedge escalation, and the 1ms interval would reach the
+    # default budget before the assertions run.
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
     _patch_phase1(monkeypatch)
     cognify_calls: list[bool] = []
     fake_citadel = _BlockingCognifyCitadel(cognify_calls)
@@ -315,6 +327,7 @@ async def test_hung_phase2_is_bounded_and_still_stamps(
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+        await _cancel_phase2_orphans()
 
 
 class _RaisingCitadel:
@@ -530,3 +543,497 @@ async def test_a_dying_scheduler_task_is_logged(monkeypatch: Any, caplog: Any) -
     died = [r for r in caplog.records if "died" in r.message]
     assert died, "a scheduler task that raised must be logged at ERROR"
     assert "evolve-scheduler" in died[0].getMessage()
+
+
+async def _cancel_phase2_orphans() -> None:
+    """Test cleanup only: reap deliberately un-cancelled Phase 2 orphans."""
+    for orphan in asyncio.all_tasks():
+        if orphan.get_name() == "evolve-phase2-cognify" and not orphan.done():
+            orphan.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await orphan
+
+
+class _CountingMaintenance:
+    def __init__(self, owner: "_CountingCognee") -> None:
+        self._owner = owner
+
+    async def __aenter__(self) -> None:
+        self._owner.entries += 1
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _CountingCognee:
+    def __init__(self) -> None:
+        self.entries = 0
+
+    def maintenance(self) -> _CountingMaintenance:
+        return _CountingMaintenance(self)
+
+
+class _LockCognee:
+    """Real asyncio.Lock-backed maintenance, mirroring the gateway's."""
+
+    def __init__(self) -> None:
+        self.maintenance_lock = asyncio.Lock()
+        self.entries = 0
+
+    @contextlib.asynccontextmanager
+    async def maintenance(self) -> Any:
+        async with self.maintenance_lock:
+            self.entries += 1
+            yield
+
+
+def _record_stamps(monkeypatch: Any) -> list[dict[str, Any]]:
+    """Count record_completed calls; the loop imports it by name at start."""
+    import kb.evolve_state as evolve_state
+
+    real = evolve_state.record_completed
+    stamps: list[dict[str, Any]] = []
+
+    def recording(path: Any, **kwargs: Any) -> None:
+        stamps.append(dict(kwargs))
+        real(path, **kwargs)
+
+    monkeypatch.setattr(evolve_state, "record_completed", recording)
+    return stamps
+
+
+async def test_pre_phase2_resume_is_vector_only(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The kick between Phase 1 and Phase 2 must be include_deferred=False
+    (baseline lanes take no maintenance/writer lock, so the drain can never
+    park behind Phase 2); the post-pass finally kick stays True so deferred
+    graph work still drains after a healthy pass.
+    """
+    import kb.server as server
+
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _FakeCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+    )
+    try:
+        for _ in range(300):
+            if len(fake_citadel.resume_calls) >= 2:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert len(fake_citadel.resume_calls) >= 2
+    assert fake_citadel.resume_calls[0] is False, "pre-Phase-2 kick must be vector-only"
+    assert fake_citadel.resume_calls[1] is True, "post-pass kick must include deferred"
+
+
+async def test_phase2_timeout_leaves_cognify_uncancelled(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """P1-B: no cancellation may reach a cognee write path in-process. A timed
+    out Phase 2 stamps cognify_timeout and flips the canary, but the inner
+    cognify task is left running un-cancelled (shield, not cancel).
+    """
+    import json as json_module
+
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if state_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert state_path.exists(), "the timed-out pass must still stamp"
+        state = json_module.loads(state_path.read_text())
+        assert state["last_run_reason"] == "cognify_timeout"
+        assert server._LAST_CANARY is not None
+        assert server._LAST_CANARY["ok"] is False
+        assert server._LAST_CANARY.get("error") == "TimeoutError"
+        assert fake_citadel.cognify_tasks, "cognify was never attempted"
+        first = fake_citadel.cognify_tasks[0]
+        assert first.get_name() == "evolve-phase2-cognify"
+        assert not first.cancelled(), (
+            "the timed-out cognify must NOT be cancelled (P1-B)"
+        )
+        assert not first.done(), (
+            "the hung cognify must be left running un-cancelled"
+        )
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        await _cancel_phase2_orphans()
+
+
+async def test_orphaned_phase2_skips_next_pass_without_pausing(
+    monkeypatch: Any, caplog: Any, tmp_path: Path
+) -> None:
+    """While a Phase 2 orphan lives, later passes are SKIPPED: no second
+    pause (a skip can never re-park the drain), no maintenance entry, no
+    second stamp, and the skip is loud.
+    """
+    import logging
+
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
+    _patch_phase1(monkeypatch)
+    stamps = _record_stamps(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    fake_citadel.cognee = _CountingCognee()
+    fake_citadel.pause_calls = 0
+
+    def _pause() -> None:
+        fake_citadel.pause_calls += 1
+
+    fake_citadel.pause_lifecycle_queue = _pause
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    with caplog.at_level(logging.ERROR, logger=server.logger.name):
+        task = asyncio.create_task(
+            server._evolve_scheduler_loop(0.001, str(state_path))
+        )
+        try:
+            for _ in range(300):
+                if any("pass skipped" in r.message for r in caplog.records):
+                    break
+                await asyncio.sleep(0.01)
+            # Let a few more intervals elapse: every one must keep skipping.
+            await asyncio.sleep(0.05)
+            skips = [r for r in caplog.records if "pass skipped" in r.message]
+            assert skips, "a skipped pass must be logged at ERROR"
+            assert fake_citadel.pause_calls == 1, (
+                "a skipped pass must not pause the queue again"
+            )
+            assert fake_citadel.cognee.entries == 1, (
+                "a skipped pass must not enter maintenance"
+            )
+            assert len(stamps) == 1, "a skipped pass must not stamp"
+            assert not task.done()
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            await _cancel_phase2_orphans()
+
+
+async def test_orphan_skip_budget_flips_canary_unhealthy(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Past CITADEL_EVOLVE_ORPHAN_MAX_SKIPS skipped passes the canary records
+    Phase2OrphanWedged so /readyz goes unhealthy and escalates to a restart.
+    """
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+    )
+    try:
+        for _ in range(300):
+            if (
+                server._LAST_CANARY is not None
+                and server._LAST_CANARY.get("error") == "Phase2OrphanWedged"
+            ):
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        await _cancel_phase2_orphans()
+
+    assert server._LAST_CANARY is not None
+    assert server._LAST_CANARY["ok"] is False
+    assert server._LAST_CANARY.get("error") == "Phase2OrphanWedged"
+
+
+class _OrphanRecoveringCitadel(_FakeCitadel):
+    """First cognify hangs until released, then completes; later ones pass."""
+
+    def __init__(self, cognify_calls: list[bool]) -> None:
+        super().__init__(cognify_calls)
+        self.cognify_started = asyncio.Event()
+        self.release = asyncio.Event()
+        self._first = True
+
+    async def cognify_dataset(
+        self, *, force: bool = False, verify: bool = False
+    ) -> dict[str, Any]:
+        if self._first:
+            self._first = False
+            self.cognify_started.set()
+            await self.release.wait()
+        return await super().cognify_dataset(force=force, verify=verify)
+
+
+async def test_orphan_completion_restores_normal_passes(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Once the orphan finishes, the next pass runs Phase 1 + Phase 2 normally
+    and stamps a full healthy cycle (orphan slot and skip counter reset).
+    """
+    import json as json_module
+
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _OrphanRecoveringCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if state_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert state_path.exists()
+        assert (
+            json_module.loads(state_path.read_text())["last_run_reason"]
+            == "cognify_timeout"
+        )
+        # The hung cognify resolves between ticks; the orphan completes and the
+        # next pass must run in full again.
+        fake_citadel.release.set()
+        for _ in range(300):
+            if (
+                state_path.exists()
+                and json_module.loads(state_path.read_text())["last_run_ok"] is True
+            ):
+                break
+            await asyncio.sleep(0.01)
+        state = json_module.loads(state_path.read_text())
+        assert state["last_run_ok"] is True, "a full pass must stamp again"
+        assert server._LAST_CANARY is not None
+        assert server._LAST_CANARY["ok"] is True
+        assert not task.done()
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        await _cancel_phase2_orphans()
+
+
+class _InterleavingCitadel(_FakeCitadel):
+    """Phase 2's cognify waits on maintenance behind a hung graph-lane job.
+
+    Mirrors the gateway: cognee.cognify acquires the maintenance lock before
+    writing, and the graph lane holds the same lock across its run_once.
+    """
+
+    def __init__(self, cognify_calls: list[bool]) -> None:
+        super().__init__(cognify_calls)
+        self.cognee = _LockCognee()
+        self.graph_lane_task: asyncio.Task[Any] | None = None
+        self.graph_lane_holding = asyncio.Event()
+        self.pause_calls = 0
+
+    def pause_lifecycle_queue(self) -> None:
+        self.pause_calls += 1
+
+    async def _graph_lane(self) -> None:
+        async with self.cognee.maintenance():
+            self.graph_lane_holding.set()
+            await asyncio.Event().wait()
+
+    async def cognify_dataset(
+        self, *, force: bool = False, verify: bool = False
+    ) -> dict[str, Any]:
+        self._cognify_calls.append(force)
+        assert verify is True
+        # A graph-lane job woken by the shared projection gate got the FIFO
+        # maintenance lock ahead of this cognify and hangs while holding it.
+        self.graph_lane_task = asyncio.create_task(self._graph_lane())
+        await self.graph_lane_holding.wait()
+        async with self.cognee.maintenance():
+            return {}
+
+
+async def test_maintenance_lock_interleaving_times_out_waiter_only(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """THE interleaving case: Phase 2 waits behind a graph-lane job on the
+    maintenance lock and hits its budget. Only the WAITER times out: the
+    graph-lane holder is untouched, the pass stamps cognify_timeout, and the
+    next tick takes the orphan-skip branch so Phase 1 never blocks on the
+    held lock.
+    """
+    import json as json_module
+
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _InterleavingCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if state_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert state_path.exists(), "the timed-out pass must still stamp"
+        state = json_module.loads(state_path.read_text())
+        assert state["last_run_reason"] == "cognify_timeout"
+        # The graph-lane holder is untouched: not cancelled, still holding.
+        graph_lane = fake_citadel.graph_lane_task
+        assert graph_lane is not None
+        assert not graph_lane.cancelled()
+        assert not graph_lane.done()
+        assert fake_citadel.cognee.maintenance_lock.locked(), (
+            "the graph-lane job must still hold the maintenance lock"
+        )
+        # Later ticks take the orphan-skip branch: no new pause, no Phase 1
+        # blocking on the held lock (entries stay at Phase 1 + graph lane).
+        entries_after_timeout = fake_citadel.cognee.entries
+        pauses_after_timeout = fake_citadel.pause_calls
+        await asyncio.sleep(0.05)
+        assert fake_citadel.pause_calls == pauses_after_timeout == 1
+        assert fake_citadel.cognee.entries == entries_after_timeout == 2
+        assert not task.done()
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        if fake_citadel.graph_lane_task is not None:
+            fake_citadel.graph_lane_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await fake_citadel.graph_lane_task
+        await _cancel_phase2_orphans()
+
+
+async def test_phase1_maintenance_entry_is_bounded(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Maintenance held by an outside task (no orphan): Phase 1's bounded
+    entry times out, the pass resumes the queue (include_deferred=True), does
+    not stamp, and defers to the next interval instead of hanging.
+    """
+    import kb.server as server
+
+    monkeypatch.setattr(
+        server, "_evolve_maintenance_acquire_timeout_seconds", lambda: 0.05
+    )
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _FakeCitadel(cognify_calls)
+    fake_citadel.cognee = _LockCognee()
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    holding = asyncio.Event()
+
+    async def _hold() -> None:
+        async with fake_citadel.cognee.maintenance():
+            holding.set()
+            await asyncio.Event().wait()
+
+    holder = asyncio.create_task(_hold())
+    await asyncio.wait_for(holding.wait(), timeout=1)
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if True in fake_citadel.resume_calls:
+                break
+            await asyncio.sleep(0.01)
+        assert True in fake_citadel.resume_calls, (
+            "a deferred pass must resume the paused queue with include_deferred=True"
+        )
+        assert not state_path.exists(), "a deferred pass must not stamp"
+        assert cognify_calls == [], "Phase 2 must not run when Phase 1 was deferred"
+        assert not task.done(), "the loop must survive a busy maintenance lock"
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        holder.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await holder
+
+
+def test_phase2_timeout_floor_respects_canary_budget(monkeypatch: Any) -> None:
+    """P2: the Phase 2 bound must always cover the canary wait plus margin,
+    and the floor tracks a raised canary budget (formula, not constant).
+    """
+    import kb.server as server
+
+    monkeypatch.delenv("CITADEL_CANARY_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv("CITADEL_EVOLVE_COGNIFY_TIMEOUT_SECONDS", "60")
+    assert server._evolve_cognify_timeout_seconds() >= 900.0
+    monkeypatch.setenv("CITADEL_CANARY_TIMEOUT_SECONDS", "2000")
+    assert server._evolve_cognify_timeout_seconds() >= 2300.0
+
+
+async def test_scheduler_teardown_cancels_phase2_task(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Loop teardown is the ONE path that still cancels the inner cognify
+    (repaired at next boot by recover_stale_cognify_runs); the cancelled pass
+    must not stamp.
+    """
+    import kb.server as server
+
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    await asyncio.wait_for(fake_citadel.cognify_started.wait(), timeout=3)
+    assert len(fake_citadel.cognify_tasks) == 1
+    inner = fake_citadel.cognify_tasks[0]
+    assert inner.get_name() == "evolve-phase2-cognify"
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    with contextlib.suppress(asyncio.CancelledError):
+        await inner
+
+    assert inner.cancelled(), "teardown must cancel the inner Phase 2 task"
+    assert not state_path.exists(), "a cancelled pass must not stamp"

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -222,6 +222,11 @@ async def test_evolve_scheduler_loop_runs_stages_in_loop_then_cognifies(
 async def test_evolve_scheduler_does_not_resume_after_phase2_cancellation(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
+    """Cancellation mid-Phase-2 must add NO extra resume.
+
+    The post-stages kick (before Phase 2) is expected and has already fired;
+    tearing the loop down must not kick the drain again on a dying loop.
+    """
     import kb.server as server
 
     _patch_phase1(monkeypatch)
@@ -233,12 +238,83 @@ async def test_evolve_scheduler_does_not_resume_after_phase2_cancellation(
         server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
     )
     await asyncio.wait_for(fake_citadel.cognify_started.wait(), timeout=3)
+    resumes_before_cancel = list(fake_citadel.resume_calls)
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
 
     assert cognify_calls
-    assert fake_citadel.resume_calls == []
+    assert fake_citadel.resume_calls == resumes_before_cancel
+
+
+async def test_drain_resume_fires_before_phase2(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The pass pauses the queue at start, so the drain kick must NOT wait
+    behind Phase 2: a hung cognify (observed live 2026-08-28) would otherwise
+    park a full-generation rebuild indefinitely.
+    """
+    import kb.server as server
+
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(tmp_path / "evolve_state.json"))
+    )
+    try:
+        await asyncio.wait_for(fake_citadel.cognify_started.wait(), timeout=3)
+        # Phase 2 is blocked right now and will never return; the drain must
+        # already have been kicked.
+        assert fake_citadel.resume_calls, (
+            "resume_lifecycle_queue must fire after Phase 1, before Phase 2"
+        )
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_hung_phase2_is_bounded_and_still_stamps(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A cognify that never returns must hit the Phase 2 bound: the canary
+    flips unhealthy with the timeout, the pass still stamps (so the next boot
+    resumes the interval instead of re-running forever), and the loop lives on.
+    """
+    import json as json_module
+
+    import kb.server as server
+
+    monkeypatch.setenv("CITADEL_EVOLVE_COGNIFY_TIMEOUT_SECONDS", "0.05")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if state_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert state_path.exists(), "the timed-out pass must still stamp"
+        state = json_module.loads(state_path.read_text())
+        assert state["last_run_ok"] is False
+        assert state["last_run_reason"] == "cognify_timeout"
+        assert server._LAST_CANARY is not None
+        assert server._LAST_CANARY["ok"] is False
+        assert server._LAST_CANARY.get("error") == "TimeoutError"
+        assert not task.done(), "the loop must survive a Phase 2 timeout"
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 class _RaisingCitadel:

--- a/tests/test_evolve_scheduler.py
+++ b/tests/test_evolve_scheduler.py
@@ -1037,3 +1037,116 @@ async def test_scheduler_teardown_cancels_phase2_task(
 
     assert inner.cancelled(), "teardown must cancel the inner Phase 2 task"
     assert not state_path.exists(), "a cancelled pass must not stamp"
+
+
+async def test_maintenance_busy_skips_consume_the_skip_budget(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A pass that cannot enter maintenance is a SKIP, same budget as the
+    orphan guard: past CITADEL_EVOLVE_ORPHAN_MAX_SKIPS deferred passes the
+    canary records MaintenanceWedged so /readyz cannot stay green while the
+    scheduler defers forever.
+    """
+    import kb.server as server
+
+    monkeypatch.setattr(
+        server, "_evolve_maintenance_acquire_timeout_seconds", lambda: 0.05
+    )
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1")
+    monkeypatch.setattr(server, "_LAST_CANARY", None)
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _FakeCitadel(cognify_calls)
+    fake_citadel.cognee = _LockCognee()
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    holding = asyncio.Event()
+
+    async def _hold() -> None:
+        async with fake_citadel.cognee.maintenance():
+            holding.set()
+            await asyncio.Event().wait()
+
+    holder = asyncio.create_task(_hold())
+    await asyncio.wait_for(holding.wait(), timeout=1)
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        for _ in range(300):
+            if (
+                server._LAST_CANARY is not None
+                and server._LAST_CANARY.get("error") == "MaintenanceWedged"
+            ):
+                break
+            await asyncio.sleep(0.01)
+        assert server._LAST_CANARY is not None, (
+            "exhausted maintenance-busy skips must flip the canary"
+        )
+        assert server._LAST_CANARY["ok"] is False
+        assert server._LAST_CANARY.get("error") == "MaintenanceWedged"
+        assert not state_path.exists(), "a skipped pass must not stamp"
+        assert cognify_calls == [], "Phase 2 must not run on a skipped pass"
+        assert not task.done(), "the loop must survive budget exhaustion"
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        holder.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await holder
+
+
+async def test_scheduler_exit_reaps_detached_phase2_orphan(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """After a timeout detaches Phase 2 as the orphan, cancelling the sleeping
+    scheduler must still reap that task: lifespan awaits only the scheduler,
+    so a leaked evolve-phase2-cognify would overlap shutdown and a later
+    lifespan.
+    """
+    import json as json_module
+
+    import kb.server as server
+
+    monkeypatch.setattr(server, "_evolve_cognify_timeout_seconds", lambda: 0.05)
+    monkeypatch.setenv("CITADEL_EVOLVE_ORPHAN_MAX_SKIPS", "1000000")
+    _patch_phase1(monkeypatch)
+    cognify_calls: list[bool] = []
+    fake_citadel = _BlockingCognifyCitadel(cognify_calls)
+    monkeypatch.setattr(server, "get_citadel", lambda: fake_citadel)
+    state_path = tmp_path / "evolve_state.json"
+
+    task = asyncio.create_task(
+        server._evolve_scheduler_loop(0.001, str(state_path))
+    )
+    try:
+        await asyncio.wait_for(fake_citadel.cognify_started.wait(), timeout=3)
+        inner = fake_citadel.cognify_tasks[0]
+        # Wait until the pass timed out and stamped, i.e. the inner task is
+        # now the detached orphan and the scheduler is sleeping.
+        for _ in range(300):
+            if state_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert state_path.exists()
+        assert (
+            json_module.loads(state_path.read_text())["last_run_reason"]
+            == "cognify_timeout"
+        )
+        assert not inner.done(), "precondition: the orphan is still running"
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        assert inner.done(), (
+            "scheduler exit must cancel and await the detached Phase 2 orphan"
+        )
+        assert inner.cancelled()
+        assert inner not in server._BACKGROUND_TASKS
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        await _cancel_phase2_orphans()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7119,23 +7119,13 @@ def test_start_lifecycle_queue_resumes_due_projection_work(monkeypatch: Any) -> 
     assert calls == ["resume"]
 
 
-async def test_lifespan_runs_stale_cognify_recovery_before_lifecycle_start(
-    monkeypatch: Any,
-) -> None:
-    """Boot must repair cognify runs a previous process abandoned mid-write
-    (teardown cancellation bypasses cognee's Exception-only rollback), and it
-    must do so BEFORE the lifecycle queue starts so nothing races the
-    rollback. A raising recovery must never abort boot.
-
-    Drives server.lifespan directly: the hosted-MCP session manager is
-    once-per-process, so a second TestClient boot in the suite would break it.
-    """
+def _patch_lifespan_boot(monkeypatch: Any, calls: list[str]) -> None:
+    """Stub the MCP session manager and record every worker starter."""
     import contextlib as contextlib_module
     from types import SimpleNamespace
 
     from kb import server
 
-    calls: list[str] = []
     # FakeCitadel's short test keys would otherwise refuse boot (M4).
     monkeypatch.setenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", "true")
 
@@ -7149,13 +7139,39 @@ async def test_lifespan_runs_stale_cognify_recovery_before_lifecycle_start(
         SimpleNamespace(session_manager=SimpleNamespace(run=_null_run)),
     )
     monkeypatch.setattr(
+        server, "_start_cognify_queue", lambda: calls.append("cognify")
+    )
+    monkeypatch.setattr(
         server, "_start_lifecycle_queue", lambda: calls.append("lifecycle")
     )
-    monkeypatch.setattr(server, "_start_repo_stats_scheduler", lambda: None)
+    monkeypatch.setattr(
+        server, "_start_evolve_scheduler", lambda: calls.append("evolve")
+    )
+    monkeypatch.setattr(
+        server, "_start_repo_stats_scheduler", lambda: calls.append("repo_stats")
+    )
+
+
+async def test_lifespan_runs_stale_cognify_recovery_before_lifecycle_start(
+    monkeypatch: Any,
+) -> None:
+    """Boot must repair cognify runs a previous process abandoned mid-write
+    (teardown cancellation bypasses cognee's Exception-only rollback), and it
+    must do so BEFORE any worker starts so nothing races the rollback. A
+    verified-clean recovery then starts all four workers.
+
+    Drives server.lifespan directly: the hosted-MCP session manager is
+    once-per-process, so a second TestClient boot in the suite would break it.
+    """
+    from kb import server
+
+    calls: list[str] = []
+    _patch_lifespan_boot(monkeypatch, calls)
 
     class _RecoveringCognee:
-        async def recover_stale_cognify_runs(self) -> None:
+        async def recover_stale_cognify_runs(self) -> list[Any]:
             calls.append("recover")
+            return []
 
     citadel = FakeCitadel()
     citadel.cognee = _RecoveringCognee()
@@ -7169,18 +7185,176 @@ async def test_lifespan_runs_stale_cognify_recovery_before_lifecycle_start(
     assert calls.index("recover") < calls.index("lifecycle"), (
         "recovery must run before the lifecycle queue starts"
     )
+    assert calls[-4:] == ["cognify", "lifecycle", "evolve", "repo_stats"], (
+        "a verified-clean recovery must start all four workers"
+    )
+
+
+async def test_lifespan_aborts_when_stale_cognify_recovery_raises(
+    monkeypatch: Any,
+) -> None:
+    """A raising recovery must abort boot, not degrade it. Skipping only the
+    boot-time starters is NOT fail-closed: live write paths restart writers
+    while the API is up (legacy remember() -> schedule_cognify() ->
+    _start_cognify_queue_drain(); /api/linear-sync/run schedules cognify), and
+    any new cognify run would bury the unrecovered latest run as
+    no-longer-latest forever. The process must exit so the platform restart
+    policy retries recovery on the next boot; no worker of any kind may start.
+    """
+    from kb import server
+
+    calls: list[str] = []
+    _patch_lifespan_boot(monkeypatch, calls)
 
     class _ExplodingCognee:
         async def recover_stale_cognify_runs(self) -> None:
             calls.append("boom")
             raise RuntimeError("recovery exploded")
 
+    citadel = FakeCitadel()
     citadel.cognee = _ExplodingCognee()
-    # Boot completes despite the raise: entering the context is the assertion.
-    async with server.lifespan(app):
-        pass
+    app.state.citadel = citadel
+    monkeypatch.setattr(server, "get_citadel", lambda: citadel)
 
-    assert "boom" in calls, "the raising recovery was never attempted"
+    with pytest.raises(RuntimeError, match="recovery exploded"):
+        async with server.lifespan(app):
+            raise AssertionError("lifespan must not yield after a failed recovery")
+
+    assert calls == ["boom"], (
+        "a failed recovery must start nothing: no cognify queue, no lifecycle "
+        "queue, no evolve scheduler, no repo-stats task"
+    )
+
+
+async def test_lifespan_aborts_when_recovery_verification_finds_stale_runs(
+    monkeypatch: Any,
+) -> None:
+    """cognee's recovery swallows its own failures, so 'the call returned' is
+    not 'the repair happened'. When the post-recovery probe still finds a
+    latest DATASET_PROCESSING_STARTED run, the client raises
+    CogneeStartupRecoveryError and boot must abort exactly like any other
+    recovery failure.
+    """
+    from kb import server
+    from kb.cognee_client import CogneeStartupRecoveryError
+
+    calls: list[str] = []
+    _patch_lifespan_boot(monkeypatch, calls)
+
+    class _UnverifiedCognee:
+        async def recover_stale_cognify_runs(self) -> None:
+            calls.append("unverified")
+            raise CogneeStartupRecoveryError(
+                "stale cognify-run recovery left 1 dataset(s) with their "
+                "latest run still DATASET_PROCESSING_STARTED: dead-beef"
+            )
+
+    citadel = FakeCitadel()
+    citadel.cognee = _UnverifiedCognee()
+    app.state.citadel = citadel
+    monkeypatch.setattr(server, "get_citadel", lambda: citadel)
+
+    with pytest.raises(CogneeStartupRecoveryError, match="dead-beef"):
+        async with server.lifespan(app):
+            raise AssertionError(
+                "lifespan must not yield while a partial cognify write is "
+                "unrecovered"
+            )
+
+    assert calls == ["unverified"], (
+        "an unverified recovery must start nothing: no cognify queue, no "
+        "lifecycle queue, no evolve scheduler, no repo-stats task"
+    )
+
+
+async def test_lifespan_teardown_stops_evolve_before_the_lifecycle_queue(
+    monkeypatch: Any,
+) -> None:
+    """Cancelling the evolve scheduler while it waits in maintenance/Phase 1
+    hits its CancelledError handler, which resumes the lifecycle queue
+    (include_deferred=True) before re-raising. Teardown must therefore cancel
+    the scheduler (and repo-stats) BEFORE stopping the lifecycle queue: the
+    old order (lifecycle -> cognify -> evolve) let that resume restart
+    vector/graph lane tasks AFTER stop_lifecycle_queue had already returned,
+    leaving live lane tasks behind a stopped queue at shutdown.
+
+    Drives the real _evolve_scheduler_loop, parked inside the bounded
+    maintenance acquire, through the real lifespan teardown.
+    """
+    import contextlib as contextlib_module
+    from types import SimpleNamespace
+
+    from kb import server
+
+    calls: list[str] = []
+    monkeypatch.setenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", "true")
+
+    @contextlib_module.asynccontextmanager
+    async def _null_run() -> Any:
+        yield
+
+    monkeypatch.setattr(
+        server,
+        "mcp_server",
+        SimpleNamespace(session_manager=SimpleNamespace(run=_null_run)),
+    )
+
+    entered_maintenance = asyncio.Event()
+
+    class _BlockedMaintenance:
+        async def __aenter__(self) -> None:
+            entered_maintenance.set()
+            await asyncio.Event().wait()
+
+        async def __aexit__(self, *exc: Any) -> bool:
+            return False
+
+    class _BlockedMaintenanceCognee:
+        def maintenance(self) -> _BlockedMaintenance:
+            return _BlockedMaintenance()
+
+        async def recover_stale_cognify_runs(self) -> list[Any]:
+            return []
+
+    class _TeardownCitadel(FakeCitadel):
+        cognee = _BlockedMaintenanceCognee()
+
+        def pause_lifecycle_queue(self) -> None:
+            calls.append("pause")
+
+        def resume_lifecycle_queue(self, *, include_deferred: bool = False) -> bool:
+            calls.append("lane_resume")
+            return True
+
+        async def stop_lifecycle_queue(self) -> None:
+            calls.append("lifecycle_stop")
+
+    citadel = _TeardownCitadel()
+    app.state.citadel = citadel
+    monkeypatch.setattr(server, "get_citadel", lambda: citadel)
+    # The real loop with a near-zero interval so the first pass parks in the
+    # maintenance acquire immediately; the floor in _start_evolve_scheduler
+    # would otherwise delay the pass by 60s.
+    monkeypatch.setattr(
+        server,
+        "_start_evolve_scheduler",
+        lambda: asyncio.create_task(server._evolve_scheduler_loop(0.001, "")),
+    )
+
+    async with server.lifespan(app):
+        await asyncio.wait_for(entered_maintenance.wait(), timeout=5)
+
+    assert "pause" in calls, "the pass never reached its maintenance acquire"
+    assert calls.count("lane_resume") >= 2, (
+        "the cancelled maintenance wait must have fired its lifecycle resume "
+        "(boot start + cancellation-window resume); the regression window was "
+        "never exercised"
+    )
+    stop_at = calls.index("lifecycle_stop")
+    assert "lane_resume" not in calls[stop_at + 1 :], (
+        "a lifecycle lane was restarted after stop_lifecycle_queue returned: "
+        "teardown must cancel the evolve scheduler before stopping the queue"
+    )
 
 
 async def test_stop_lifecycle_queue_awaits_worker_shutdown(monkeypatch: Any) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7119,6 +7119,70 @@ def test_start_lifecycle_queue_resumes_due_projection_work(monkeypatch: Any) -> 
     assert calls == ["resume"]
 
 
+async def test_lifespan_runs_stale_cognify_recovery_before_lifecycle_start(
+    monkeypatch: Any,
+) -> None:
+    """Boot must repair cognify runs a previous process abandoned mid-write
+    (teardown cancellation bypasses cognee's Exception-only rollback), and it
+    must do so BEFORE the lifecycle queue starts so nothing races the
+    rollback. A raising recovery must never abort boot.
+
+    Drives server.lifespan directly: the hosted-MCP session manager is
+    once-per-process, so a second TestClient boot in the suite would break it.
+    """
+    import contextlib as contextlib_module
+    from types import SimpleNamespace
+
+    from kb import server
+
+    calls: list[str] = []
+    # FakeCitadel's short test keys would otherwise refuse boot (M4).
+    monkeypatch.setenv("CITADEL_ALLOW_WEAK_ACCESS_KEYS", "true")
+
+    @contextlib_module.asynccontextmanager
+    async def _null_run() -> Any:
+        yield
+
+    monkeypatch.setattr(
+        server,
+        "mcp_server",
+        SimpleNamespace(session_manager=SimpleNamespace(run=_null_run)),
+    )
+    monkeypatch.setattr(
+        server, "_start_lifecycle_queue", lambda: calls.append("lifecycle")
+    )
+    monkeypatch.setattr(server, "_start_repo_stats_scheduler", lambda: None)
+
+    class _RecoveringCognee:
+        async def recover_stale_cognify_runs(self) -> None:
+            calls.append("recover")
+
+    citadel = FakeCitadel()
+    citadel.cognee = _RecoveringCognee()
+    app.state.citadel = citadel
+    monkeypatch.setattr(server, "get_citadel", lambda: citadel)
+
+    async with server.lifespan(app):
+        pass
+
+    assert calls.count("recover") == 1, "recovery must run exactly once at boot"
+    assert calls.index("recover") < calls.index("lifecycle"), (
+        "recovery must run before the lifecycle queue starts"
+    )
+
+    class _ExplodingCognee:
+        async def recover_stale_cognify_runs(self) -> None:
+            calls.append("boom")
+            raise RuntimeError("recovery exploded")
+
+    citadel.cognee = _ExplodingCognee()
+    # Boot completes despite the raise: entering the context is the assertion.
+    async with server.lifespan(app):
+        pass
+
+    assert "boom" in calls, "the raising recovery was never attempted"
+
+
 async def test_stop_lifecycle_queue_awaits_worker_shutdown(monkeypatch: Any) -> None:
     from kb import server
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -391,6 +391,67 @@ async def test_vector_lane_runs_while_graph_lane_holds_maintenance(
         await kb.stop_lifecycle_queue()
 
 
+class MaintenanceCountingVectorLaneCognee(VectorLaneCognee):
+    def __init__(self) -> None:
+        super().__init__()
+        self.maintenance_entries = 0
+
+    @asynccontextmanager
+    async def maintenance(self):
+        self.maintenance_entries += 1
+        yield
+
+
+@pytest.mark.asyncio
+async def test_baseline_lane_never_enters_maintenance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """The load-bearing claim behind the evolve scheduler's vector-only
+    pre-Phase-2 kick: a baseline drain (resume WITHOUT include_deferred)
+    writes relational and vector receipts, defers graph, and never enters
+    cognee.maintenance() — so it can never park behind a Phase 2 (or any
+    other holder) of that lock.
+    """
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-1")
+    monkeypatch.setenv("DB_PROVIDER", "sqlite")
+    monkeypatch.setenv("VECTOR_DB_PROVIDER", "qdrant")
+    monkeypatch.setenv("GRAPH_DATABASE_PROVIDER", "ladybug")
+    fake = MaintenanceCountingVectorLaneCognee()
+    kb = Citadel(
+        CitadelConfig(
+            default_dataset="seat:alice",
+            user_id="alice",
+            lifecycle_enabled=True,
+            lifecycle_store_path=str(tmp_path / "lifecycle.sqlite3"),
+        ),
+        cognee=fake,
+    )
+
+    accepted = await kb.ingest(
+        "baseline lane content reaches relational and vector search only",
+        source_key="manual:alice:baseline-lane",
+        defer_cognify=True,
+    )
+    kb.resume_lifecycle_queue()
+    await kb.wait_for_lifecycle_idle()
+
+    operation = kb.lifecycle_store.get_operation(accepted.projection_job_id)
+    assert operation.job.state == "deferred", "graph work must stay deferred"
+    assert next(
+        receipt.state
+        for receipt in operation.receipts
+        if receipt.backend == "relational"
+    ) == "searchable"
+    assert next(
+        receipt.state for receipt in operation.receipts if receipt.backend == "vector"
+    ) == "searchable"
+    assert accepted.source_revision_id in fake.vector_ids
+    assert fake.maintenance_entries == 0, (
+        "the baseline lane must never enter maintenance"
+    )
+
+
 def test_lifecycle_config_digest_tracks_projection_affecting_environment(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,


### PR DESCRIPTION
## Goal

Stop a hung evolve Phase 2 from parking the lifecycle drain (observed live 2026-08-28: a 12,400-job generation rebuild sat frozen for 50+ minutes behind a wedged cognify pass), and make the scheduler safe to re-enable during and after the v058 drain.

## What this does

**Scheduler (kb/server.py)**
- **Drain kick before Phase 2** (`resume_lifecycle_queue(include_deferred=False)`): the vector/relational drain resumes before the pass enters its cognify wait, so a slow or hung Phase 2 can no longer park the baseline lanes.
- **Bounded Phase 2 with a single-orphan slot**: the cognify pass runs as a named background task awaited via `asyncio.timeout` + `shield`. On timeout the task is NOT cancelled in-flight; it becomes the single tracked orphan, later passes skip while it runs.
- **Bounded Phase 1 maintenance entry** (`CITADEL_EVOLVE_MAINTENANCE_TIMEOUT_SECONDS`, default 900s): a graph-lane job holding `cognee.maintenance()` times out only the waiter.
- **Shared wedge budget**: orphan-wait skips and maintenance-busy skips consume ONE consecutive-skip budget (`CITADEL_EVOLVE_ORPHAN_MAX_SKIPS`, default 2); exhaustion records a failed canary verdict (`Phase2OrphanWedged` / `MaintenanceWedged`) so `/readyz` cannot stay green through a wedge.
- **Cognify timeout floor**: the Phase 2 bound is at least `canary_timeout + 300s` regardless of env.
- **Scheduler exit reaps detached tasks**: loop teardown cancels and awaits (bounded) the in-flight Phase 2 task and any orphan.
- **Teardown ordering**: lifespan now stops evolve (and repo-stats) BEFORE the lifecycle and cognify queues — the scheduler's cancellation path resumes the lifecycle queue, which previously could restart lanes after their stop.
- **Python 3.11 hang fix**: all scheduler await sites use `asyncio.timeout` instead of `wait_for` — 3.11's `wait_for` can swallow an outer cancellation that lands in the same tick where the inner future completed (CPython gh-96764), which hung the 3.11 CI leg.

**Startup recovery (kb/cognee_client.py) — fail-closed, in-house**
- cognee 1.4.1's `recover_stale_cognify_runs_on_startup` swallows both candidate-query failures and per-run rollback failures, only examines each dataset's latest run, and skips runs younger than 3600s — so a mid-cognify crash could leave partial graph/vector writes that the next cognify silently buries. Replaced with an in-house loop that runs under `cognee.maintenance()` before ANY writer starts:
  - **Per-run detection**: every run whose OWN latest event is `DATASET_PROCESSING_STARTED` is dangling — including runs hidden behind newer terminal runs (cognee's per-dataset selection never sees those).
  - **Run-scoped rollback** via cognee's own `cognify_rollback_handler` (verified run-scoped on both provenance paths), newest-first, then a terminal `ERRORED` event for the SAME run id (cognee's reset logs INITIATED under a fresh uuid4, which would otherwise re-flag every successfully recovered run forever), then `reset_pipeline_run_status`.
  - **Fail closed, never guess**: a dangling run with a missing `Dataset` row (no ownership context to roll back) or with a COMPLETED sibling at a newer-or-equal timestamp (cognee never transfers source-ref ownership, so rollback would delete artifacts the completed run reuses; equal timestamps cannot prove ordering) is NOT touched — boot aborts naming the run.
  - **Backstop probe**: after the loop, the detection query re-runs; any remaining dangling run raises `CogneeStartupRecoveryError`.
- **Lifespan aborts on unverified recovery** (no swallow, no partial start): skipping starters is not fail-closed because runtime write paths restart writers (`remember()` → `schedule_cognify()`, `/api/linear-sync/run`). The platform restart policy retries recovery; a genuinely poisoned store crash-loops loudly instead of serving while enrichment is corrupt. Age guard is unnecessary in this sole-writer window.

## Review chain

Six adversarial rounds, each on the newest commit only; every round's REAL findings were closed with red/green-proven fixes before the next:

1. Draft (becc637): 2 P1 (graph-lane maintenance interleaving; cancellation bypassing cognee rollback) → redesign spec (EvolveDesigner) → implemented in 7dcada4, full red/green.
2. 7dcada4: 3 P1 (maintenance-skip path unbudgeted; min-age guard defeats boot recovery; detached task not reaped) + 3.11 CI hang root-caused (gh-96764) → ca5e394.
3. ca5e394: zero findings — then an advisory chain (5 blockers) forced the recovery redesign: swallowed failures → verification probe; skip-starters → abort lifespan; scheduler inside the gate; teardown ordering; missing-dataset fail-closed → c09c9c8.
4. c09c9c8: 1 P1 (per-dataset probe hides older dangling runs) → all-dangling per-run loop in 0a184e2 (+ real-model in-memory sqlite tests, CHANGELOG).
5. 0a184e2: 1 P1 (unconditional rollback deletes artifacts a newer COMPLETED run reuses) → newer-completed guard, newest-first ordering in f4f2916.
6. f4f2916: 1 P1 (strict `>` lets an equal-timestamp COMPLETED sibling slip the guard) → `>=` in ccc7ae7, red/green both directions. ccc7ae7 implements round 6's own prescription verbatim, so no seventh round was run.

Gates on ccc7ae7: full 3.12 suite `2519 passed, 6 skipped`, ruff clean, 3.11 focused file `133 passed`; CI 18/18 on every pushed revision.

## Deploy context

`CITADEL_EVOLVE_SCHEDULER_ENABLED=false` is set in production while the v058 generation rebuild drains; re-enabling the scheduler after this merges is the sanctioned path for graph enrichment to resume. Merging to main auto-deploys; the boot-abort behavior change is in the CHANGELOG.

Refs #228
