### PR TITLE
fix: add recovery cutover and backup wiring

### DIFF
--- a/kb/generation_backup.py
+++ b/kb/generation_backup.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import fcntl
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -18,7 +19,7 @@ from uuid import uuid4
 
 from qdrant_client import QdrantClient, models
 
-from kb.lite_runtime import LiteConfigurationError, acquire_single_instance_lock
+from kb.lite_lock import LiteConfigurationError, acquire_single_instance_lock
 
 
 _MANIFEST_SCHEMA_VERSION = 1
@@ -29,6 +30,32 @@ _PRIVATE_FILE_MODE = 0o600
 
 class GenerationBackupError(RuntimeError):
     pass
+_QDRANT_SNAPSHOT_TIMEOUT_ENV = "CITADEL_QDRANT_SNAPSHOT_TIMEOUT_SECONDS"
+_DEFAULT_QDRANT_SNAPSHOT_TIMEOUT_SECONDS = 900
+_MIN_QDRANT_SNAPSHOT_TIMEOUT_SECONDS = 1
+
+
+def _qdrant_snapshot_timeout_seconds() -> int:
+    raw = os.getenv(_QDRANT_SNAPSHOT_TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_QDRANT_SNAPSHOT_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError as error:
+        raise GenerationBackupError(
+            f"{_QDRANT_SNAPSHOT_TIMEOUT_ENV} must be a finite number"
+        ) from error
+    if not math.isfinite(value):
+        raise GenerationBackupError(
+            f"{_QDRANT_SNAPSHOT_TIMEOUT_ENV} must be a finite number"
+        )
+    if value < _MIN_QDRANT_SNAPSHOT_TIMEOUT_SECONDS:
+        raise GenerationBackupError(
+            f"{_QDRANT_SNAPSHOT_TIMEOUT_ENV} must be at least "
+            f"{_MIN_QDRANT_SNAPSHOT_TIMEOUT_SECONDS} second"
+        )
+    return math.ceil(value)
+
 
 
 _CANONICAL_SYSTEM_ROOT = Path("cognee-system")
@@ -324,6 +351,24 @@ def _sqlite_backup(source_path: Path, destination_path: Path) -> None:
         )
 
 
+def _copy_sqlite(source_path: Path, destination_path: Path) -> None:
+    if not source_path.is_file():
+        raise GenerationBackupError(f"required SQLite database is missing: {source_path}")
+    _make_private_directory(destination_path.parent)
+    _prepare_private_file(destination_path)
+    try:
+        shutil.copyfile(source_path, destination_path)
+        destination_path.chmod(_PRIVATE_FILE_MODE)
+        with sqlite3.connect(f"file:{destination_path}?mode=ro", uri=True) as connection:
+            integrity = str(connection.execute("PRAGMA integrity_check").fetchone()[0])
+    except (OSError, sqlite3.Error) as error:
+        raise GenerationBackupError(f"SQLite restore failed for {source_path}") from error
+    if integrity != "ok":
+        raise GenerationBackupError(
+            f"SQLite restore integrity check failed for {source_path}: {integrity}"
+        )
+
+
 def _copy_tree(
     source: Path,
     destination: Path,
@@ -479,11 +524,11 @@ def _restore_lite_state(source_root: Path, target_layout: _LiteStorageLayout) ->
         target_layout.state_root,
         excluded=frozenset(state_excluded),
     )
-    _sqlite_backup(
+    _copy_sqlite(
         source_root / _CANONICAL_DATABASE,
         target_layout.database_file,
     )
-    _sqlite_backup(
+    _copy_sqlite(
         source_root / _CANONICAL_LIFECYCLE,
         target_layout.lifecycle_file,
     )
@@ -812,7 +857,12 @@ class QdrantSnapshotStore:
     def __init__(self, *, url: str, api_key: str | None) -> None:
         self._url = url.rstrip("/")
         self._api_key = api_key
-        self._client = QdrantClient(url=self._url, api_key=api_key)
+        self._snapshot_timeout_seconds = _qdrant_snapshot_timeout_seconds()
+        self._client = QdrantClient(
+            url=self._url,
+            api_key=api_key,
+            timeout=self._snapshot_timeout_seconds,
+        )
 
     def close(self) -> None:
         self._client.close()
@@ -852,7 +902,9 @@ class QdrantSnapshotStore:
         )
         try:
             try:
-                with urlopen(request, timeout=300) as response:  # noqa: S310
+                with urlopen(
+                    request, timeout=self._snapshot_timeout_seconds
+                ) as response:  # noqa: S310
                     with destination.open("wb") as handle:
                         shutil.copyfileobj(response, handle)
             except OSError as error:

--- a/kb/lite_lock.py
+++ b/kb/lite_lock.py
@@ -1,0 +1,46 @@
+"""Single-instance lock and Lite configuration error.
+
+Leaf module: imports nothing from ``kb``. Both ``kb.lite_runtime`` and
+``kb.generation_backup`` need these two names; keeping them here breaks the
+``lite_runtime <-> generation_backup`` import cycle.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+import socket
+from typing import IO
+
+
+class LiteConfigurationError(RuntimeError):
+    pass
+
+
+_LOCK_HANDLE: IO[str] | None = None
+
+
+def acquire_single_instance_lock(
+    root: Path,
+    *,
+    state_root: Path | None = None,
+) -> IO[str]:
+    global _LOCK_HANDLE
+    lock_path = (state_root or root / "citadel-state") / "lite-runtime.lock"
+    handle = lock_path.open("a+", encoding="utf-8")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as error:
+        handle.close()
+        raise LiteConfigurationError(
+            "SQLite Lite allows exactly one Citadel process for this data volume"
+        ) from error
+    handle.seek(0)
+    handle.truncate()
+    handle.write(f"pid={os.getpid()} host={socket.gethostname()}\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+    os.set_inheritable(handle.fileno(), True)
+    _LOCK_HANDLE = handle
+    return handle

--- a/kb/lite_runtime.py
+++ b/kb/lite_runtime.py
@@ -2,27 +2,52 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-import fcntl
 import json
 import os
 from pathlib import Path
 import pwd
-import socket
 import sqlite3
 import sys
 import time
-from typing import IO, Any
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 
-class LiteConfigurationError(RuntimeError):
-    pass
+from kb.lite_lock import LiteConfigurationError, acquire_single_instance_lock
 
-
-_LOCK_HANDLE: IO[str] | None = None
+__all__ = ["LiteConfigurationError", "acquire_single_instance_lock"]
+# Set this to run one offline generation backup before normal Lite startup.
+LITE_BACKUP_DESTINATION_ENV = "CITADEL_LITE_BACKUP_DESTINATION"
+LITE_PROJECTION_CUTOVER_ROOT_ENV = "CITADEL_LITE_PROJECTION_CUTOVER_ROOT"
+LITE_PROJECTION_CUTOVER_BACKUP_ROOT_ENV = "CITADEL_LITE_PROJECTION_CUTOVER_BACKUP_ROOT"
+LITE_PROJECTION_CUTOVER_MANIFEST_SHA256_ENV = (
+    "CITADEL_LITE_PROJECTION_CUTOVER_MANIFEST_SHA256"
+)
+LITE_PROJECTION_CUTOVER_MANIFEST_ENV = LITE_PROJECTION_CUTOVER_MANIFEST_SHA256_ENV
 _QDRANT_ADAPTER_BASELINE = "7311f4572b3ec328f3c2fe5ba3d49a6a79d6ae29"
+_LITE_PERSISTED_PATH_ENV_NAMES = (
+    # kb/config.py
+    "CITADEL_ACCESS_STORE_PATH",
+    "CITADEL_CONTACT_STORE_PATH",
+    "CITADEL_OBSIDIAN_SYNC_STATE_PATH",
+    "CITADEL_CONFLICTS_STORE_PATH",
+    "CITADEL_GITHUB_SYNC_STATE_PATH",
+    "CITADEL_REPO_STATS_STATE_PATH",
+    "CITADEL_REPO_CONTENT_SYNC_STATE_PATH",
+    "CITADEL_EVOLVE_STATE_PATH",
+    "CITADEL_EVALUATION_GATE_PATH",
+    "CITADEL_REPAIR_JOURNAL_PATH",
+    "CITADEL_COGNIFY_QUEUE_PATH",
+    "CITADEL_LIFECYCLE_STORE_PATH",
+    "CITADEL_BACKUP_MIRROR_ROOT_PATH",
+    "CITADEL_LINEAR_SYNC_STATE_PATH",
+    # kb/embedding_profile.py, kb/skills.py, retrieval_eval.py
+    "CITADEL_EMBEDDING_PROFILE_STATE_PATH",
+    "CITADEL_SKILLS_STATE_PATH",
+    "CITADEL_REPO_STATE_PATH",
+)
 
 
 def _required(name: str) -> str:
@@ -159,6 +184,150 @@ def configure_lite_environment(data_root: Path | None = None) -> Path:
     return root
 
 
+def run_prelock_backup(root: Path) -> dict[str, Any] | None:
+    destination = os.getenv(LITE_BACKUP_DESTINATION_ENV, "").strip()
+    if not destination:
+        return None
+    from kb.generation_backup import QdrantSnapshotStore, create_generation_backup
+
+    generation_id = _required("CITADEL_GENERATION_ID")
+    qdrant_url = _required("VECTOR_DB_URL")
+    qdrant_key = _required("VECTOR_DB_KEY")
+    with QdrantSnapshotStore(url=qdrant_url, api_key=qdrant_key) as snapshot_store:
+        return create_generation_backup(
+            generation_id=generation_id,
+            data_root=root,
+            destination=Path(destination).expanduser(),
+            snapshot_store=snapshot_store,
+        )
+
+def _clear_cognee_config_caches() -> None:
+    try:
+        from kb import cognee_client
+    except Exception:
+        return
+    cognee_client._PREPARED_COGNEE_STORAGE_SIGNATURE = None
+    clear = getattr(cognee_client.CogneePublicClient, "_clear_cognee_config_caches", None)
+    if callable(clear):
+        clear()
+
+
+def _rebind_lite_paths(root: Path) -> Path:
+    previous_root_value = os.getenv("CITADEL_LITE_DATA_ROOT", "").strip() or "/data"
+    previous_root = Path(previous_root_value).expanduser().resolve()
+    def _previous_storage_root(name: str, fallback: str) -> Path:
+        fallback_path = previous_root / fallback
+        configured = Path(
+            os.getenv(name, "").strip() or str(fallback_path)
+        ).expanduser()
+        if not configured.is_absolute():
+            configured = previous_root / configured
+        configured = configured.resolve()
+        return configured if configured.is_relative_to(previous_root) else fallback_path
+
+    previous_state_root = _previous_storage_root("CITADEL_STATE_DIRECTORY", "citadel-state")
+    previous_system_root = _previous_storage_root("SYSTEM_ROOT_DIRECTORY", "cognee-system")
+    previous_data_root = _previous_storage_root("DATA_ROOT_DIRECTORY", "data-storage")
+
+    persisted_values = {
+        name: os.environ.get(name) for name in _LITE_PERSISTED_PATH_ENV_NAMES
+    }
+    root = root.expanduser().resolve()
+    state_root = root / "citadel-state"
+    storage_roots = tuple(
+        sorted(
+            (
+                (previous_state_root, state_root),
+                (previous_system_root, root / "cognee-system"),
+                (previous_data_root, root / "data-storage"),
+            ),
+            key=lambda item: len(item[0].parts),
+            reverse=True,
+        )
+    )
+    fastembed_cache_path = os.environ.get("FASTEMBED_CACHE_PATH")
+    if not fastembed_cache_path or not fastembed_cache_path.strip():
+        fastembed_cache_path = str(root / "cache/fastembed")
+    path_values = {
+        "CITADEL_LITE_DATA_ROOT": root,
+        "SYSTEM_ROOT_DIRECTORY": root / "cognee-system",
+        "DATA_ROOT_DIRECTORY": root / "data-storage",
+        "CACHE_ROOT_DIRECTORY": root / "cache",
+        "FASTEMBED_CACHE_PATH": fastembed_cache_path,
+        "COGNEE_LOGS_DIR": root / "logs",
+        "CITADEL_STATE_DIRECTORY": state_root,
+        "LADYBUG_HOME_DIRECTORY": root / "ladybug-home",
+        "DB_PATH": root / "cognee-system/databases",
+        "DB_NAME": Path("cognee.db"),
+    }
+    for name, value in path_values.items():
+        os.environ[name] = str(value)
+    for name, value in persisted_values.items():
+        if not value or not value.strip():
+            if name == "CITADEL_LIFECYCLE_STORE_PATH":
+                os.environ[name] = str(state_root / "lifecycle.sqlite3")
+            elif name == "CITADEL_COGNIFY_QUEUE_PATH":
+                os.environ[name] = str(state_root / "cognify_queue.json")
+            continue
+        configured = Path(value).expanduser()
+        if not configured.is_absolute():
+            continue
+        try:
+            resolved = configured.resolve(strict=False)
+        except (OSError, RuntimeError) as error:
+            raise LiteConfigurationError(
+                f"{name} must resolve as a direct path: {configured}"
+            ) from error
+        if not resolved.is_relative_to(previous_root):
+            continue
+        if name == "CITADEL_LIFECYCLE_STORE_PATH":
+            os.environ[name] = str(state_root / "lifecycle.sqlite3")
+            continue
+        for old_storage_root, new_storage_root in storage_roots:
+            if not resolved.is_relative_to(old_storage_root):
+                continue
+            relative = resolved.relative_to(old_storage_root)
+            os.environ[name] = str(new_storage_root / relative)
+            break
+    _clear_cognee_config_caches()
+    return root
+
+
+def run_prelock_projection_cutover() -> dict[str, Any] | None:
+    configured = {
+        LITE_PROJECTION_CUTOVER_ROOT_ENV: os.getenv(LITE_PROJECTION_CUTOVER_ROOT_ENV, "").strip(),
+        LITE_PROJECTION_CUTOVER_BACKUP_ROOT_ENV: os.getenv(
+            LITE_PROJECTION_CUTOVER_BACKUP_ROOT_ENV, ""
+        ).strip(),
+        LITE_PROJECTION_CUTOVER_MANIFEST_ENV: os.getenv(
+            LITE_PROJECTION_CUTOVER_MANIFEST_ENV, ""
+        ).strip(),
+    }
+    if not any(configured.values()):
+        return None
+    if any(not value for value in configured.values()):
+        raise LiteConfigurationError(
+            "projection cutover requires "
+            f"{LITE_PROJECTION_CUTOVER_ROOT_ENV}, "
+            f"{LITE_PROJECTION_CUTOVER_BACKUP_ROOT_ENV}, and "
+            f"{LITE_PROJECTION_CUTOVER_MANIFEST_ENV}"
+        )
+
+    try:
+        from kb.projection_cutover import prepare_projection_cutover
+
+        result = prepare_projection_cutover(
+            backup_root=Path(configured[LITE_PROJECTION_CUTOVER_BACKUP_ROOT_ENV]).expanduser(),
+            target_root=Path(configured[LITE_PROJECTION_CUTOVER_ROOT_ENV]).expanduser(),
+            generation_id=_required("CITADEL_GENERATION_ID"),
+            manifest_sha256=configured[LITE_PROJECTION_CUTOVER_MANIFEST_ENV],
+        )
+        _rebind_lite_paths(Path(configured[LITE_PROJECTION_CUTOVER_ROOT_ENV]).expanduser())
+    except Exception as error:
+        raise LiteConfigurationError(f"projection cutover failed: {error}") from error
+    return result
+
+
 def sqlite_database_path() -> Path:
     return Path(os.environ["DB_PATH"]) / os.environ["DB_NAME"]
 
@@ -240,29 +409,8 @@ def drop_root_privileges(root: Path, *, user_name: str = "citadel") -> None:
     os.setuid(account.pw_uid)
 
 
-def acquire_single_instance_lock(
-    root: Path,
-    *,
-    state_root: Path | None = None,
-) -> IO[str]:
-    global _LOCK_HANDLE
-    lock_path = (state_root or root / "citadel-state") / "lite-runtime.lock"
-    handle = lock_path.open("a+", encoding="utf-8")
-    try:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError as error:
-        handle.close()
-        raise LiteConfigurationError(
-            "SQLite Lite allows exactly one Citadel process for this data volume"
-        ) from error
-    handle.seek(0)
-    handle.truncate()
-    handle.write(f"pid={os.getpid()} host={socket.gethostname()}\n")
-    handle.flush()
-    os.fsync(handle.fileno())
-    os.set_inheritable(handle.fileno(), True)
-    _LOCK_HANDLE = handle
-    return handle
+# acquire_single_instance_lock lives in kb.lite_lock (imported above) so that
+# kb.generation_backup can use it without importing this runtime module.
 
 
 def wait_for_qdrant(*, timeout_seconds: float = 90.0) -> None:
@@ -356,7 +504,21 @@ def web_command() -> list[str]:
 
 def main() -> None:
     try:
-        root = configure_lite_environment()
+        projection_cutover = run_prelock_projection_cutover()
+        if projection_cutover is None:
+            root = configure_lite_environment()
+        else:
+            root = configure_lite_environment(
+                Path(os.environ[LITE_PROJECTION_CUTOVER_ROOT_ENV])
+            )
+            print(json.dumps(projection_cutover, sort_keys=True), flush=True)
+        try:
+            backup = run_prelock_backup(root)
+        except Exception as error:
+            raise SystemExit(f"Citadel Lite pre-lock backup failed: {error}") from error
+        if backup is not None:
+            print(json.dumps(backup, sort_keys=True), flush=True)
+            return
         drop_root_privileges(root)
         acquire_single_instance_lock(root)
         quarantined = quarantine_unreadable_sqlite()

--- a/kb/projection_cutover.py
+++ b/kb/projection_cutover.py
@@ -1,0 +1,676 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+from typing import Any
+from uuid import UUID
+
+from kb.generation_backup import GenerationBackupError
+
+
+PROJECTION_CUTOVER_SCHEMA_VERSION = 1
+PROJECTION_CUTOVER_SCHEMA = "citadel.projection-cutover"
+PROJECTION_CUTOVER_RECEIPT = Path("citadel-state/projection-cutover.json")
+_ARCHIVE_TABLE = "pipeline_runs_cognify_archive"
+_ARCHIVE_METADATA_TABLE = "projection_cutover_archive_metadata"
+_GENERATION_SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+_HEX_SHA256 = re.compile(r"[0-9a-fA-F]{64}")
+_GRAPH_SUFFIXES = (".lbug", ".lbug.wal")
+
+
+class ProjectionCutoverError(GenerationBackupError):
+    """Raised when the clean projection cutover cannot be applied safely."""
+
+
+def _direct_path(path: Path, *, label: str) -> Path:
+    absolute = Path(os.path.abspath(os.fspath(path)))
+    try:
+        resolved = absolute.resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise ProjectionCutoverError(f"{label} is not a direct path: {absolute}") from error
+    if resolved != absolute:
+        raise ProjectionCutoverError(
+            f"{label} must not resolve through a symbolic link: {absolute}"
+        )
+    return absolute
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _require_generation(generation_id: str) -> str:
+    generation = generation_id.strip()
+    if not generation:
+        raise ProjectionCutoverError("generation ID must not be empty")
+    return generation
+
+
+def _require_manifest_hash(manifest_sha256: str) -> str:
+    digest = manifest_sha256.strip().lower()
+    if _HEX_SHA256.fullmatch(digest) is None:
+        raise ProjectionCutoverError("manifest SHA256 must be 64 hexadecimal characters")
+    return digest
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _receipt_digest(receipt: dict[str, Any]) -> str:
+    unsigned = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    return hashlib.sha256(_canonical_json(unsigned).encode("utf-8")).hexdigest()
+
+
+def _read_existing_receipt(
+    target_root: Path,
+    *,
+    generation_id: str,
+    manifest_sha256: str,
+) -> dict[str, Any] | None:
+    receipt_path = target_root / PROJECTION_CUTOVER_RECEIPT
+    if not receipt_path.exists():
+        return None
+    if receipt_path.is_symlink() or not receipt_path.is_file():
+        raise ProjectionCutoverError("projection cutover receipt must be a regular file")
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ProjectionCutoverError("projection cutover receipt is unreadable") from error
+    if not isinstance(receipt, dict):
+        raise ProjectionCutoverError("projection cutover receipt is malformed")
+    if receipt.get("schema") != PROJECTION_CUTOVER_SCHEMA:
+        raise ProjectionCutoverError("projection cutover receipt schema is unsupported")
+    if receipt.get("schema_version") != PROJECTION_CUTOVER_SCHEMA_VERSION:
+        raise ProjectionCutoverError("projection cutover receipt schema is unsupported")
+    if receipt.get("generation_id") != generation_id or receipt.get("manifest_sha256") != manifest_sha256:
+        raise ProjectionCutoverError("projection cutover receipt does not match requested cutover")
+    if receipt.get("receipt_sha256") != _receipt_digest(receipt):
+        raise ProjectionCutoverError("projection cutover receipt hash mismatch")
+    return receipt
+
+
+def _layout(target_root: Path, backup_module: Any) -> Any:
+    return backup_module._LiteStorageLayout(
+        system_root=target_root / "cognee-system",
+        data_storage_root=target_root / "data-storage",
+        state_root=target_root / "citadel-state",
+        database_path=target_root / "cognee-system/databases",
+        database_file=target_root / "cognee-system/databases/cognee.db",
+        lifecycle_file=target_root / "citadel-state/lifecycle.sqlite3",
+    )
+
+
+def _reject_symlinks(root: Path, *, label: str) -> None:
+    if not root.exists():
+        raise ProjectionCutoverError(f"{label} is missing: {root}")
+    if root.is_symlink():
+        raise ProjectionCutoverError(f"{label} must not contain symbolic links: {root}")
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ProjectionCutoverError(f"{label} must not contain symbolic links: {path}")
+
+
+def _validate_manifest(
+    backup_root: Path,
+    *,
+    target_layout: Any,
+    generation_id: str,
+    manifest_sha256: str,
+    backup_module: Any,
+) -> dict[str, Any]:
+    if not backup_root.is_dir() or backup_root.is_symlink():
+        raise ProjectionCutoverError(f"backup root is not a direct directory: {backup_root}")
+    manifest_path = backup_root / "manifest.json"
+    actual_hash = _sha256(manifest_path) if manifest_path.is_file() else ""
+    if actual_hash != manifest_sha256:
+        raise ProjectionCutoverError(
+            f"backup manifest hash mismatch: expected {manifest_sha256}, got {actual_hash}"
+        )
+    manifest = backup_module._load_manifest(backup_root)
+    if manifest.get("generation_id") != generation_id:
+        raise ProjectionCutoverError(
+            "generation ID mismatch: "
+            f"cutover is {generation_id!r}, backup is {manifest.get('generation_id')!r}"
+        )
+    local_files = manifest.get("local_files")
+    collections = manifest.get("qdrant_collections")
+    if not isinstance(local_files, list) or not isinstance(collections, list):
+        raise ProjectionCutoverError("backup manifest inventory is malformed")
+    local_root = backup_root / "local"
+    _reject_symlinks(local_root, label="backup local tree")
+    backup_module._verify_inventory(local_root, local_files)
+    for item in local_files:
+        relative = str(item.get("path", ""))
+        try:
+            backup_module._archive_path_to_target(relative, target_layout)
+        except GenerationBackupError as error:
+            raise ProjectionCutoverError(str(error)) from error
+    backup_module._verify_qdrant_artifacts(backup_root, collections)
+    return manifest
+
+
+def _normalize_id(value: Any) -> str:
+    text = str(value).strip()
+    try:
+        return UUID(text).hex
+    except (ValueError, AttributeError):
+        return text.casefold()
+
+
+def _safe_error_ids(values: set[str]) -> str:
+    safe = []
+    for value in sorted(values)[:20]:
+        safe.append(value if re.fullmatch(r"[A-Za-z0-9_.:-]+", value) else "<unsafe>")
+    return ",".join(safe) or "-"
+
+
+def _validate_lifecycle_projection(
+    lifecycle_path: Path,
+    *,
+    generation_id: str,
+) -> set[str]:
+    if not lifecycle_path.is_file() or lifecycle_path.is_symlink():
+        raise ProjectionCutoverError(f"lifecycle SQLite is missing: {lifecycle_path}")
+    allowed_job_states = {"pending", "running", "deferred"}
+    allowed_receipt_states = {"pending", "running"}
+    try:
+        with sqlite3.connect(f"{lifecycle_path.as_uri()}?mode=ro", uri=True) as connection:
+            tables = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            required_tables = {
+                "source_heads",
+                "source_revisions",
+                "projection_jobs",
+                "projection_receipts",
+            }
+            if not required_tables.issubset(tables):
+                raise ProjectionCutoverError(
+                    "lifecycle projection precondition failed: "
+                    "missing_projection_tables_count=1"
+                )
+            rows = connection.execute(
+                """
+                SELECT revisions.source_revision_id,
+                       jobs.projection_job_id,
+                       jobs.state,
+                       receipts.projection_receipt_id,
+                       receipts.generation_id,
+                       receipts.state,
+                       receipts.source_revision_id
+                FROM source_heads AS heads
+                LEFT JOIN source_revisions AS revisions
+                  ON revisions.source_revision_id = heads.source_revision_id
+                LEFT JOIN projection_jobs AS jobs
+                  ON jobs.source_revision_id = revisions.source_revision_id
+                 AND jobs.generation_id = ?
+                LEFT JOIN projection_receipts AS receipts
+                  ON receipts.projection_job_id = jobs.projection_job_id
+                 AND receipts.backend = 'graph'
+                WHERE revisions.tombstone = 0
+                ORDER BY revisions.source_revision_id,
+                         jobs.projection_job_id,
+                         receipts.projection_receipt_id
+                """,
+                (generation_id,),
+            ).fetchall()
+    except ProjectionCutoverError:
+        raise
+    except (OSError, sqlite3.Error) as error:
+        raise ProjectionCutoverError("lifecycle SQLite cannot be read") from error
+
+    rows_by_source: dict[str, list[tuple[Any, ...]]] = {}
+    for row in rows:
+        source_id = _normalize_id(row[0])
+        rows_by_source.setdefault(source_id, []).append(tuple(row))
+
+    missing_sources: set[str] = set()
+    duplicate_sources: set[str] = set()
+    invalid_job_ids: set[str] = set()
+    invalid_receipt_ids: set[str] = set()
+    mismatched_receipt_ids: set[str] = set()
+    active_ids = set(rows_by_source)
+    for source_id, source_rows in rows_by_source.items():
+        job_ids = {
+            _normalize_id(row[1])
+            for row in source_rows
+            if row[1] is not None
+        }
+        receipt_ids = {
+            _normalize_id(row[3])
+            for row in source_rows
+            if row[3] is not None
+        }
+        if not job_ids or not receipt_ids:
+            missing_sources.add(source_id)
+        if len(job_ids) > 1 or len(receipt_ids) > 1:
+            duplicate_sources.add(source_id)
+
+        job_states: dict[str, set[str]] = {}
+        receipt_states: dict[str, set[str]] = {}
+        for row in source_rows:
+            if row[1] is not None:
+                job_id = _normalize_id(row[1])
+                job_states.setdefault(job_id, set()).add(str(row[2]))
+            if row[3] is not None:
+                receipt_id = _normalize_id(row[3])
+                receipt_states.setdefault(receipt_id, set()).add(str(row[5]))
+                if (
+                    str(row[4]) != generation_id
+                    or _normalize_id(row[6]) != source_id
+                ):
+                    mismatched_receipt_ids.add(receipt_id)
+        for job_id, states in job_states.items():
+            if not states.issubset(allowed_job_states):
+                invalid_job_ids.add(job_id)
+        for receipt_id, states in receipt_states.items():
+            if not states.issubset(allowed_receipt_states):
+                invalid_receipt_ids.add(receipt_id)
+
+    if (
+        missing_sources
+        or duplicate_sources
+        or invalid_job_ids
+        or invalid_receipt_ids
+        or mismatched_receipt_ids
+    ):
+        raise ProjectionCutoverError(
+            "lifecycle projection precondition failed: "
+            f"active_source_count={len(active_ids)} "
+            f"missing_job_or_receipt_count={len(missing_sources)} "
+            f"missing_source_revision_ids={_safe_error_ids(missing_sources)} "
+            f"duplicate_job_or_receipt_count={len(duplicate_sources)} "
+            f"duplicate_source_revision_ids={_safe_error_ids(duplicate_sources)} "
+            f"invalid_job_state_count={len(invalid_job_ids)} "
+            f"invalid_job_ids={_safe_error_ids(invalid_job_ids)} "
+            f"invalid_graph_receipt_state_count={len(invalid_receipt_ids)} "
+            f"invalid_graph_receipt_ids={_safe_error_ids(invalid_receipt_ids)} "
+            f"mismatched_graph_receipt_count={len(mismatched_receipt_ids)} "
+            f"mismatched_graph_receipt_ids={_safe_error_ids(mismatched_receipt_ids)}"
+        )
+    return active_ids
+
+
+def _identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> list[str]:
+    try:
+        rows = connection.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    except sqlite3.Error as error:
+        raise ProjectionCutoverError(f"cannot inspect SQLite table: {table}") from error
+    columns = [str(row[1]) for row in rows]
+    if not columns:
+        raise ProjectionCutoverError(f"required SQLite table is missing: {table}")
+    return columns
+
+
+def _safe_graph_name(value: Any, *, dataset_id: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or Path(value).is_absolute()
+        or Path(value).name != value
+        or value.endswith(".lbug.wal")
+        or not value.endswith(".lbug")
+    ):
+        raise ProjectionCutoverError(f"malformed graph mapping for dataset {dataset_id}")
+    return value
+
+
+def _safe_component(value: Any, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or Path(value).name != value
+        or value in {".", ".."}
+    ):
+        raise ProjectionCutoverError(f"malformed graph mapping {label}")
+    return value
+
+
+def _uuid_path_component(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ProjectionCutoverError(f"malformed graph mapping {label}")
+    try:
+        return str(UUID(value))
+    except ValueError:
+        return _safe_component(value, label=label)
+
+
+def _generation_slug(generation_id: str) -> str:
+    slug = _GENERATION_SAFE.sub("-", generation_id).strip(".-")
+    return slug[:48] or "generation"
+
+
+def _graph_mapping_plan(
+    connection: sqlite3.Connection,
+    target_root: Path,
+    generation_id: str,
+) -> list[dict[str, Any]]:
+    columns = set(_table_columns(connection, "dataset_database"))
+    required = {"owner_id", "dataset_id", "graph_database_name"}
+    if not required.issubset(columns):
+        missing = ", ".join(sorted(required - columns))
+        raise ProjectionCutoverError(f"dataset_database schema is missing: {missing}")
+    rows = connection.execute(
+        "SELECT owner_id, dataset_id, graph_database_name FROM dataset_database ORDER BY dataset_id"
+    ).fetchall()
+    seen_dataset_ids: set[str] = set()
+    seen_old_paths: set[Path] = set()
+    seen_new_paths: set[Path] = set()
+    digest = hashlib.sha256(generation_id.encode("utf-8")).hexdigest()[:12]
+    slug = _generation_slug(generation_id)
+    plan: list[dict[str, Any]] = []
+    for row in rows:
+        owner_value = row[0]
+        owner = _uuid_path_component(owner_value, label="owner ID")
+        dataset = _safe_component(row[1], label="dataset ID")
+        normalized_dataset = _normalize_id(dataset)
+        if normalized_dataset in seen_dataset_ids:
+            raise ProjectionCutoverError(f"duplicate dataset mapping: {dataset}")
+        seen_dataset_ids.add(normalized_dataset)
+        old_name = _safe_graph_name(row[2], dataset_id=dataset)
+        old_path = target_root / "cognee-system/databases" / owner / old_name
+        if (
+            not old_path.exists()
+            and isinstance(owner_value, str)
+            and owner_value != owner
+        ):
+            raw_owner_path = target_root / "cognee-system/databases" / owner_value / old_name
+            if raw_owner_path.exists():
+                old_path = raw_owner_path
+        new_name = f"{dataset}.projection-{slug}-{digest}.lbug"
+        new_path = target_root / "cognee-system/databases" / owner / new_name
+        if old_path in seen_old_paths or new_path in seen_new_paths:
+            raise ProjectionCutoverError(f"duplicate graph mapping for dataset {dataset}")
+        if new_path.exists():
+            raise ProjectionCutoverError(f"new graph path already exists: {new_path}")
+        seen_old_paths.add(old_path)
+        seen_new_paths.add(new_path)
+        plan.append(
+            {
+                "dataset_id": row[1],
+                "old": old_path.relative_to(target_root).as_posix(),
+                "new": new_path.relative_to(target_root).as_posix(),
+                "archive": None,
+            }
+        )
+    return plan
+
+
+def _graph_files(target_root: Path) -> list[Path]:
+    database_root = target_root / "cognee-system/databases"
+    if not database_root.is_dir() or database_root.is_symlink():
+        raise ProjectionCutoverError(f"Cognee database tree is missing: {database_root}")
+    paths: list[Path] = []
+    for path in sorted(database_root.rglob("*")):
+        if path.is_symlink():
+            raise ProjectionCutoverError(
+                f"Cognee database tree must not contain symbolic links: {path}"
+            )
+        if path.is_file() and path.name.endswith(_GRAPH_SUFFIXES):
+            paths.append(path)
+    return paths
+
+
+def _move_graph_files(target_root: Path, paths: list[Path]) -> dict[str, str]:
+    archive_root = target_root / "graph-archive"
+    if archive_root.exists() and archive_root.is_symlink():
+        raise ProjectionCutoverError("graph archive must not be a symbolic link")
+    archive_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    moved: dict[str, str] = {}
+    destinations: list[tuple[Path, Path]] = []
+    for source in paths:
+        relative = source.relative_to(target_root).as_posix()
+        destination = archive_root / source.relative_to(target_root / "cognee-system/databases")
+        if destination.exists() or destination.is_symlink():
+            raise ProjectionCutoverError(f"graph archive path already exists: {destination}")
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        destinations.append((source, destination))
+        moved[relative] = destination.relative_to(target_root).as_posix()
+    for source, destination in destinations:
+        shutil.move(os.fspath(source), os.fspath(destination))
+    return moved
+
+
+def _archive_pipeline_runs(
+    connection: sqlite3.Connection,
+    *,
+    generation_id: str,
+) -> int:
+    columns = _table_columns(connection, "pipeline_runs")
+    if "pipeline_name" not in columns:
+        raise ProjectionCutoverError("pipeline_runs schema is missing pipeline_name")
+    existing = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (_ARCHIVE_TABLE,),
+    ).fetchone()
+    if existing is not None:
+        raise ProjectionCutoverError(f"archive table already exists: {_ARCHIVE_TABLE}")
+    source_schema_row = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'pipeline_runs'"
+    ).fetchone()
+    source_schema = source_schema_row[0] if source_schema_row else None
+    if not isinstance(source_schema, str) or not source_schema:
+        raise ProjectionCutoverError("pipeline_runs schema is unavailable")
+    archive_name = _identifier(_ARCHIVE_TABLE)
+    source_name = _identifier("pipeline_runs")
+    connection.execute(f"CREATE TABLE {archive_name} AS SELECT * FROM {source_name} WHERE 0")
+    column_list = ", ".join(_identifier(column) for column in columns)
+    cursor = connection.execute(
+        f"INSERT INTO {archive_name} ({column_list}) "
+        f"SELECT {column_list} FROM {source_name} WHERE pipeline_name = ?",
+        ("cognify_pipeline",),
+    )
+    archived_count = cursor.rowcount
+    connection.execute(
+        f"CREATE TABLE {_identifier(_ARCHIVE_METADATA_TABLE)} ("
+        "archive_table TEXT PRIMARY KEY, generation_id TEXT NOT NULL, "
+        "source_table TEXT NOT NULL, source_schema TEXT NOT NULL, "
+        "archived_row_count INTEGER NOT NULL, archived_at TEXT NOT NULL)"
+    )
+    connection.execute(
+        f"INSERT INTO {_identifier(_ARCHIVE_METADATA_TABLE)} VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            _ARCHIVE_TABLE,
+            generation_id,
+            "pipeline_runs",
+            source_schema,
+            archived_count,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    connection.execute(
+        "DELETE FROM pipeline_runs WHERE pipeline_name = ?", ("cognify_pipeline",)
+    )
+    return archived_count
+
+
+def _clear_active_data_status(
+    connection: sqlite3.Connection,
+    active_ids: set[str],
+) -> int:
+    columns = _table_columns(connection, "data")
+    if not {"id", "pipeline_status"}.issubset(columns):
+        raise ProjectionCutoverError("data schema is missing pipeline status")
+    cleared = 0
+    rows = connection.execute("SELECT id, pipeline_status FROM data").fetchall()
+    for row in rows:
+        if _normalize_id(row[0]) not in active_ids:
+            continue
+        raw_status = row[1]
+        if raw_status is None:
+            continue
+        try:
+            status = json.loads(raw_status) if isinstance(raw_status, (str, bytes)) else raw_status
+        except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ProjectionCutoverError(f"data pipeline_status is invalid for {row[0]}") from error
+        if not isinstance(status, dict):
+            raise ProjectionCutoverError(f"data pipeline_status is not an object for {row[0]}")
+        if "cognify_pipeline" not in status:
+            continue
+        del status["cognify_pipeline"]
+        connection.execute(
+            "UPDATE data SET pipeline_status = ? WHERE id = ?",
+            (_canonical_json(status), row[0]),
+        )
+        cleared += 1
+    return cleared
+
+
+def _write_receipt(target_root: Path, receipt: dict[str, Any]) -> Path:
+    receipt_path = target_root / PROJECTION_CUTOVER_RECEIPT
+    if receipt_path.is_symlink():
+        raise ProjectionCutoverError("projection cutover receipt must not be a symbolic link")
+    receipt_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = dict(receipt)
+    payload["receipt_sha256"] = _receipt_digest(payload)
+    temporary = receipt_path.with_name(f".{receipt_path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.chmod(0o600)
+        os.replace(temporary, receipt_path)
+    except OSError as error:
+        # Best-effort cleanup: the temporary file may already be gone, and the
+        # original OSError below is the failure that matters.
+        with suppress(OSError):
+            temporary.unlink()
+        raise ProjectionCutoverError("projection cutover receipt could not be written") from error
+    return receipt_path
+
+
+def prepare_projection_cutover(
+    *,
+    backup_root: Path,
+    target_root: Path,
+    generation_id: str,
+    manifest_sha256: str,
+    snapshot_store: Any | None = None,
+) -> dict[str, Any]:
+    """Restore a sealed Lite backup and move its graph projection to new paths."""
+    del snapshot_store
+    generation = _require_generation(generation_id)
+    manifest_hash = _require_manifest_hash(manifest_sha256)
+    target = _direct_path(Path(target_root), label="projection cutover target")
+    backup = _direct_path(Path(backup_root), label="projection cutover backup")
+    if target == backup or backup in target.parents:
+        raise ProjectionCutoverError(
+            f"projection cutover target must not be inside the backup: {target}"
+        )
+    if target.exists() and target.is_symlink():
+        raise ProjectionCutoverError(
+            f"projection cutover target must not be a symbolic link: {target}"
+        )
+    if target.exists() and not target.is_dir():
+        raise ProjectionCutoverError(f"projection cutover target is not a directory: {target}")
+    if target.exists():
+        receipt = _read_existing_receipt(
+            target,
+            generation_id=generation,
+            manifest_sha256=manifest_hash,
+        )
+        if receipt is not None:
+            return {**receipt, "ok": True, "idempotent": True}
+        if any(target.iterdir()):
+            raise ProjectionCutoverError(
+                "projection cutover target must be empty or contain a matching receipt"
+            )
+    else:
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    stage = target.with_name(f".{target.name}.projection-cutover-{os.getpid()}.tmp")
+    if stage.exists() or stage.is_symlink():
+        raise ProjectionCutoverError(f"projection cutover staging path already exists: {stage}")
+    stage.mkdir(mode=0o700)
+    target_removed = False
+    try:
+        from kb import generation_backup as backup_module
+
+        target_layout = _layout(stage, backup_module)
+        manifest = _validate_manifest(
+            backup,
+            target_layout=target_layout,
+            generation_id=generation,
+            manifest_sha256=manifest_hash,
+            backup_module=backup_module,
+        )
+        backup_module._restore_lite_state(backup / "local", target_layout)
+        backup_module._verify_restored_inventory(target_layout, manifest["local_files"])
+        active_ids = _validate_lifecycle_projection(
+            target_layout.lifecycle_file,
+            generation_id=generation,
+        )
+        graph_paths = _graph_files(stage)
+        with sqlite3.connect(target_layout.database_file) as connection:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                graph_plan = _graph_mapping_plan(connection, stage, generation)
+                archived_count = _archive_pipeline_runs(connection, generation_id=generation)
+                cleared_count = _clear_active_data_status(connection, active_ids)
+                for entry in graph_plan:
+                    connection.execute(
+                        "UPDATE dataset_database SET graph_database_name = ? WHERE dataset_id = ?",
+                        (Path(entry["new"]).name, entry["dataset_id"]),
+                    )
+                connection.commit()
+            except Exception:
+                if connection.in_transaction:
+                    connection.rollback()
+                raise
+        archived_graphs = _move_graph_files(stage, graph_paths)
+        receipt_graph_plan = [
+            {
+                "old": entry["old"],
+                "new": entry["new"],
+                "archive": archived_graphs.get(entry["old"]),
+            }
+            for entry in graph_plan
+        ]
+        receipt = {
+            "schema": PROJECTION_CUTOVER_SCHEMA,
+            "schema_version": PROJECTION_CUTOVER_SCHEMA_VERSION,
+            "generation_id": generation,
+            "manifest_sha256": manifest_hash,
+            "archived_pipeline_run_count": archived_count,
+            "cleared_data_count": cleared_count,
+            "remapped_dataset_count": len(graph_plan),
+            "old_new_graph_paths": receipt_graph_plan,
+            "archived_graph_paths": [
+                archived_graphs[key] for key in sorted(archived_graphs)
+            ],
+        }
+        _write_receipt(stage, receipt)
+        if target.exists():
+            if any(target.iterdir()):
+                raise ProjectionCutoverError(
+                    "projection cutover target changed while preparing cutover"
+                )
+            target.rmdir()
+            target_removed = True
+        os.replace(stage, target)
+    except Exception:
+        if target_removed and not target.exists():
+            target.mkdir(mode=0o700)
+        if stage.exists() and not stage.is_symlink():
+            shutil.rmtree(stage)
+        raise
+    return {**receipt, "ok": True, "idempotent": False}

--- a/tests/test_generation_backup.py
+++ b/tests/test_generation_backup.py
@@ -16,6 +16,7 @@ import kb.generation_backup as generation_backup
 from kb.cli import _backup_generation_create, _backup_generation_restore, build_parser
 from kb.generation_backup import (
     GenerationBackupError,
+    QdrantSnapshotStore,
     create_generation_backup,
     restore_generation_backup,
 )
@@ -85,6 +86,59 @@ def _lite_root(root: Path) -> None:
     (root / "data-storage/source.txt").write_text("retained source", encoding="utf-8")
     (root / "citadel-state/auth.json").write_text('{"key":"hash-only"}\n', encoding="utf-8")
 
+@pytest.mark.parametrize(
+    ("configured_timeout", "expected_timeout"),
+    [(None, 900), ("1200", 1200)],
+)
+def test_qdrant_snapshot_store_passes_snapshot_timeout_to_client(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_timeout: str | None,
+    expected_timeout: int,
+) -> None:
+    client_kwargs: dict[str, Any] = {}
+
+    class FakeQdrantClient:
+        def __init__(self, **kwargs: Any) -> None:
+            client_kwargs.update(kwargs)
+
+    monkeypatch.setattr(generation_backup, "QdrantClient", FakeQdrantClient)
+    if configured_timeout is None:
+        monkeypatch.delenv("CITADEL_QDRANT_SNAPSHOT_TIMEOUT_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("CITADEL_QDRANT_SNAPSHOT_TIMEOUT_SECONDS", configured_timeout)
+
+    QdrantSnapshotStore(url="http://qdrant:6333", api_key="secret")
+
+    assert client_kwargs == {
+        "url": "http://qdrant:6333",
+        "api_key": "secret",
+        "timeout": expected_timeout,
+    }
+
+
+@pytest.mark.parametrize(
+    ("configured_timeout", "error"),
+    [
+        ("not-a-number", "must be a finite number"),
+        ("0", "must be at least 1 second"),
+    ],
+)
+def test_qdrant_snapshot_store_rejects_invalid_snapshot_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_timeout: str,
+    error: str,
+) -> None:
+    class FakeQdrantClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+    monkeypatch.setattr(generation_backup, "QdrantClient", FakeQdrantClient)
+    monkeypatch.setenv("CITADEL_QDRANT_SNAPSHOT_TIMEOUT_SECONDS", configured_timeout)
+
+    with pytest.raises(GenerationBackupError, match=error):
+        QdrantSnapshotStore(url="http://qdrant:6333", api_key="secret")
+
+
 
 def test_parser_exposes_generation_backup_and_restore() -> None:
     parser = build_parser()
@@ -136,6 +190,25 @@ def test_generation_backup_restores_every_provider_from_downloaded_artifacts(
     assert (backup_root / "local/data-storage/source.txt").read_text(encoding="utf-8") == "retained source"
     assert json.loads((backup_root / "manifest.json").read_text(encoding="utf-8")) == manifest
 
+    lifecycle_artifact = backup_root / "local/citadel-state/lifecycle.sqlite3"
+    lifecycle_bytes = bytearray(lifecycle_artifact.read_bytes())
+    lifecycle_bytes[24:28] = b"\x00\x00\x00\x00"
+    lifecycle_artifact.write_bytes(lifecycle_bytes)
+    for item in manifest["local_files"]:
+        if item["path"] == "citadel-state/lifecycle.sqlite3":
+            item["size"] = len(lifecycle_bytes)
+            item["sha256"] = hashlib.sha256(lifecycle_bytes).hexdigest()
+            break
+    manifest_path = backup_root / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (backup_root / "manifest.sha256").write_text(
+        f"{hashlib.sha256(manifest_path.read_bytes()).hexdigest()}  manifest.json\n",
+        encoding="ascii",
+    )
+
     restore_root = tmp_path / "restore"
     restore_store = MemorySnapshotStore({})
     result = restore_generation_backup(
@@ -147,13 +220,60 @@ def test_generation_backup_restores_every_provider_from_downloaded_artifacts(
 
     assert result["generation_id"] == "generation-1"
     assert restore_store.restored == snapshots
-    with sqlite3.connect(restore_root / "cognee-system/databases/cognee.db") as connection:
+    restored_database = restore_root / "cognee-system/databases/cognee.db"
+    restored_lifecycle = restore_root / "citadel-state/lifecycle.sqlite3"
+    assert restored_database.read_bytes() == (
+        backup_root / "local/cognee-system/databases/cognee.db"
+    ).read_bytes()
+    assert restored_lifecycle.read_bytes() == lifecycle_artifact.read_bytes()
+    with sqlite3.connect(restored_database) as connection:
+        assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
         assert connection.execute("SELECT value FROM documents").fetchall() == [("doc-1",)]
-    with sqlite3.connect(restore_root / "citadel-state/lifecycle.sqlite3") as connection:
+    with sqlite3.connect(restored_lifecycle) as connection:
+        assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
         assert connection.execute("SELECT value FROM revisions").fetchall() == [
             ("revision-1",)
         ]
 
+
+def test_generation_restore_rejects_mutated_target_sqlite_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "source"
+    _lite_root(source_root)
+    backup_root = tmp_path / "generation-backup"
+    create_generation_backup(
+        generation_id="generation-1",
+        data_root=source_root,
+        destination=backup_root,
+        snapshot_store=MemorySnapshotStore({"collection-1": b"snapshot"}),
+    )
+    restore_store = MemorySnapshotStore({})
+    original_copy_sqlite = generation_backup._copy_sqlite
+
+    def copy_and_mutate_target(source_path: Path, destination_path: Path) -> None:
+        original_copy_sqlite(source_path, destination_path)
+        if destination_path.name == "lifecycle.sqlite3":
+            mutated = bytearray(destination_path.read_bytes())
+            mutated[-1] ^= 1
+            destination_path.write_bytes(mutated)
+
+    monkeypatch.setattr(generation_backup, "_copy_sqlite", copy_and_mutate_target)
+
+    with pytest.raises(
+        GenerationBackupError,
+        match="restored artifact digest mismatch: citadel-state/lifecycle.sqlite3",
+    ):
+        restore_generation_backup(
+            generation_id="generation-1",
+            backup_root=backup_root,
+            target_data_root=tmp_path / "restore",
+            snapshot_store=restore_store,
+        )
+
+    assert restore_store.restored == {}
+    assert not (tmp_path / "restore").exists()
 
 def test_generation_backup_maps_configured_lite_roots_and_database_names(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_lite_runtime.py
+++ b/tests/test_lite_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ LITE_WRITTEN_ENV_KEYS = (
     "SYSTEM_ROOT_DIRECTORY",
     "DATA_ROOT_DIRECTORY",
     "CACHE_ROOT_DIRECTORY",
+    "FASTEMBED_CACHE_PATH",
     "COGNEE_LOGS_DIR",
     "CITADEL_STATE_DIRECTORY",
     "LADYBUG_HOME_DIRECTORY",
@@ -29,6 +31,11 @@ LITE_WRITTEN_ENV_KEYS = (
     "TELEMETRY_DISABLED",
     "AUTO_FEEDBACK",
     "CITADEL_COGNIFY_QUEUE_PATH",
+    "CITADEL_LITE_DATA_ROOT",
+    "CITADEL_LIFECYCLE_STORE_PATH",
+    "CITADEL_LITE_PROJECTION_CUTOVER_ROOT",
+    "CITADEL_LITE_PROJECTION_CUTOVER_BACKUP_ROOT",
+    "CITADEL_LITE_PROJECTION_CUTOVER_MANIFEST_SHA256",
 )
 
 
@@ -187,6 +194,141 @@ def test_configure_lite_environment_preserves_cache_root_override(
 
     assert Path(os.environ["CACHE_ROOT_DIRECTORY"]) == cache_override
     assert cache_override.is_dir()
+
+
+def test_rebind_lite_paths_preserves_nested_persisted_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    old_root = Path("/data")
+    new_root = tmp_path / "new-root"
+    external = tmp_path / "external" / "access.json"
+    configured = {
+        "CITADEL_ACCESS_STORE_PATH": old_root / "citadel-state/auth/access.json",
+        "CITADEL_REPAIR_JOURNAL_PATH": old_root / "citadel-state/repair/repair.jsonl",
+        "CITADEL_EVALUATION_GATE_PATH": old_root / "citadel-state/gates/evaluation.json",
+        "CITADEL_CONTACT_STORE_PATH": external,
+    }
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", str(old_root))
+    root_paths = "README.md,docs/"
+    monkeypatch.setenv("CITADEL_REPO_CONTENT_SYNC_ROOT_PATHS", root_paths)
+
+    for name, value in configured.items():
+        monkeypatch.setenv(name, str(value))
+
+    lite_runtime._rebind_lite_paths(new_root)
+
+    state_root = new_root / "citadel-state"
+    assert Path(os.environ["CITADEL_ACCESS_STORE_PATH"]) == state_root / "auth/access.json"
+    assert Path(os.environ["CITADEL_REPAIR_JOURNAL_PATH"]) == state_root / "repair/repair.jsonl"
+    assert Path(os.environ["CITADEL_EVALUATION_GATE_PATH"]) == (
+        state_root / "gates/evaluation.json"
+    )
+    assert os.environ["CITADEL_CONTACT_STORE_PATH"] == str(external)
+    assert os.environ["CITADEL_REPO_CONTENT_SYNC_ROOT_PATHS"] == root_paths
+
+
+def test_rebind_lite_paths_preserves_external_fastembed_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fastembed_cache = "/opt/fastembed-cache"
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", "/data")
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", fastembed_cache)
+
+    lite_runtime._rebind_lite_paths(tmp_path / "new-root")
+
+    assert os.environ["FASTEMBED_CACHE_PATH"] == fastembed_cache
+
+
+def test_rebind_lite_paths_preserves_relative_persisted_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    relative = "citadel-state/contacts.json"
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", "/data")
+    monkeypatch.setenv("CITADEL_CONTACT_STORE_PATH", relative)
+
+    lite_runtime._rebind_lite_paths(tmp_path / "new-root")
+
+    assert os.environ["CITADEL_CONTACT_STORE_PATH"] == relative
+
+
+def test_rebind_lite_paths_canonicalizes_lifecycle_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    old_root = Path("/data")
+    new_root = tmp_path / "new-root"
+    old_state = old_root / ".citadel"
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", str(old_root))
+    monkeypatch.setenv("CITADEL_STATE_DIRECTORY", str(old_state))
+    monkeypatch.setenv(
+        "CITADEL_LIFECYCLE_STORE_PATH",
+        str(old_state / "legacy/lifecycle.sqlite3"),
+    )
+    monkeypatch.setenv(
+        "CITADEL_ACCESS_STORE_PATH",
+        str(old_state / "auth/access.json"),
+    )
+
+    lite_runtime._rebind_lite_paths(new_root)
+
+    assert Path(os.environ["CITADEL_LIFECYCLE_STORE_PATH"]) == (
+        new_root / "citadel-state/lifecycle.sqlite3"
+    )
+    assert Path(os.environ["CITADEL_ACCESS_STORE_PATH"]) == (
+        new_root / "citadel-state/auth/access.json"
+    )
+
+
+def test_rebind_lite_paths_maps_all_storage_root_descendants(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    old_root = Path("/data")
+    old_system_root = old_root / "cognee-system"
+    old_data_root = old_root / "data-storage"
+    old_state_root = old_root / "citadel-state"
+    new_root = tmp_path / "new-root"
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", str(old_root))
+    monkeypatch.setenv("SYSTEM_ROOT_DIRECTORY", str(old_system_root))
+    monkeypatch.setenv("DATA_ROOT_DIRECTORY", str(old_data_root))
+    monkeypatch.setenv("CITADEL_STATE_DIRECTORY", str(old_state_root))
+    monkeypatch.setenv(
+        "CITADEL_CONTACT_STORE_PATH",
+        str(old_data_root / "nested/contact.json"),
+    )
+    monkeypatch.setenv(
+        "CITADEL_REPAIR_JOURNAL_PATH",
+        str(old_system_root / "nested/repair.jsonl"),
+    )
+    monkeypatch.setenv(
+        "CITADEL_LIFECYCLE_STORE_PATH",
+        str(old_system_root / "nested/lifecycle.sqlite3"),
+    )
+    monkeypatch.setenv(
+        "CITADEL_EVALUATION_GATE_PATH",
+        str(old_state_root / "nested/evaluation.json"),
+    )
+    outside_storage = str(old_root / "outside/persisted.json")
+    monkeypatch.setenv("CITADEL_OBSIDIAN_SYNC_STATE_PATH", outside_storage)
+
+    lite_runtime._rebind_lite_paths(new_root)
+
+    assert Path(os.environ["CITADEL_CONTACT_STORE_PATH"]) == (
+        new_root / "data-storage/nested/contact.json"
+    )
+    assert Path(os.environ["CITADEL_REPAIR_JOURNAL_PATH"]) == (
+        new_root / "cognee-system/nested/repair.jsonl"
+    )
+    assert Path(os.environ["CITADEL_EVALUATION_GATE_PATH"]) == (
+        new_root / "citadel-state/nested/evaluation.json"
+    )
+    assert os.environ["CITADEL_OBSIDIAN_SYNC_STATE_PATH"] == outside_storage
+    assert Path(os.environ["CITADEL_LIFECYCLE_STORE_PATH"]) == (
+        new_root / "citadel-state/lifecycle.sqlite3"
+    )
 
 
 def test_configure_lite_environment_rejects_postgres(
@@ -359,3 +501,220 @@ def test_quarantine_renames_unreadable_sqlite_and_sidecars(tmp_path: Path) -> No
     assert (tmp_path / "cognee.db.corrupt-20260817T073000Z-shm").read_bytes() == b"shm"
     assert not wal.exists()
     assert not shm.exists()
+
+
+def test_main_runs_prelock_backup_before_startup(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    events: list[object] = []
+
+    destination = "/data/backups/v058-canonical-20260829"
+
+    monkeypatch.setenv("CITADEL_LITE_BACKUP_DESTINATION", destination)
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-058")
+    monkeypatch.setenv("VECTOR_DB_URL", "http://qdrant:6333")
+    monkeypatch.setenv("VECTOR_DB_KEY", "qdrant-key")
+
+    def configure(data_root: Path | None = None) -> Path:
+        events.append(("configure", data_root))
+        return Path("/data")
+
+    class FakeSnapshotStore:
+        def __init__(self, *, url: str, api_key: str | None) -> None:
+            events.append(("qdrant", url, api_key))
+
+        def __enter__(self) -> FakeSnapshotStore:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("qdrant-close")
+
+    def create_backup(
+        *,
+        generation_id: str,
+        data_root: Path,
+        destination: Path,
+        snapshot_store: object,
+    ) -> dict[str, object]:
+        events.append(
+            ("backup", generation_id, data_root, destination, snapshot_store.__class__.__name__)
+        )
+        return {"generation_id": generation_id, "destination": str(destination)}
+
+    monkeypatch.setattr(lite_runtime, "configure_lite_environment", configure)
+
+    def drop_privileges(_root: Path) -> None:
+        raise AssertionError("pre-lock backup must run before dropping privileges")
+
+    monkeypatch.setattr(lite_runtime, "drop_root_privileges", drop_privileges)
+
+    def lock(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("pre-lock backup must not acquire the Lite writer lock")
+    monkeypatch.setattr(lite_runtime, "acquire_single_instance_lock", lock)
+
+    async def migrations() -> None:
+        raise AssertionError("pre-lock backup must not run migrations")
+    monkeypatch.setattr(lite_runtime, "run_migrations", migrations)
+
+    fake_generation_backup = SimpleNamespace(
+        QdrantSnapshotStore=FakeSnapshotStore,
+        create_generation_backup=create_backup,
+    )
+    monkeypatch.setitem(sys.modules, "kb.generation_backup", fake_generation_backup)
+
+    lite_runtime.main()
+
+    assert events == [
+        ("configure", None),
+        ("qdrant", "http://qdrant:6333", "qdrant-key"),
+        ("backup", "generation-058", Path("/data"), Path(destination), "FakeSnapshotStore"),
+        "qdrant-close",
+    ]
+    assert json.dumps(
+        {"generation_id": "generation-058", "destination": destination}, sort_keys=True
+    ) in capsys.readouterr().out
+
+
+def test_main_reports_prelock_backup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CITADEL_LITE_BACKUP_DESTINATION", "/data/backups/failure")
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-058")
+    monkeypatch.setenv("VECTOR_DB_URL", "http://qdrant:6333")
+    monkeypatch.setenv("VECTOR_DB_KEY", "qdrant-key")
+
+    def configure(data_root: Path | None = None) -> Path:
+        return Path("/data")
+
+    class FailingSnapshotStore:
+        def __init__(self, *, url: str, api_key: str | None) -> None:
+            pass
+
+        def __enter__(self) -> FailingSnapshotStore:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    def create_backup(**_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("backup failed")
+
+    fake_generation_backup = SimpleNamespace(
+        QdrantSnapshotStore=FailingSnapshotStore,
+        create_generation_backup=create_backup,
+    )
+    monkeypatch.setitem(sys.modules, "kb.generation_backup", fake_generation_backup)
+
+    monkeypatch.setattr(lite_runtime, "configure_lite_environment", configure)
+    monkeypatch.setattr(
+        lite_runtime,
+        "acquire_single_instance_lock",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pre-lock backup must run before the Lite writer lock")
+        ),
+    )
+
+    with pytest.raises(SystemExit, match="backup failed") as error:
+        lite_runtime.main()
+
+    assert error.value.code != 0
+
+
+def test_main_runs_projection_cutover_before_lock_and_starts_web(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    events: list[object] = []
+    target = tmp_path / "clean-root"
+    backup = tmp_path / "backup"
+    manifest_hash = "a" * 64
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_ROOT", str(target))
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_BACKUP_ROOT", str(backup))
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_MANIFEST_SHA256", manifest_hash)
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-059")
+
+    def cutover() -> dict[str, object]:
+        events.append(
+            ("cutover", {"target_root": Path(os.environ["CITADEL_LITE_PROJECTION_CUTOVER_ROOT"])})
+        )
+        target.mkdir()
+        return {"ok": True, "generation_id": "generation-059"}
+
+    def configure(data_root: Path | None = None) -> Path:
+        events.append(("configure", data_root))
+        return Path(data_root or target)
+    monkeypatch.setattr(lite_runtime, "configure_lite_environment", configure)
+    monkeypatch.setattr(lite_runtime, "run_prelock_projection_cutover", cutover)
+    monkeypatch.setattr(lite_runtime, "drop_root_privileges", lambda root: events.append("drop"))
+    monkeypatch.setattr(
+        lite_runtime,
+        "acquire_single_instance_lock",
+        lambda *_args, **_kwargs: events.append("lock"),
+    )
+    monkeypatch.setattr(lite_runtime, "wait_for_qdrant", lambda: events.append("qdrant"))
+
+    async def migrations() -> None:
+        events.append("migrations")
+
+    monkeypatch.setattr(lite_runtime, "run_migrations", migrations)
+    monkeypatch.setattr(
+        lite_runtime,
+        "write_bootstrap_receipt",
+        lambda root: events.append(("receipt", root)) or target / "bootstrap.json",
+    )
+    monkeypatch.setattr(lite_runtime.os, "execv", lambda executable, args: events.append(("exec", args)))
+    lite_runtime.main()
+
+    assert [item[0] if isinstance(item, tuple) else item for item in events] == [
+        "cutover",
+        "configure",
+        "drop",
+        "lock",
+        "qdrant",
+        "migrations",
+        "receipt",
+        "exec",
+    ]
+    assert events[0][1]["target_root"] == target
+    assert events[1][1] == target
+
+
+def test_projection_cutover_rebinds_persisted_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from kb import projection_cutover
+
+    target = tmp_path / "clean-root"
+    backup = tmp_path / "backup"
+    manifest_hash = "b" * 64
+    monkeypatch.setenv("CITADEL_LITE_DATA_ROOT", "/data")
+    monkeypatch.setenv("CITADEL_ACCESS_STORE_PATH", "/data/citadel-state/auth/access.json")
+    monkeypatch.setenv("CITADEL_GENERATION_ID", "generation-060")
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_ROOT", str(target))
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_BACKUP_ROOT", str(backup))
+    monkeypatch.setenv("CITADEL_LITE_PROJECTION_CUTOVER_MANIFEST_SHA256", manifest_hash)
+    calls: list[dict[str, object]] = []
+
+    def prepare(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"ok": True, "generation_id": "generation-060"}
+
+    monkeypatch.setattr(projection_cutover, "prepare_projection_cutover", prepare)
+
+    assert lite_runtime.run_prelock_projection_cutover() == {
+        "ok": True,
+        "generation_id": "generation-060",
+    }
+
+    assert calls == [
+        {
+            "backup_root": backup,
+            "target_root": target,
+            "generation_id": "generation-060",
+            "manifest_sha256": manifest_hash,
+        }
+    ]
+    assert Path(os.environ["CITADEL_ACCESS_STORE_PATH"]) == (
+        target / "citadel-state/auth/access.json"
+    )

--- a/tests/test_projection_cutover.py
+++ b/tests/test_projection_cutover.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import sqlite3
+from typing import Any
+
+import pytest
+
+from kb import projection_cutover
+from kb.generation_backup import GenerationBackupError
+from kb.projection_cutover import ProjectionCutoverError, prepare_projection_cutover
+
+
+GENERATION = "generation-059"
+OWNER = "2a868377-2ed0-4882-b536-7f43c099af3d"
+ACTIVE_ID = "0d8aa28c-b6bd-5abc-b500-95085c38830b"
+STALE_ID = "1e9f89ff-cc36-50bc-bbf3-c915b8c8fdf2"
+DATA_ONLY_ID = "e70a9a75-c785-5d7f-bfd2-c2a6650e7079"
+DATASET = "e75f1811-0b4d-5e8b-8cdc-13fcfb7d0d32"
+
+
+class _SnapshotStore:
+    def require_empty(self) -> None:
+        return None
+
+    def restore_collection(
+        self,
+        collection: str,
+        snapshot_path: Path,
+        *,
+        expected_sha256: str,
+    ) -> int:
+        assert hashlib.sha256(snapshot_path.read_bytes()).hexdigest() == expected_sha256
+        return 0
+
+    def delete_collection(self, collection: str) -> None:
+        return None
+
+
+def _sqlite_schema(
+    root: Path,
+    *,
+    active_job_states: tuple[str, ...] = ("pending",),
+    active_graph_receipt_states: tuple[str, ...] = ("pending",),
+) -> None:
+    database = root / "cognee-system/databases/cognee.db"
+    lifecycle = root / "citadel-state/lifecycle.sqlite3"
+    database.parent.mkdir(parents=True)
+    lifecycle.parent.mkdir(parents=True)
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE data (
+                id TEXT PRIMARY KEY,
+                pipeline_status TEXT
+            );
+            CREATE TABLE pipeline_runs (
+                id TEXT PRIMARY KEY,
+                created_at TEXT,
+                status TEXT,
+                pipeline_run_id TEXT,
+                pipeline_name TEXT,
+                pipeline_id TEXT,
+                dataset_id TEXT,
+                run_info TEXT
+            );
+            CREATE TABLE dataset_database (
+                owner_id TEXT,
+                dataset_id TEXT PRIMARY KEY,
+                vector_database_name TEXT NOT NULL,
+                graph_database_name TEXT NOT NULL,
+                vector_database_provider TEXT NOT NULL,
+                graph_database_provider TEXT NOT NULL,
+                graph_dataset_database_handler TEXT NOT NULL,
+                vector_dataset_database_handler TEXT NOT NULL
+            );
+            INSERT INTO data VALUES
+                ('0d8aa28cb6bd5abcb50095085c38830b', '{"add_pipeline":"done","cognify_pipeline":"old"}'),
+                ('1e9f89ffcc3650bcbbf3c915b8c8fdf2', '{"cognify_pipeline":"old","other":{"keep":true}}'),
+                ('e70a9a75c7855d7fbfd2c2a6650e7079', '{"other":"stale"}');
+            INSERT INTO pipeline_runs VALUES
+                ('run-cognify-1', '2026-08-17', 'STARTED', 'pipeline-run-1', 'cognify_pipeline', 'pipeline-1', 'dataset-1', '{"payload":"archive me"}'),
+                ('run-cognify-2', '2026-08-18', 'COMPLETED', 'pipeline-run-2', 'cognify_pipeline', 'pipeline-1', 'dataset-1', '{"payload":"archive me too"}'),
+                ('run-add', '2026-08-18', 'COMPLETED', 'pipeline-run-3', 'add_pipeline', 'pipeline-2', 'dataset-1', '{"payload":"keep active"}');
+            INSERT INTO dataset_database VALUES
+                ('2a868377-2ed0-4882-b536-7f43c099af3d', 'e75f1811-0b4d-5e8b-8cdc-13fcfb7d0d32', 'vector', 'e75f1811-0b4d-5e8b-8cdc-13fcfb7d0d32.lbug', 'qdrant', 'ladybug', 'ladybug', 'qdrant');
+            """
+        )
+    with sqlite3.connect(lifecycle) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE source_revisions (
+                source_revision_id TEXT PRIMARY KEY,
+                tombstone INTEGER NOT NULL
+            );
+            CREATE TABLE source_heads (
+                dataset TEXT NOT NULL,
+                source_key TEXT NOT NULL,
+                source_revision_id TEXT NOT NULL
+            );
+            CREATE TABLE projection_jobs (
+                projection_job_id TEXT PRIMARY KEY,
+                source_revision_id TEXT NOT NULL,
+                generation_id TEXT NOT NULL,
+                state TEXT NOT NULL
+            );
+            CREATE TABLE projection_receipts (
+                projection_receipt_id TEXT PRIMARY KEY,
+                projection_job_id TEXT NOT NULL,
+                source_revision_id TEXT NOT NULL,
+                generation_id TEXT NOT NULL,
+                backend TEXT NOT NULL,
+                state TEXT NOT NULL
+            );
+            """
+        )
+        connection.executemany(
+            "INSERT INTO source_revisions VALUES (?, ?)",
+            [(ACTIVE_ID, 0), (STALE_ID, 1), (DATA_ONLY_ID, 0)],
+        )
+        connection.executemany(
+            "INSERT INTO source_heads VALUES (?, ?, ?)",
+            [("dataset", "active", ACTIVE_ID), ("dataset", "tombstone", STALE_ID)],
+        )
+        active_jobs = [
+            (f"job-active-{index}", ACTIVE_ID, GENERATION, state)
+            for index, state in enumerate(active_job_states, start=1)
+        ]
+        connection.executemany(
+            "INSERT INTO projection_jobs VALUES (?, ?, ?, ?)",
+            [*active_jobs, ("job-tombstone", STALE_ID, GENERATION, "completed")],
+        )
+        active_receipts = [
+            (
+                f"receipt-active-{index}",
+                "job-active-1",
+                ACTIVE_ID,
+                GENERATION,
+                "graph",
+                state,
+            )
+            for index, state in enumerate(active_graph_receipt_states, start=1)
+        ]
+        connection.executemany(
+            "INSERT INTO projection_receipts VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                *active_receipts,
+                (
+                    "receipt-tombstone",
+                    "job-tombstone",
+                    STALE_ID,
+                    GENERATION,
+                    "graph",
+                    "searchable",
+                ),
+            ],
+        )
+
+
+def _make_backup(
+    tmp_path: Path,
+    *,
+    active_job_states: tuple[str, ...] = ("pending",),
+    active_graph_receipt_states: tuple[str, ...] = ("pending",),
+) -> tuple[Path, Path, str]:
+    source = tmp_path / "source"
+    _sqlite_schema(
+        source,
+        active_job_states=active_job_states,
+        active_graph_receipt_states=active_graph_receipt_states,
+    )
+    database_dir = source / "cognee-system/databases" / OWNER
+    database_dir.mkdir(parents=True)
+    (database_dir / f"{DATASET}.lbug").write_bytes(b"old graph")
+    (database_dir / f"{DATASET}.lbug.wal").write_bytes(b"old wal")
+    (database_dir / "unmapped.lbug").write_bytes(b"unmapped graph")
+    (source / "data-storage/source.txt").parent.mkdir(parents=True)
+    (source / "data-storage/source.txt").write_text("retain", encoding="utf-8")
+    (source / "citadel-state/auth.json").write_text('{"keep":true}\n', encoding="utf-8")
+
+    backup = tmp_path / "backup"
+    local = backup / "local"
+    shutil.copytree(source, local)
+    files = []
+    for path in sorted(local.rglob("*")):
+        if path.is_file():
+            files.append(
+                {
+                    "path": path.relative_to(local).as_posix(),
+                    "size": path.stat().st_size,
+                    "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                }
+            )
+    snapshot = backup / "qdrant/chunks.snapshot"
+    snapshot.parent.mkdir(parents=True)
+    snapshot.write_bytes(b"snapshot")
+    snapshot_hash = hashlib.sha256(snapshot.read_bytes()).hexdigest()
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "generation_id": GENERATION,
+        "local_files": files,
+        "qdrant_collections": [
+            {
+                "collection": "chunks",
+                "artifact": "qdrant/chunks.snapshot",
+                "point_count": 0,
+                "size": snapshot.stat().st_size,
+                "sha256": snapshot_hash,
+            }
+        ],
+    }
+    manifest_path = backup / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    (backup / "manifest.sha256").write_text(f"{manifest_hash}  manifest.json\n", encoding="ascii")
+    return backup, source, manifest_hash
+
+
+def test_prepare_rejects_target_inside_backup(tmp_path: Path) -> None:
+    backup, _source, manifest_hash = _make_backup(tmp_path)
+    before = sorted(path.relative_to(backup) for path in backup.rglob("*"))
+    with pytest.raises(ProjectionCutoverError, match="inside the backup"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=backup / "local" / "new-root",
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+        )
+    with pytest.raises(ProjectionCutoverError, match="inside the backup"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=backup,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+        )
+    after = sorted(path.relative_to(backup) for path in backup.rglob("*"))
+    assert after == before
+
+
+def test_prepare_rejects_manifest_hash_and_generation_mismatch(tmp_path: Path) -> None:
+    backup, _source, manifest_hash = _make_backup(tmp_path)
+    with pytest.raises(GenerationBackupError, match="manifest hash mismatch"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=tmp_path / "target-hash",
+            generation_id=GENERATION,
+            manifest_sha256="0" * 64,
+            snapshot_store=_SnapshotStore(),
+        )
+    with pytest.raises(GenerationBackupError, match="generation ID mismatch"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=tmp_path / "target-generation",
+            generation_id="generation-other",
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+
+
+def test_prepare_cuts_over_projection_and_is_idempotent(tmp_path: Path) -> None:
+    backup, source, manifest_hash = _make_backup(tmp_path)
+    lifecycle_path = backup / "local/citadel-state/lifecycle.sqlite3"
+    lifecycle_before = lifecycle_path.read_bytes()
+    source_lifecycle_path = source / "citadel-state/lifecycle.sqlite3"
+    source_lifecycle_before = source_lifecycle_path.read_bytes()
+    target = tmp_path / "target"
+    result = prepare_projection_cutover(
+        backup_root=backup,
+        target_root=target,
+        generation_id=GENERATION,
+        manifest_sha256=manifest_hash,
+        snapshot_store=_SnapshotStore(),
+    )
+
+    assert result["archived_pipeline_run_count"] == 2
+    assert result["cleared_data_count"] == 1
+    assert result["remapped_dataset_count"] == 1
+    assert (target / "data-storage/source.txt").read_text(encoding="utf-8") == "retain"
+    assert not (target / "cognee-system/databases" / OWNER / f"{DATASET}.lbug").exists()
+    assert (target / "graph-archive" / OWNER / f"{DATASET}.lbug").read_bytes() == b"old graph"
+    assert (target / "graph-archive" / OWNER / f"{DATASET}.lbug.wal").read_bytes() == b"old wal"
+    assert (target / "graph-archive" / OWNER / "unmapped.lbug").read_bytes() == b"unmapped graph"
+
+    with sqlite3.connect(target / "cognee-system/databases/cognee.db") as connection:
+        active_status = json.loads(
+            connection.execute("SELECT pipeline_status FROM data WHERE id LIKE '0d8a%'").fetchone()[0]
+        )
+        stale_status = json.loads(
+            connection.execute("SELECT pipeline_status FROM data WHERE id LIKE '1e9f%'").fetchone()[0]
+        )
+        archive_rows = connection.execute(
+            "SELECT id, pipeline_name FROM pipeline_runs_cognify_archive ORDER BY id"
+        ).fetchall()
+        active_runs = connection.execute(
+            "SELECT id, pipeline_name FROM pipeline_runs ORDER BY id"
+        ).fetchall()
+        graph_name = connection.execute(
+            "SELECT graph_database_name FROM dataset_database"
+        ).fetchone()[0]
+    assert active_status == {"add_pipeline": "done"}
+    assert stale_status == {"cognify_pipeline": "old", "other": {"keep": True}}
+    assert archive_rows == [("run-cognify-1", "cognify_pipeline"), ("run-cognify-2", "cognify_pipeline")]
+    assert active_runs == [("run-add", "add_pipeline")]
+    assert GENERATION in graph_name
+    assert graph_name.endswith(".lbug")
+    assert lifecycle_path.read_bytes() == lifecycle_before
+    assert source_lifecycle_path.read_bytes() == source_lifecycle_before
+    assert (target / "citadel-state/lifecycle.sqlite3").read_bytes() == lifecycle_before
+    with sqlite3.connect(target / "citadel-state/lifecycle.sqlite3") as connection:
+        lifecycle_states = connection.execute(
+            """
+            SELECT revisions.source_revision_id, jobs.state, receipts.state
+            FROM source_heads AS heads
+            JOIN source_revisions AS revisions
+              ON revisions.source_revision_id = heads.source_revision_id
+            JOIN projection_jobs AS jobs
+              ON jobs.source_revision_id = revisions.source_revision_id
+             AND jobs.generation_id = ?
+            JOIN projection_receipts AS receipts
+              ON receipts.projection_job_id = jobs.projection_job_id
+             AND receipts.backend = 'graph'
+            ORDER BY revisions.source_revision_id
+            """,
+            (GENERATION,),
+        ).fetchall()
+    assert lifecycle_states == [
+        (ACTIVE_ID, "pending", "pending"),
+        (STALE_ID, "completed", "searchable"),
+    ]
+    receipt_path = target / "citadel-state/projection-cutover.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["manifest_sha256"] == manifest_hash
+    assert receipt["old_new_graph_paths"]
+    rerun = prepare_projection_cutover(
+        backup_root=backup,
+        target_root=target,
+        generation_id=GENERATION,
+        manifest_sha256=manifest_hash,
+        snapshot_store=_SnapshotStore(),
+    )
+    assert rerun["idempotent"] is True
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt
+
+def test_prepare_rejects_completed_active_projection_before_graph_archive(
+    tmp_path: Path,
+) -> None:
+    backup, source, manifest_hash = _make_backup(
+        tmp_path,
+        active_job_states=("completed",),
+        active_graph_receipt_states=("searchable",),
+    )
+    target = tmp_path / "target"
+    target.mkdir()
+    graph_path = source / "cognee-system/databases" / OWNER / f"{DATASET}.lbug"
+    graph_before = graph_path.read_bytes()
+    with pytest.raises(ProjectionCutoverError, match="lifecycle projection precondition"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=target,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+    assert list(target.iterdir()) == []
+    assert graph_path.read_bytes() == graph_before
+    assert (backup / "local/citadel-state/lifecycle.sqlite3").read_bytes() == (
+        source / "citadel-state/lifecycle.sqlite3"
+    ).read_bytes()
+
+
+@pytest.mark.parametrize(
+    "active_graph_receipt_states",
+    [(), ("pending", "pending")],
+    ids=["missing", "duplicate"],
+)
+def test_prepare_rejects_missing_or_duplicate_active_graph_receipt(
+    tmp_path: Path,
+    active_graph_receipt_states: tuple[str, ...],
+) -> None:
+    backup, source, manifest_hash = _make_backup(
+        tmp_path,
+        active_graph_receipt_states=active_graph_receipt_states,
+    )
+    target = tmp_path / "target"
+    target.mkdir()
+    graph_path = source / "cognee-system/databases" / OWNER / f"{DATASET}.lbug"
+    graph_before = graph_path.read_bytes()
+    with pytest.raises(ProjectionCutoverError, match="lifecycle projection precondition"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=target,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+    assert list(target.iterdir()) == []
+    assert graph_path.read_bytes() == graph_before
+
+
+
+
+def test_prepare_rejects_symlink_target(tmp_path: Path) -> None:
+    backup, _source, manifest_hash = _make_backup(tmp_path)
+    real_target = tmp_path / "real-target"
+    real_target.mkdir()
+    symlink_target = tmp_path / "target"
+    symlink_target.symlink_to(real_target, target_is_directory=True)
+    with pytest.raises(GenerationBackupError, match="symbolic link"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=symlink_target,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+
+
+def test_prepare_rejects_mismatched_existing_receipt(tmp_path: Path) -> None:
+    backup, _source, manifest_hash = _make_backup(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    state = target / "citadel-state"
+    state.mkdir()
+    (state / "projection-cutover.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generation_id": "other",
+                "manifest_sha256": manifest_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ProjectionCutoverError, match="receipt"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=target,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+
+
+def test_prepare_failure_keeps_target_unmodified(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    backup, _source, manifest_hash = _make_backup(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+
+    def fail_receipt(*_args: object, **_kwargs: object) -> Path:
+        raise ProjectionCutoverError("receipt write failed")
+
+    monkeypatch.setattr(projection_cutover, "_write_receipt", fail_receipt)
+    with pytest.raises(ProjectionCutoverError, match="receipt write failed"):
+        prepare_projection_cutover(
+            backup_root=backup,
+            target_root=target,
+            generation_id=GENERATION,
+            manifest_sha256=manifest_hash,
+            snapshot_store=_SnapshotStore(),
+        )
+    assert list(target.iterdir()) == []


### PR DESCRIPTION
## What

Adds the projection cutover module and wires the pre-lock backup and lite runtime
boot path, so an operator-staged cutover or one-shot backup runs safely at startup
and normal boots stay unchanged.

## Why

The recovery effort needs a safe way to restore or cut over the projection data
root before the web process takes its single-instance lock. This slice adds
`kb/projection_cutover.py`, the `run_prelock_backup` and cutover wiring in
`kb/lite_runtime.py`, and generation-backup support. All one-shot behavior is
gated by env vars that are empty in the live deploy, so this deploy boots
normally.

First slice of a 9-PR stacked series. The `cognify_selected_data` seam that an
earlier draft bundled here now ships with its caller in the projection-barriers
slice.

Verification: `pytest -q tests/test_projection_cutover.py tests/test_lite_runtime.py tests/test_generation_backup.py` → `57 passed, 10 warnings`.

Rollback: revert this merge commit; with no cutover staged, storage stays on the
active data root.

Refs #228 (the projection cutover is the store-migration path the deferred re-index work waits on).
