### PR TITLE
fix: leave time for search hook fail-open output

### DIFF
--- a/kb/onboard.py
+++ b/kb/onboard.py
@@ -131,7 +131,7 @@ def _user_prompt_submit_hook(python: str | None = None) -> dict[str, Any]:
     return {
         "type": "command",
         "command": f'"{py}" -m {SEARCH_MODULE}',
-        "timeout": 10,
+        "timeout": 15,
         "allowedEnvVars": [TOKEN_ENV, BASE_URL_ENV],
     }
 

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -197,6 +197,7 @@ def test_merge_claude_settings_adds_then_idempotent(tmp_path: Path) -> None:
     prompt_hooks = [h for g in prompt_groups for h in g["hooks"]]
     assert any("kb.hooks.search_inject" in h["command"] for h in prompt_hooks)
     assert prompt_hooks[0]["allowedEnvVars"] == [TOKEN_ENV, BASE_URL_ENV]
+    assert prompt_hooks[0]["timeout"] == 15
     start_groups = data["hooks"]["SessionStart"]
     start_cmds = [h["command"] for g in start_groups for h in g["hooks"]]
     assert any("kb.hooks.sync_start" in c for c in start_cmds)


### PR DESCRIPTION
## What

Raises the outer UserPromptSubmit command timeout from 10 to 15 seconds while the search hook keeps its 10-second HTTP bound.

## Why

The 10-second HTTP bound matched the 10-second outer command deadline. A slow request could be cancelled before the hook emitted its fail-open policy output. The extra 5 seconds leaves time for timeout handling and policy output.

Part of #317.

Verification: with the outer timeout pinned to 10, the onboarding test failed (`assert 10 == 15`); restored 15 passed. Hook and onboarding tests pass with Ruff clean.

Rollback: revert this merge commit; the hook remains fail-open.
