### PR TITLE
feat: inject search context during onboarding

### DIFF
--- a/kb/hooks/search_inject.py
+++ b/kb/hooks/search_inject.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Task-aware search context for the Claude Code ``UserPromptSubmit`` hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+from kb.capture_config import DEFAULT_NODE_URL
+from kb.hooks.sync_start import AGENT_POLICY_REMINDER, read_hook_payload
+from kb.security_scan import redact_secrets
+
+TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
+BASE_URL_ENV = "CITADEL_BASE_URL"
+SEARCH_MODULE = "kb.hooks.search_inject"
+HTTP_TIMEOUT_SECONDS = 5
+MAX_QUERY_CHARS = 1000
+MAX_CONTEXT_CHARS = 6000
+MAX_SNIPPET_CHARS = 500
+MAX_FIELD_CHARS = 300
+MAX_RESULTS = 3
+MAX_LOG_LINE_CHARS = 400
+MAX_LOG_TOKEN_CHARS = 200
+
+_URL_RE = re.compile(r"https?://[^\s<>'\"`]+", re.IGNORECASE)
+_GITHUB_TASK_URL_RE = re.compile(
+    r"https?://(?:www\.)?github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/"
+    r"(?P<kind>issues?|pulls?)/(?P<number>\d+)[^\s<>'\"`]*",
+    re.IGNORECASE,
+)
+_LINEAR_TASK_URL_RE = re.compile(
+    r"https?://(?:www\.)?linear\.app/[^\s<>'\"`]*/issue/"
+    r"(?P<issue>[A-Z][A-Z0-9]*-\d+)[^\s<>'\"`]*",
+    re.IGNORECASE,
+)
+_INLINE_COMMAND_RE = re.compile(
+    r"`\s*(?:\$\s*)?(?:bash|sh|zsh|fish|pwsh|powershell|cmd|python|python3|uv|pytest|"
+    r"npm|npx|yarn|pnpm|git|curl|wget|docker|kubectl|make)\b[^`]*`",
+    re.IGNORECASE,
+)
+_COMMAND_LINE_RE = re.compile(
+    r"^(?:[$>]\s+|(?:bash|sh|zsh|fish|pwsh|powershell|cmd)\b(?:\s+-[lc])?\s+|"
+    r"(?:python|python3|uv|pytest|npm|npx|yarn|pnpm|git|curl|wget|docker|kubectl|make)\b\s+)",
+    re.IGNORECASE,
+)
+_LOG_LINE_RE = re.compile(
+    r"^(?:\d{4}-\d{2}-\d{2}[T ][^ ]+\s+)?"
+    r"(?:DEBUG|INFO|NOTICE|WARN(?:ING)?|ERROR|CRITICAL)\b(?:\s*[:|\-]|\s+)",
+    re.IGNORECASE,
+)
+_TRACEBACK_START_RE = re.compile(r"^Traceback \(most recent call last\):\s*$")
+_TRACEBACK_FRAME_RE = re.compile(r'^File\s+[\"\']')
+_TRACEBACK_EXCEPTION_RE = re.compile(
+    r"^(?:[\w.]+(?:Error|Exception|Warning)|KeyboardInterrupt|SystemExit|GeneratorExit)"
+    r"(?:\s*:\s*.*)?$",
+    re.IGNORECASE,
+)
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so the seat token never reaches another URL."""
+
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirectHandler)
+
+
+def _clean_line(line: str) -> str:
+    line = _GITHUB_TASK_URL_RE.sub(
+        lambda match: f"{match.group('repo')} #{match.group('number')}",
+        line,
+    )
+    line = _LINEAR_TASK_URL_RE.sub(lambda match: match.group("issue"), line)
+    line = _URL_RE.sub(" ", line)
+    line = _INLINE_COMMAND_RE.sub(" ", line)
+    return line
+
+
+def extract_task_query(prompt: str, *, max_chars: int = MAX_QUERY_CHARS) -> str | None:
+    """Extract a bounded, human task query without logs or executable wrappers."""
+    if not isinstance(prompt, str) or max_chars <= 0:
+        return None
+
+    lines: list[str] = []
+    in_fence = False
+    in_traceback = False
+    traceback_exception_seen = False
+    for raw_line in prompt.splitlines():
+        stripped = raw_line.strip()
+        if (
+            len(stripped) > MAX_LOG_LINE_CHARS
+            and any(len(token) > MAX_LOG_TOKEN_CHARS for token in stripped.split())
+        ):
+            continue
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if _TRACEBACK_START_RE.match(stripped):
+            in_traceback = True
+            traceback_exception_seen = False
+            continue
+        if in_traceback:
+            if not stripped:
+                continue
+            if stripped.startswith(("During ", "...")):
+                continue
+            if _TRACEBACK_FRAME_RE.match(stripped):
+                continue
+            if _TRACEBACK_EXCEPTION_RE.match(stripped):
+                traceback_exception_seen = True
+                continue
+            if not traceback_exception_seen:
+                continue
+            in_traceback = False
+            traceback_exception_seen = False
+        if not stripped or _LOG_LINE_RE.match(stripped) or _COMMAND_LINE_RE.match(stripped):
+            continue
+        cleaned = _clean_line(raw_line).strip()
+        if cleaned:
+            lines.append(cleaned)
+
+    query = " ".join(" ".join(lines).split())
+    return query[:max_chars] or None
+
+
+def _search_url(base_url: str) -> str:
+    if not isinstance(base_url, str):
+        raise ValueError("invalid Citadel base URL")
+    base_url = base_url.strip()
+    parsed = urlsplit(base_url)
+    if parsed.scheme.lower() != "https" or not parsed.netloc:
+        raise ValueError("refusing non-HTTPS Citadel base URL")
+    return f"{base_url.rstrip('/')}/search"
+
+
+def _bounded_text(value: Any, *, limit: int = MAX_FIELD_CHARS) -> str:
+    if value is None:
+        return ""
+    text = " ".join(str(value).split())
+    return text[:limit]
+
+
+def _first_text(*values: Any, limit: int = MAX_FIELD_CHARS) -> str:
+    for value in values:
+        text = _bounded_text(value, limit=limit)
+        if text:
+            return text
+    return ""
+
+
+def _provenance(result: Mapping[str, Any], envelope: Mapping[str, Any]) -> str:
+    value = result.get("provenance")
+    if not isinstance(value, Mapping):
+        value = envelope.get("provenance")
+    if isinstance(value, str):
+        return _bounded_text(value)
+    if not isinstance(value, Mapping):
+        value = {}
+    parts: list[str] = []
+    for key in ("source", "repo", "path", "title", "source_url", "source_locator", "commit", "blob"):
+        text = _bounded_text(value.get(key))
+        if text:
+            parts.append(f"{key}={text}")
+    return "; ".join(parts)[:MAX_FIELD_CHARS]
+
+
+def format_task_context(payload: Mapping[str, Any], *, limit: int = MAX_RESULTS) -> str:
+    """Render a small, explicitly untrusted context block from a search payload."""
+    if not isinstance(payload, Mapping):
+        return ""
+    results = payload.get("results")
+    if not isinstance(results, list):
+        results = payload.get("matches")
+    if not isinstance(results, list):
+        return ""
+
+    bounded_limit = max(0, min(int(limit), MAX_RESULTS))
+    selected = [item for item in results if isinstance(item, Mapping)][:bounded_limit]
+    if not selected:
+        return ""
+
+    search_id = _first_text(payload.get("search_id"), payload.get("id")) or "unknown"
+    default_dataset = _first_text(payload.get("dataset"), payload.get("primary_dataset")) or "unknown"
+    lines = [
+        "# Citadel task context (untrusted context)",
+        f"Search ID: {search_id}",
+        "",
+    ]
+    for index, result in enumerate(selected, start=1):
+        envelope = result.get("_citadel")
+        if not isinstance(envelope, Mapping):
+            envelope = {}
+        result_id = _first_text(result.get("id"), result.get("result_id"), envelope.get("result_id")) or "unknown"
+        title = _first_text(result.get("title"), result.get("name"), envelope.get("title")) or "Untitled result"
+        snippet = _first_text(
+            result.get("snippet"), result.get("summary"), result.get("text"), result.get("content"),
+            limit=MAX_SNIPPET_CHARS,
+        )
+        dataset = _first_text(result.get("dataset"), envelope.get("dataset"), default_dataset) or "unknown"
+        trust_tier = _first_text(
+            result.get("trust_tier"), envelope.get("trust_tier"), envelope.get("trust")
+        ) or "unattested"
+        provenance = _provenance(result, envelope) or "unavailable"
+        lines.extend(
+            [
+                f"Result {index}:",
+                f"- Result ID: {result_id}",
+                f"- Title: {title}",
+                f"- Dataset: {dataset}",
+                f"- Trust tier: {trust_tier}",
+                f"- Provenance: {provenance}",
+                f"- Snippet: {snippet or 'unavailable'}",
+                "",
+            ]
+        )
+
+    return redact_secrets("\n".join(lines)[:MAX_CONTEXT_CHARS])[:MAX_CONTEXT_CHARS]
+
+
+def fetch_task_hits(base_url: str, token: str, query: str, *, limit: int = MAX_RESULTS) -> dict[str, Any]:
+    """POST a task query to the authenticated Node ``/search`` endpoint."""
+    if not isinstance(token, str) or not token.strip():
+        raise ValueError("missing Citadel access token")
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("missing task query")
+    url = _search_url(base_url)
+    bounded_limit = max(1, min(int(limit), MAX_RESULTS))
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"query": query, "top_k": bounded_limit}).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token.strip()}",
+        },
+        method="POST",
+    )
+    with _OPENER.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        status = getattr(response, "status", None)
+        if isinstance(status, int) and not 200 <= status < 300:
+            raise ValueError("unexpected search response status")
+        body = response.read().decode("utf-8")
+    payload = json.loads(body) if body else None
+    if not isinstance(payload, dict):
+        raise ValueError("malformed search response")
+    results = payload.get("results")
+    if results is None:
+        results = payload.get("matches")
+    if not isinstance(results, list):
+        raise ValueError("malformed search response")
+    payload["results"] = results
+    return payload
+
+
+def _base_url() -> str:
+    configured = os.getenv(BASE_URL_ENV)
+    return configured.rstrip("/") if configured else DEFAULT_NODE_URL
+
+
+def run(stream_in: Any) -> int:
+    """Hook entrypoint. Always emits policy and always returns zero."""
+    try:
+        payload = read_hook_payload(stream_in)
+        prompt = payload.get("prompt")
+        query = extract_task_query(prompt) if isinstance(prompt, str) else None
+        token = os.getenv(TOKEN_ENV)
+        if query and token:
+            # Redact BEFORE transmission: a prompt can carry live credentials,
+            # and the caller's own token must never ride its own query.
+            safe_query = redact_secrets(query, token)
+            hits = fetch_task_hits(_base_url(), token, safe_query, limit=MAX_RESULTS)
+            context = format_task_context(hits, limit=MAX_RESULTS)
+            if context:
+                context = redact_secrets(context, token)
+                sys.stdout.write(context + "\n\n")
+    except Exception:
+        pass
+    sys.stdout.write(AGENT_POLICY_REMINDER + "\n")
+    return 0
+
+
+def main() -> None:
+    sys.exit(run(sys.stdin))
+
+
+if __name__ == "__main__":
+    main()

--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from kb.capture_config import DEFAULT_NODE_URL
+from kb.hooks.search_inject import BASE_URL_ENV, SEARCH_MODULE
 from kb.hooks.sync_start import AGENT_POLICY_REMINDER
 
 TOKEN_ENV = "CITADEL_MCP_ACCESS_TOKEN"
@@ -38,6 +39,7 @@ START_MODULE = "kb.hooks.sync_start"
 _SESSION_HOOK_MARKER = SESSION_MODULE
 _START_HOOK_MARKER = START_MODULE
 
+_SEARCH_HOOK_MARKER = SEARCH_MODULE
 
 def _hook_python() -> str:
     """The interpreter that has `kb` installed (so the hooks can import it)."""
@@ -121,6 +123,16 @@ def _session_start_hook(python: str | None = None) -> dict[str, Any]:
         "command": f'"{py}" -m {START_MODULE}',
         "timeout": 10,
         "allowedEnvVars": [TOKEN_ENV],
+    }
+
+
+def _user_prompt_submit_hook(python: str | None = None) -> dict[str, Any]:
+    py = python or _hook_python()
+    return {
+        "type": "command",
+        "command": f'"{py}" -m {SEARCH_MODULE}',
+        "timeout": 10,
+        "allowedEnvVars": [TOKEN_ENV, BASE_URL_ENV],
     }
 
 
@@ -248,11 +260,12 @@ def merge_mcp_config(path: Path, base_url: str = DEFAULT_NODE_URL) -> str:
 
 
 def merge_claude_settings(path: Path, python: str | None = None) -> str:
-    """Merge the SessionEnd + SessionStart hooks into .claude/settings.json.
+    """Merge the SessionEnd, SessionStart, and UserPromptSubmit hooks.
 
     SessionEnd distills the closing session to the dev's node; SessionStart
-    injects a recent-activity digest. Both are idempotent (detected by module
-    marker) so the merge never duplicates them on re-run.
+    injects a recent-activity digest; UserPromptSubmit injects task search
+    context. All hooks are idempotent (detected by module marker) so the merge
+    never duplicates them on re-run.
     """
     data = _load_json_object(path)
     hooks = data.setdefault("hooks", {})
@@ -264,6 +277,9 @@ def merge_claude_settings(path: Path, python: str | None = None) -> str:
     session_start = hooks.setdefault("SessionStart", [])
     if not isinstance(session_start, list):
         raise ValueError(f"corrupt {path}: hooks.SessionStart must be an array")
+    user_prompt_submit = hooks.setdefault("UserPromptSubmit", [])
+    if not isinstance(user_prompt_submit, list):
+        raise ValueError(f"corrupt {path}: hooks.UserPromptSubmit must be an array")
 
     changed = False
     if not _event_has_marker(session_end, _SESSION_HOOK_MARKER):
@@ -272,12 +288,16 @@ def merge_claude_settings(path: Path, python: str | None = None) -> str:
     if not _event_has_marker(session_start, _START_HOOK_MARKER):
         session_start.append({"matcher": "startup|resume", "hooks": [_session_start_hook(python)]})
         changed = True
+    if not _event_has_marker(user_prompt_submit, _SEARCH_HOOK_MARKER):
+        user_prompt_submit.append({"hooks": [_user_prompt_submit_hook(python)]})
+        changed = True
     allowed = data.setdefault("httpHookAllowedEnvVars", [])
     if not isinstance(allowed, list):
         raise ValueError(f"corrupt {path}: httpHookAllowedEnvVars must be an array")
-    if TOKEN_ENV not in allowed:
-        allowed.append(TOKEN_ENV)
-        changed = True
+    for env_name in (TOKEN_ENV, BASE_URL_ENV):
+        if env_name not in allowed:
+            allowed.append(env_name)
+            changed = True
     if not changed:
         return "unchanged"
     _write_json(path, data)

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -10,6 +10,7 @@ import pytest
 
 from kb.cli import _onboard
 from kb.onboard import (
+    BASE_URL_ENV,
     TOKEN_ENV,
     POLICY_MARKER_END,
     POLICY_MARKER_START,
@@ -191,6 +192,11 @@ def test_merge_claude_settings_adds_then_idempotent(tmp_path: Path) -> None:
     ]
     assert any("kb.hooks.sync_session" in c for c in cmds)
     assert TOKEN_ENV in data["httpHookAllowedEnvVars"]
+    assert BASE_URL_ENV in data["httpHookAllowedEnvVars"]
+    prompt_groups = data["hooks"]["UserPromptSubmit"]
+    prompt_hooks = [h for g in prompt_groups for h in g["hooks"]]
+    assert any("kb.hooks.search_inject" in h["command"] for h in prompt_hooks)
+    assert prompt_hooks[0]["allowedEnvVars"] == [TOKEN_ENV, BASE_URL_ENV]
     start_groups = data["hooks"]["SessionStart"]
     start_cmds = [h["command"] for g in start_groups for h in g["hooks"]]
     assert any("kb.hooks.sync_start" in c for c in start_cmds)
@@ -200,6 +206,7 @@ def test_merge_claude_settings_adds_then_idempotent(tmp_path: Path) -> None:
     data2 = json.loads(path.read_text())
     assert len(data2["hooks"]["SessionEnd"]) == 1  # not duplicated
     assert len(data2["hooks"]["SessionStart"]) == 1  # not duplicated
+    assert len(data2["hooks"]["UserPromptSubmit"]) == 1  # not duplicated
 
 
 def _make_repo(tmp_path: Path) -> Path:

--- a/tests/test_search_inject.py
+++ b/tests/test_search_inject.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import pytest
+
+from kb.hooks import search_inject
+from kb.onboard import merge_claude_settings
+from kb.hooks.sync_start import AGENT_POLICY_REMINDER
+
+
+class _Response:
+    def __init__(self, body: bytes, *, status: int = 200) -> None:
+        self.body = body
+        self.status = status
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+class _Opener:
+    def __init__(self, response: _Response | Exception) -> None:
+        self.response = response
+        self.calls: list[tuple[Any, float]] = []
+
+    def open(self, request: Any, *, timeout: float) -> _Response:
+        self.calls.append((request, timeout))
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def test_extract_task_query_keeps_issue_repo_and_path_without_long_logs() -> None:
+    prompt = """
+    Fix #123 in masumi-network/Citadel at kb/hooks/search_inject.py.
+    Preserve task-aware search terms.
+    ```python
+    def noisy_example():
+        return 'remove this fenced code'
+    ```
+    2026-08-30T10:00:00Z ERROR worker failed: this long log should not enter the query
+    Traceback (most recent call last):
+    $ bash -lc 'pytest -q tests/test_search_inject.py'
+    `pytest -q tests/test_search_inject.py`
+    https://example.com/issues/123
+    """
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "#123" in query
+    assert "masumi-network/Citadel" in query
+    assert "kb/hooks/search_inject.py" in query
+    assert "noisy_example" not in query
+    assert "2026-08-30T10:00:00Z" not in query
+    assert "bash -lc" not in query
+    assert "pytest -q" not in query
+
+
+def test_run_redacts_outbound_query_before_transmission(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    token = "ctdl_abcdefghijklmnopqrstuvwxyz012345"
+    monkeypatch.setenv(search_inject.TOKEN_ENV, token)
+    monkeypatch.setenv(search_inject.BASE_URL_ENV, "https://vault.example")
+    captured: list[str] = []
+
+    def fake_fetch(base_url: str, sent_token: str, query: str, *, limit: int = 3) -> dict[str, Any]:
+        captured.append(query)
+        return {"search_id": "search:redaction", "results": []}
+
+    monkeypatch.setattr(search_inject, "fetch_task_hits", fake_fetch)
+    prompt = (
+        "Fix search for api_key=sk-proj-abcdefghijklmnopqrstuvwxyz0123456789 "
+        f"github ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789 and my token {token} in kb/service.py"
+    )
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": prompt}))) == 0
+    assert captured, "query was not sent"
+    sent = captured[0]
+    assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in sent
+    assert "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789" not in sent
+    assert token not in sent
+    assert "kb/service.py" in sent
+
+
+def test_extract_task_query_drops_unbounded_log_lines() -> None:
+    prompt = "Investigate #123 in kb/hooks/search_inject.py.\n" + ("raw log " + "x" * 5000)
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "#123" in query
+    assert "kb/hooks/search_inject.py" in query
+    assert "raw log" not in query
+
+
+def test_extract_task_query_preserves_identifiers_from_task_url() -> None:
+    query = search_inject.extract_task_query(
+        "Fix https://github.com/masumi-network/Citadel/issues/123"
+    )
+
+    assert query is not None
+    assert "masumi-network/Citadel" in query
+    assert "#123" in query
+    assert "https://" not in query
+
+
+def test_extract_task_query_retains_long_valid_task_line() -> None:
+    prompt = "Implement " + ("task-aware search " * 30) + "preserve-domain-term"
+    assert len(prompt) > search_inject.MAX_LOG_LINE_CHARS
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "preserve-domain-term" in query
+    assert len(query) <= search_inject.MAX_QUERY_CHARS
+
+
+def test_extract_task_query_skips_traceback_body_and_exception() -> None:
+    prompt = """Fix #123 in kb/hooks/search_inject.py.
+Traceback (most recent call last):
+  File "worker.py", line 4, in <module>
+    source_call()
+ValueError: traceback body must not become the task query
+
+Continue the task-aware search implementation.
+"""
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "#123" in query
+    assert "kb/hooks/search_inject.py" in query
+    assert "Continue the task-aware search implementation." in query
+    assert "Traceback" not in query
+    assert "source_call" not in query
+    assert "ValueError" not in query
+
+
+def test_extract_task_query_keeps_prose_after_message_less_traceback() -> None:
+    prompt = """Fix #123 in kb/hooks/search_inject.py.
+Traceback (most recent call last):
+  File "worker.py", line 4, in <module>
+ValueError
+
+Continue the task-aware search implementation.
+"""
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "Continue the task-aware search implementation." in query
+    assert "ValueError" not in query
+
+
+def test_extract_task_query_skips_chained_traceback_separator() -> None:
+    prompt = """Fix #123 in kb/hooks/search_inject.py.
+Traceback (most recent call last):
+  File "worker.py", line 4, in <module>
+ValueError: first failure
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "worker.py", line 8, in <module>
+RuntimeError: second failure
+
+Continue the task-aware search implementation.
+"""
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "Continue the task-aware search implementation." in query
+    assert "During handling of the above exception" not in query
+    assert "RuntimeError" not in query
+
+
+def test_extract_task_query_keeps_direct_post_traceback_prose() -> None:
+    prompt = """Traceback (most recent call last):
+  File "worker.py", line 4, in <module>
+ValueError
+Please fix #123 in kb/hooks/search_inject.py.
+"""
+
+    query = search_inject.extract_task_query(prompt)
+
+    assert query is not None
+    assert "Please fix #123 in kb/hooks/search_inject.py." in query
+    assert "ValueError" not in query
+
+
+def test_fetch_task_hits_posts_authenticated_bounded_search_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opener = _Opener(_Response(b'{"search_id": "search-1", "results": []}'))
+    monkeypatch.setattr(search_inject, "_OPENER", opener)
+
+    payload = search_inject.fetch_task_hits(
+        "https://node.example/",
+        "ctdl_secret",
+        "Fix #123",
+        limit=20,
+    )
+
+    request, timeout = opener.calls[0]
+    assert request.full_url == "https://node.example/search"
+    assert json.loads(request.data) == {"query": "Fix #123", "top_k": 3}
+    assert request.get_header("Authorization") == "Bearer ctdl_secret"
+    assert request.get_header("Content-type") == "application/json"
+    assert timeout == search_inject.HTTP_TIMEOUT_SECONDS
+    assert payload["search_id"] == "search-1"
+
+
+def test_format_task_context_includes_three_hit_metadata() -> None:
+    payload = {
+        "search_id": "search-123",
+        "dataset": "seat:alice",
+        "results": [
+            {
+                "id": "result-1",
+                "title": "search_inject.py",
+                "snippet": "Task-aware injection implementation.",
+                "_citadel": {
+                    "result_id": "result-1",
+                    "trust_tier": "unattested",
+                    "provenance": {
+                        "source": "repo-content",
+                        "repo": "masumi-network/Citadel",
+                        "path": "kb/hooks/search_inject.py",
+                    },
+                },
+            },
+            {"id": "result-2", "title": "onboard.py", "snippet": "Installer."},
+            {"id": "result-3", "title": "sync_start.py", "snippet": "Policy."},
+            {"id": "result-4", "title": "ignored.py", "snippet": "Too many."},
+        ],
+    }
+
+    context = search_inject.format_task_context(payload)
+
+    assert context.count("result-") == 3
+    assert "search-123" in context
+    assert "result-1" in context
+    assert "unattested" in context
+    assert "repo-content" in context
+    assert "masumi-network/Citadel" in context
+    assert "kb/hooks/search_inject.py" in context
+    assert "ignored.py" not in context
+    assert "untrusted context" in context.lower()
+
+
+def test_format_task_context_redacts_secret_like_text() -> None:
+    payload = {
+        "search_id": "search-123",
+        "results": [
+            {
+                "id": "result-1",
+                "title": "Bearer super-secret-value-123456",
+                "snippet": "api_key=sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+                "provenance": {"source": "token=ctdl_abcdefghijklmnopqrstuvwxyz"},
+            }
+        ],
+    }
+
+    context = search_inject.format_task_context(payload)
+
+    assert "super-secret-value-123456" not in context
+    assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in context
+    assert "ctdl_abcdefghijklmnopqrstuvwxyz" not in context
+    assert "[REDACTED]" in context
+
+
+def test_run_without_token_emits_policy_only(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.delenv(search_inject.TOKEN_ENV, raising=False)
+    monkeypatch.setattr(
+        search_inject,
+        "fetch_task_hits",
+        lambda *args, **kwargs: pytest.fail("fetch must not run without a token"),
+    )
+
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "search #123"}))) == 0
+    assert capsys.readouterr().out.strip() == AGENT_POLICY_REMINDER.strip()
+
+
+def test_run_non_https_and_redirect_emit_policy_only(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setenv(search_inject.TOKEN_ENV, "ctdl_test-token")
+    monkeypatch.setenv(search_inject.BASE_URL_ENV, "http://node.example")
+    opener = _Opener(_Response(b'{"results": []}', status=302))
+    monkeypatch.setattr(search_inject, "_OPENER", opener)
+
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "search #123"}))) == 0
+    assert opener.calls == []
+    assert capsys.readouterr().out.strip() == AGENT_POLICY_REMINDER.strip()
+
+    monkeypatch.setenv(search_inject.BASE_URL_ENV, "https://node.example")
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "search #123"}))) == 0
+    assert capsys.readouterr().out.strip() == AGENT_POLICY_REMINDER.strip()
+    assert len(opener.calls) == 1
+
+
+def test_run_timeout_and_malformed_response_emit_policy_only(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setenv(search_inject.TOKEN_ENV, "ctdl_test-token")
+    monkeypatch.setenv(search_inject.BASE_URL_ENV, "https://node.example")
+    opener = _Opener(TimeoutError("timed out"))
+    monkeypatch.setattr(search_inject, "_OPENER", opener)
+
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "search #123"}))) == 0
+    assert capsys.readouterr().out.strip() == AGENT_POLICY_REMINDER.strip()
+
+    opener.response = _Response(b"not-json")
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "search #123"}))) == 0
+    assert capsys.readouterr().out.strip() == AGENT_POLICY_REMINDER.strip()
+
+
+def test_run_calls_fetch_and_injects_task_context(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setenv(search_inject.TOKEN_ENV, "ctdl_test-token")
+    monkeypatch.setenv(search_inject.BASE_URL_ENV, "https://node.example")
+    calls: list[tuple[str, str, str, int]] = []
+
+    def fake_fetch(base_url: str, token: str, query: str, *, limit: int) -> dict[str, Any]:
+        calls.append((base_url, token, query, limit))
+        return {
+            "search_id": "search-123",
+            "results": [{"id": "result-1", "title": "Task result", "snippet": "Useful context."}],
+        }
+
+    monkeypatch.setattr(search_inject, "fetch_task_hits", fake_fetch)
+
+    assert search_inject.run(io.StringIO(json.dumps({"prompt": "Fix #123 in repo/path.py"}))) == 0
+    output = capsys.readouterr().out
+    assert calls and calls[0][0] == "https://node.example"
+    assert calls[0][1] == "ctdl_test-token"
+    assert "#123" in calls[0][2]
+    assert calls[0][3] == 3
+    assert "search-123" in output
+    assert "Task result" in output
+    assert AGENT_POLICY_REMINDER in output
+
+
+def test_merge_claude_settings_adds_user_prompt_submit_once(tmp_path) -> None:
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"hooks": {"SessionEnd": [], "SessionStart": []}}))
+
+    assert merge_claude_settings(path, python="/usr/bin/python3") == "added"
+    first = json.loads(path.read_text())
+    assert len(first["hooks"]["SessionEnd"]) == 1
+    assert len(first["hooks"]["SessionStart"]) == 1
+    assert len(first["hooks"]["UserPromptSubmit"]) == 1
+    assert "kb.hooks.search_inject" in first["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    assert search_inject.TOKEN_ENV in first["httpHookAllowedEnvVars"]
+    assert search_inject.BASE_URL_ENV in first["httpHookAllowedEnvVars"]
+
+    assert merge_claude_settings(path, python="/usr/bin/python3") == "unchanged"
+    assert json.loads(path.read_text()) == first


### PR DESCRIPTION
## What

Adds the task-aware search injection hook (`kb/hooks/search_inject.py`) and wires it into `citadel onboard` as a `UserPromptSubmit` hook.

## Why

Agent prompts gain bounded, secret-redacted, provenance-labeled vault context: no LLM call, HTTPS only, redirects refused, every failure exits 0 silently so the hook can never break a session. Output is capped at three hits.

Second slice of the stacked core-completion rollout. Part of #317.

Verification: `pytest -q tests/test_search_inject.py tests/test_sync_start.py tests/test_onboard.py` passed at this state (`73 passed`); production check after merge is the hook smoke (`# Citadel task context` injected for a Citadel-naming prompt).

Rollback: revert this merge commit; the hook is client-side and the server surface is unchanged.
