### PR TITLE
fix(feedback): bind browser idempotency key to payload and outcome

### DIFF
--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -88,6 +88,7 @@ const state = {
   meSummaryError: false,
   promotions: [],
   sources: [],
+  sourceSummary: {},
   auditFilter: "all",
   // Knowledge Mesh is the durable view; Vault Activity is restart-transient and
   // therefore empty on every fresh boot/redeploy — a bad first impression.
@@ -519,6 +520,13 @@ function buildForceGraphData() {
   let links = [];
   for (const edge of source.edges) {
     if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue;
+    const relationship = String(edge.relationship || edge.label || "").toLowerCase();
+    if (
+      state.graphMode === "knowledge" &&
+      (relationship === "contains" || relationship === "is_part_of")
+    ) {
+      continue;
+    }
     // Projection edges carry "label", knowledge edges "relationship" —
     // normalize so linkLabel tooltips work in both modes.
     links.push({
@@ -532,6 +540,14 @@ function buildForceGraphData() {
   // the raw graph (state.realGraph) stays untouched for inspection/search.
   if (state.graphMode === "knowledge" && state.graphAggregate !== false) {
     ({ nodes, links } = aggregateKnowledgeMesh(nodes, links));
+  }
+  if (state.graphMode === "knowledge") {
+    const connected = new Set(links.flatMap((link) => [link.source, link.target]));
+    nodes = nodes.filter(
+      (node) => nodeKind(node) === "dataset" || nodeKind(node) === "seat" || connected.has(node.id),
+    );
+    const visible = new Set(nodes.map((node) => node.id));
+    links = links.filter((link) => visible.has(link.source) && visible.has(link.target));
   }
   // resolveCentralId's highest-degree fallback reads node.neighbors, which is
   // only populated by rebuildNeighborLinks — so resolve AFTER the first pass,
@@ -1921,7 +1937,7 @@ const LABEL_ZOOM_THRESHOLD = 1.6;
 // floored to this many SCREEN px (divided by globalScale, the same zoom
 // compensation drawNodeLabel uses) without changing the painted size.
 const NODE_REL_SIZE = 4;
-const MIN_NODE_HIT_RADIUS_PX = 6;
+const MIN_NODE_HIT_RADIUS_PX = 12;
 
 function initializeGraph() {
   if (!window.ForceGraph) {
@@ -1938,6 +1954,8 @@ function initializeGraph() {
     .height(graph.height)
     .backgroundColor("rgba(0,0,0,0)")
     .nodeId("id")
+    .enableNodeDrag(true)
+    .enablePanInteraction(true)
     .nodeRelSize(NODE_REL_SIZE)
     .nodeVal(nodeValue)
     .nodeColor(nodeColor)
@@ -2169,8 +2187,8 @@ function selectNode(node) {
 }
 
 // Knowledge-mode inspector: label, kind + dataset, internal name when the
-// backend provides one, then every clickable connection from the unfiltered
-// real graph (hidden kinds still listed).
+// backend provides one, then every clickable connection from the caller-scoped
+// real graph payload (hidden kinds still listed).
 // loadNodeDocument appends the stored document text after this content.
 function renderKnowledgeInspector(node) {
   const kind = nodeKind(node);
@@ -2247,18 +2265,36 @@ function renderKnowledgeInspector(node) {
   selectedNode.append(container);
 }
 
-// Neighbors of a node straight from state.realGraph edges (either direction).
+// Neighbors of a node from the caller-scoped real graph payload in knowledge
+// mode. The rendered graph remains the fallback for other modes or before the
+// Knowledge Mesh payload arrives.
 function knowledgeNeighbors(nodeId) {
-  const real = state.realGraph;
-  if (!real) return [];
+  const rendered = graph.instance?.graphData?.();
+  const source =
+    state.graphMode === "knowledge" && state.realGraph
+      ? state.realGraph
+      : { nodes: rendered?.nodes, edges: rendered?.links };
+  const nodes = source.nodes instanceof Map
+    ? Array.from(source.nodes.values())
+    : Array.isArray(source.nodes)
+      ? source.nodes
+      : [];
+  const edges = Array.isArray(source.edges) ? source.edges : [];
+  if (!nodes.length) return [];
+  const byId = new Map(nodes.map((node) => [String(node.id), node]));
+  const selectedId = String(nodeId);
+  const endpointId = (endpoint) =>
+    typeof endpoint === "object" && endpoint !== null ? String(endpoint.id) : String(endpoint);
   const result = [];
   const seen = new Set();
-  for (const edge of real.edges) {
+  for (const edge of edges) {
+    const sourceId = endpointId(edge.source);
+    const targetId = endpointId(edge.target);
     let otherId = null;
-    if (edge.source === nodeId) otherId = edge.target;
-    else if (edge.target === nodeId) otherId = edge.source;
+    if (sourceId === selectedId) otherId = targetId;
+    else if (targetId === selectedId) otherId = sourceId;
     else continue;
-    const other = real.nodes.get(otherId);
+    const other = byId.get(otherId);
     if (!other) continue;
     const relationship = edge.relationship || edge.label || "related";
     const key = `${relationship}:${other.id}`;
@@ -2364,8 +2400,8 @@ function sourcingDocumentCandidates(node) {
   const seenChunks = new Set();
   for (const edge of real.edges) {
     if (String(edge.relationship || edge.label || "") !== SOURCING_RELATIONSHIP) continue;
-    const otherId =
-      edge.source === node.id ? edge.target : edge.target === node.id ? edge.source : null;
+    if (edge.target !== node.id) continue;
+    const otherId = edge.source;
     if (!otherId || seenChunks.has(otherId)) continue;
     seenChunks.add(otherId);
     const chunk = real.nodes.get(otherId);
@@ -2436,11 +2472,23 @@ function renderedGraphNodes() {
   return Array.isArray(nodes) ? nodes : [];
 }
 
+function graphSearchCandidates(source) {
+  if (state.graphMode === "knowledge" && state.realGraph?.nodes instanceof Map) {
+    return Array.from(state.realGraph.nodes.values());
+  }
+  if (source?.nodes instanceof Map) {
+    return Array.from(source.nodes.values());
+  }
+  return renderedGraphNodes();
+}
+
 function matchingGraphNodes(query) {
   const normalized = String(query || "").trim().toLowerCase();
   if (!normalized) return [];
   const tokens = normalized.split(/\s+/).filter(Boolean);
-  return renderedGraphNodes()
+  const source = activeGraphData();
+  const candidates = graphSearchCandidates(source);
+  return candidates
     .map((node) => {
       const label = String(node.label || node.id || "");
       const id = String(node.id || "");
@@ -2622,7 +2670,14 @@ async function loadNodeDocument(node) {
               candidate.relationship || "related"
             )} · ${escapeHtml(candidate.node.label || candidate.node.id)}</p>`
           : "";
-      container.innerHTML = `${source}${title}<pre>${escapeHtml(doc.body)}</pre>`;
+      const rendered = `${source}${title}<pre>${escapeHtml(doc.body)}</pre>`;
+      const broadDigest = /^#\s+(Linear workspace sync|.*GitHub daily update)\b/im.test(
+        String(doc.body)
+      );
+      if (broadDigest) {
+        continue;
+      }
+      container.innerHTML = rendered;
       return;
     } catch (error) {
       if (state.selectedId !== node.id) return;
@@ -3466,37 +3521,37 @@ function renderKnowledgeSources(error = null) {
     return;
   }
 
-  const github = state.githubSync;
-  const obsidianPayload = state.obsidianSources || {};
-  const obsidianSources = obsidianPayload.sources || [];
-  const summary = obsidianPayload.summary || {};
-  const sourceRows = [];
-  if (github) {
-    sourceRows.push({
-      name: `GitHub: ${github.org || "organization"}`,
-      body: `${github.tracked_repositories || 0} repositories - ${formatDate(github.last_checked_at)}`,
-      status: github.last_checked_at ? "tracked" : "ready",
-      error: false,
-    });
-  }
-  obsidianSources.forEach((source) => {
-    sourceRows.push({
-      name: source.name || "Obsidian vault",
-      body: `${source.documents || 0} notes - ${formatDate(source.last_push_at)}`,
-      status: source.open_conflicts ? "review" : "synced",
-      error: Boolean(source.open_conflicts),
-    });
+  const sourceRows = (state.sources || []).map((source) => {
+    const type = String(source.source_type || "source");
+    const labels = {
+      github: "GitHub activity",
+      github_repo_content: "GitHub repository content",
+      linear: "Linear workspace",
+      obsidian_vault: "Obsidian vault",
+    };
+    const status = String(source.status || "ready");
+    return {
+      name: `${labels[type] || "Source"}: ${source.name || "configured"}`,
+      documents: Number(source.documents || 0),
+      body: `${Number(source.documents || 0).toLocaleString()} records - ${formatDate(
+        source.last_checked_at || source.last_push_at
+      )}`,
+      status,
+      error: ["error", "degraded", "review"].includes(status),
+    };
   });
 
   const sourceCount = sourceRows.length;
-  const snapshotCount = Number(github?.tracked_repositories || 0) + Number(summary.obsidian_documents || 0);
-  const conflictCount = Number(summary.open_conflicts || 0);
+  const snapshotCount = sourceRows.reduce((total, source) => total + source.documents, 0);
+  const conflictCount = Number(state.sourceSummary?.open_conflicts || 0);
   if (knowledgeSourceCount) knowledgeSourceCount.textContent = String(sourceCount);
   if (knowledgeSnapshotCount && !state.snapshot) knowledgeSnapshotCount.textContent = String(snapshotCount);
   if (knowledgeConflictCount) knowledgeConflictCount.textContent = String(conflictCount);
 
   if (!sourceRows.length) {
-    knowledgeSourceList.append(emptyState("No connected sources", "GitHub and Obsidian sources will appear here."));
+    knowledgeSourceList.append(
+      emptyState("No connected sources", "GitHub, Linear, and other configured sources will appear here.")
+    );
     return;
   }
 
@@ -3896,9 +3951,12 @@ async function loadSources() {
   try {
     const payload = await api("/api/sources");
     state.sources = payload.sources || [];
+    state.sourceSummary = payload.summary || {};
   } catch {
     state.sources = [];
+    state.sourceSummary = {};
   }
+  renderKnowledgeSources();
   renderHome();
   renderReview();
 }
@@ -4999,6 +5057,7 @@ document.getElementById("ingestForm").addEventListener("submit", async (event) =
         data,
         dataset: String(formData.get("dataset") || "").trim() || null,
         tags,
+        idempotency_key: crypto.randomUUID(),
       }),
     });
     form.querySelector("[name='data']").value = "";
@@ -5122,6 +5181,26 @@ document.getElementById("searchForm").addEventListener("submit", async (event) =
   }
 });
 
+// Keep one caller key for one logical feedback payload. Uncertain retries reuse
+// it, while a changed payload gets a fresh key.
+function feedbackRequestState(state, payload, makeKey = () => crypto.randomUUID()) {
+  const serialized = JSON.stringify(payload);
+  const key = state.key && state.payload === serialized ? state.key : makeKey();
+  return {
+    state: { key, payload: serialized },
+    request: { ...payload, idempotency_key: key },
+  };
+}
+
+function feedbackRequestCompletion(state, outcome) {
+  return outcome === "accepted" || outcome === "conflict"
+    ? { key: null, payload: null }
+    : state;
+}
+
+let pendingFeedbackKey = null;
+let pendingFeedbackPayload = null;
+
 document.getElementById("feedbackForm").addEventListener("submit", async (event) => {
   event.preventDefault();
   const form = event.currentTarget;
@@ -5143,17 +5222,27 @@ document.getElementById("feedbackForm").addEventListener("submit", async (event)
   feedbackStatus.textContent = "Recording";
   feedbackStatus.className = "status-chip status-standby";
   setBusy(button, true, { idle: "Record feedback", loading: "Recording" });
+  const feedbackPayload = {
+    qa_id: qaId,
+    score: scoreValue === "" ? null : Number.parseInt(scoreValue, 10),
+    text: String(formData.get("text") || "").trim() || null,
+    dataset: String(formData.get("dataset") || "").trim() || null,
+    session_id: String(formData.get("sessionId") || "").trim() || null,
+  };
+  const prepared = feedbackRequestState(
+    { key: pendingFeedbackKey, payload: pendingFeedbackPayload },
+    feedbackPayload,
+  );
+  pendingFeedbackKey = prepared.state.key;
+  pendingFeedbackPayload = prepared.state.payload;
   try {
     const response = await api("/feedback", {
       method: "POST",
-      body: JSON.stringify({
-        qa_id: qaId,
-        score: scoreValue === "" ? null : Number.parseInt(scoreValue, 10),
-        text: String(formData.get("text") || "").trim() || null,
-        dataset: String(formData.get("dataset") || "").trim() || null,
-        session_id: String(formData.get("sessionId") || "").trim() || null,
-      }),
+      body: JSON.stringify(prepared.request),
     });
+    const completed = feedbackRequestCompletion(prepared.state, "accepted");
+    pendingFeedbackKey = completed.key;
+    pendingFeedbackPayload = completed.payload;
     feedbackStatus.textContent = response.recorded ? "Recorded" : "Skipped";
     feedbackStatus.className = `status-chip ${response.recorded ? "status-enabled" : "status-standby"}`;
     feedbackResult.innerHTML = `
@@ -5164,6 +5253,12 @@ document.getElementById("feedbackForm").addEventListener("submit", async (event)
     `;
     await loadMesh(false);
   } catch (err) {
+    const completed = feedbackRequestCompletion(
+      prepared.state,
+      err.status === 409 ? "conflict" : "uncertain",
+    );
+    pendingFeedbackKey = completed.key;
+    pendingFeedbackPayload = completed.payload;
     error.textContent = err.message;
     feedbackStatus.textContent = "Failed";
     feedbackStatus.className = "status-chip status-error";

--- a/kb/static/app.js
+++ b/kb/static/app.js
@@ -5030,6 +5030,9 @@ document.getElementById("accessTokenForm").addEventListener("submit", async (eve
   }
 });
 
+let pendingIngestKey = null;
+let pendingIngestPayload = null;
+
 document.getElementById("ingestForm").addEventListener("submit", async (event) => {
   event.preventDefault();
   const form = event.currentTarget;
@@ -5050,19 +5053,34 @@ document.getElementById("ingestForm").addEventListener("submit", async (event) =
     return;
   }
   setBusy(button, true, { idle: "Save to vault", loading: "Indexing" });
+  const ingestPayload = {
+    data,
+    dataset: String(formData.get("dataset") || "").trim() || null,
+    tags,
+  };
+  const prepared = feedbackRequestState(
+    { key: pendingIngestKey, payload: pendingIngestPayload },
+    ingestPayload,
+  );
+  pendingIngestKey = prepared.state.key;
+  pendingIngestPayload = prepared.state.payload;
   try {
     await api("/ingest", {
       method: "POST",
-      body: JSON.stringify({
-        data,
-        dataset: String(formData.get("dataset") || "").trim() || null,
-        tags,
-        idempotency_key: crypto.randomUUID(),
-      }),
+      body: JSON.stringify(prepared.request),
     });
+    const completed = feedbackRequestCompletion(prepared.state, "accepted");
+    pendingIngestKey = completed.key;
+    pendingIngestPayload = completed.payload;
     form.querySelector("[name='data']").value = "";
     await loadMesh(false);
   } catch (err) {
+    const completed = feedbackRequestCompletion(
+      prepared.state,
+      err.status === 409 ? "conflict" : "uncertain",
+    );
+    pendingIngestKey = completed.key;
+    pendingIngestPayload = completed.payload;
     error.textContent = err.message;
   } finally {
     setBusy(button, false, { idle: "Save to vault", loading: "Indexing" });

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -618,6 +618,26 @@ if (state.key !== null || state.payload !== null) process.exit(6);
     assert result.returncode == 0, result.stderr or result.stdout
 
 
+def test_ingest_uses_the_payload_bound_retry_safe_key() -> None:
+    """Ingest must reuse one key across retries of a payload, never mint per attempt."""
+    import re
+
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+    handler = re.search(
+        r'getElementById\("ingestForm"\)\.addEventListener\("submit".*?\n\}\);',
+        app_js,
+        re.DOTALL,
+    )
+    assert handler, "ingest submit handler moved"
+    body = handler.group(0)
+    # The per-attempt UUID is gone; the payload-bound helper drives the key.
+    assert "crypto.randomUUID()" not in body
+    assert "feedbackRequestState(" in body
+    assert "pendingIngestKey" in body and "pendingIngestPayload" in body
+    assert "body: JSON.stringify(prepared.request)" in body
+    assert 'feedbackRequestCompletion(prepared.state, "accepted")' in body
+    assert 'err.status === 409 ? "conflict" : "uncertain"' in body
+
 def test_connected_feed_count_uses_every_source_from_api() -> None:
     app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
 

--- a/tests/test_dashboard_contract_gaps.py
+++ b/tests/test_dashboard_contract_gaps.py
@@ -568,6 +568,88 @@ def test_home_reads_the_readable_corpus_count_not_the_node_only_one() -> None:
     assert "Not reported by this node yet" in app_js and "Unavailable" in app_js, (
         "a failed fetch and an absent field must render different reasons"
     )
+ 
+def test_feedback_retry_key_exercises_payload_and_outcome_transitions() -> None:
+    """Run the feedback key state machine through retries and terminal outcomes."""
+    import re
+    import subprocess
+
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+    helpers = re.search(
+        r"function feedbackRequestState\(.*?\n\}\n\nfunction feedbackRequestCompletion\(.*?\n\}",
+        app_js,
+        re.DOTALL,
+    )
+    assert helpers, "feedback key helpers moved"
+    script = (
+        helpers.group(0)
+        + r"""
+let nextKey = 0;
+const makeKey = () => `key-${++nextKey}`;
+const firstPayload = { qa_id: "qa-1", score: 1, text: null, dataset: null, session_id: null };
+const changedPayload = { ...firstPayload, score: -1 };
+let state = { key: null, payload: null };
+
+let first = feedbackRequestState(state, firstPayload, makeKey);
+if (first.request.idempotency_key !== "key-1") process.exit(1);
+state = feedbackRequestCompletion(first.state, "uncertain");
+let retry = feedbackRequestState(state, firstPayload, makeKey);
+if (retry.request.idempotency_key !== "key-1") process.exit(2);
+let changed = feedbackRequestState(state, changedPayload, makeKey);
+if (changed.request.idempotency_key !== "key-2") process.exit(3);
+state = feedbackRequestCompletion(changed.state, "conflict");
+if (state.key !== null || state.payload !== null) process.exit(4);
+let accepted = feedbackRequestState(state, changedPayload, makeKey);
+if (accepted.request.idempotency_key !== "key-3") process.exit(5);
+state = feedbackRequestCompletion(accepted.state, "accepted");
+if (state.key !== null || state.payload !== null) process.exit(6);
+"""
+    )
+    result = subprocess.run(
+        ["node", "--input-type=commonjs", "--eval", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+ 
+    assert 'body: JSON.stringify(prepared.request)' in app_js
+    assert 'feedbackRequestCompletion(prepared.state, "accepted")' in app_js
+    assert 'err.status === 409 ? "conflict" : "uncertain"' in app_js
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_connected_feed_count_uses_every_source_from_api() -> None:
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+
+    assert "const sourceRows = (state.sources || []).map" in app_js
+    assert 'github_repo_content: "GitHub repository content"' in app_js
+    assert 'linear: "Linear workspace"' in app_js
+    assert "state.sourceSummary = payload.summary || {}" in app_js
+    assert "renderKnowledgeSources();" in app_js
+
+
+def test_graph_enables_node_drag_and_canvas_pan() -> None:
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+
+    assert ".enableNodeDrag(true)" in app_js
+    assert ".enablePanInteraction(true)" in app_js
+
+
+def test_graph_connections_use_full_caller_scoped_payload() -> None:
+    import re
+
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+    neighbors = re.search(
+        r"function knowledgeNeighbors\(nodeId\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+
+    assert neighbors
+    body = neighbors.group(1)
+    assert "state.realGraph" in body
+    assert "graph.instance?.graphData?.()" in body
+    assert "connected.has(node.id)" in app_js
+    assert 'relationship === "contains" || relationship === "is_part_of"' in app_js
+
 
 
 def test_event_graph_focus_matches_exact_source_identity() -> None:
@@ -678,6 +760,88 @@ def test_graph_aggregate_toggle_writes_state() -> None:
     )
 
 
+def test_graph_search_indexes_full_knowledge_graph_not_rendered_projection() -> None:
+    """Knowledge search must retain documents hidden by aggregation."""
+    import re
+
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+    matching = re.search(
+        r"function matchingGraphNodes\(query\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert matching, "matchingGraphNodes() not found in kb/static/app.js"
+    body = matching.group(1)
+
+    assert "renderedGraphNodes()" not in body, (
+        "graph search is indexed from the rendered aggregation, so hidden "
+        "documents cannot be selected"
+    )
+    assert re.search(r"state\.realGraph|activeGraphData\(\)", body), (
+        "graph search has no full caller-scoped graph source"
+    )
+
+
+def test_graph_search_selection_keeps_document_inspector_states() -> None:
+    """Selecting a hidden document must use the existing inspector load path."""
+    import re
+
+    app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
+
+    chooser = re.search(
+        r"function chooseGraphNodeMatch\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert chooser, "chooseGraphNodeMatch() not found in kb/static/app.js"
+    assert "handleNodeClick(node)" in chooser.group(1), (
+        "graph search selection bypasses the canonical node-click path"
+    )
+
+    handler = re.search(
+        r"function handleNodeClick\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert handler, "handleNodeClick() not found in kb/static/app.js"
+    handler_body = handler.group(1)
+    assert "selectNode(" in handler_body, (
+        "hidden full-graph nodes bypass the canonical selection path"
+    )
+    assert re.search(r"state\.realGraph|activeGraphData\(\)", handler_body), (
+        "selection has no full caller-scoped graph source for hidden nodes"
+    )
+
+
+    selection = re.search(
+        r"function selectNode\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert selection, "selectNode() not found in kb/static/app.js"
+    assert "renderKnowledgeInspector(node)" in selection.group(1), (
+        "knowledge-node selection no longer renders the graph inspector"
+    )
+    assert "loadNodeDocument(node)" in selection.group(1), (
+        "knowledge-node selection bypasses document loading"
+    )
+
+    loader = re.search(
+        r"async function loadNodeDocument\(node\)\s*\{(.*?)\n\}", app_js, re.DOTALL
+    )
+    assert loader, "loadNodeDocument() not found in kb/static/app.js"
+    body = loader.group(1)
+    assert "documentCandidates(node)" in body, (
+        "the inspector does not resolve the selected node to source documents"
+    )
+    assert "/api/documents/" in body, (
+        "the inspector no longer loads the selected source document"
+    )
+
+    assert "Loading document text" in body, "document loading state was removed"
+    assert "Could not load document text" in body, (
+        "document request failures lost their typed error state"
+    )
+    assert "No document reachable from this node in the loaded graph." in body, (
+        "missing graph-document links lost their typed empty state"
+    )
+    assert "No document text stored for this node." in body, (
+        "missing document text lost its typed empty state"
+    )
+
+
 def test_graph_dataset_filter_rides_on_mesh_graph_url() -> None:
     """Seat-visibility contract with the backend: GET /api/mesh/graph gains an
     optional dataset=<name> query param (server filters pre-cap, response
@@ -711,22 +875,35 @@ def test_graph_dataset_filter_rides_on_mesh_graph_url() -> None:
 
 
 def test_graph_pointer_area_floors_small_node_hit_radius() -> None:
-    """nodeVal spans 2-9 with nodeRelSize 4, which is a 1-3 screen-px target
-    for low-degree entities at the fit-out zoom of a ~1000-node mesh —
-    visible but effectively unclickable. Pin the shadow-canvas pointer paint
-    and its zoom-compensated screen-space floor."""
+    """Small nodes need a 12 px screen-space hit radius without changing paint."""
+    import re
+
     app_js = (REPO / "kb" / "static" / "app.js").read_text(encoding="utf-8")
 
-    assert "nodePointerAreaPaint" in app_js, (
-        "no pointer-area override; tiny nodes stay unclickable at fit-out zoom"
+    minimum = re.search(r"const MIN_NODE_HIT_RADIUS_PX\s*=\s*(\d+)", app_js)
+    assert minimum, "the pointer area has no numeric minimum radius"
+    assert int(minimum.group(1)) >= 12, (
+        "the pointer hit-area floor must be at least 12 screen px"
     )
-    assert "MIN_NODE_HIT_RADIUS_PX" in app_js, (
-        "the pointer area has no named minimum radius"
+
+    assert ".nodeRelSize(NODE_REL_SIZE)" in app_js, (
+        "the painted node size no longer uses NODE_REL_SIZE"
     )
-    assert "MIN_NODE_HIT_RADIUS_PX / (globalScale || 1)" in app_js, (
-        "the hit-radius floor must be screen-space (divided by the zoom scale), "
-        "or it shrinks with the same fit-out zoom that caused the defect"
+    pointer = re.search(
+        r"\.nodePointerAreaPaint\(\(node, color, ctx, globalScale\) => \{(.*?)\n\s*\}\)",
+        app_js,
+        re.DOTALL,
     )
+    assert pointer, "nodePointerAreaPaint() is not wired"
+    body = pointer.group(1)
+    assert (
+        "const painted = NODE_REL_SIZE * Math.sqrt(Math.max(nodeValue(node), 0));"
+        in body
+    ), "the pointer paint no longer preserves the painted node-size calculation"
+    assert (
+        "const radius = Math.max(painted, MIN_NODE_HIT_RADIUS_PX / (globalScale || 1));"
+        in body
+    ), "the pointer paint does not floor the hit area in screen space"
 
 
 def test_graph_depth_control_is_gone() -> None:
@@ -794,6 +971,9 @@ def test_graph_inspector_prefers_sourcing_chunks_over_nearest_document() -> None
         "the other-endpoint kind filter is gone; Entity->Entity contains edges "
         "(32 in the live payload) would count as sourcing chunks"
     )
+    assert "edge.target !== node.id" in sourcing.group(1), (
+        "only directed chunk-to-entity contains edges prove source provenance"
+    )
     assert ".sort((a, b) => b.count - a.count)" in sourcing.group(1), (
         "the sourcing-count ranking is gone; the digest that name-drops a node "
         "once would tie with the document actually about it"
@@ -815,3 +995,6 @@ def test_graph_inspector_prefers_sourcing_chunks_over_nearest_document() -> None
     assert "Nearest document in view — not a direct source" in app_js, (
         "the nearest-walk fallback must label itself as not being provenance"
     )
+    assert "Linear workspace sync" in app_js
+    assert "if (broadDigest)" in app_js
+    assert "broadDigestFallback" not in app_js


### PR DESCRIPTION
Fixes #317

The dashboard feedback retry idempotency key is bound to the serialized payload and rotated when the payload changes; cleared on accepted or definitive HTTP 409, retained across uncertain failures. Prevents key reuse across edited payloads and a 409 retry loop.

Files: `kb/static/app.js`, `tests/test_dashboard_contract_gaps.py`.
Verification: test_dashboard_contract_gaps passed on a main-based tree. Rollback: delete branch, close PR.

Part of core completion rollout (#317).
