### PR TITLE
feat(boundary): duplicate-path, trace-id, and status-json hardening

### DIFF
--- a/kb/knowledge_mesh.py
+++ b/kb/knowledge_mesh.py
@@ -20,6 +20,7 @@ import re
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Callable
+from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,14 @@ DEFAULT_MAX_NODES = 200
 
 _LABEL_KEYS = ("name", "label", "title", "text", "id")
 _TYPE_KEYS = ("type", "node_type", "entity_type", "category")
+_DOCUMENT_NODE_TYPES = frozenset({"text", "pdf", "audio", "image"})
+
+
+def _is_document_node_type(value: Any) -> bool:
+    normalized = str(value).strip().lower()
+    return "chunk" not in normalized and (
+        "document" in normalized or normalized in _DOCUMENT_NODE_TYPES
+    )
 
 # Cognee names document nodes ``text_<md5>``/``data_<md5>`` — useless to
 # humans. Labels matching this (or a bare node id) are candidates for
@@ -41,6 +50,23 @@ _CHUNK_LABEL_MAX = 64
 _SEAT_PREFIX = "seat:"
 _SESSION_TRACES_DATASET = "session-traces"
 _ATTESTATION_METADATA_KEY = "citadel_attestation"
+
+# A Shared Session Trace embeds one ``Trace-Id:`` line (kb.session_trace). The
+# withdrawal path hides a trace by ID, so stamp it onto derived graph nodes so
+# a scoped read can drop a withdrawn trace before a projection rebuild does.
+# Match on one line only: horizontal whitespace after the marker and a non-CR/LF
+# value, so an empty marker cannot borrow the next line as a false trace ID.
+_TRACE_ID_RE = re.compile(r"^Trace-Id:[ \t]*([^\r\n]+)\r?$", re.MULTILINE)
+
+
+def _node_trace_id(properties: Any) -> str | None:
+    if not isinstance(properties, dict):
+        return None
+    text = properties.get("text")
+    if not isinstance(text, str):
+        return None
+    match = _TRACE_ID_RE.search(text)
+    return match.group(1).strip() if match else None
 
 # YAML frontmatter closing fences are searched within this many leading lines.
 _FRONTMATTER_SCAN_LINES = 30
@@ -383,6 +409,7 @@ def build_graph_payload(
     limit: int = DEFAULT_MAX_NODES,
     dataset_map: dict[str, list[str]] | None = None,
     presence: list[dict[str, Any]] | None = None,
+    preferred_ids: set[str] | None = None,
     collapse_orphan_documents: bool = False,
 ) -> dict[str, Any]:
     """Shape raw Cognee graph tuples into the ``{nodes, edges}`` contract.
@@ -426,9 +453,11 @@ def build_graph_payload(
     """
     limit = max(1, limit)
     dataset_map = dataset_map or {}
-    nodes: list[dict[str, Any]] = []
-    kept_ids: set[str] = set()
-    node_by_id: dict[str, dict[str, Any]] = {}
+    # Parse every valid node before applying the cap. The old implementation
+    # stopped at the first ``limit`` rows, which could leave a capped graph
+    # with no complete relationship even when a later pair existed.
+    node_rows: list[tuple[str, dict[str, Any]]] = []
+    seen_node_ids: set[str] = set()
     for raw in raw_nodes:
         try:
             node_id, properties = raw[0], raw[1]
@@ -437,25 +466,115 @@ def build_graph_payload(
         if not isinstance(properties, dict):
             properties = {}
         node_key = str(node_id)
-        if node_key in kept_ids:
+        if node_key in seen_node_ids:
             continue
-        kept_ids.add(node_key)
+        seen_node_ids.add(node_key)
+        node_rows.append((node_key, properties))
+
+    selected_ids: set[str] = set()
+    if len(node_rows) <= limit:
+        selected_ids = {node_id for node_id, _ in node_rows}
+    else:
+        # Seat-first callers reserve their own nodes before relationship
+        # selection. This keeps the caller's content visible even when the
+        # graph enumeration starts with another connected component.
+        preferred = preferred_ids or set()
+        # Reserve complete preferred endpoint pairs before filling the cap
+        # with individual preferred nodes. Seat-first callers otherwise can
+        # spend the whole cap on documents and lose every chunk relationship.
+        for raw in raw_edges:
+            endpoints = _raw_endpoints(raw)
+            try:
+                str(raw[2])
+            except (TypeError, IndexError, KeyError):
+                continue
+            if endpoints is None:
+                continue
+            source, target = endpoints
+            missing_ids = {source, target} - selected_ids
+            if (
+                source == target
+                or source not in preferred
+                or target not in preferred
+                or source not in seen_node_ids
+                or target not in seen_node_ids
+                or not missing_ids
+                or len(selected_ids) + len(missing_ids) > limit
+            ):
+                continue
+            selected_ids.update(missing_ids)
+            if len(selected_ids) >= limit:
+                break
+        for node_id, _ in node_rows:
+            if len(selected_ids) >= limit:
+                break
+            if node_id in preferred:
+                selected_ids.add(node_id)
+        # Prefer whole endpoint pairs in raw edge order. If one endpoint is
+        # already selected, add its missing endpoint when the cap allows it.
+        for raw in raw_edges:
+            endpoints = _raw_endpoints(raw)
+            try:
+                str(raw[2])
+            except (TypeError, IndexError, KeyError):
+                continue
+            if endpoints is None:
+                continue
+            source, target = endpoints
+            if (
+                source == target
+                or source not in seen_node_ids
+                or target not in seen_node_ids
+            ):
+                continue
+            source_selected = source in selected_ids
+            target_selected = target in selected_ids
+            if source_selected and target_selected:
+                continue
+            if source_selected or target_selected:
+                if len(selected_ids) < limit:
+                    selected_ids.add(target if source_selected else source)
+                continue
+            if len(selected_ids) + 2 > limit:
+                continue
+            selected_ids.add(source)
+            selected_ids.add(target)
+        if len(selected_ids) < limit:
+            for node_id, _ in node_rows:
+                if node_id in selected_ids:
+                    continue
+                selected_ids.add(node_id)
+                if len(selected_ids) >= limit:
+                    break
+
+    nodes: list[dict[str, Any]] = []
+    kept_ids: set[str] = set()
+    node_by_id: dict[str, dict[str, Any]] = {}
+    for node_key, properties in node_rows:
+        if node_key not in selected_ids:
+            continue
         node: dict[str, Any] = {
             "id": node_key,
             "label": _node_label(node_key, properties),
             "type": _node_type(properties),
             "trust_tier": _trust_tier(dataset_map.get(node_key)),
         }
+        if _is_document_node_type(node["type"]):
+            node["document_endpoint"] = (
+                f"/api/documents/{quote(node_key, safe=':._-')}"
+            )
         names = dataset_map.get(node_key)
         if names:
             node["dataset"] = names[0]
             node["datasets"] = list(names)
             node["trust_tier"] = _trust_tier(names)
         node.update(_promotion_metadata(properties))
+        node_trace = _node_trace_id(properties)
+        if node_trace:
+            node["trace_id"] = node_trace
         nodes.append(node)
+        kept_ids.add(node_key)
         node_by_id[node_key] = node
-        if len(nodes) >= limit:
-            break
 
     # Captured before collapse can shrink ``nodes`` so ``truncated`` keeps its
     # meaning ("more raw nodes exist than were shaped"), not "collapse removed
@@ -528,6 +647,9 @@ def build_graph_payload(
                     best = (key, text)
             if best is None:
                 continue
+            doc_trace_match = _TRACE_ID_RE.search(best[1])
+            if doc_trace_match:
+                internal_nodes[doc_id]["trace_id"] = doc_trace_match.group(1).strip()
             label = _first_line_label(best[1], _DOC_LABEL_MAX, clean=_strip_summary_lead)
             if not label:
                 continue
@@ -571,7 +693,7 @@ def build_graph_payload(
                     if (
                         doc_id in still_internal
                         and set_id in nodeset_ids
-                        and "document" in str(node_by_id[doc_id].get("type", "")).lower()
+                        and _is_document_node_type(node_by_id[doc_id].get("type", ""))
                     ):
                         collapse_into.setdefault(doc_id, set_id)
         for doc_id, set_id in collapse_into.items():
@@ -733,8 +855,9 @@ def fallback_graph(
 class KnowledgeMesh:
     """Reads the real knowledge graph through a Cognee gateway."""
 
-    def __init__(self, gateway: Any) -> None:
+    def __init__(self, gateway: Any, *, lifecycle_store: Any | None = None) -> None:
         self.gateway = gateway
+        self.lifecycle_store = lifecycle_store
 
     async def graph(
         self,
@@ -756,8 +879,8 @@ class KnowledgeMesh:
         may not read are stripped — no node tag, no hub, no belongs_to edge.
         ``total_nodes``/``total_edges`` keep the raw org-wide counts while
         ``visible_nodes`` reports the caller-scoped count so the UI can be
-        honest. ``None`` applies no filtering (bypass/admin callers) and keeps
-        the exact unfiltered behavior.
+        honest. ``None`` skips ADR-0009 dataset filtering for bypass callers;
+        lifecycle current-head filtering still applies.
 
         ``dataset`` narrows the view to one dataset's subgraph using the SAME
         layered inclusion the visibility pass runs (documents, their chunks,
@@ -794,6 +917,168 @@ class KnowledgeMesh:
             )
         raw_nodes = list(raw_nodes)
         raw_edges = list(raw_edges)
+        total_nodes = len(raw_nodes)
+        total_edges = len(raw_edges)
+        lifecycle_removed_ids: set[str] = set()
+        if self.lifecycle_store is not None:
+            status_reader = getattr(self.lifecycle_store, "source_revision_statuses", None)
+            try:
+                if not callable(status_reader):
+                    raise AttributeError("source_revision_statuses is unavailable")
+                source_statuses = await asyncio.to_thread(status_reader)
+                if not isinstance(source_statuses, Mapping):
+                    raise TypeError("source_revision_statuses must return a mapping")
+                lifecycle_statuses: dict[str, bool] = {}
+                for source_id, is_current in source_statuses.items():
+                    if (
+                        not isinstance(source_id, str)
+                        or not source_id
+                        or not isinstance(is_current, bool)
+                    ):
+                        raise ValueError("invalid lifecycle source revision status")
+                    lifecycle_statuses[source_id] = is_current
+            except Exception as exc:
+                logger.warning(
+                    "Knowledge mesh lifecycle status read failed with %s; "
+                    "returning a fail-closed graph",
+                    exc.__class__.__name__,
+                )
+                return fallback_graph(
+                    f"lifecycle_status_error:{exc.__class__.__name__}", presence
+                )
+
+            stale_ids = {
+                source_id
+                for source_id, is_current in lifecycle_statuses.items()
+                if not is_current
+            }
+            if stale_ids:
+                chunk_ids: set[str] = set()
+                unmanaged_document_ids: set[str] = set()
+                raw_node_ids = {
+                    node_id for raw in raw_nodes if (node_id := _raw_id(raw)) is not None
+                }
+                adjacency: dict[str, set[str]] = {}
+                for raw in raw_edges:
+                    try:
+                        str(raw[2])
+                    except (TypeError, IndexError, KeyError):
+                        continue
+                    endpoints = _raw_endpoints(raw)
+                    if endpoints is None:
+                        continue
+                    source_id, target_id = endpoints
+                    if source_id not in raw_node_ids or target_id not in raw_node_ids:
+                        continue
+                    adjacency.setdefault(source_id, set()).add(target_id)
+                    adjacency.setdefault(target_id, set()).add(source_id)
+                for raw in raw_nodes:
+                    node_id = _raw_id(raw)
+                    if node_id is None:
+                        continue
+                    try:
+                        properties = raw[1]
+                    except (TypeError, IndexError, KeyError):
+                        properties = {}
+                    if not isinstance(properties, dict):
+                        properties = {}
+                    node_type = _node_type(properties).lower()
+                    if "chunk" in node_type or (
+                        not _is_document_node_type(node_type)
+                        and any(
+                            isinstance(properties.get(key), str)
+                            and properties[key].strip()
+                            for key in ("text", "chunk", "content", "raw_content")
+                        )
+                    ):
+                        chunk_ids.add(node_id)
+                    elif _is_document_node_type(node_type) and node_id not in lifecycle_statuses:
+                        unmanaged_document_ids.add(node_id)
+
+                lifecycle_removed_ids = set(stale_ids)
+                for raw in raw_edges:
+                    endpoints = _raw_endpoints(raw)
+                    try:
+                        relationship = str(raw[2])
+                    except (TypeError, IndexError, KeyError):
+                        continue
+                    if endpoints is None or relationship != "is_part_of":
+                        continue
+                    source_id, target_id = endpoints
+                    if (
+                        source_id in stale_ids
+                        and (
+                            source_id not in chunk_ids
+                            or target_id in chunk_ids
+                        )
+                    ):
+                        lifecycle_removed_ids.add(target_id)
+                    if (
+                        target_id in stale_ids
+                        and (
+                            target_id not in chunk_ids
+                            or source_id in chunk_ids
+                        )
+                    ):
+                        lifecycle_removed_ids.add(source_id)
+
+                affected_component_ids: set[str] = set()
+                pending = [source_id for source_id in stale_ids if source_id in raw_node_ids]
+                while pending:
+                    node_id = pending.pop()
+                    if node_id in affected_component_ids:
+                        continue
+                    affected_component_ids.add(node_id)
+                    pending.extend(
+                        neighbor
+                        for neighbor in adjacency.get(node_id, ())
+                        if neighbor not in affected_component_ids
+                    )
+
+                current_ids = {
+                    source_id
+                    for source_id, is_current in lifecycle_statuses.items()
+                    if is_current and source_id in raw_node_ids
+                } | unmanaged_document_ids
+                reachable_current_ids: set[str] = set()
+                pending = [
+                    source_id
+                    for source_id in current_ids
+                    if source_id not in lifecycle_removed_ids
+                ]
+                while pending:
+                    node_id = pending.pop()
+                    if node_id in reachable_current_ids or node_id in lifecycle_removed_ids:
+                        continue
+                    reachable_current_ids.add(node_id)
+                    pending.extend(
+                        neighbor
+                        for neighbor in adjacency.get(node_id, ())
+                        if neighbor not in reachable_current_ids
+                        and neighbor not in lifecycle_removed_ids
+                    )
+                lifecycle_removed_ids.update(
+                    node_id
+                    for node_id in affected_component_ids
+                    if node_id not in reachable_current_ids
+                )
+                raw_nodes = [
+                    raw
+                    for raw in raw_nodes
+                    if _raw_id(raw) not in lifecycle_removed_ids
+                ]
+                raw_edges = [
+                    raw
+                    for raw in raw_edges
+                    if (
+                        (endpoints := _raw_endpoints(raw)) is None
+                        or (
+                            endpoints[0] not in lifecycle_removed_ids
+                            and endpoints[1] not in lifecycle_removed_ids
+                        )
+                    )
+                ]
+
         dataset_map: dict[str, list[str]] = {}
         node_dataset_map = getattr(self.gateway, "node_dataset_map", None)
         if callable(node_dataset_map):
@@ -806,6 +1091,12 @@ class KnowledgeMesh:
                     exc.__class__.__name__,
                 )
                 dataset_map = {}
+        if lifecycle_removed_ids:
+            dataset_map = {
+                node_id: names
+                for node_id, names in dataset_map.items()
+                if node_id not in lifecycle_removed_ids
+            }
         if presence:
             # Fill presence document counts from the RAW map, before caller
             # scoping strips hidden names: contribution counts are presence
@@ -818,13 +1109,11 @@ class KnowledgeMesh:
                 {**entry, "documents": counts.get(str(entry.get("dataset")), 0)}
                 for entry in presence
             ]
-        if not raw_nodes:
+        if not raw_nodes and total_nodes == 0:
             # ADR-0009: seats are ALWAYS visible — the empty-graph fallback
             # still renders presence hubs, with document counts from the
             # dataset map read above (0 when nothing is mapped).
             return fallback_graph("graph_empty", presence)
-        total_nodes = len(raw_nodes)
-        total_edges = len(raw_edges)
         visible_nodes: int | None = None
         if dataset_visible is not None:
             # ADR-0009 scoping is pure Python over already-materialized tuples/
@@ -873,6 +1162,7 @@ class KnowledgeMesh:
             ]
             if visible_nodes is not None:
                 visible_nodes = len(raw_nodes)
+        priority_ids: set[str] = set()
         if seat_first:
             # Seat-first ordering pre-cap: the caller's own cluster (same
             # layered inclusion) moves ahead of the enumeration tail. Pure
@@ -898,13 +1188,17 @@ class KnowledgeMesh:
                 limit=limit,
                 dataset_map=dataset_map,
                 presence=presence,
+                preferred_ids=priority_ids,
                 collapse_orphan_documents=collapse_orphans,
             )
         )
+        if dataset_visible is not None or self.lifecycle_store is not None:
+            # Totals remain raw graph counts, including rows removed from the
+            # caller-facing lifecycle projection.
+            payload["total_nodes"] = total_nodes
+            payload["total_edges"] = total_edges
         if dataset_visible is not None:
             # Raw org-wide totals stay honest about what exists; the caller's
             # scope is reported separately.
-            payload["total_nodes"] = total_nodes
-            payload["total_edges"] = total_edges
             payload["visible_nodes"] = visible_nodes
         return {"ok": True, "fallback": False, **payload}

--- a/kb/obsidian_sync.py
+++ b/kb/obsidian_sync.py
@@ -213,6 +213,21 @@ class ObsidianSyncStore:
         conflicts: list[dict[str, Any]] = []
         now = now_iso()
 
+        # Reject a batch that maps two request paths to one normalized path
+        # before any mutation. The store keys a document by normalized path, so
+        # a slash/dot duplicate (``notes/a.md`` and ``./notes/a.md``) would
+        # otherwise resolve to one document with order-dependent content. Fail
+        # the whole push and leave the manifest unchanged.
+        seen_paths: dict[str, str] = {}
+        for incoming in documents:
+            normalized = normalize_path(incoming.path)
+            if normalized in seen_paths:
+                raise ValueError(
+                    f"Duplicate normalized path in push batch: {normalized!r} "
+                    f"(from {seen_paths[normalized]!r} and {incoming.path!r})."
+                )
+            seen_paths[normalized] = incoming.path
+
         for incoming in documents:
             normalized_path = normalize_path(incoming.path)
             body = "" if incoming.deleted else incoming.content

--- a/kb/session_trace.py
+++ b/kb/session_trace.py
@@ -1,9 +1,25 @@
-"""Shared Session Trace server-side enrichment (ADR-0011)."""
+"""Shared Session Trace server-side enrichment, metadata, and withdrawal.
+
+Author-Seat and Trace-Id pinning and the optional dead-end LLM pass are the
+original ADR-0011 concerns. This module also owns Shared Session Trace metadata
+and a durable withdrawal tombstone store (v1 release contract section 10):
+withdrawal hides a trace from search and drilldown, records a minimal audit
+tombstone, and lets search and graph paths filter it before it resurfaces.
+"""
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import re
+import tempfile
+from collections.abc import Collection, Mapping
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
 
 from kb.llm_enrichment import (
     content_flagged_by_security_scan,
@@ -11,11 +27,25 @@ from kb.llm_enrichment import (
     openrouter_chat,
 )
 from kb.model_routing import route_for
+
 logger = logging.getLogger(__name__)
+
+SHARED_TRACE_HEADER = "# Shared Session Trace"
+TRACE_ID_PREFIX = "trace:"
+TRACE_TRUST = "reference-only"
 
 __all__ = [
     "enrich_shared_trace",
     "force_shared_trace_author_seat",
+    "force_shared_trace_id",
+    "mint_trace_id",
+    "extract_trace_id",
+    "result_trace_id",
+    "result_source_revision_id",
+    "SharedTraceMetadata",
+    "TraceTombstone",
+    "SessionTraceStore",
+    "prune_withdrawn_graph",
 ]
 
 _AUTHOR_SEAT_LINE = re.compile(r"^Author-Seat:\s*.+$", re.MULTILINE)
@@ -61,3 +91,399 @@ def enrich_shared_trace(data: str, *, has_tool_errors: bool) -> str:
         logger.warning("shared trace LLM output blocked by security scan; using deterministic text")
         return data
     return content.strip()
+
+
+# The marker must stay on one line: ``\s`` would let the value span a newline,
+# so an empty ``Trace-Id:`` line could steal the next content line as the ID.
+# Restrict the gap to horizontal whitespace and the value to non-CR/LF text.
+_TRACE_ID_LINE = re.compile(r"^Trace-Id:[ \t]*([^\r\n]+)\r?$", re.MULTILINE)
+_RESULT_TEXT_KEYS = ("text", "content", "chunk", "body")
+
+
+def mint_trace_id(seat_slug: str, session_id: str, data: str) -> str:
+    """Deterministic stable trace ID from author, session, and content.
+
+    Deterministic so re-sharing identical content mints the same ID and the
+    withdrawal tombstone still matches. The ID is opaque: it carries no source
+    or query text.
+    """
+    material = f"{seat_slug.strip()}\n{session_id.strip()}\n{data}"
+    digest = sha256(material.encode("utf-8")).hexdigest()[:32]
+    return f"{TRACE_ID_PREFIX}{digest}"
+
+
+def extract_trace_id(text: str | None) -> str | None:
+    """Return the ``Trace-Id:`` value embedded in trace markdown, if any."""
+    if not text:
+        return None
+    match = _TRACE_ID_LINE.search(text)
+    return match.group(1).strip() if match else None
+
+
+def force_shared_trace_id(data: str, trace_id: str) -> str:
+    """Pin one ``Trace-Id:`` line so every downstream chunk carries the ID.
+
+    Mirrors ``force_shared_trace_author_seat``: rewrite every occurrence so a
+    tail chunk cannot carry a stale or spoofed trace ID.
+    """
+    line = f"Trace-Id: {trace_id.strip()}"
+    if _TRACE_ID_LINE.search(data):
+        return _TRACE_ID_LINE.sub(line, data)
+    lines = data.splitlines()
+    if lines and lines[0].strip() == SHARED_TRACE_HEADER:
+        return "\n".join([lines[0], line, *lines[1:]])
+    return f"{line}\n{data}"
+
+
+def _direct_trace_id(value: Any) -> str | None:
+    """Return a direct ``Trace-Id``/``trace_id`` mapping value if single-line.
+
+    A direct field is line-oriented like the marker: an embedded CR/LF would
+    let a spoofed second line ride along, so reject any value that carries one.
+    """
+    if not isinstance(value, str):
+        return None
+    if "\r" in value or "\n" in value:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def result_trace_id(result: Any) -> str | None:
+    """Extract a trace ID from a search result or graph node, dict or string."""
+    if isinstance(result, str):
+        return extract_trace_id(result)
+    if not isinstance(result, Mapping):
+        return None
+    for key in ("Trace-Id", "trace_id"):
+        found = _direct_trace_id(result.get(key))
+        if found:
+            return found
+    metadata = result.get("metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("Trace-Id", "trace_id"):
+            found = _direct_trace_id(metadata.get(key))
+            if found:
+                return found
+    for key in _RESULT_TEXT_KEYS:
+        found = extract_trace_id(result.get(key) if isinstance(result.get(key), str) else None)
+        if found:
+            return found
+    if isinstance(metadata, Mapping):
+        for key in _RESULT_TEXT_KEYS:
+            candidate = metadata.get(key)
+            found = extract_trace_id(candidate if isinstance(candidate, str) else None)
+            if found:
+                return found
+    return None
+
+
+def result_source_revision_id(result: Any) -> str | None:
+    """Extract lifecycle source identity from a raw hit or graph node."""
+    if not isinstance(result, Mapping):
+        return None
+    containers: list[Mapping[str, Any]] = [result]
+    for key in ("metadata", "_citadel", "_lifecycle", "properties", "props"):
+        value = result.get(key)
+        if isinstance(value, Mapping):
+            containers.append(value)
+    for container in containers:
+        value = container.get("source_revision_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+@dataclass(frozen=True)
+class SharedTraceMetadata:
+    """Server-held Shared Session Trace metadata (v1 contract section 10)."""
+
+    trace_id: str
+    author_principal: str
+    author_kind: str = "human"
+    seat_scope: str | None = None
+    captured_at: str | None = None
+    shared_at: str | None = None
+    source_references: tuple[str, ...] = ()
+    redaction_result: str = "clean"
+    visibility: str = "seat-shared"
+    citations: tuple[str, ...] = ()
+    trust: str = TRACE_TRUST
+    source_revision_ids: tuple[str, ...] = ()
+    withdrawn: bool = False
+    withdrawn_at: str | None = None
+    withdrawal_reason: str | None = None
+    withdrawn_by: str | None = None
+
+
+class TraceStoreCorruptionError(RuntimeError):
+    """Raised when withdrawal state cannot be trusted for privacy filtering."""
+
+
+@dataclass(frozen=True)
+class TraceTombstone:
+    """Minimal durable withdrawal record: no source or query text."""
+
+    trace_id: str
+    actor_principal: str
+    withdrawn_at: str
+    reason_code: str
+
+
+def _utc_now_text(now: datetime | None = None) -> str:
+    moment = now or datetime.now(UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).isoformat()
+
+
+def _as_str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item) for item in value if isinstance(item, str) and item.strip())
+
+
+class SessionTraceStore:
+    """Durable JSON-backed trace metadata and withdrawal tombstones.
+
+    Withdrawal is idempotent: the first call writes the tombstone and the
+    stored timestamp never moves on repeat. A tombstone is recorded even for a
+    trace that was never registered, so a filter path can hide it regardless.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except FileNotFoundError:
+            return {"version": 1, "traces": {}, "tombstones": {}}
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise TraceStoreCorruptionError(
+                "Shared Session Trace withdrawal state is unreadable."
+            ) from error
+        if (
+            not isinstance(data, dict)
+            or data.get("version") != 1
+            or not isinstance(data.get("traces"), dict)
+            or not isinstance(data.get("tombstones"), dict)
+        ):
+            raise TraceStoreCorruptionError(
+                "Shared Session Trace withdrawal state has an invalid schema."
+            )
+        return data
+
+    def _save(self, data: Mapping[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2)
+        fd, tmp = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+            os.replace(tmp, self._path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def register(self, metadata: SharedTraceMetadata) -> SharedTraceMetadata:
+        """Persist trace metadata. Preserves an existing withdrawal."""
+        data = self._load()
+        traces = data["traces"]
+        existing = traces.get(metadata.trace_id)
+        record = dict(asdict(metadata))
+        if isinstance(existing, Mapping) and existing.get("withdrawn"):
+            record.update(
+                {
+                    "withdrawn": True,
+                    "withdrawn_at": existing.get("withdrawn_at"),
+                    "withdrawal_reason": existing.get("withdrawal_reason"),
+                    "withdrawn_by": existing.get("withdrawn_by"),
+                }
+            )
+        traces[metadata.trace_id] = record
+        self._save(data)
+        return self._metadata_from_record(record)
+
+    def get(self, trace_id: str) -> SharedTraceMetadata | None:
+        record = self._load()["traces"].get(trace_id)
+        if not isinstance(record, Mapping):
+            return None
+        return self._metadata_from_record(record)
+
+    def withdraw(
+        self,
+        trace_id: str,
+        *,
+        actor_principal: str,
+        reason_code: str,
+        now: datetime | None = None,
+    ) -> TraceTombstone:
+        """Record an idempotent, durable withdrawal tombstone."""
+        clean_id = str(trace_id).strip()
+        if not clean_id:
+            raise ValueError("trace_id must be a non-empty string")
+        clean_reason = str(reason_code).strip()
+        if not clean_reason:
+            raise ValueError("reason_code must be a non-empty string")
+        clean_actor = str(actor_principal).strip()
+        if not clean_actor:
+            raise ValueError("actor_principal must be a non-empty string")
+        data = self._load()
+        tombstones = data["tombstones"]
+        existing = tombstones.get(clean_id)
+        if isinstance(existing, Mapping):
+            return TraceTombstone(
+                trace_id=clean_id,
+                actor_principal=str(existing.get("actor_principal", clean_actor)),
+                withdrawn_at=str(existing.get("withdrawn_at", _utc_now_text(now))),
+                reason_code=str(existing.get("reason_code", clean_reason)),
+            )
+        withdrawn_at = _utc_now_text(now)
+        tombstone = TraceTombstone(
+            trace_id=clean_id,
+            actor_principal=clean_actor,
+            withdrawn_at=withdrawn_at,
+            reason_code=clean_reason,
+        )
+        tombstones[clean_id] = asdict(tombstone)
+        record = data["traces"].get(clean_id)
+        if isinstance(record, dict):
+            record.update(
+                {
+                    "withdrawn": True,
+                    "withdrawn_at": withdrawn_at,
+                    "withdrawal_reason": clean_reason,
+                    "withdrawn_by": clean_actor,
+                }
+            )
+        self._save(data)
+        return tombstone
+
+    def tombstone(self, trace_id: str) -> TraceTombstone | None:
+        record = self._load()["tombstones"].get(str(trace_id).strip())
+        if not isinstance(record, Mapping):
+            return None
+        return TraceTombstone(
+            trace_id=str(record.get("trace_id", trace_id)),
+            actor_principal=str(record.get("actor_principal", "")),
+            withdrawn_at=str(record.get("withdrawn_at", "")),
+            reason_code=str(record.get("reason_code", "")),
+        )
+
+    def is_withdrawn(self, trace_id: str | None) -> bool:
+        if not trace_id:
+            return False
+        return str(trace_id).strip() in self._load()["tombstones"]
+
+    def withdrawn_trace_ids(self) -> frozenset[str]:
+        return frozenset(self._load()["tombstones"].keys())
+
+    def withdrawn_source_revision_ids(self) -> frozenset[str]:
+        """Return source revisions bound to every durably withdrawn trace."""
+        data = self._load()
+        withdrawn = set(data["tombstones"])
+        revisions: set[str] = set()
+        for trace_id, record in data["traces"].items():
+            if trace_id not in withdrawn and not (
+                isinstance(record, Mapping) and record.get("withdrawn")
+            ):
+                continue
+            if isinstance(record, Mapping):
+                revisions.update(_as_str_tuple(record.get("source_revision_ids")))
+        return frozenset(revisions)
+
+    @staticmethod
+    def _metadata_from_record(record: Mapping[str, Any]) -> SharedTraceMetadata:
+        return SharedTraceMetadata(
+            trace_id=str(record.get("trace_id", "")),
+            author_principal=str(record.get("author_principal", "")),
+            author_kind=str(record.get("author_kind", "human")),
+            seat_scope=record.get("seat_scope"),
+            captured_at=record.get("captured_at"),
+            shared_at=record.get("shared_at"),
+            source_references=_as_str_tuple(record.get("source_references")),
+            redaction_result=str(record.get("redaction_result", "clean")),
+            visibility=str(record.get("visibility", "seat-shared")),
+            citations=_as_str_tuple(record.get("citations")),
+            trust=str(record.get("trust", TRACE_TRUST)),
+            source_revision_ids=_as_str_tuple(record.get("source_revision_ids")),
+            withdrawn=bool(record.get("withdrawn", False)),
+            withdrawn_at=record.get("withdrawn_at"),
+            withdrawal_reason=record.get("withdrawal_reason"),
+            withdrawn_by=record.get("withdrawn_by"),
+        )
+
+
+def _node_carries_withdrawn_trace(
+    node: Mapping[str, Any],
+    withdrawn: Collection[str],
+    withdrawn_source_revisions: Collection[str] = (),
+) -> bool:
+    trace_id = result_trace_id(node)
+    if trace_id and trace_id in withdrawn:
+        return True
+    source_revision_id = result_source_revision_id(node)
+    if source_revision_id and source_revision_id in withdrawn_source_revisions:
+        return True
+    # A graph node may expose its raw properties rather than trace text.
+    for key in ("properties", "props", "metadata"):
+        value = node.get(key)
+        if isinstance(value, Mapping):
+            found = result_trace_id(value)
+            if found and found in withdrawn:
+                return True
+            source_revision_id = result_source_revision_id(value)
+            if source_revision_id and source_revision_id in withdrawn_source_revisions:
+                return True
+    return False
+
+
+def prune_withdrawn_graph(
+    payload: Mapping[str, Any],
+    withdrawn: Collection[str] | None,
+    withdrawn_source_revisions: Collection[str] | None = None,
+) -> dict[str, Any]:
+    """Drop withdrawn trace nodes and their dangling edges."""
+    result = dict(payload)
+    withdrawn_set = {str(item).strip() for item in (withdrawn or ()) if str(item).strip()}
+    source_revision_set = {
+        str(item).strip()
+        for item in (withdrawn_source_revisions or ())
+        if str(item).strip()
+    }
+    if not withdrawn_set and not source_revision_set:
+        return result
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list):
+        return result
+    removed_ids: set[str] = set()
+    kept_nodes: list[Any] = []
+    for node in nodes:
+        if isinstance(node, Mapping) and _node_carries_withdrawn_trace(
+            node,
+            withdrawn_set,
+            source_revision_set,
+        ):
+            node_id = node.get("id")
+            if isinstance(node_id, str):
+                removed_ids.add(node_id)
+            continue
+        kept_nodes.append(node)
+    result["nodes"] = kept_nodes
+    edges = payload.get("edges")
+    if isinstance(edges, list) and removed_ids:
+        kept_edges: list[Any] = []
+        for edge in edges:
+            if isinstance(edge, Mapping):
+                source = edge.get("source")
+                target = edge.get("target")
+                if source in removed_ids or target in removed_ids:
+                    continue
+            kept_edges.append(edge)
+        result["edges"] = kept_edges
+    return result

--- a/kb/status.py
+++ b/kb/status.py
@@ -13,6 +13,7 @@ raising, so the report always renders.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -192,12 +193,21 @@ class StatusReport:
         return out
 
     def to_dict(self) -> dict[str, Any]:
+        checks: list[dict[str, Any]] = []
+        for check in self.checks:
+            item = asdict(check)
+            if check.name == "token":
+                # JSON is an automation boundary. Even a masked suffix can
+                # correlate with a credential, so expose only its state.
+                item["detail"] = "configured" if check.ok else "not configured"
+                item["data"] = {}
+            checks.append(item)
         return {
             "node_url": self.node_url,
             "healthy": self.healthy,
             "identity": self.identity,
-            "checks": [asdict(c) for c in self.checks],
-            "recent": self.recent,
+            "checks": checks,
+            "recent": _sanitize_recent(self.recent),
             "repo": self.repo,
             "readiness": self.readiness(),
         }
@@ -600,7 +610,19 @@ def ingest_node(
     """
     if cognify:
         raise ValueError("User ingest is capture-only; run scheduled projection separately")
-    payload: dict[str, Any] = {"data": data, "tags": list(tags), "cognify": False}
+    tag_list = list(tags)
+    payload: dict[str, Any] = {
+        "data": data,
+        "tags": tag_list,
+        "cognify": False,
+        "idempotency_key": hashlib.sha256(
+            json.dumps(
+                ["citadel-ingest", data, tag_list],
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest(),
+    }
     resolved = timeout if timeout is not None else _INGEST_TIMEOUT
     return _request(
         "POST",
@@ -906,6 +928,32 @@ def check_local_setup(repo: Path, config_path: Path | None = None) -> list[Check
     return checks
 
 
+# JSON status is an automation boundary. Upstream ``/api/contributions/recent``
+# returns full audit rows (actor_id, actor_kind, role, dataset, detail, …), but
+# only these scalar display fields belong in status output. Everything else,
+# including actor identity, tokens, datasets, detail payloads, and unknown keys,
+# is dropped. Non-scalar values are dropped even for allowed keys.
+_RECENT_ALLOWED_FIELDS = ("created_at", "timestamp", "title", "action")
+
+
+def _sanitize_recent(rows: Any) -> list[dict[str, Any]]:
+    """Field-allowlist recent contribution rows for the status boundary."""
+    if not isinstance(rows, list):
+        return []
+    clean: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        item: dict[str, Any] = {}
+        for key in _RECENT_ALLOWED_FIELDS:
+            value = row.get(key)
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                if value is not None:
+                    item[key] = value
+        clean.append(item)
+    return clean
+
+
 def fetch_recent(
     base_url: str, token: str | None, *, limit: int = 5, timeout: float = _TIMEOUT
 ) -> list[dict[str, Any]]:
@@ -920,7 +968,7 @@ def fetch_recent(
         )
     except Exception:
         return []
-    return data.get("contributions") or []
+    return _sanitize_recent(data.get("contributions"))
 
 
 def gather_status(

--- a/kb/status.py
+++ b/kb/status.py
@@ -968,7 +968,8 @@ def fetch_recent(
         )
     except Exception:
         return []
-    return _sanitize_recent(data.get("contributions"))
+    payload = data if isinstance(data, dict) else {}
+    return _sanitize_recent(payload.get("contributions"))
 
 
 def gather_status(

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -262,3 +262,61 @@ def test_onboard_json_no_prompts(tmp_path: Path, monkeypatch, capsys) -> None:
     assert "git pre-push hook" in names and "SessionEnd hook" in names
     assert "…" in out["token_masked"]  # masked, never the raw token
     assert "ctdl_headless_abcdef1234" not in json.dumps(out)
+
+
+def test_default_status_json_is_redacted_and_allowlisted(monkeypatch, capsys) -> None:
+    # Default `citadel status --json` must never smoke /search, never pull the
+    # full mesh graph, and must carry no graph nodes/edges/events, query labels,
+    # or token-derived values.
+    from kb.status import Check, StatusReport
+
+    seen: list[tuple[str, object]] = []
+
+    def fake_gather(node_url, token, **kw):
+        seen.append(("with_search", kw.get("with_search")))
+        return StatusReport(
+            node_url=node_url,
+            healthy=True,
+            identity={"seat_slug": "alice", "role": "writer", "scopes": ["kb:search"]},
+            checks=[
+                Check("node", True, "healthy"),
+                Check("auth", True, "valid"),
+                Check("token", True, "…6789"),
+            ],
+            recent=[
+                {
+                    "title": "feat: safe",
+                    "created_at": "2026-06-27T10:00:00",
+                    "actor_id": "principal_secret",
+                    "token": "ctdl_hostiletoken",
+                    "dataset": "seat:alice",
+                    "detail": {"query": "confidential text"},
+                }
+            ],
+            repo=".",
+        )
+
+    def fake_summary(node_url, token, **kw):
+        return {"detail": "summary", "tracked_sources": 3}
+
+    def forbidden_full_mesh(*_a, **_k):
+        raise AssertionError("default --json must not fetch the full mesh graph")
+
+    monkeypatch.setattr("kb.cli.gather_status", fake_gather)
+    monkeypatch.setattr("kb.cli.fetch_mesh_summary", fake_summary)
+    monkeypatch.setattr("kb.cli.fetch_mesh", forbidden_full_mesh)
+    rc = _run(["status", "--json", "--node-url", "https://node.example"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    blob = json.dumps(out)
+    assert "6789" not in blob
+    token_check = next(item for item in out["checks"] if item["name"] == "token")
+    assert token_check["detail"] == "configured"
+    assert ("with_search", False) in seen  # never the /search smoke by default
+    assert "nodes" not in blob and "edges" not in blob and "events" not in blob
+    assert "query" not in blob
+    assert "…" not in blob  # no masked token suffix
+    # Hostile recent-row fields are gone; only display scalars survive.
+    for leaked in ("principal_secret", "ctdl_hostiletoken", "seat:alice", "confidential text"):
+        assert leaked not in blob
+    assert out["recent"] == [{"title": "feat: safe", "created_at": "2026-06-27T10:00:00"}]

--- a/tests/test_knowledge_mesh.py
+++ b/tests/test_knowledge_mesh.py
@@ -194,6 +194,7 @@ def test_dataset_map_tags_document_and_appends_hub() -> None:
     doc = next(node for node in payload["nodes"] if node["id"] == "doc-1")
     assert doc["dataset"] == "seat:alice"
     assert doc["datasets"] == ["seat:alice"]
+    assert doc["document_endpoint"] == "/api/documents/doc-1"
     hub = next(node for node in payload["nodes"] if node["id"] == "dataset:seat:alice")
     assert hub == {
         "id": "dataset:seat:alice",
@@ -1107,6 +1108,29 @@ async def test_graph_seat_first_orders_callers_content_before_the_cap() -> None:
     assert _content_ids(seated) == ["doc-seat", "doc-c0"]
 
 
+async def test_graph_seat_first_keeps_connected_pair_before_cap() -> None:
+    nodes = [
+        ("doc-central-0", {"type": "TextDocument"}),
+        ("doc-central-1", {"type": "TextDocument"}),
+        ("doc-seat", {"type": "TextDocument"}),
+        ("chunk-seat", {"type": "DocumentChunk", "text": "seat content"}),
+    ]
+    edges = [
+        ("doc-central-0", "doc-central-1", "related", {}),
+        ("chunk-seat", "doc-seat", "is_part_of", {}),
+    ]
+    mapping = {
+        "doc-central-0": ["masumi-network"],
+        "doc-central-1": ["masumi-network"],
+        "doc-seat": ["seat:alice"],
+    }
+    mesh = KnowledgeMesh(FakeDatasetMapGateway(nodes, edges, mapping))
+
+    seated = await mesh.graph(limit=2, seat_first="seat:alice")
+
+    assert _content_ids(seated) == ["doc-seat", "chunk-seat"]
+
+
 async def test_graph_seat_first_without_matching_content_changes_nothing() -> None:
     mesh = KnowledgeMesh(
         FakeDatasetMapGateway(
@@ -1115,3 +1139,288 @@ async def test_graph_seat_first_without_matching_content_changes_nothing() -> No
     )
 
     assert await mesh.graph(seat_first="seat:ghost") == await mesh.graph()
+
+
+# --- lifecycle current-head graph filtering -----------------------------------
+
+
+class FakeLifecycleStore:
+    def __init__(self, statuses: dict[str, bool]) -> None:
+        self.statuses = statuses
+
+    def source_revision_statuses(self) -> dict[str, bool]:
+        return dict(self.statuses)
+
+
+CURRENT_SOURCE_REVISION_IDS = {"doc-current", "doc-hidden-current"}
+STALE_SOURCE_REVISION_IDS = {"doc-stale"}
+TOMBSTONED_SOURCE_REVISION_IDS = {"doc-tombstoned"}
+LIFECYCLE_SOURCE_STATUSES = {
+    **{source_id: True for source_id in CURRENT_SOURCE_REVISION_IDS},
+    **{source_id: False for source_id in STALE_SOURCE_REVISION_IDS},
+    **{source_id: False for source_id in TOMBSTONED_SOURCE_REVISION_IDS},
+}
+
+
+async def test_graph_filters_stale_and_tombstoned_nodes_before_scope_and_cap() -> None:
+    nodes = [
+        ("doc-stale", {"name": "stale document", "type": "TextDocument"}),
+        ("chunk-stale", {"text": "stale chunk", "type": "DocumentChunk"}),
+        (
+            "doc-tombstoned",
+            {"name": "tombstoned document", "type": "TextDocument"},
+        ),
+        (
+            "chunk-tombstoned",
+            {"text": "tombstoned chunk", "type": "DocumentChunk"},
+        ),
+        (
+            "doc-hidden-current",
+            {"name": "private current document", "type": "TextDocument"},
+        ),
+        (
+            "chunk-hidden-current",
+            {"text": "private current chunk", "type": "DocumentChunk"},
+        ),
+        ("doc-current", {"name": "current document", "type": "TextDocument"}),
+        ("chunk-current", {"text": "current chunk", "type": "DocumentChunk"}),
+    ]
+    edges = [
+        ("chunk-stale", "doc-stale", "is_part_of", {}),
+        ("chunk-tombstoned", "doc-tombstoned", "is_part_of", {}),
+        ("chunk-hidden-current", "doc-hidden-current", "is_part_of", {}),
+        ("chunk-current", "doc-current", "is_part_of", {}),
+    ]
+    gateway = FakeDatasetGateway(
+        nodes,
+        edges,
+        dataset_map={
+            "doc-stale": ["masumi-network"],
+            "doc-tombstoned": ["masumi-network"],
+            "doc-hidden-current": ["seat:alice"],
+            "doc-current": ["masumi-network"],
+        },
+    )
+    mesh = KnowledgeMesh(
+        gateway,
+        lifecycle_store=FakeLifecycleStore(LIFECYCLE_SOURCE_STATUSES),
+    )
+
+    full_graph = await mesh.graph(limit=20, dataset_visible=_central_only)
+
+    full_ids = {node["id"] for node in full_graph["nodes"]}
+    assert {"doc-current", "chunk-current"} <= full_ids
+    assert {
+        "source": "chunk-current",
+        "target": "doc-current",
+        "relationship": "is_part_of",
+    } in full_graph["edges"]
+    assert "doc-hidden-current" not in full_ids
+    assert "chunk-hidden-current" not in full_ids
+    for stale_id in (
+        STALE_SOURCE_REVISION_IDS
+        | TOMBSTONED_SOURCE_REVISION_IDS
+        | {"chunk-stale", "chunk-tombstoned"}
+    ):
+        assert stale_id not in full_ids
+    payload_text = json.dumps(full_graph, sort_keys=True)
+    for stale_id in STALE_SOURCE_REVISION_IDS | TOMBSTONED_SOURCE_REVISION_IDS:
+        assert stale_id not in payload_text
+        assert f"/api/documents/{stale_id}" not in payload_text
+    assert "stale chunk" not in payload_text
+    assert "tombstoned chunk" not in payload_text
+    assert "private current document" not in payload_text
+    assert "/api/documents/doc-current" in payload_text
+    assert all(
+        edge["source"] in full_ids and edge["target"] in full_ids
+        for edge in full_graph["edges"]
+    )
+
+    capped_graph = await mesh.graph(limit=2, dataset_visible=_central_only)
+    capped_content_ids = [
+        node["id"]
+        for node in capped_graph["nodes"]
+        if node["type"] != "dataset"
+    ]
+    assert capped_content_ids == ["doc-current", "chunk-current"]
+
+async def test_graph_prunes_stale_only_nodes_from_bypass_view() -> None:
+    gateway = FakeDatasetGateway(
+        [
+            ("doc-current", {"name": "current", "type": "TextDocument"}),
+            ("chunk-current", {"text": "current body", "type": "DocumentChunk"}),
+            ("entity-shared", {"name": "shared", "type": "Entity"}),
+            ("doc-stale", {"name": "stale", "type": "TextDocument"}),
+            ("chunk-stale", {"text": "stale body", "type": "DocumentChunk"}),
+            ("entity-stale", {"name": "stale entity", "type": "Entity"}),
+            ("summary-stale", {"text": "stale summary", "type": "TextSummary"}),
+        ],
+        [
+            ("chunk-current", "doc-current", "is_part_of", {}),
+            ("entity-shared", "chunk-current", "contains", {}),
+            ("entity-shared", "chunk-stale", "contains", {}),
+            ("chunk-stale", "doc-stale", "is_part_of", {}),
+            ("summary-stale", "chunk-stale", "made_from", {}),
+            ("entity-stale", "doc-current"),
+            ("entity-stale", "chunk-stale", "contains", {}),
+        ],
+    )
+    mesh = KnowledgeMesh(
+        gateway,
+        lifecycle_store=FakeLifecycleStore(
+            {
+                "doc-current": True,
+                "doc-stale": False,
+            }
+        ),
+    )
+
+    graph = await mesh.graph(limit=20)
+
+    ids = {node["id"] for node in graph["nodes"]}
+    assert {"doc-current", "chunk-current", "entity-shared"} <= ids
+    assert not ids.intersection({"doc-stale", "chunk-stale", "entity-stale", "summary-stale"})
+
+
+async def test_graph_preserves_unmanaged_document_roots() -> None:
+    gateway = FakeDatasetGateway(
+        [
+            ("doc-stale", {"name": "stale", "type": "TextDocument"}),
+            ("chunk-stale", {"text": "stale body", "type": "DocumentChunk"}),
+            ("entity-shared", {"name": "shared", "type": "Entity"}),
+            (
+                "doc-unmanaged",
+                {
+                    "name": "unmanaged",
+                    "type": "text",
+                    "text": "unmanaged document body",
+                },
+            ),
+            ("chunk-unmanaged", {"text": "unmanaged body", "type": "DocumentChunk"}),
+        ],
+        [
+            ("chunk-stale", "doc-stale", "is_part_of", {}),
+            ("entity-shared", "chunk-stale", "contains", {}),
+            ("entity-shared", "chunk-unmanaged", "contains", {}),
+            ("chunk-unmanaged", "doc-unmanaged", "is_part_of", {}),
+        ],
+    )
+    mesh = KnowledgeMesh(
+        gateway,
+        lifecycle_store=FakeLifecycleStore({"doc-stale": False}),
+    )
+
+    graph = await mesh.graph(limit=20)
+
+    ids = {node["id"] for node in graph["nodes"]}
+    assert {"doc-unmanaged", "chunk-unmanaged", "entity-shared"} <= ids
+    assert "/api/documents/doc-unmanaged" in json.dumps(graph)
+    assert not ids.intersection({"doc-stale", "chunk-stale"})
+
+def test_graph_payload_cap_prefers_later_connected_pair() -> None:
+    payload = build_graph_payload(
+        [
+            ("isolated", {"name": "orphan", "type": "Entity"}),
+            ("hub", {"name": "Central", "type": "Hub"}),
+            ("pair-left", {"name": "left", "type": "Entity"}),
+            ("pair-right", {"name": "right", "type": "Entity"}),
+        ],
+        [("pair-left", "pair-right", "related", {})],
+        limit=2,
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"pair-left", "pair-right"}
+    assert payload["edges"] == [
+        {"source": "pair-left", "target": "pair-right", "relationship": "related"}
+    ]
+    assert all(
+        edge["source"] in ids and edge["target"] in ids for edge in payload["edges"]
+    )
+def test_graph_payload_cap_reserves_preferred_endpoint_pairs() -> None:
+    payload = build_graph_payload(
+        [
+            ("doc-a", {"name": "A", "type": "TextDocument"}),
+            ("doc-b", {"name": "B", "type": "TextDocument"}),
+            ("chunk-a", {"text": "A body", "type": "DocumentChunk"}),
+            ("chunk-b", {"text": "B body", "type": "DocumentChunk"}),
+        ],
+        [
+            ("chunk-a", "doc-a", "is_part_of", {}),
+            ("chunk-b", "doc-b", "is_part_of", {}),
+        ],
+        limit=2,
+        preferred_ids={"doc-a", "doc-b", "chunk-a", "chunk-b"},
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"doc-a", "chunk-a"}
+    assert payload["edges"] == [
+        {"source": "chunk-a", "target": "doc-a", "relationship": "is_part_of"}
+    ]
+def test_graph_payload_cap_completes_preferred_pair_with_missing_endpoint() -> None:
+    payload = build_graph_payload(
+        [
+            ("a", {"name": "A", "type": "Entity"}),
+            ("b", {"name": "B", "type": "Entity"}),
+            ("d", {"name": "D", "type": "Entity"}),
+            ("c", {"name": "C", "type": "Entity"}),
+        ],
+        [
+            ("a", "b", "related", {}),
+            ("b", "c", "related", {}),
+        ],
+        limit=3,
+        preferred_ids={"a", "b", "c", "d"},
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"a", "b", "c"}
+    assert payload["edges"] == [
+        {"source": "a", "target": "b", "relationship": "related"},
+        {"source": "b", "target": "c", "relationship": "related"},
+    ]
+
+
+def test_graph_payload_cap_ignores_malformed_preferred_edges() -> None:
+    payload = build_graph_payload(
+        [
+            ("bad-left", {"name": "bad left", "type": "Entity"}),
+            ("bad-right", {"name": "bad right", "type": "Entity"}),
+            ("valid-left", {"name": "valid left", "type": "Entity"}),
+            ("valid-right", {"name": "valid right", "type": "Entity"}),
+        ],
+        [
+            ("bad-left", "bad-right"),
+            ("valid-left", "valid-right", "related", {}),
+        ],
+        limit=2,
+        preferred_ids={"bad-left", "bad-right", "valid-left", "valid-right"},
+    )
+
+    ids = {node["id"] for node in payload["nodes"]}
+    assert ids == {"valid-left", "valid-right"}
+    assert payload["edges"] == [
+        {"source": "valid-left", "target": "valid-right", "relationship": "related"}
+    ]
+
+
+def test_graph_payload_stamps_trace_id_and_prune_hides_withdrawn() -> None:
+    from kb.session_trace import prune_withdrawn_graph
+
+    payload = build_graph_payload(
+        [
+            ("chunk-a", {"type": "DocumentChunk", "text": "# Shared Session Trace\nTrace-Id: trace:gone\n\nDead end"}),
+            ("chunk-b", {"type": "DocumentChunk", "text": "ordinary note with no marker"}),
+        ],
+        [("chunk-a", "chunk-b", "related", {})],
+    )
+    node_by_id = {node["id"]: node for node in payload["nodes"]}
+    assert node_by_id["chunk-a"].get("trace_id") == "trace:gone"
+    assert "trace_id" not in node_by_id["chunk-b"]
+
+    pruned = prune_withdrawn_graph(payload, {"trace:gone"})
+    kept_ids = {node["id"] for node in pruned["nodes"]}
+    assert kept_ids == {"chunk-b"}
+    # The edge to the withdrawn node is dropped with it.
+    assert pruned["edges"] == []

--- a/tests/test_obsidian_sync.py
+++ b/tests/test_obsidian_sync.py
@@ -147,3 +147,25 @@ def test_unknown_vault_raises_key_error(tmp_path: Path) -> None:
 
     with pytest.raises(KeyError):
         sync.manifest(vault_id="vault_missing")
+
+
+def test_duplicate_normalized_paths_rejected_without_mutation(tmp_path: Path) -> None:
+    sync, vault_id = vault_store(tmp_path)
+    # Seed one document so a rejected batch has an existing manifest to preserve.
+    push_one(sync, vault_id, path="notes/a.md", content="Original")
+    before = sync.manifest(vault_id=vault_id)
+
+    # ``notes/a.md`` and ``./notes/a.md`` collapse to the same normalized path.
+    with pytest.raises(ValueError, match="Duplicate normalized path"):
+        sync.push(
+            vault_id=vault_id,
+            actor=ACTOR,
+            documents=[
+                SyncPushDocument(path="notes/a.md", content="First", base_rev=1),
+                SyncPushDocument(path="./notes/a.md", content="Second", base_rev=1),
+            ],
+        )
+
+    after = sync.manifest(vault_id=vault_id)
+    assert after["documents"] == before["documents"]
+    assert after["next_cursor"] == before["next_cursor"]

--- a/tests/test_search_format.py
+++ b/tests/test_search_format.py
@@ -1024,6 +1024,9 @@ _SESSION_TRACE_WORST_CASE_INPUTS: list[tuple[str, str, Callable[[int], str]]] = 
     ("_AUTHOR_SEAT_LINE", "search", lambda n: "Author-Seat:" + " " * n),
     ("_AUTHOR_SEAT_LINE", "search", lambda n: "Author-Seat:" + "\n" * n),
     ("_AUTHOR_SEAT_LINE", "search", lambda n: "Author-Seat:\n" * (n // 13)),
+    ("_TRACE_ID_LINE", "search", lambda n: "Trace-Id:" + " " * n),
+    ("_TRACE_ID_LINE", "search", lambda n: "Trace-Id:" + "\n" * n),
+    ("_TRACE_ID_LINE", "search", lambda n: "Trace-Id:\n" * (n // 10)),
 ]
 
 

--- a/tests/test_session_trace.py
+++ b/tests/test_session_trace.py
@@ -7,7 +7,18 @@ from typing import Any
 import pytest
 
 from kb.capture_config import matched_capture_root
-from kb.session_trace import enrich_shared_trace, force_shared_trace_author_seat
+from kb.session_trace import (
+    SessionTraceStore,
+    SharedTraceMetadata,
+    TraceStoreCorruptionError,
+    enrich_shared_trace,
+    extract_trace_id,
+    force_shared_trace_author_seat,
+    force_shared_trace_id,
+    mint_trace_id,
+    prune_withdrawn_graph,
+    result_trace_id,
+)
 from kb.session_trace_distill import (
     distill_trace,
     format_compact_context,
@@ -180,3 +191,172 @@ def test_enrich_shared_trace_preserves_forced_author(monkeypatch: pytest.MonkeyP
     forced = force_shared_trace_author_seat(enriched, "alice")
     assert "Author-Seat: alice" in forced
     assert "Author-Seat: eve" not in forced
+
+
+def test_mint_trace_id_is_deterministic_and_opaque() -> None:
+    data = "# Shared Session Trace\nAuthor-Seat: alice\n\nTask: x"
+    first = mint_trace_id("alice", "sess-1", data)
+    second = mint_trace_id("alice", "sess-1", data)
+    assert first == second
+    assert first.startswith("trace:")
+    # Opaque: no source or query text leaks into the ID.
+    assert "Task" not in first and "alice" not in first
+
+
+def test_force_and_extract_trace_id_roundtrip() -> None:
+    forced = force_shared_trace_id("# Shared Session Trace\n\nTask: x", "trace:abc123")
+    assert forced.splitlines()[1] == "Trace-Id: trace:abc123"
+    assert extract_trace_id(forced) == "trace:abc123"
+
+
+def test_force_trace_id_replaces_every_occurrence() -> None:
+    data = "# Shared Session Trace\nTrace-Id: trace:spoof\n\nTask\nTrace-Id: trace:spoof2\n"
+    forced = force_shared_trace_id(data, "trace:real")
+    assert "trace:spoof" not in forced
+    assert forced.count("Trace-Id: trace:real") == 2
+
+
+def test_result_trace_id_reads_dict_field_and_text() -> None:
+    assert result_trace_id({"trace_id": "trace:x"}) == "trace:x"
+    assert result_trace_id({"text": "# Shared Session Trace\nTrace-Id: trace:y\n"}) == "trace:y"
+    assert result_trace_id({"metadata": {"content": "Trace-Id: trace:z"}}) == "trace:z"
+    assert result_trace_id({"text": "no marker"}) is None
+
+
+def test_empty_trace_marker_does_not_steal_next_line() -> None:
+    # An empty ``Trace-Id:`` line must not borrow the following content line as
+    # the ID: ``\s*`` used to let the value span the newline.
+    text = "# Shared Session Trace\nTrace-Id:\nTask: private text\n"
+    assert extract_trace_id(text) is None
+
+
+def test_trace_marker_parses_normal_crlf_line() -> None:
+    text = "# Shared Session Trace\r\nTrace-Id: trace:abc\r\nTask: x\r\n"
+    assert extract_trace_id(text) == "trace:abc"
+
+
+def test_direct_trace_id_field_rejects_embedded_newline() -> None:
+    # A direct mapping value is line-oriented; a CR/LF would smuggle a second
+    # spoofed line, so reject it rather than strip it.
+    assert result_trace_id({"trace_id": "trace:x\nTrace-Id: trace:spoof"}) is None
+    assert result_trace_id({"Trace-Id": "trace:y\r\nextra"}) is None
+    assert result_trace_id({"trace_id": "trace:clean"}) == "trace:clean"
+
+
+def test_mesh_trace_regex_matches_session_trace_parsing() -> None:
+    from kb.knowledge_mesh import _node_trace_id
+
+    # Graph node parity: the mesh copy must reject the empty marker the same way.
+    assert _node_trace_id({"text": "Trace-Id: trace:node\nbody"}) == "trace:node"
+    assert _node_trace_id({"text": "Trace-Id:\nTask: private text"}) is None
+
+
+def test_session_trace_store_metadata_roundtrip(tmp_path: Path) -> None:
+    store = SessionTraceStore(tmp_path / "traces.json")
+    metadata = SharedTraceMetadata(
+        trace_id="trace:1",
+        author_principal="seat:alice",
+        author_kind="human",
+        seat_scope="alice",
+        captured_at="2026-09-05T00:00:00+00:00",
+        shared_at="2026-09-05T00:01:00+00:00",
+        source_references=("repo", "main"),
+        redaction_result="scanned",
+        visibility="seat-shared",
+        citations=("kb/server.py",),
+        source_revision_ids=("source:abc",),
+    )
+    store.register(metadata)
+    reopened = SessionTraceStore(tmp_path / "traces.json")
+    loaded = reopened.get("trace:1")
+    assert loaded is not None
+    assert loaded.trace_id == "trace:1"
+    assert loaded.author_principal == "seat:alice"
+    assert loaded.trust == "reference-only"
+    assert loaded.source_references == ("repo", "main")
+    assert loaded.source_revision_ids == ("source:abc",)
+    assert loaded.withdrawn is False
+
+def test_session_trace_store_fails_closed_on_corrupt_withdrawal_state(tmp_path: Path) -> None:
+    path = tmp_path / "traces.json"
+    path.write_text("{", encoding="utf-8")
+    store = SessionTraceStore(path)
+
+    with pytest.raises(TraceStoreCorruptionError):
+        store.withdrawn_trace_ids()
+
+
+
+def test_session_trace_withdrawal_is_durable_and_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "traces.json"
+    store = SessionTraceStore(path)
+    store.register(
+        SharedTraceMetadata(trace_id="trace:1", author_principal="seat:alice")
+    )
+    first = store.withdraw("trace:1", actor_principal="seat:bob", reason_code="privacy")
+    assert first.trace_id == "trace:1"
+    assert first.actor_principal == "seat:bob"
+    assert first.reason_code == "privacy"
+    # Idempotent: repeat withdrawal keeps the original tombstone timestamp/actor.
+    second = store.withdraw("trace:1", actor_principal="seat:carol", reason_code="other")
+    assert second == first
+    # Durable across reopen.
+    reopened = SessionTraceStore(path)
+    assert reopened.is_withdrawn("trace:1") is True
+    assert reopened.withdrawn_trace_ids() == frozenset({"trace:1"})
+    meta = reopened.get("trace:1")
+    assert meta is not None and meta.withdrawn is True
+    assert meta.withdrawn_by == "seat:bob"
+
+
+def test_withdraw_unregistered_trace_still_tombstones(tmp_path: Path) -> None:
+    store = SessionTraceStore(tmp_path / "traces.json")
+    tombstone = store.withdraw("trace:ghost", actor_principal="seat:a", reason_code="x")
+    assert tombstone.trace_id == "trace:ghost"
+    assert store.is_withdrawn("trace:ghost") is True
+    assert store.get("trace:ghost") is None
+
+
+def test_withdraw_rejects_empty_inputs(tmp_path: Path) -> None:
+    store = SessionTraceStore(tmp_path / "traces.json")
+    with pytest.raises(ValueError):
+        store.withdraw("  ", actor_principal="seat:a", reason_code="x")
+    with pytest.raises(ValueError):
+        store.withdraw("trace:1", actor_principal="seat:a", reason_code="  ")
+
+
+def test_register_preserves_existing_withdrawal(tmp_path: Path) -> None:
+    store = SessionTraceStore(tmp_path / "traces.json")
+    store.register(SharedTraceMetadata(trace_id="trace:1", author_principal="seat:a"))
+    store.withdraw("trace:1", actor_principal="seat:a", reason_code="privacy")
+    # A later re-share must not silently un-withdraw the trace.
+    refreshed = store.register(
+        SharedTraceMetadata(trace_id="trace:1", author_principal="seat:a")
+    )
+    assert refreshed.withdrawn is True
+    assert store.is_withdrawn("trace:1") is True
+
+
+def test_prune_withdrawn_graph_drops_nodes_and_dangling_edges() -> None:
+    payload = {
+        "nodes": [
+            {"id": "n1", "label": "keep", "properties": {"text": "ordinary"}},
+            {"id": "n2", "text": "# Shared Session Trace\nTrace-Id: trace:gone\n"},
+            {"id": "n3", "label": "also keep"},
+        ],
+        "edges": [
+            {"source": "n1", "target": "n3"},
+            {"source": "n1", "target": "n2"},
+            {"source": "n2", "target": "n3"},
+        ],
+    }
+    pruned = prune_withdrawn_graph(payload, {"trace:gone"})
+    node_ids = {node["id"] for node in pruned["nodes"]}
+    assert node_ids == {"n1", "n3"}
+    assert pruned["edges"] == [{"source": "n1", "target": "n3"}]
+
+
+def test_prune_withdrawn_graph_noop_without_withdrawn() -> None:
+    payload = {"nodes": [{"id": "n1"}], "edges": []}
+    assert prune_withdrawn_graph(payload, None)["nodes"] == [{"id": "n1"}]
+    assert prune_withdrawn_graph(payload, set())["nodes"] == [{"id": "n1"}]

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -340,6 +340,13 @@ def test_sanitize_recent_drops_non_dict_and_non_scalar() -> None:
     assert _sanitize_recent([{"title": ["nested"], "action": "ok"}]) == [{"action": "ok"}]
 
 
+def test_fetch_recent_fails_closed_on_non_dict_response(monkeypatch) -> None:
+    # A malformed API response (list, None, scalar) must yield [], never raise.
+    for shape in ([{"contributions": []}], None, "boom", 5):
+        monkeypatch.setattr(status_mod, "_request", lambda *a, **k: shape)
+        assert status_mod.fetch_recent("https://node.example", "tok") == []
+
+
 def test_readiness_auth_required_and_search_codes(tmp_path: Path) -> None:
     report = StatusReport(
         node_url="https://node.example",

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -288,6 +288,58 @@ def test_gather_status_healthy(tmp_path: Path, monkeypatch) -> None:
     assert report.to_dict()["readiness"]["search"] is True
 
 
+def test_gather_status_allowlists_hostile_recent_fields(tmp_path: Path, monkeypatch) -> None:
+    # A hostile audit row carrying actor identity, a token-like value, dataset,
+    # and a nested detail payload must be stripped to display scalars only.
+    hostile = {
+        "title": "feat: safe",
+        "created_at": "2026-06-27T10:00:00",
+        "action": "contribute",
+        "actor_id": "principal_secret",
+        "actor_name": "Alice",
+        "role": "admin",
+        "dataset": "seat:alice",
+        "token": "ctdl_supersecrettoken",
+        "detail": {"query": "confidential text", "nested": "payload"},
+        "unknown_key": "drop me",
+    }
+    monkeypatch.setattr(
+        status_mod._OPENER,
+        "open",
+        _route(
+            {
+                "/healthz": {"ok": True, "service": "citadel"},
+                "/api/session": {"ok": True, "role": "writer", "seat_slug": "alice"},
+                "/api/contributions/recent": {"contributions": [hostile]},
+            }
+        ),
+    )
+    report = gather_status(
+        "https://node.example",
+        "ctdl_tok",
+        repo=tmp_path,
+        config_path=tmp_path / "c.json",
+    )
+    row = report.recent[0]
+    assert row == {
+        "title": "feat: safe",
+        "created_at": "2026-06-27T10:00:00",
+        "action": "contribute",
+    }
+    blob = json.dumps(report.to_dict())
+    for leaked in ("principal_secret", "ctdl_supersecrettoken", "seat:alice", "confidential text", "admin", "drop me"):
+        assert leaked not in blob
+
+
+def test_sanitize_recent_drops_non_dict_and_non_scalar() -> None:
+    from kb.status import _sanitize_recent
+
+    assert _sanitize_recent("not a list") == []
+    assert _sanitize_recent([None, "x", 5]) == []
+    # A scalar-only allowlist; a dict/list value under an allowed key is dropped.
+    assert _sanitize_recent([{"title": ["nested"], "action": "ok"}]) == [{"action": "ok"}]
+
+
 def test_readiness_auth_required_and_search_codes(tmp_path: Path) -> None:
     report = StatusReport(
         node_url="https://node.example",
@@ -1071,3 +1123,34 @@ def test_pre_push_check_distinguishes_no_git_repo(tmp_path: Path) -> None:
     assert "no git repo" in hook.detail
     assert str(tmp_path) in hook.detail
     assert hook.data["git_repo"] is False
+
+
+def test_ingest_node_carries_stable_idempotency_key(monkeypatch: Any) -> None:
+    seen: list[dict[str, Any]] = []
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        seen.append(kwargs["payload"])
+        return {"accepted": True}
+
+    monkeypatch.setattr(status_mod, "_request", fake_request)
+    status_mod.ingest_node("https://node.example", "ctdl_x", "smoke note", ["smoke"])
+    status_mod.ingest_node("https://node.example", "ctdl_x", "smoke note", ["smoke"])
+
+    assert seen[0]["idempotency_key"]
+    assert seen[0]["idempotency_key"] == seen[1]["idempotency_key"]
+
+
+def test_ingest_node_idempotency_key_avoids_delimiter_collision(
+    monkeypatch: Any,
+) -> None:
+    seen: list[dict[str, Any]] = []
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        seen.append(kwargs["payload"])
+        return {"accepted": True}
+
+    monkeypatch.setattr(status_mod, "_request", fake_request)
+    status_mod.ingest_node("https://node.example", "ctdl_x", "a\x1fb", ["c"])
+    status_mod.ingest_node("https://node.example", "ctdl_x", "a", ["b", "c"])
+
+    assert seen[0]["idempotency_key"] != seen[1]["idempotency_key"]


### PR DESCRIPTION
Fixes #317

Boundary parsing/status hardening.

- `kb/obsidian_sync.py`: reject duplicate normalized paths (slash/dot variants) before any mutation.
- `kb/session_trace.py` + `kb/knowledge_mesh.py`: Trace-Id parsing restricted to a single line; reject embedded CR/LF.
- `kb/status.py`: recent contributions field-allowlisted in headless JSON (no actor/token/detail/dataset).

Verification: focused suite -> 215 passed on a main-based tree. Rollback: delete branch, close PR.

Part of core completion rollout (#317).
